### PR TITLE
feat: show explicit error when root access is denied

### DIFF
--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/MainActivity.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/MainActivity.kt
@@ -23,6 +23,7 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.core.graphics.drawable.toBitmap
@@ -45,6 +46,14 @@ data class AppEntry(
     val selected: Boolean,
 )
 
+private sealed class RootState {
+    data object Checking : RootState()
+
+    data object Granted : RootState()
+
+    data object Denied : RootState()
+}
+
 class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         enableEdgeToEdge()
@@ -53,12 +62,14 @@ class MainActivity : ComponentActivity() {
     }
 }
 
+/**
+ * Returns exit code and stdout. Exit code -1 means the su binary
+ * couldn't be executed at all (not installed or permission denied).
+ */
 private fun suExec(cmd: String): Pair<Int, String> =
     try {
         val proc = Runtime.getRuntime().exec(arrayOf("su", "-c", cmd))
         try {
-            // Drain stderr in the background to prevent the process from
-            // blocking if it produces error output.
             val stderrDrain = Thread { proc.errorStream.readBytes() }
             stderrDrain.start()
             val stdout = proc.inputStream.bufferedReader().readText()
@@ -75,6 +86,12 @@ private fun suExec(cmd: String): Pair<Int, String> =
 
 private suspend fun suExecAsync(cmd: String): Pair<Int, String> = withContext(Dispatchers.IO) { suExec(cmd) }
 
+/** Quick root check: run `su -c id` and see if it succeeds. */
+private fun checkRootAccess(): Boolean {
+    val (exitCode, stdout) = suExec("id")
+    return exitCode == 0 && stdout.contains("uid=0")
+}
+
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun VpnHideApp() {
@@ -88,200 +105,308 @@ fun VpnHideApp() {
         }
 
     MaterialTheme(colorScheme = colorScheme) {
-        val context = LocalContext.current
-        val pm = context.packageManager
-
-        var allApps by remember { mutableStateOf<List<AppEntry>>(emptyList()) }
-        var searchQuery by remember { mutableStateOf("") }
-        var showSystem by remember { mutableStateOf(false) }
-        var loading by remember { mutableStateOf(true) }
-        var saving by remember { mutableStateOf(false) }
-        var dirty by remember { mutableStateOf(false) }
-        var snackMessage by remember { mutableStateOf<String?>(null) }
-        val snackbarHostState = remember { SnackbarHostState() }
-
-        LaunchedEffect(snackMessage) {
-            snackMessage?.let {
-                snackbarHostState.showSnackbar(it)
-                snackMessage = null
-            }
-        }
+        var rootState by remember { mutableStateOf<RootState>(RootState.Checking) }
 
         LaunchedEffect(Unit) {
-            withContext(Dispatchers.IO) {
-                val (_, targetsRaw) =
-                    suExec(
-                        "cat $KMOD_TARGETS 2>/dev/null || cat $ZYGISK_TARGETS 2>/dev/null || true",
+            rootState =
+                withContext(Dispatchers.IO) {
+                    if (checkRootAccess()) RootState.Granted else RootState.Denied
+                }
+        }
+
+        when (rootState) {
+            RootState.Checking -> RootCheckingScreen()
+            RootState.Denied -> RootDeniedScreen()
+            RootState.Granted -> AppPickerScreen()
+        }
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun RootCheckingScreen() {
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text(stringResource(R.string.toolbar_title)) },
+                colors =
+                    TopAppBarDefaults.topAppBarColors(
+                        containerColor = MaterialTheme.colorScheme.primaryContainer,
+                        titleContentColor = MaterialTheme.colorScheme.onPrimaryContainer,
+                    ),
+            )
+        },
+    ) { innerPadding ->
+        Box(
+            modifier =
+                Modifier
+                    .fillMaxSize()
+                    .padding(innerPadding),
+            contentAlignment = Alignment.Center,
+        ) {
+            Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                CircularProgressIndicator()
+                Spacer(Modifier.height(16.dp))
+                Text(
+                    text = stringResource(R.string.root_checking),
+                    style = MaterialTheme.typography.bodyLarge,
+                )
+            }
+        }
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun RootDeniedScreen() {
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text(stringResource(R.string.toolbar_title)) },
+                colors =
+                    TopAppBarDefaults.topAppBarColors(
+                        containerColor = MaterialTheme.colorScheme.errorContainer,
+                        titleContentColor = MaterialTheme.colorScheme.onErrorContainer,
+                    ),
+            )
+        },
+    ) { innerPadding ->
+        Box(
+            modifier =
+                Modifier
+                    .fillMaxSize()
+                    .padding(innerPadding)
+                    .padding(32.dp),
+            contentAlignment = Alignment.Center,
+        ) {
+            Card(
+                colors =
+                    CardDefaults.cardColors(
+                        containerColor = MaterialTheme.colorScheme.errorContainer,
+                    ),
+            ) {
+                Column(
+                    modifier = Modifier.padding(24.dp),
+                    horizontalAlignment = Alignment.CenterHorizontally,
+                ) {
+                    Text(
+                        text = stringResource(R.string.root_error_title),
+                        style = MaterialTheme.typography.headlineSmall,
+                        fontWeight = FontWeight.Bold,
+                        color = MaterialTheme.colorScheme.onErrorContainer,
                     )
-                val selected =
-                    targetsRaw
-                        .lines()
-                        .map { it.trim() }
-                        .filter { it.isNotEmpty() && !it.startsWith("#") }
-                        .toSet()
+                    Spacer(Modifier.height(16.dp))
+                    Text(
+                        text = stringResource(R.string.root_error_message),
+                        style = MaterialTheme.typography.bodyLarge,
+                        color = MaterialTheme.colorScheme.onErrorContainer,
+                        textAlign = TextAlign.Center,
+                    )
+                }
+            }
+        }
+    }
+}
 
-                val installedApps = pm.getInstalledApplications(PackageManager.GET_META_DATA)
-                val entries =
-                    installedApps
-                        .map { info ->
-                            val label =
-                                try {
-                                    pm.getApplicationLabel(info).toString()
-                                } catch (_: Exception) {
-                                    info.packageName
-                                }
-                            val icon =
-                                try {
-                                    pm.getApplicationIcon(info)
-                                } catch (_: Exception) {
-                                    null
-                                }
-                            val isSystem = (info.flags and ApplicationInfo.FLAG_SYSTEM) != 0
-                            AppEntry(
-                                packageName = info.packageName,
-                                label = label,
-                                icon = icon,
-                                isSystem = isSystem,
-                                selected = info.packageName in selected,
-                            )
-                        }.sortedWith(compareByDescending<AppEntry> { it.selected }.thenBy { it.label.lowercase() })
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun AppPickerScreen() {
+    val context = LocalContext.current
+    val pm = context.packageManager
 
-                allApps = entries
-                loading = false
+    var allApps by remember { mutableStateOf<List<AppEntry>>(emptyList()) }
+    var searchQuery by remember { mutableStateOf("") }
+    var showSystem by remember { mutableStateOf(false) }
+    var loading by remember { mutableStateOf(true) }
+    var saving by remember { mutableStateOf(false) }
+    var dirty by remember { mutableStateOf(false) }
+    var snackMessage by remember { mutableStateOf<String?>(null) }
+    val snackbarHostState = remember { SnackbarHostState() }
+
+    LaunchedEffect(snackMessage) {
+        snackMessage?.let {
+            snackbarHostState.showSnackbar(it)
+            snackMessage = null
+        }
+    }
+
+    LaunchedEffect(Unit) {
+        withContext(Dispatchers.IO) {
+            val (_, targetsRaw) =
+                suExec(
+                    "cat $KMOD_TARGETS 2>/dev/null || cat $ZYGISK_TARGETS 2>/dev/null || true",
+                )
+            val selected =
+                targetsRaw
+                    .lines()
+                    .map { it.trim() }
+                    .filter { it.isNotEmpty() && !it.startsWith("#") }
+                    .toSet()
+
+            val installedApps = pm.getInstalledApplications(PackageManager.GET_META_DATA)
+            val entries =
+                installedApps
+                    .map { info ->
+                        val label =
+                            try {
+                                pm.getApplicationLabel(info).toString()
+                            } catch (_: Exception) {
+                                info.packageName
+                            }
+                        val icon =
+                            try {
+                                pm.getApplicationIcon(info)
+                            } catch (_: Exception) {
+                                null
+                            }
+                        val isSystem = (info.flags and ApplicationInfo.FLAG_SYSTEM) != 0
+                        AppEntry(
+                            packageName = info.packageName,
+                            label = label,
+                            icon = icon,
+                            isSystem = isSystem,
+                            selected = info.packageName in selected,
+                        )
+                    }.sortedWith(compareByDescending<AppEntry> { it.selected }.thenBy { it.label.lowercase() })
+
+            allApps = entries
+            loading = false
+        }
+    }
+
+    val filteredApps =
+        remember(allApps, searchQuery, showSystem) {
+            val q = searchQuery.trim().lowercase()
+            allApps.filter { app ->
+                (showSystem || !app.isSystem || app.selected) &&
+                    (q.isEmpty() || app.label.lowercase().contains(q) || app.packageName.lowercase().contains(q))
             }
         }
 
-        val filteredApps =
-            remember(allApps, searchQuery, showSystem) {
-                val q = searchQuery.trim().lowercase()
-                allApps.filter { app ->
-                    (showSystem || !app.isSystem || app.selected) &&
-                        (q.isEmpty() || app.label.lowercase().contains(q) || app.packageName.lowercase().contains(q))
-                }
-            }
+    val selectedCount = remember(allApps) { allApps.count { it.selected } }
 
-        val selectedCount = remember(allApps) { allApps.count { it.selected } }
-
-        Scaffold(
-            snackbarHost = { SnackbarHost(snackbarHostState) },
-            topBar = {
-                TopAppBar(
-                    title = { Text(stringResource(R.string.toolbar_title)) },
-                    colors =
-                        TopAppBarDefaults.topAppBarColors(
-                            containerColor = MaterialTheme.colorScheme.primaryContainer,
-                            titleContentColor = MaterialTheme.colorScheme.onPrimaryContainer,
-                        ),
-                )
-            },
-            bottomBar = {
-                Surface(tonalElevation = 3.dp) {
-                    Row(
-                        modifier =
-                            Modifier
-                                .fillMaxWidth()
-                                .navigationBarsPadding()
-                                .padding(horizontal = 16.dp, vertical = 12.dp),
-                        verticalAlignment = Alignment.CenterVertically,
-                    ) {
-                        Text(
-                            text = stringResource(R.string.selected_count, selectedCount),
-                            style = MaterialTheme.typography.bodyMedium,
-                            color = MaterialTheme.colorScheme.onSurfaceVariant,
-                            modifier = Modifier.weight(1f),
-                        )
-                        Button(
-                            onClick = {
-                                saving = true
-                                dirty = false
-                            },
-                            enabled = dirty && !saving,
-                        ) {
-                            Text(stringResource(R.string.btn_save))
-                        }
-                    }
-                }
-            },
-        ) { innerPadding ->
-            Column(
-                modifier =
-                    Modifier
-                        .fillMaxSize()
-                        .padding(innerPadding),
-            ) {
-                // Search + system toggle
+    Scaffold(
+        snackbarHost = { SnackbarHost(snackbarHostState) },
+        topBar = {
+            TopAppBar(
+                title = { Text(stringResource(R.string.toolbar_title)) },
+                colors =
+                    TopAppBarDefaults.topAppBarColors(
+                        containerColor = MaterialTheme.colorScheme.primaryContainer,
+                        titleContentColor = MaterialTheme.colorScheme.onPrimaryContainer,
+                    ),
+            )
+        },
+        bottomBar = {
+            Surface(tonalElevation = 3.dp) {
                 Row(
                     modifier =
                         Modifier
                             .fillMaxWidth()
-                            .padding(horizontal = 16.dp, vertical = 8.dp),
+                            .navigationBarsPadding()
+                            .padding(horizontal = 16.dp, vertical = 12.dp),
                     verticalAlignment = Alignment.CenterVertically,
                 ) {
-                    OutlinedTextField(
-                        value = searchQuery,
-                        onValueChange = { searchQuery = it },
-                        placeholder = { Text(stringResource(R.string.search_placeholder)) },
-                        singleLine = true,
+                    Text(
+                        text = stringResource(R.string.selected_count, selectedCount),
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
                         modifier = Modifier.weight(1f),
                     )
-                    Spacer(Modifier.width(8.dp))
-                    FilterChip(
-                        selected = showSystem,
-                        onClick = { showSystem = !showSystem },
-                        label = { Text(stringResource(R.string.filter_system)) },
-                    )
-                }
-
-                if (loading) {
-                    Box(
-                        modifier = Modifier.fillMaxSize(),
-                        contentAlignment = Alignment.Center,
+                    Button(
+                        onClick = {
+                            saving = true
+                            dirty = false
+                        },
+                        enabled = dirty && !saving,
                     ) {
-                        CircularProgressIndicator()
+                        Text(stringResource(R.string.btn_save))
                     }
-                } else {
-                    LazyColumn(modifier = Modifier.fillMaxSize()) {
-                        items(filteredApps, key = { it.packageName }) { app ->
-                            AppRow(
-                                app = app,
-                                onToggle = {
-                                    allApps =
-                                        allApps.map {
-                                            if (it.packageName == app.packageName) it.copy(selected = !it.selected) else it
-                                        }
-                                    dirty = true
-                                },
-                            )
-                        }
+                }
+            }
+        },
+    ) { innerPadding ->
+        Column(
+            modifier =
+                Modifier
+                    .fillMaxSize()
+                    .padding(innerPadding),
+        ) {
+            // Search + system toggle
+            Row(
+                modifier =
+                    Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = 16.dp, vertical = 8.dp),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                OutlinedTextField(
+                    value = searchQuery,
+                    onValueChange = { searchQuery = it },
+                    placeholder = { Text(stringResource(R.string.search_placeholder)) },
+                    singleLine = true,
+                    modifier = Modifier.weight(1f),
+                )
+                Spacer(Modifier.width(8.dp))
+                FilterChip(
+                    selected = showSystem,
+                    onClick = { showSystem = !showSystem },
+                    label = { Text(stringResource(R.string.filter_system)) },
+                )
+            }
+
+            if (loading) {
+                Box(
+                    modifier = Modifier.fillMaxSize(),
+                    contentAlignment = Alignment.Center,
+                ) {
+                    CircularProgressIndicator()
+                }
+            } else {
+                LazyColumn(modifier = Modifier.fillMaxSize()) {
+                    items(filteredApps, key = { it.packageName }) { app ->
+                        AppRow(
+                            app = app,
+                            onToggle = {
+                                allApps =
+                                    allApps.map {
+                                        if (it.packageName == app.packageName) it.copy(selected = !it.selected) else it
+                                    }
+                                dirty = true
+                            },
+                        )
                     }
                 }
             }
         }
+    }
 
-        // Save effect
-        if (saving) {
-            LaunchedEffect(Unit) {
-                val selected = allApps.filter { it.selected }.map { it.packageName }.sorted()
-                val header = context.getString(R.string.save_header_comment)
-                val body =
-                    "$header\n" +
-                        selected.joinToString("\n") +
-                        if (selected.isNotEmpty()) "\n" else ""
+    // Save effect
+    if (saving) {
+        LaunchedEffect(Unit) {
+            val selected = allApps.filter { it.selected }.map { it.packageName }.sorted()
+            val header = context.getString(R.string.save_header_comment)
+            val body =
+                "$header\n" +
+                    selected.joinToString("\n") +
+                    if (selected.isNotEmpty()) "\n" else ""
 
-                try {
-                    val (exitCode, _) = suExecAsync(buildSaveCommand(body, selected))
-                    if (exitCode == 0) {
-                        snackMessage = context.getString(R.string.save_success, selected.size)
-                    } else {
-                        snackMessage = context.getString(R.string.save_failed_exit, exitCode)
-                        dirty = true
-                    }
-                } catch (e: Exception) {
-                    snackMessage = context.getString(R.string.save_failed_error, e.message ?: "")
+            try {
+                val (exitCode, _) = suExecAsync(buildSaveCommand(body, selected))
+                if (exitCode == 0) {
+                    snackMessage = context.getString(R.string.save_success, selected.size)
+                } else if (exitCode == -1) {
+                    snackMessage = context.getString(R.string.save_failed_root)
+                    dirty = true
+                } else {
+                    snackMessage = context.getString(R.string.save_failed_exit, exitCode)
                     dirty = true
                 }
-                saving = false
+            } catch (e: Exception) {
+                snackMessage = context.getString(R.string.save_failed_error, e.message ?: "")
+                dirty = true
             }
+            saving = false
         }
     }
 }
@@ -304,8 +429,6 @@ private fun buildSaveCommand(
     parts += "cp $ZYGISK_TARGETS $ZYGISK_MODULE_TARGETS 2>/dev/null; true"
 
     // Resolve UIDs and write to /proc/vpnhide_targets + /data/system/vpnhide_uids.txt
-    // Uses the same approach as kmod/service.sh — real newlines in $UIDS via heredoc-style
-    // accumulation, not printf \n escapes.
     if (selectedPackages.isNotEmpty()) {
         val uidResolution =
             buildString {
@@ -314,7 +437,6 @@ private fun buildSaveCommand(
                 for (pkg in selectedPackages) {
                     append("; U=\$(echo \"\$ALL_PKGS\" | grep '^package:$pkg ' | sed 's/.*uid://')")
                     append("; if [ -n \"\$U\" ]; then if [ -z \"\$UIDS\" ]; then UIDS=\"\$U\"; else UIDS=\"\$UIDS")
-                    // Real newline in the shell string — not \n escape
                     append("\n")
                     append("\$U\"; fi; fi")
                 }
@@ -325,8 +447,6 @@ private fun buildSaveCommand(
             }
         parts += uidResolution
     } else {
-        // No targets — clear the UIDs files. echo -n writes a zero-length
-        // string which triggers the proc write handler (unlike bare > redirect).
         parts += "echo > $PROC_TARGETS 2>/dev/null; true"
         parts += "echo > $SS_UIDS_FILE 2>/dev/null; true"
     }

--- a/lsposed/app/src/main/res/values-ru/strings.xml
+++ b/lsposed/app/src/main/res/values-ru/strings.xml
@@ -13,8 +13,14 @@
     <string name="search_placeholder">Поиск приложений&#8230;</string>
     <string name="filter_system">Системные</string>
 
+    <!-- Root status -->
+    <string name="root_error_title">Требуется root-доступ</string>
+    <string name="root_error_message">VPN Hide необходим root-доступ для управления целевыми приложениями. Предоставьте root-права этому приложению в менеджере root (Magisk, KernelSU и т.д.) и откройте приложение заново.</string>
+    <string name="root_checking">Проверка root-доступа&#8230;</string>
+
     <!-- Save feedback -->
     <string name="save_success">Сохранено целей: %d</string>
     <string name="save_failed_exit">Ошибка сохранения (код выхода %d)</string>
     <string name="save_failed_error">Ошибка сохранения: %s</string>
+    <string name="save_failed_root">Ошибка сохранения: root-доступ запрещён</string>
 </resources>

--- a/lsposed/app/src/main/res/values/strings.xml
+++ b/lsposed/app/src/main/res/values/strings.xml
@@ -13,9 +13,15 @@
     <string name="search_placeholder">Search apps&#8230;</string>
     <string name="filter_system">System</string>
 
+    <!-- Root status -->
+    <string name="root_error_title">Root access required</string>
+    <string name="root_error_message">VPN Hide needs root access to manage target apps. Grant root permissions to this app in your root manager (Magisk, KernelSU, etc.) and reopen the app.</string>
+    <string name="root_checking">Checking root access&#8230;</string>
+
     <!-- Save feedback -->
     <string name="save_success">Saved %d target(s)</string>
     <string name="save_failed_exit">Save failed (exit code %d)</string>
     <string name="save_failed_error">Save failed: %s</string>
+    <string name="save_failed_root">Save failed: root access denied</string>
     <string name="save_header_comment"># Managed by VPN Hide app</string>
 </resources>


### PR DESCRIPTION
- Check root on app launch with `su -c id` before showing the picker
- Show full-screen error card if root is denied, explaining how to fix
- Distinguish root denial from other save failures in snackbar messages
- Add Russian translations for all root-related strings