### PR TITLE
feat: add LinkProperties routes filtering, expand ioctl coverage

### DIFF
--- a/kmod/vpnhide_kmod.c
+++ b/kmod/vpnhide_kmod.c
@@ -166,13 +166,18 @@ static const struct proc_ops targets_proc_ops = {
 };
 
 /* ================================================================== */
-/*  Hook 1: dev_ioctl — SIOCGIFFLAGS / SIOCGIFNAME                   */
+/*  Hook 1: dev_ioctl — all per-interface ioctls                      */
 /*                                                                    */
 /*  dev_ioctl() on GKI 6.1:                                          */
 /*    int dev_ioctl(struct net *net, unsigned int cmd,                */
 /*                  struct ifreq *ifr, void __user *data,            */
 /*                  bool *need_copyout)                               */
 /*  arm64: x0=net, x1=cmd, x2=ifr (KERNEL ptr), x3=data (__user)   */
+/*                                                                    */
+/*  Covers SIOCGIFFLAGS, SIOCGIFNAME, SIOCGIFMTU, SIOCGIFINDEX,     */
+/*  SIOCGIFHWADDR, SIOCGIFADDR, and any other cmd that goes through  */
+/*  dev_ioctl with a VPN interface name in ifr_name. Returns ENODEV  */
+/*  for all of them.                                                  */
 /*                                                                    */
 /*  Note: SIOCGIFCONF goes through sock_ioctl -> dev_ifconf, not     */
 /*  through dev_ioctl, so it is not covered here.                    */
@@ -202,9 +207,6 @@ static int dev_ioctl_ret(struct kretprobe_instance *ri, struct pt_regs *regs)
 	char name[IFNAMSIZ];
 
 	if (data->cmd == 0 || regs_return_value(regs) != 0)
-		return 0;
-
-	if (data->cmd != SIOCGIFFLAGS && data->cmd != SIOCGIFNAME)
 		return 0;
 
 	/*

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/HookEntry.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/HookEntry.kt
@@ -3,6 +3,7 @@ package dev.okhsunrog.vpnhide
 import android.net.LinkProperties
 import android.net.NetworkCapabilities
 import android.net.NetworkInfo
+import android.net.RouteInfo
 import android.os.Binder
 import de.robv.android.xposed.IXposedHookLoadPackage
 import de.robv.android.xposed.XC_MethodHook
@@ -292,11 +293,12 @@ class HookEntry : IXposedHookLoadPackage {
     }
 
     /**
-     * Hook LinkProperties.writeToParcel — clear VPN interface name from
-     * LP for target callers. Instead of skipping writeToParcel (which
-     * would corrupt the Parcel stream), temporarily clear the interface
-     * name and let serialization proceed normally.
+     * Hook LinkProperties.writeToParcel — clear VPN interface name and
+     * filter routes with VPN interfaces for target callers. Instead of
+     * skipping writeToParcel (which would corrupt the Parcel stream),
+     * temporarily mutate and let serialization proceed normally.
      */
+    @Suppress("UNCHECKED_CAST")
     private fun hookLPWriteToParcel() {
         XposedHelpers.findAndHookMethod(
             LinkProperties::class.java,
@@ -305,6 +307,7 @@ class HookEntry : IXposedHookLoadPackage {
             Integer.TYPE,
             object : XC_MethodHook() {
                 private val savedIfname = ThreadLocal<String>()
+                private val savedRoutes = ThreadLocal<List<RouteInfo>>()
 
                 override fun beforeHookedMethod(param: MethodHookParam) {
                     if (!isTargetCaller()) return
@@ -315,6 +318,20 @@ class HookEntry : IXposedHookLoadPackage {
 
                         savedIfname.set(ifname)
                         XposedHelpers.setObjectField(lp, "mIfaceName", null)
+
+                        // Filter routes that reference VPN interfaces
+                        try {
+                            val routes = XposedHelpers.getObjectField(lp, "mRoutes") as? MutableList<RouteInfo>
+                            if (routes != null && routes.isNotEmpty()) {
+                                savedRoutes.set(ArrayList(routes))
+                                routes.removeAll { route ->
+                                    val routeIface = route.`interface`
+                                    routeIface != null && isVpnInterfaceName(routeIface)
+                                }
+                            }
+                        } catch (_: Throwable) {
+                            // mRoutes may not exist on all Android versions
+                        }
                     } catch (t: Throwable) {
                         XposedBridge.log("VpnHide: LP.writeToParcel before error: ${t.message}")
                     }
@@ -323,8 +340,17 @@ class HookEntry : IXposedHookLoadPackage {
                 override fun afterHookedMethod(param: MethodHookParam) {
                     val origIfname = savedIfname.get() ?: return
                     savedIfname.remove()
+                    val origRoutes = savedRoutes.get()
+                    savedRoutes.remove()
                     try {
                         XposedHelpers.setObjectField(param.thisObject, "mIfaceName", origIfname)
+                        if (origRoutes != null) {
+                            val routes = XposedHelpers.getObjectField(param.thisObject, "mRoutes") as? MutableList<RouteInfo>
+                            if (routes != null) {
+                                routes.clear()
+                                routes.addAll(origRoutes)
+                            }
+                        }
                     } catch (_: Throwable) {
                     }
                 }

--- a/test-app/app/src/main/java/dev/okhsunrog/vpnhide/test/MainActivity.kt
+++ b/test-app/app/src/main/java/dev/okhsunrog/vpnhide/test/MainActivity.kt
@@ -279,6 +279,7 @@ private fun runAllChecks(
     val native =
         listOf(
             nativeCheck(res.getString(R.string.check_ioctl_flags)) { NativeChecks.checkIoctlSiocgifflags() },
+            nativeCheck(res.getString(R.string.check_ioctl_mtu)) { NativeChecks.checkIoctlSiocgifmtu() },
             nativeCheck(res.getString(R.string.check_ioctl_conf)) { NativeChecks.checkIoctlSiocgifconf() },
             nativeCheck(res.getString(R.string.check_getifaddrs)) { NativeChecks.checkGetifaddrs() },
             nativeCheck(res.getString(R.string.check_netlink_getlink)) { NativeChecks.checkNetlinkGetlink() },
@@ -305,6 +306,7 @@ private fun runAllChecks(
             checkAllNetworksVpn(cm, res.getString(R.string.check_all_networks_vpn)),
             checkActiveNetworkVpn(cm, res.getString(R.string.check_active_network_vpn)),
             checkLinkPropertiesIfname(cm, res.getString(R.string.check_link_properties)),
+            checkLinkPropertiesRoutes(cm, res.getString(R.string.check_link_properties_routes)),
             checkProxyHost(res.getString(R.string.check_proxy_host)),
         )
 
@@ -502,6 +504,34 @@ private fun checkLinkPropertiesIfname(
         }
     Log.i(TAG, "[$name] $detail")
     return CheckResult(name, !isVpn, detail)
+}
+
+private fun checkLinkPropertiesRoutes(
+    cm: ConnectivityManager,
+    name: String,
+): CheckResult {
+    Log.i(TAG, "=== CHECK: $name ===")
+    val net =
+        cm.activeNetwork
+            ?: return CheckResult(name, true, "PASS: no active network").also { Log.i(TAG, "[$name] ${it.detail}") }
+    val lp =
+        cm.getLinkProperties(net)
+            ?: return CheckResult(name, true, "PASS: no link properties").also { Log.i(TAG, "[$name] ${it.detail}") }
+    val routes = lp.routes
+    val vpnRoutes =
+        routes.filter { route ->
+            val iface = route.`interface` ?: return@filter false
+            VPN_PREFIXES.any { iface.startsWith(it) }
+        }
+    val detail =
+        if (vpnRoutes.isEmpty()) {
+            "PASS: ${routes.size} routes, none via VPN interfaces"
+        } else {
+            val vpnDesc = vpnRoutes.joinToString("; ") { "${it.destination} dev ${it.`interface`}" }
+            "FAIL: ${vpnRoutes.size} route(s) via VPN: $vpnDesc"
+        }
+    Log.i(TAG, "[$name] $detail")
+    return CheckResult(name, vpnRoutes.isEmpty(), detail)
 }
 
 private fun checkProxyHost(name: String): CheckResult {

--- a/test-app/app/src/main/java/dev/okhsunrog/vpnhide/test/NativeChecks.kt
+++ b/test-app/app/src/main/java/dev/okhsunrog/vpnhide/test/NativeChecks.kt
@@ -7,6 +7,8 @@ object NativeChecks {
 
     external fun checkIoctlSiocgifflags(): String
 
+    external fun checkIoctlSiocgifmtu(): String
+
     external fun checkIoctlSiocgifconf(): String
 
     external fun checkGetifaddrs(): String

--- a/test-app/app/src/main/res/values/strings.xml
+++ b/test-app/app/src/main/res/values/strings.xml
@@ -22,6 +22,7 @@
 
     <!-- Native check names -->
     <string name="check_ioctl_flags">ioctl SIOCGIFFLAGS tun0</string>
+    <string name="check_ioctl_mtu">ioctl SIOCGIFMTU tun0</string>
     <string name="check_ioctl_conf">ioctl SIOCGIFCONF enum</string>
     <string name="check_getifaddrs">getifaddrs() enum</string>
     <string name="check_netlink_getlink">netlink RTM_GETLINK</string>
@@ -46,5 +47,6 @@
     <string name="check_all_networks_vpn">getAllNetworks() VPN scan</string>
     <string name="check_active_network_vpn">ActiveNetwork transports</string>
     <string name="check_link_properties">LinkProperties ifname</string>
+    <string name="check_link_properties_routes">LinkProperties routes</string>
     <string name="check_proxy_host">System proxy properties</string>
 </resources>

--- a/test-app/native/src/lib.rs
+++ b/test-app/native/src/lib.rs
@@ -131,6 +131,35 @@ fn check_ioctl_siocgifflags() -> String {
     }
 }
 
+fn check_ioctl_siocgifmtu() -> String {
+    logi("=== CHECK: ioctl SIOCGIFMTU on tun0 ===");
+    unsafe {
+        let fd = libc::socket(libc::AF_INET, libc::SOCK_DGRAM, 0);
+        if fd < 0 {
+            return format!("FAIL: cannot create socket: {}", last_os_error());
+        }
+
+        let mut ifr: libc::ifreq = std::mem::zeroed();
+        let name = b"tun0\0";
+        ifr.ifr_name[..name.len()].copy_from_slice(&name.map(|b| b as libc::c_char));
+
+        let ret = libc::ioctl(fd, libc::SIOCGIFMTU as i32, &ifr);
+        let err = last_os_errno();
+        libc::close(fd);
+
+        if ret < 0 {
+            if err == libc::ENODEV || err == libc::ENXIO {
+                "PASS: ioctl(tun0, SIOCGIFMTU) returned ENODEV — interface not visible".into()
+            } else {
+                format!("FAIL: ioctl returned error {err} ({})", last_os_error())
+            }
+        } else {
+            let mtu = ifr.ifr_ifru.ifru_mtu;
+            format!("FAIL: tun0 is visible! MTU={mtu}")
+        }
+    }
+}
+
 fn check_ioctl_siocgifconf() -> String {
     logi("=== CHECK: ioctl SIOCGIFCONF enumeration ===");
     unsafe {
@@ -523,6 +552,10 @@ macro_rules! jni_fn {
 jni_fn!(
     Java_dev_okhsunrog_vpnhide_test_NativeChecks_checkIoctlSiocgifflags,
     check_ioctl_siocgifflags()
+);
+jni_fn!(
+    Java_dev_okhsunrog_vpnhide_test_NativeChecks_checkIoctlSiocgifmtu,
+    check_ioctl_siocgifmtu()
 );
 jni_fn!(
     Java_dev_okhsunrog_vpnhide_test_NativeChecks_checkIoctlSiocgifconf,

--- a/zygisk/src/hooks.rs
+++ b/zygisk/src/hooks.rs
@@ -27,7 +27,7 @@ use core::cell::Cell;
 use core::ffi::{c_int, c_void};
 use core::sync::atomic::{AtomicPtr, Ordering};
 
-use libc::{SIOCGIFCONF, SIOCGIFFLAGS, SIOCGIFNAME, ifreq};
+use libc::{SIOCGIFCONF, SIOCGIFNAME, ifreq};
 
 use crate::filter::is_vpn_iface_bytes;
 
@@ -102,18 +102,15 @@ pub fn set_real_ioctl_ptr(p: *const ()) {
 
 /// Replacement for `libc::ioctl`.
 ///
-/// Handles:
-/// * `SIOCGIFNAME` — called with `ifr_ifindex` to translate an index to an
-///   interface name. If the real result is a VPN name, we rewrite it to
-///   look like the index doesn't exist by setting errno=ENODEV and
-///   returning -1. The app treats that like "no interface at this index"
-///   and moves on.
-/// * `SIOCGIFFLAGS` — called with `ifr_name` to get the flags of a specific
-///   interface. If the input name is already a VPN, we short-circuit with
-///   errno=ENODEV WITHOUT calling the real ioctl (so the kernel never tells
-///   us the flags include `IFF_POINTOPOINT` and similar tells).
+/// Handles all network interface ioctls that could reveal VPN presence:
 ///
-/// Any other request falls straight through to the real ioctl unchanged.
+/// * `SIOCGIFNAME` — translates index to name. If the result is a VPN
+///   name, returns ENODEV.
+/// * `SIOCGIFCONF` — enumerates all interfaces. VPN entries are compacted
+///   out of the returned array.
+/// * All other `SIOCGIF*` (FLAGS, MTU, INDEX, HWADDR, ADDR, etc.) — the
+///   app provides an interface name in `ifr_name`. If it's a VPN name,
+///   we short-circuit with ENODEV before calling the real ioctl.
 ///
 /// # Safety
 ///
@@ -136,19 +133,14 @@ pub unsafe extern "C" fn hooked_ioctl(
         return unsafe { real(fd, request, arg) };
     }
 
-    // SIOCGIFFLAGS — the app has a name and wants flags. Pre-screen input.
-    if request == SIOCGIFFLAGS as libc::c_ulong {
-        if !arg.is_null() {
-            let req = unsafe { &*(arg as *const ifreq) };
-            let name_bytes = unsafe {
-                core::slice::from_raw_parts(req.ifr_name.as_ptr().cast::<u8>(), req.ifr_name.len())
-            };
-            if is_vpn_iface_bytes(name_bytes) {
-                set_errno(libc::ENODEV);
-                return -1;
-            }
+    // SIOCGIFCONF — enumerate all interfaces. Call through, then compact
+    // the returned ifreq array, removing VPN entries.
+    if request == SIOCGIFCONF as libc::c_ulong {
+        let ret = unsafe { real(fd, request, arg) };
+        if ret == 0 && !arg.is_null() {
+            unsafe { filter_ifconf(arg as *mut ifconf) };
         }
-        return unsafe { real(fd, request, arg) };
+        return ret;
     }
 
     // SIOCGIFNAME — the app has an index and wants a name. Call through,
@@ -168,18 +160,28 @@ pub unsafe extern "C" fn hooked_ioctl(
         return ret;
     }
 
-    // SIOCGIFCONF — enumerate all interfaces. Call through, then compact
-    // the returned ifreq array, removing VPN entries.
-    if request == SIOCGIFCONF as libc::c_ulong {
-        let ret = unsafe { real(fd, request, arg) };
-        if ret == 0 && !arg.is_null() {
-            unsafe { filter_ifconf(arg as *mut ifconf) };
+    // All other SIOCGIF* ioctls (FLAGS, MTU, INDEX, HWADDR, ADDR, etc.)
+    // take an ifreq with the interface name as input. Pre-screen it.
+    if !arg.is_null() && is_siocgif(request) {
+        let req = unsafe { &*(arg as *const ifreq) };
+        let name_bytes = unsafe {
+            core::slice::from_raw_parts(req.ifr_name.as_ptr().cast::<u8>(), req.ifr_name.len())
+        };
+        if is_vpn_iface_bytes(name_bytes) {
+            set_errno(libc::ENODEV);
+            return -1;
         }
-        return ret;
     }
 
-    // Anything else: pass through unmodified.
     unsafe { real(fd, request, arg) }
+}
+
+/// Check if the ioctl request is a SIOCGIF* command (0x8910..0x8930 range).
+/// These all use struct ifreq with ifr_name as input.
+fn is_siocgif(request: libc::c_ulong) -> bool {
+    // SIOCGIF* range: 0x8910 (SIOCGIFNAME) to ~0x8927 (SIOCGIFVLAN)
+    // SIOCGIFCONF (0x8912) is handled separately above.
+    (0x8910..=0x8930).contains(&(request as u32))
 }
 
 /// Walk the `ifreq[]` array inside an `ifconf` and remove VPN entries


### PR DESCRIPTION
- lsposed: filter VPN routes from LinkProperties.mRoutes before serialization (save-mutate-restore pattern). Previously only mIfaceName was cleared but routes with VPN interface names leaked.

- kmod: remove SIOCGIFFLAGS/SIOCGIFNAME whitelist from dev_ioctl_ret. Now all dev_ioctl commands return ENODEV for VPN interfaces, covering SIOCGIFMTU (MTU fingerprinting), SIOCGIFINDEX, SIOCGIFHWADDR, etc.

- zygisk: replace per-command ioctl checks with a SIOCGIF* range check (0x8910-0x8930). Same coverage as kmod — any ioctl with a VPN interface name in ifr_name returns ENODEV.

toString() on NetworkCapabilities is already covered: we mutate the underlying fields before writeToParcel, so the deserialized object on the client produces a clean toString() output.