### PR TITLE
Add app update check and changelog

### DIFF
--- a/lsposed/app/src/main/assets/changelog.json
+++ b/lsposed/app/src/main/assets/changelog.json
@@ -1,0 +1,130 @@
+{
+  "version": "0.5.0",
+  "sections": [
+    {
+      "type": "added",
+      "items": [
+        {
+          "en": "Dashboard with module status, LSPosed config validation, version checks, and live protection verification",
+          "ru": "Панель обзора со статусом модулей, проверкой конфигурации LSPosed, проверкой версий и проверкой защиты в реальном времени"
+        },
+        {
+          "en": "Native module install recommendation — the app detects your kernel and tells you exactly which module to download",
+          "ru": "Рекомендация нативного модуля — приложение определяет ядро и подсказывает, какой модуль скачать"
+        },
+        {
+          "en": "Per-app protection layer toggles (L/K/Z) — control LSPosed, kernel module, and Zygisk independently for each app",
+          "ru": "Раздельное управление уровнями защиты (L/K/Z) — LSPosed, модуль ядра и Zygisk для каждого приложения отдельно"
+        },
+        {
+          "en": "Magisk/KSU auto-update for kmod and zygisk modules",
+          "ru": "Автообновление модулей kmod и zygisk через Magisk/KSU"
+        },
+        {
+          "en": "App update check via GitHub Releases",
+          "ru": "Проверка обновлений приложения через GitHub Releases"
+        },
+        {
+          "en": "Changelog with version history",
+          "ru": "Список изменений с историей версий"
+        }
+      ]
+    },
+    {
+      "type": "fixed",
+      "items": [
+        {
+          "en": "App no longer removes itself from target lists when saving",
+          "ru": "Приложение больше не удаляет себя из списков целей при сохранении"
+        }
+      ]
+    }
+  ],
+  "history": [
+    {
+      "version": "0.4.2",
+      "sections": [
+        {
+          "type": "added",
+          "items": [
+            {
+              "en": "ioctl SIOCGIFMTU detection and filtering",
+              "ru": "Обнаружение и фильтрация ioctl SIOCGIFMTU"
+            },
+            {
+              "en": "LinkProperties routes filtering in LSPosed hooks",
+              "ru": "Фильтрация маршрутов LinkProperties в хуках LSPosed"
+            }
+          ]
+        },
+        {
+          "type": "fixed",
+          "items": [
+            {
+              "en": "Fixed VPN LinkProperties deserialization crash",
+              "ru": "Исправлен краш десериализации VPN LinkProperties"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "version": "0.4.1",
+      "sections": [
+        {
+          "type": "added",
+          "items": [
+            {
+              "en": "Russian translation",
+              "ru": "Русский перевод"
+            },
+            {
+              "en": "Root access error screen with clear instructions",
+              "ru": "Экран ошибки root-доступа с инструкциями"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "version": "0.4.0",
+      "sections": [
+        {
+          "type": "added",
+          "items": [
+            {
+              "en": "VPN Hide app with target picker UI — select apps to hide VPN from",
+              "ru": "Приложение VPN Hide с выбором целевых приложений"
+            },
+            {
+              "en": "Built-in diagnostics — 26 checks covering all detection vectors",
+              "ru": "Встроенная диагностика — 26 проверок по всем векторам обнаружения"
+            },
+            {
+              "en": "Auto-detect VPN and auto-add self to target list",
+              "ru": "Автоопределение VPN и автодобавление себя в список целей"
+            }
+          ]
+        },
+        {
+          "type": "changed",
+          "items": [
+            {
+              "en": "Replaced WebUI with native Compose UI",
+              "ru": "WebUI заменён на нативный Compose UI"
+            }
+          ]
+        },
+        {
+          "type": "fixed",
+          "items": [
+            {
+              "en": "Zygisk targets reading on Magisk (SELinux blocking /data/adb/)",
+              "ru": "Чтение целей Zygisk на Magisk (SELinux блокировал /data/adb/)"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DashboardScreen.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DashboardScreen.kt
@@ -1,9 +1,11 @@
 package dev.okhsunrog.vpnhide
 
+import android.content.Intent
 import android.content.pm.PackageManager
 import android.database.sqlite.SQLiteDatabase
 import android.net.ConnectivityManager
 import android.net.NetworkCapabilities
+import android.net.Uri
 import android.os.Build
 import android.util.Log
 import androidx.compose.foundation.isSystemInDarkTheme
@@ -11,6 +13,9 @@ import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.KeyboardArrowLeft
+import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
@@ -144,9 +149,32 @@ fun DashboardScreen(
     val cm = context.getSystemService(ConnectivityManager::class.java)
 
     var state by remember { mutableStateOf<DashboardState?>(null) }
+    var updateInfo by remember { mutableStateOf<UpdateInfo?>(null) }
+    var showChangelog by remember { mutableStateOf(false) }
+    var changelogData by remember { mutableStateOf<ChangelogData?>(null) }
 
     LaunchedEffect(Unit) {
         state = withContext(Dispatchers.IO) { loadDashboardState(cm, context, selfNeedsRestart) }
+    }
+    LaunchedEffect(Unit) {
+        updateInfo = withContext(Dispatchers.IO) { checkForUpdate(BuildConfig.VERSION_NAME) }
+    }
+    LaunchedEffect(Unit) {
+        if (shouldShowChangelog(context)) {
+            val data = withContext(Dispatchers.IO) { loadChangelog(context) }
+            if (data != null) {
+                changelogData = data
+                showChangelog = true
+            }
+            markChangelogSeen(context)
+        }
+    }
+
+    if (showChangelog && changelogData != null) {
+        ChangelogDialog(
+            data = changelogData!!,
+            onDismiss = { showChangelog = false },
+        )
     }
 
     Column(
@@ -182,6 +210,10 @@ fun DashboardScreen(
         s.nativeInstallRecommendation?.let { recommendation ->
             Spacer(Modifier.height(8.dp))
             NativeInstallRecommendationCard(recommendation)
+        }
+        updateInfo?.let { info ->
+            Spacer(Modifier.height(8.dp))
+            UpdateAvailableCard(info)
         }
 
         // Protection status
@@ -581,6 +613,132 @@ private fun StatusBanner(
     }
 }
 
+// ── Update & Changelog ──────────────────────────────────────────────────
+
+@Composable
+private fun UpdateAvailableCard(info: UpdateInfo) {
+    val context = LocalContext.current
+    val darkTheme = isSystemInDarkTheme()
+    Card(
+        shape = RoundedCornerShape(12.dp),
+        colors =
+            CardDefaults.cardColors(
+                containerColor = if (darkTheme) Color(0xFF0D47A1).copy(alpha = 0.28f) else Color(0xFFE3F2FD),
+            ),
+        modifier = Modifier.fillMaxWidth(),
+    ) {
+        Row(
+            modifier = Modifier.padding(16.dp).fillMaxWidth(),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Column(Modifier.weight(1f)) {
+                Text(
+                    text = stringResource(R.string.update_available_title),
+                    style = MaterialTheme.typography.titleSmall,
+                    fontWeight = FontWeight.Bold,
+                )
+                Text(
+                    text = stringResource(R.string.update_available_subtitle, info.latestVersion),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.7f),
+                )
+            }
+            Spacer(Modifier.width(12.dp))
+            Button(
+                onClick = {
+                    context.startActivity(
+                        Intent(Intent.ACTION_VIEW, Uri.parse(info.downloadUrl)),
+                    )
+                },
+            ) {
+                Text(stringResource(R.string.update_download))
+            }
+        }
+    }
+}
+
+@Composable
+private fun ChangelogDialog(
+    data: ChangelogData,
+    onDismiss: () -> Unit,
+) {
+    val entries = remember(data) { listOf(data.current) + data.history }
+    var index by remember { mutableIntStateOf(0) }
+    val entry = entries[index]
+    val locale =
+        LocalContext.current.resources.configuration.locales[0]
+            .language
+    val sectionLabels =
+        mapOf(
+            "added" to stringResource(R.string.changelog_section_added),
+            "changed" to stringResource(R.string.changelog_section_changed),
+            "fixed" to stringResource(R.string.changelog_section_fixed),
+            "notes" to stringResource(R.string.changelog_section_notes),
+        )
+
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                if (entries.size > 1) {
+                    IconButton(
+                        onClick = { index-- },
+                        enabled = index > 0,
+                    ) {
+                        Icon(
+                            Icons.AutoMirrored.Filled.KeyboardArrowLeft,
+                            contentDescription = null,
+                        )
+                    }
+                }
+                Text(
+                    text = stringResource(R.string.changelog_title, entry.version),
+                    modifier = Modifier.weight(1f),
+                )
+                if (entries.size > 1) {
+                    IconButton(
+                        onClick = { index++ },
+                        enabled = index < entries.size - 1,
+                    ) {
+                        Icon(
+                            Icons.AutoMirrored.Filled.KeyboardArrowRight,
+                            contentDescription = null,
+                        )
+                    }
+                }
+            }
+        },
+        text = {
+            Column(
+                modifier = Modifier.verticalScroll(rememberScrollState()),
+                verticalArrangement = Arrangement.spacedBy(12.dp),
+            ) {
+                for (section in entry.sections) {
+                    if (section.items.isEmpty()) continue
+                    Text(
+                        text = sectionLabels[section.type] ?: section.type,
+                        style = MaterialTheme.typography.titleSmall,
+                        fontWeight = FontWeight.Bold,
+                    )
+                    for (item in section.items) {
+                        val text = if (locale == "ru") item.ru else item.en
+                        Text(
+                            text = "\u2022 $text",
+                            style = MaterialTheme.typography.bodyMedium,
+                        )
+                    }
+                }
+            }
+        },
+        confirmButton = {
+            TextButton(onClick = onDismiss) {
+                Text("OK")
+            }
+        },
+    )
+}
+
 // ── Data loading ─────────────────────────────────────────────────────────
 
 private const val TAG = "VpnHide-Dashboard"
@@ -619,31 +777,6 @@ private fun loadDashboardState(
                 val parts = it.split("=", limit = 2)
                 if (parts.size == 2) parts[0] to parts[1] else null
             }.toMap()
-
-    fun normalizeVersion(version: String): String = version.trim().removePrefix("v")
-
-    fun compareSemver(
-        left: String,
-        right: String,
-    ): Int? {
-        fun parse(version: String): List<Int>? =
-            normalizeVersion(version)
-                .split('.')
-                .map { it.toIntOrNull() }
-                .takeIf { parts ->
-                    parts.isNotEmpty() && parts.all { it != null }
-                }?.map { it!! }
-
-        val l = parse(left) ?: return null
-        val r = parse(right) ?: return null
-        val maxSize = maxOf(l.size, r.size)
-        for (i in 0 until maxSize) {
-            val lv = l.getOrElse(i) { 0 }
-            val rv = r.getOrElse(i) { 0 }
-            if (lv != rv) return lv.compareTo(rv)
-        }
-        return 0
-    }
 
     fun buildModuleVersionIssue(
         kind: NativeModuleKind,

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/MainActivity.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/MainActivity.kt
@@ -553,7 +553,7 @@ fun AppPickerScreen(modifier: Modifier = Modifier) {
                     Modifier
                         .fillMaxWidth()
                         .padding(horizontal = 16.dp)
-                        .padding(top = 8.dp),
+                        .padding(top = 4.dp),
             ) {
                 Column(modifier = Modifier.padding(12.dp)) {
                     Text(
@@ -570,33 +570,25 @@ fun AppPickerScreen(modifier: Modifier = Modifier) {
                 }
             }
 
-            OutlinedTextField(
-                value = searchQuery,
-                onValueChange = { searchQuery = it },
-                placeholder = { Text(stringResource(R.string.search_placeholder)) },
-                singleLine = true,
-                modifier =
-                    Modifier
-                        .fillMaxWidth()
-                        .padding(horizontal = 16.dp, vertical = 8.dp),
-            )
-
             Row(
                 modifier =
                     Modifier
                         .fillMaxWidth()
-                        .clickable { showSystem = !showSystem }
-                        .padding(horizontal = 16.dp),
+                        .padding(horizontal = 16.dp, vertical = 4.dp),
                 verticalAlignment = Alignment.CenterVertically,
             ) {
-                Checkbox(
-                    checked = showSystem,
-                    onCheckedChange = { showSystem = it },
+                OutlinedTextField(
+                    value = searchQuery,
+                    onValueChange = { searchQuery = it },
+                    placeholder = { Text(stringResource(R.string.search_placeholder)) },
+                    singleLine = true,
+                    modifier = Modifier.weight(1f),
                 )
-                Spacer(Modifier.width(4.dp))
-                Text(
-                    text = stringResource(R.string.filter_show_system),
-                    style = MaterialTheme.typography.bodyMedium,
+                Spacer(Modifier.width(8.dp))
+                FilterChip(
+                    selected = showSystem,
+                    onClick = { showSystem = !showSystem },
+                    label = { Text(stringResource(R.string.filter_system)) },
                 )
             }
 

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/UpdateChecker.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/UpdateChecker.kt
@@ -1,0 +1,167 @@
+package dev.okhsunrog.vpnhide
+
+import android.content.Context
+import android.util.Log
+import org.json.JSONObject
+import java.net.HttpURLConnection
+import java.net.URL
+
+private const val TAG = "VpnHide-Update"
+private const val GITHUB_RELEASES_URL =
+    "https://api.github.com/repos/okhsunrog/vpnhide/releases/latest"
+private const val PREFS_NAME = "vpnhide_prefs"
+private const val KEY_LAST_SEEN_VERSION = "last_seen_version"
+
+data class UpdateInfo(
+    val latestVersion: String,
+    val downloadUrl: String,
+)
+
+data class ChangelogData(
+    val current: ChangelogEntry,
+    val history: List<ChangelogEntry>,
+)
+
+data class ChangelogEntry(
+    val version: String,
+    val sections: List<ChangelogSection>,
+)
+
+data class ChangelogSection(
+    val type: String,
+    val items: List<BilingualItem>,
+)
+
+data class BilingualItem(
+    val en: String,
+    val ru: String,
+)
+
+internal fun normalizeVersion(version: String): String = version.trim().removePrefix("v")
+
+internal fun compareSemver(
+    left: String,
+    right: String,
+): Int? {
+    fun parse(version: String): List<Int>? =
+        normalizeVersion(version)
+            .split('.')
+            .map { it.toIntOrNull() }
+            .takeIf { parts ->
+                parts.isNotEmpty() && parts.all { it != null }
+            }?.map { it!! }
+
+    val l = parse(left) ?: return null
+    val r = parse(right) ?: return null
+    val maxSize = maxOf(l.size, r.size)
+    for (i in 0 until maxSize) {
+        val lv = l.getOrElse(i) { 0 }
+        val rv = r.getOrElse(i) { 0 }
+        if (lv != rv) return lv.compareTo(rv)
+    }
+    return 0
+}
+
+/**
+ * Check GitHub Releases for a newer APK version.
+ * Returns [UpdateInfo] if a newer version exists, null otherwise.
+ * Silently returns null on any error (network, parse, rate limit).
+ */
+fun checkForUpdate(currentVersion: String): UpdateInfo? {
+    try {
+        val conn = URL(GITHUB_RELEASES_URL).openConnection() as HttpURLConnection
+        conn.setRequestProperty("User-Agent", "vpnhide-android")
+        conn.setRequestProperty("Accept", "application/vnd.github+json")
+        conn.connectTimeout = 5_000
+        conn.readTimeout = 5_000
+        try {
+            if (conn.responseCode != 200) {
+                Log.d(TAG, "GitHub API returned ${conn.responseCode}")
+                return null
+            }
+            val body = conn.inputStream.bufferedReader().readText()
+            val release = JSONObject(body)
+            val remoteVersion = normalizeVersion(release.getString("tag_name"))
+            val cmp = compareSemver(remoteVersion, normalizeVersion(currentVersion))
+            if (cmp == null || cmp <= 0) {
+                Log.d(TAG, "No update: remote=$remoteVersion current=$currentVersion")
+                return null
+            }
+            val assets = release.getJSONArray("assets")
+            var apkUrl: String? = null
+            for (i in 0 until assets.length()) {
+                val asset = assets.getJSONObject(i)
+                if (asset.getString("name").endsWith(".apk")) {
+                    apkUrl = asset.getString("browser_download_url")
+                    break
+                }
+            }
+            val downloadUrl = apkUrl ?: release.getString("html_url")
+            Log.i(TAG, "Update available: $remoteVersion (url=$downloadUrl)")
+            return UpdateInfo(latestVersion = remoteVersion, downloadUrl = downloadUrl)
+        } finally {
+            conn.disconnect()
+        }
+    } catch (e: Exception) {
+        Log.d(TAG, "Update check failed: ${e.message}")
+        return null
+    }
+}
+
+/** Parse bundled changelog.json from assets. */
+fun loadChangelog(context: Context): ChangelogData? =
+    try {
+        val json =
+            context.assets
+                .open("changelog.json")
+                .bufferedReader()
+                .readText()
+        val obj = JSONObject(json)
+        val current = parseChangelogEntry(obj)
+        val history =
+            obj.optJSONArray("history")?.let { arr ->
+                (0 until arr.length()).map { parseChangelogEntry(arr.getJSONObject(it)) }
+            } ?: emptyList()
+        ChangelogData(current = current, history = history)
+    } catch (e: Exception) {
+        Log.w(TAG, "Failed to load changelog: ${e.message}")
+        null
+    }
+
+private fun parseChangelogEntry(obj: JSONObject): ChangelogEntry {
+    val sections = obj.getJSONArray("sections")
+    val sectionList =
+        (0 until sections.length()).map { i ->
+            val section = sections.getJSONObject(i)
+            val items = section.getJSONArray("items")
+            ChangelogSection(
+                type = section.getString("type"),
+                items =
+                    (0 until items.length()).map { j ->
+                        val item = items.getJSONObject(j)
+                        BilingualItem(
+                            en = item.getString("en"),
+                            ru = item.getString("ru"),
+                        )
+                    },
+            )
+        }
+    return ChangelogEntry(
+        version = obj.getString("version"),
+        sections = sectionList,
+    )
+}
+
+fun shouldShowChangelog(context: Context): Boolean {
+    val prefs = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+    val lastSeen = prefs.getString(KEY_LAST_SEEN_VERSION, null)
+    return lastSeen != BuildConfig.VERSION_NAME
+}
+
+fun markChangelogSeen(context: Context) {
+    context
+        .getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+        .edit()
+        .putString(KEY_LAST_SEEN_VERSION, BuildConfig.VERSION_NAME)
+        .apply()
+}

--- a/lsposed/app/src/main/res/values-ru/strings.xml
+++ b/lsposed/app/src/main/res/values-ru/strings.xml
@@ -70,6 +70,18 @@
     <string name="dashboard_issue_zygisk_version_mismatch">Несоответствие версий модуля Zygisk: модуль %1$s, приложение %2$s. Откройте KernelSU/Magisk → Модули для обновления.</string>
     <string name="dashboard_running_version">Версия запущенного модуля: %s</string>
 
+    <!-- Update -->
+    <string name="update_available_title">Доступно обновление</string>
+    <string name="update_available_subtitle">Доступна версия %1$s</string>
+    <string name="update_download">Скачать</string>
+
+    <!-- Changelog -->
+    <string name="changelog_title">Что нового в v%1$s</string>
+    <string name="changelog_section_added">Добавлено</string>
+    <string name="changelog_section_changed">Изменено</string>
+    <string name="changelog_section_fixed">Исправлено</string>
+    <string name="changelog_section_notes">Заметки</string>
+
     <!-- Diagnostics -->
     <string name="summary_running">Выполняется&#8230;</string>
     <string name="summary_format">%1$d/%2$d пройдено</string>

--- a/lsposed/app/src/main/res/values/strings.xml
+++ b/lsposed/app/src/main/res/values/strings.xml
@@ -86,6 +86,18 @@
     <string name="dashboard_issue_zygisk_version_mismatch">Zygisk version mismatch: module %1$s, app %2$s. Open KernelSU/Magisk → Modules to update the module.</string>
     <string name="dashboard_running_version">Running module version: %s</string>
 
+    <!-- Update -->
+    <string name="update_available_title">Update available</string>
+    <string name="update_available_subtitle">Version %1$s is available</string>
+    <string name="update_download">Download</string>
+
+    <!-- Changelog -->
+    <string name="changelog_title">What\'s new in v%1$s</string>
+    <string name="changelog_section_added">Added</string>
+    <string name="changelog_section_changed">Changed</string>
+    <string name="changelog_section_fixed">Fixed</string>
+    <string name="changelog_section_notes">Notes</string>
+
     <!-- Native check names (technical, not translatable) -->
     <string name="check_ioctl_flags" translatable="false">ioctl SIOCGIFFLAGS tun0</string>
     <string name="check_ioctl_mtu" translatable="false">ioctl SIOCGIFMTU tun0</string>


### PR DESCRIPTION
App self-update check via GitHub Releases API and bundled changelog with version history navigation.

- Check GitHub Releases on Dashboard load, show "Update available" card with direct APK download
- Bundled changelog.json (en/ru) with history navigation (arrow icons) shown automatically after app update
- Post-update detection via SharedPreferences (lastSeenVersion)
- Extract shared compareSemver/normalizeVersion to UpdateChecker.kt
- Apps tab: replace system apps checkbox with FilterChip next to search field, reduce top padding