### PR TITLE
Add app-to-app package visibility hooks

### DIFF
--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/AppHidingScreen.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/AppHidingScreen.kt
@@ -1,0 +1,488 @@
+package dev.okhsunrog.vpnhide
+
+import android.content.pm.ApplicationInfo
+import android.content.pm.PackageManager
+import android.graphics.drawable.Drawable
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.interaction.collectIsDraggedAsState
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.defaultMinSize
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.wrapContentHeight
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Button
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.drawBehind
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.asImageBitmap
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.core.graphics.drawable.toBitmap
+import io.github.oikvpqya.compose.fastscroller.VerticalScrollbar
+import io.github.oikvpqya.compose.fastscroller.indicator.IndicatorConstants
+import io.github.oikvpqya.compose.fastscroller.material3.defaultMaterialScrollbarStyle
+import io.github.oikvpqya.compose.fastscroller.rememberScrollbarAdapter
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+
+internal data class HidingEntry(
+    val packageName: String,
+    val label: String,
+    val icon: Drawable?,
+    val isSystem: Boolean,
+    val hidden: Boolean = false,
+    val observer: Boolean = false,
+) {
+    val anySelected get() = hidden || observer
+}
+
+internal enum class HidingRole { HIDDEN, OBSERVER }
+
+@Composable
+fun AppHidingScreen(
+    searchQuery: String,
+    showSystem: Boolean,
+    showRussianOnly: Boolean,
+    modifier: Modifier = Modifier,
+) {
+    val context = LocalContext.current
+    val pm = context.packageManager
+
+    var allApps by remember { mutableStateOf<List<HidingEntry>>(emptyList()) }
+    var loading by remember { mutableStateOf(true) }
+    var saving by remember { mutableStateOf(false) }
+    var dirty by remember { mutableStateOf(false) }
+    var snackMessage by remember { mutableStateOf<String?>(null) }
+    val snackbarHostState = remember { SnackbarHostState() }
+
+    LaunchedEffect(snackMessage) {
+        snackMessage?.let {
+            snackbarHostState.showSnackbar(it)
+            snackMessage = null
+        }
+    }
+
+    LaunchedEffect(Unit) {
+        withContext(Dispatchers.IO) {
+            // Read hidden packages (by name) and observer UIDs → map back to names.
+            fun readLines(path: String): Set<String> {
+                val (_, raw) = suExec("cat $path 2>/dev/null || true")
+                return raw
+                    .lines()
+                    .map { it.trim() }
+                    .filter { it.isNotEmpty() && !it.startsWith("#") }
+                    .toSet()
+            }
+            val hiddenNames = readLines(SS_HIDDEN_PKGS_FILE)
+            val observerUids = readLines(SS_OBSERVER_UIDS_FILE).mapNotNull { it.toIntOrNull() }.toSet()
+
+            // Resolve observer UIDs → package names via `pm list packages -U`.
+            val (_, listing) = suExec("pm list packages -U 2>/dev/null")
+            val uidToPkg =
+                listing
+                    .lines()
+                    .mapNotNull { line ->
+                        val pkgMatch = Regex("^package:(\\S+) uid:(\\d+)").find(line) ?: return@mapNotNull null
+                        pkgMatch.groupValues[1] to pkgMatch.groupValues[2].toInt()
+                    }.associate { (pkg, uid) -> uid to pkg }
+            val observerNames = observerUids.mapNotNull { uidToPkg[it] }.toSet()
+
+            val selfPkg = context.packageName
+            val installedApps = pm.getInstalledApplications(PackageManager.GET_META_DATA)
+            val entries =
+                installedApps
+                    .filter { it.packageName != selfPkg } // self is always hidden; managed invisibly
+                    .map { info ->
+                        val label =
+                            try {
+                                pm.getApplicationLabel(info).toString()
+                            } catch (_: Exception) {
+                                info.packageName
+                            }
+                        val icon =
+                            try {
+                                pm.getApplicationIcon(info)
+                            } catch (_: Exception) {
+                                null
+                            }
+                        val isSystem = (info.flags and ApplicationInfo.FLAG_SYSTEM) != 0
+                        val pkg = info.packageName
+                        HidingEntry(
+                            packageName = pkg,
+                            label = label,
+                            icon = icon,
+                            isSystem = isSystem,
+                            hidden = pkg in hiddenNames,
+                            observer = pkg in observerNames,
+                        )
+                    }.sortedBy { it.label.lowercase() }
+
+            allApps = entries
+            loading = false
+        }
+    }
+
+    val filteredApps =
+        remember(allApps, searchQuery, showSystem, showRussianOnly) {
+            val q = searchQuery.trim().lowercase()
+            allApps.filter { app ->
+                (showSystem || !app.isSystem || app.anySelected) &&
+                    (!showRussianOnly || isRussianApp(app.packageName, app.label)) &&
+                    (q.isEmpty() || app.label.lowercase().contains(q) || app.packageName.lowercase().contains(q))
+            }
+        }
+
+    val hiddenCount = remember(allApps) { allApps.count { it.hidden } }
+    val observerCount = remember(allApps) { allApps.count { it.observer } }
+
+    Column(modifier = modifier.fillMaxSize()) {
+        if (loading) {
+            Box(
+                modifier = Modifier.fillMaxSize(),
+                contentAlignment = Alignment.Center,
+            ) {
+                CircularProgressIndicator()
+            }
+        } else {
+            val listState = rememberLazyListState()
+            Box(modifier = Modifier.weight(1f)) {
+                LazyColumn(
+                    state = listState,
+                    modifier = Modifier.fillMaxSize(),
+                ) {
+                    items(filteredApps, key = { it.packageName }) { app ->
+                        HidingAppRow(
+                            app = app,
+                            onToggle = { role ->
+                                allApps =
+                                    allApps.map {
+                                        if (it.packageName != app.packageName) {
+                                            it
+                                        } else {
+                                            when (role) {
+                                                HidingRole.HIDDEN -> it.copy(hidden = !it.hidden)
+                                                HidingRole.OBSERVER -> it.copy(observer = !it.observer)
+                                            }
+                                        }
+                                    }
+                                dirty = true
+                            },
+                        )
+                    }
+                }
+                val interactionSource = remember { MutableInteractionSource() }
+                val isDragging by interactionSource.collectIsDraggedAsState()
+                val indicatorAlpha by animateFloatAsState(
+                    if (isDragging) 1f else 0f,
+                    label = "indicatorAlpha",
+                )
+                VerticalScrollbar(
+                    adapter = rememberScrollbarAdapter(scrollState = listState),
+                    interactionSource = interactionSource,
+                    style = defaultMaterialScrollbarStyle(),
+                    enablePressToScroll = false,
+                    modifier =
+                        Modifier
+                            .align(Alignment.TopEnd)
+                            .fillMaxHeight(),
+                    indicator = { position, isVisible ->
+                        val firstChar =
+                            filteredApps
+                                .getOrNull(listState.firstVisibleItemIndex)
+                                ?.label
+                                ?.firstOrNull()
+                                ?.uppercase() ?: ""
+                        Box(
+                            modifier =
+                                Modifier
+                                    .align(Alignment.TopEnd)
+                                    .padding(end = IndicatorConstants.Default.PADDING)
+                                    .graphicsLayer {
+                                        val y = -(IndicatorConstants.Default.MIN_HEIGHT / 2).toPx()
+                                        translationY = (y + position).coerceAtLeast(0f)
+                                        alpha = indicatorAlpha
+                                    },
+                        ) {
+                            val indicatorColor =
+                                if (isVisible) MaterialTheme.colorScheme.primary else Color.Transparent
+                            val textColor =
+                                if (isVisible) MaterialTheme.colorScheme.onPrimary else Color.Transparent
+                            Box(
+                                modifier =
+                                    Modifier
+                                        .defaultMinSize(
+                                            minHeight = IndicatorConstants.Default.MIN_HEIGHT,
+                                            minWidth = IndicatorConstants.Default.MIN_WIDTH,
+                                        ).graphicsLayer {
+                                            clip = true
+                                            shape = IndicatorConstants.Default.SHAPE
+                                        }.drawBehind { drawRect(indicatorColor) },
+                            )
+                            Text(
+                                text = firstChar,
+                                color = textColor,
+                                textAlign = TextAlign.Center,
+                                style = MaterialTheme.typography.titleMedium,
+                                modifier =
+                                    Modifier
+                                        .align(Alignment.CenterEnd)
+                                        .wrapContentHeight()
+                                        .padding(end = IndicatorConstants.Default.PADDING)
+                                        .width(IndicatorConstants.Default.MIN_HEIGHT),
+                            )
+                        }
+                    },
+                )
+            }
+            Surface(tonalElevation = 3.dp) {
+                Row(
+                    modifier =
+                        Modifier
+                            .fillMaxWidth()
+                            .padding(horizontal = 16.dp, vertical = 12.dp),
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    Text(
+                        text = "H: $hiddenCount · O: $observerCount",
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        modifier = Modifier.weight(1f),
+                    )
+                    Button(
+                        onClick = {
+                            saving = true
+                            dirty = false
+                        },
+                        enabled = dirty && !saving,
+                    ) {
+                        Text(stringResource(R.string.btn_save))
+                    }
+                }
+            }
+        }
+
+        SnackbarHost(snackbarHostState)
+    }
+
+    if (saving) {
+        LaunchedEffect(Unit) {
+            // Always include self in the hidden list — self is managed invisibly, never shown in UI.
+            val selfPkg = context.packageName
+            val hiddenPkgs =
+                (allApps.filter { it.hidden }.map { it.packageName } + selfPkg).distinct().sorted()
+            val observerPkgs = allApps.filter { it.observer }.map { it.packageName }.sorted()
+            val header = context.getString(R.string.save_header_comment)
+
+            try {
+                val (exitCode, _) =
+                    suExecAsync(buildHidingSaveCommand(header, hiddenPkgs, observerPkgs))
+                if (exitCode == 0) {
+                    snackMessage =
+                        context.getString(R.string.hiding_save_success, hiddenPkgs.size, observerPkgs.size)
+                } else if (exitCode == -1) {
+                    snackMessage = context.getString(R.string.save_failed_root)
+                    dirty = true
+                } else {
+                    snackMessage = context.getString(R.string.save_failed_exit, exitCode)
+                    dirty = true
+                }
+            } catch (e: Exception) {
+                snackMessage = context.getString(R.string.save_failed_error, e.message ?: "")
+                dirty = true
+            }
+            saving = false
+        }
+    }
+}
+
+private fun buildHidingSaveCommand(
+    header: String,
+    hiddenPkgs: List<String>,
+    observerPkgs: List<String>,
+): String {
+    fun encode(body: String): String = android.util.Base64.encodeToString(body.toByteArray(), android.util.Base64.NO_WRAP)
+
+    val parts = mutableListOf<String>()
+
+    // Hidden list: package names, one per line.
+    val hiddenBody = "$header\n" + hiddenPkgs.joinToString("\n") + if (hiddenPkgs.isNotEmpty()) "\n" else ""
+    val hiddenB64 = encode(hiddenBody)
+    parts +=
+        "echo '$hiddenB64' | base64 -d > $SS_HIDDEN_PKGS_FILE && chmod 644 $SS_HIDDEN_PKGS_FILE" +
+        " && chcon u:object_r:system_data_file:s0 $SS_HIDDEN_PKGS_FILE 2>/dev/null; true"
+
+    // Observer list: resolved UIDs.
+    if (observerPkgs.isNotEmpty()) {
+        parts += buildHidingUidResolver(observerPkgs, SS_OBSERVER_UIDS_FILE)
+        parts += "chmod 644 $SS_OBSERVER_UIDS_FILE 2>/dev/null"
+        parts += "chcon u:object_r:system_data_file:s0 $SS_OBSERVER_UIDS_FILE 2>/dev/null; true"
+    } else {
+        parts +=
+            "echo > $SS_OBSERVER_UIDS_FILE 2>/dev/null;" +
+            " chmod 644 $SS_OBSERVER_UIDS_FILE 2>/dev/null;" +
+            " chcon u:object_r:system_data_file:s0 $SS_OBSERVER_UIDS_FILE 2>/dev/null; true"
+    }
+
+    return parts.joinToString(" ; ")
+}
+
+private fun buildHidingUidResolver(
+    packages: List<String>,
+    outputFile: String,
+): String =
+    buildString {
+        append("ALL_PKGS=\"\$(pm list packages -U 2>/dev/null)\"")
+        append("; UIDS=\"\"")
+        for (pkg in packages) {
+            append("; U=\$(echo \"\$ALL_PKGS\" | grep '^package:$pkg ' | sed 's/.*uid://')")
+            append("; if [ -n \"\$U\" ]; then if [ -z \"\$UIDS\" ]; then UIDS=\"\$U\"; else UIDS=\"\$UIDS")
+            append("\n")
+            append("\$U\"; fi; fi")
+        }
+        append("; if [ -n \"\$UIDS\" ]; then echo \"\$UIDS\" > $outputFile 2>/dev/null")
+        append("; else echo > $outputFile 2>/dev/null; fi")
+    }
+
+@Composable
+fun AppHidingHelpDialog(onDismiss: () -> Unit) {
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text(stringResource(R.string.hiding_help_title)) },
+        text = {
+            Column(
+                modifier = Modifier.verticalScroll(rememberScrollState()),
+                verticalArrangement = Arrangement.spacedBy(8.dp),
+            ) {
+                Text(
+                    text = stringResource(R.string.hiding_hint_roles),
+                    style = MaterialTheme.typography.bodyMedium,
+                )
+                Text(
+                    text = stringResource(R.string.hiding_hint_system),
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+                Text(
+                    text = stringResource(R.string.hiding_hint_reboot),
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+        },
+        confirmButton = {
+            TextButton(onClick = onDismiss) { Text("OK") }
+        },
+    )
+}
+
+@Composable
+private fun HidingAppRow(
+    app: HidingEntry,
+    onToggle: (HidingRole) -> Unit,
+) {
+    Row(
+        modifier =
+            Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 16.dp, vertical = 10.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        app.icon?.let { drawable ->
+            Image(
+                bitmap = drawable.toBitmap(48, 48).asImageBitmap(),
+                contentDescription = null,
+                modifier = Modifier.size(40.dp),
+            )
+            Spacer(Modifier.width(12.dp))
+        }
+        Column(modifier = Modifier.weight(1f)) {
+            Text(
+                text = app.label,
+                style = MaterialTheme.typography.bodyLarge,
+                fontWeight = FontWeight.Medium,
+            )
+            Text(
+                text = app.packageName,
+                style = MaterialTheme.typography.bodySmall,
+                fontFamily = FontFamily.Monospace,
+                fontSize = 12.sp,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            Spacer(Modifier.height(4.dp))
+            Row(horizontalArrangement = Arrangement.spacedBy(6.dp)) {
+                RoleChip(
+                    label = stringResource(R.string.hiding_chip_hidden),
+                    enabled = app.hidden,
+                    onClick = { onToggle(HidingRole.HIDDEN) },
+                )
+                RoleChip(
+                    label = stringResource(R.string.hiding_chip_observer),
+                    enabled = app.observer,
+                    onClick = { onToggle(HidingRole.OBSERVER) },
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun RoleChip(
+    label: String,
+    enabled: Boolean,
+    onClick: () -> Unit,
+) {
+    val containerColor = if (enabled) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.surfaceVariant
+    val contentColor = if (enabled) MaterialTheme.colorScheme.onPrimary else MaterialTheme.colorScheme.onSurfaceVariant
+    Surface(
+        shape = RoundedCornerShape(4.dp),
+        color = containerColor,
+        modifier = Modifier.clickable(onClick = onClick),
+    ) {
+        Text(
+            text = label,
+            style = MaterialTheme.typography.labelSmall,
+            fontWeight = FontWeight.Bold,
+            color = contentColor,
+            modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
+        )
+    }
+}

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/HookEntry.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/HookEntry.kt
@@ -50,6 +50,7 @@ class HookEntry : IXposedHookLoadPackage {
         if (hookInstalled.compareAndSet(false, true)) {
             XposedBridge.log("VpnHide: system_server detected, installing Binder hooks")
             installSystemServerHooks()
+            tryHook("PackageVisibility") { PackageVisibilityHooks.install(lpparam.classLoader) }
             writeHookStatusFile()
         }
     }

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/MainActivity.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/MainActivity.kt
@@ -78,7 +78,7 @@ fun VpnHideApp() {
     }
 }
 
-private enum class Tab { Dashboard, Apps, Diagnostics }
+private enum class Tab { Dashboard, Protection, Diagnostics }
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -102,19 +102,15 @@ private fun MainScreen() {
     }
 
     LaunchedEffect(currentTab) {
-        if (currentTab != Tab.Apps) {
+        if (currentTab != Tab.Protection) {
             searchActive = false
             searchQuery = ""
         }
     }
 
-    if (showHelp) {
-        AppsHelpDialog(onDismiss = { showHelp = false })
-    }
-
     Scaffold(
         topBar = {
-            if (searchActive && currentTab == Tab.Apps) {
+            if (searchActive && currentTab == Tab.Protection) {
                 SearchBar(
                     query = searchQuery,
                     onQueryChange = { searchQuery = it },
@@ -148,7 +144,7 @@ private fun MainScreen() {
                             titleContentColor = MaterialTheme.colorScheme.onPrimaryContainer,
                         ),
                     actions = {
-                        if (currentTab == Tab.Apps) {
+                        if (currentTab == Tab.Protection) {
                             IconButton(onClick = { searchActive = true }) {
                                 Icon(
                                     Icons.Default.Search,
@@ -217,10 +213,10 @@ private fun MainScreen() {
                     label = { Text(stringResource(R.string.tab_dashboard)) },
                 )
                 NavigationBarItem(
-                    selected = currentTab == Tab.Apps,
-                    onClick = { currentTab = Tab.Apps },
+                    selected = currentTab == Tab.Protection,
+                    onClick = { currentTab = Tab.Protection },
                     icon = { Icon(Icons.AutoMirrored.Filled.List, contentDescription = null) },
-                    label = { Text(stringResource(R.string.tab_apps)) },
+                    label = { Text(stringResource(R.string.tab_protection)) },
                 )
                 NavigationBarItem(
                     selected = currentTab == Tab.Diagnostics,
@@ -248,11 +244,13 @@ private fun MainScreen() {
                     )
                 }
 
-                Tab.Apps -> {
-                    AppPickerScreen(
+                Tab.Protection -> {
+                    ProtectionScreen(
                         searchQuery = searchQuery,
                         showSystem = showSystem,
                         showRussianOnly = showRussianOnly,
+                        showHelp = showHelp,
+                        onDismissHelp = { showHelp = false },
                         modifier = Modifier.padding(innerPadding),
                     )
                 }

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/PackageVisibilityHooks.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/PackageVisibilityHooks.kt
@@ -1,0 +1,312 @@
+package dev.okhsunrog.vpnhide
+
+import android.content.pm.ApplicationInfo
+import android.content.pm.PackageInfo
+import android.content.pm.ResolveInfo
+import android.os.Binder
+import android.os.FileObserver
+import android.os.Process
+import de.robv.android.xposed.XC_MethodHook
+import de.robv.android.xposed.XposedBridge
+import de.robv.android.xposed.XposedHelpers
+import java.io.File
+
+/**
+ * Package-visibility policy — hide packages from selected callers.
+ *
+ * Two flat groups:
+ *   - hiddenPackages: package names to hide from PM responses
+ *   - observerUids: caller UIDs that should not see hidden packages
+ *
+ * When the Binder caller in system_server is an observer, results of
+ * PackageManager queries are filtered to exclude hidden packages:
+ *   - list queries (getInstalledPackages / queryIntentActivities / ...)
+ *     have matching entries removed from the returned ParceledListSlice
+ *   - single-package queries (getPackageInfo / getApplicationInfo /
+ *     resolveService / ...) return null, which the caller side converts
+ *     to NameNotFoundException
+ *
+ * Targets the PackageManagerService Binder stub via
+ * com.android.server.pm.IPackageManagerBase — same file in AOSP 13/14/15.
+ * Filtering happens post-AppsFilter (AppsFilter runs inside ComputerEngine,
+ * before these methods return), so we subtract further.
+ *
+ * System callers (UID < 10000) are always exempt to avoid breaking
+ * installd, LauncherApps, StatusBar, etc.
+ */
+internal object PackageVisibilityHooks {
+    private const val HIDDEN_PKGS_FILE = "/data/system/vpnhide_hidden_pkgs.txt"
+    private const val OBSERVER_UIDS_FILE = "/data/system/vpnhide_observer_uids.txt"
+    private const val IPM_BASE = "com.android.server.pm.IPackageManagerBase"
+    private const val IPM_LEGACY = "com.android.server.pm.PackageManagerService"
+    private const val PARCELED_LIST_SLICE = "android.content.pm.ParceledListSlice"
+
+    @Volatile private var parceledListSliceClass: Class<*>? = null
+
+    @Volatile private var hiddenPackages: Set<String>? = null
+
+    @Volatile private var observerUids: Set<Int>? = null
+
+    @Volatile private var fileObserver: FileObserver? = null
+    private val lock = Any()
+
+    fun install(classLoader: ClassLoader) {
+        val ipmClass =
+            try {
+                classLoader.loadClass(IPM_BASE)
+            } catch (_: ClassNotFoundException) {
+                try {
+                    classLoader.loadClass(IPM_LEGACY)
+                } catch (t: Throwable) {
+                    XposedBridge.log("VpnHide/PV: neither $IPM_BASE nor $IPM_LEGACY found: ${t.message}")
+                    return
+                }
+            }
+        XposedBridge.log("VpnHide/PV: hooking ${ipmClass.name}")
+
+        parceledListSliceClass =
+            try {
+                classLoader.loadClass(PARCELED_LIST_SLICE)
+            } catch (t: Throwable) {
+                XposedBridge.log("VpnHide/PV: ParceledListSlice not found: ${t.message}")
+                return
+            }
+
+        hook(ipmClass, "getInstalledPackages", listFilter<PackageInfo> { it.packageName })
+        hook(ipmClass, "getInstalledApplications", listFilter<ApplicationInfo> { it.packageName })
+        hook(ipmClass, "queryIntentActivities", resolveInfoListFilter())
+        hook(ipmClass, "queryIntentServices", resolveInfoListFilter())
+        hook(ipmClass, "queryIntentReceivers", resolveInfoListFilter())
+        hook(ipmClass, "queryIntentContentProviders", resolveInfoListFilter())
+
+        hook(ipmClass, "getPackageInfo", singleHideByFirstStringArg())
+        hook(ipmClass, "getApplicationInfo", singleHideByFirstStringArg())
+        hook(ipmClass, "getInstallerPackageName", singleHideByFirstStringArg())
+        hook(ipmClass, "getInstallSourceInfo", singleHideByFirstStringArg())
+        hook(ipmClass, "getPackageUid", packageUidHide())
+        hook(ipmClass, "resolveIntent", resolveInfoSingleHide())
+        hook(ipmClass, "resolveService", resolveInfoSingleHide())
+        hook(ipmClass, "getPackagesForUid", packagesForUidHide())
+
+        watchConfigFiles()
+    }
+
+    // ------------------------------------------------------------------
+    //  Caller classification
+    // ------------------------------------------------------------------
+
+    private fun isObserverCaller(): Boolean {
+        val uid = Binder.getCallingUid()
+        // Exempt system callers: installd, shell, system_server itself,
+        // LauncherApps, StatusBar, etc. all run under UID < 10000.
+        if (uid < Process.FIRST_APPLICATION_UID) return false
+        if (uid == Process.myUid()) return false
+        return loadObserverUids().contains(uid)
+    }
+
+    private fun loadObserverUids(): Set<Int> {
+        observerUids?.let { return it }
+        synchronized(lock) {
+            observerUids?.let { return it }
+            val result = readUidFile(OBSERVER_UIDS_FILE)
+            observerUids = result
+            if (result.isNotEmpty()) {
+                XposedBridge.log("VpnHide/PV: loaded ${result.size} observer UIDs: $result")
+            }
+            return result
+        }
+    }
+
+    private fun loadHiddenPackages(): Set<String> {
+        hiddenPackages?.let { return it }
+        synchronized(lock) {
+            hiddenPackages?.let { return it }
+            val result = readLineFile(HIDDEN_PKGS_FILE)
+            hiddenPackages = result
+            if (result.isNotEmpty()) {
+                XposedBridge.log("VpnHide/PV: loaded ${result.size} hidden packages: $result")
+            }
+            return result
+        }
+    }
+
+    private fun readUidFile(path: String): Set<Int> =
+        try {
+            val f = File(path)
+            if (!f.exists()) {
+                emptySet()
+            } else {
+                f
+                    .readLines()
+                    .mapNotNull { it.trim().takeIf { s -> s.isNotEmpty() && !s.startsWith("#") }?.toIntOrNull() }
+                    .toSet()
+            }
+        } catch (t: Throwable) {
+            XposedBridge.log("VpnHide/PV: failed to read $path: ${t.message}")
+            emptySet()
+        }
+
+    private fun readLineFile(path: String): Set<String> =
+        try {
+            val f = File(path)
+            if (!f.exists()) {
+                emptySet()
+            } else {
+                f
+                    .readLines()
+                    .map { it.trim() }
+                    .filter { it.isNotEmpty() && !it.startsWith("#") }
+                    .toSet()
+            }
+        } catch (t: Throwable) {
+            XposedBridge.log("VpnHide/PV: failed to read $path: ${t.message}")
+            emptySet()
+        }
+
+    private fun watchConfigFiles() {
+        val observer =
+            object : FileObserver(File("/data/system"), CREATE or CLOSE_WRITE or MOVED_TO or MODIFY) {
+                override fun onEvent(
+                    event: Int,
+                    path: String?,
+                ) {
+                    when (path) {
+                        "vpnhide_hidden_pkgs.txt" -> {
+                            XposedBridge.log("VpnHide/PV: hidden_pkgs changed, invalidating")
+                            hiddenPackages = null
+                        }
+
+                        "vpnhide_observer_uids.txt" -> {
+                            XposedBridge.log("VpnHide/PV: observer_uids changed, invalidating")
+                            observerUids = null
+                        }
+                    }
+                }
+            }
+        fileObserver = observer
+        observer.startWatching()
+        XposedBridge.log("VpnHide/PV: watching /data/system for config changes")
+    }
+
+    // ------------------------------------------------------------------
+    //  Hook installation
+    // ------------------------------------------------------------------
+
+    private fun hook(
+        clazz: Class<*>,
+        methodName: String,
+        handler: XC_MethodHook,
+    ) {
+        try {
+            val hooked = XposedBridge.hookAllMethods(clazz, methodName, handler)
+            if (hooked.isEmpty()) {
+                XposedBridge.log("VpnHide/PV: no method '$methodName' on ${clazz.name}")
+            } else {
+                XposedBridge.log("VpnHide/PV: hooked $methodName (${hooked.size} overload(s))")
+            }
+        } catch (t: Throwable) {
+            XposedBridge.log("VpnHide/PV: hook $methodName failed: ${t::class.java.simpleName}: ${t.message}")
+        }
+    }
+
+    // ------------------------------------------------------------------
+    //  Hook handlers
+    // ------------------------------------------------------------------
+
+    /**
+     * Generic list filter for ParceledListSlice<T>.
+     * Removes items whose packageName (extracted by [pkgOf]) is in hiddenPackages.
+     */
+    private inline fun <reified T> listFilter(crossinline pkgOf: (T) -> String?): XC_MethodHook =
+        object : XC_MethodHook() {
+            override fun afterHookedMethod(param: MethodHookParam) {
+                if (param.hasThrowable()) return
+                if (!isObserverCaller()) return
+                val hidden = loadHiddenPackages()
+                if (hidden.isEmpty()) return
+
+                val result = param.result ?: return
+                val pls = parceledListSliceClass ?: return
+                if (!pls.isInstance(result)) return
+
+                @Suppress("UNCHECKED_CAST")
+                val original = XposedHelpers.callMethod(result, "getList") as? List<T> ?: return
+                val filtered =
+                    original.filter {
+                        val p = pkgOf(it)
+                        p == null || p !in hidden
+                    }
+                if (filtered.size != original.size) {
+                    param.result = XposedHelpers.newInstance(pls, filtered)
+                }
+            }
+        }
+
+    /** ResolveInfo list: packageName is on the inner ComponentInfo (activityInfo / serviceInfo / providerInfo). */
+    private fun resolveInfoListFilter(): XC_MethodHook = listFilter<ResolveInfo> { resolveInfoPackageName(it) }
+
+    private fun resolveInfoPackageName(ri: ResolveInfo): String? =
+        ri.activityInfo?.packageName
+            ?: ri.serviceInfo?.packageName
+            ?: ri.providerInfo?.packageName
+
+    /**
+     * For getPackageInfo / getApplicationInfo / getInstallerPackageName / getInstallSourceInfo.
+     * Signature starts with `String packageName`. If that package is hidden and caller is an
+     * observer, set result=null. Caller-side API converts null to NameNotFoundException.
+     */
+    private fun singleHideByFirstStringArg(): XC_MethodHook =
+        object : XC_MethodHook() {
+            override fun afterHookedMethod(param: MethodHookParam) {
+                if (param.hasThrowable()) return
+                if (param.result == null) return
+                val pkg = param.args.firstOrNull() as? String ?: return
+                if (!isObserverCaller()) return
+                if (pkg in loadHiddenPackages()) {
+                    param.result = null
+                }
+            }
+        }
+
+    /** getPackageUid(String, long/int, int): returns -1 if hidden. */
+    private fun packageUidHide(): XC_MethodHook =
+        object : XC_MethodHook() {
+            override fun afterHookedMethod(param: MethodHookParam) {
+                if (param.hasThrowable()) return
+                val pkg = param.args.firstOrNull() as? String ?: return
+                if (!isObserverCaller()) return
+                if (pkg in loadHiddenPackages()) {
+                    param.result = -1
+                }
+            }
+        }
+
+    /** resolveIntent / resolveService: ResolveInfo result. Null it out if it points to a hidden pkg. */
+    private fun resolveInfoSingleHide(): XC_MethodHook =
+        object : XC_MethodHook() {
+            override fun afterHookedMethod(param: MethodHookParam) {
+                if (param.hasThrowable()) return
+                val ri = param.result as? ResolveInfo ?: return
+                if (!isObserverCaller()) return
+                val pkg = resolveInfoPackageName(ri) ?: return
+                if (pkg in loadHiddenPackages()) {
+                    param.result = null
+                }
+            }
+        }
+
+    /** getPackagesForUid(int): String[]. Filter out hidden entries. Return null if all filtered. */
+    private fun packagesForUidHide(): XC_MethodHook =
+        object : XC_MethodHook() {
+            override fun afterHookedMethod(param: MethodHookParam) {
+                if (param.hasThrowable()) return
+                val arr = param.result as? Array<*> ?: return
+                if (!isObserverCaller()) return
+                val hidden = loadHiddenPackages()
+                if (hidden.isEmpty()) return
+                val filtered = arr.filterIsInstance<String>().filter { it !in hidden }
+                if (filtered.size == arr.size) return
+                param.result = if (filtered.isEmpty()) null else filtered.toTypedArray()
+            }
+        }
+}

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/ProtectionScreen.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/ProtectionScreen.kt
@@ -1,0 +1,117 @@
+package dev.okhsunrog.vpnhide
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.SegmentedButton
+import androidx.compose.material3.SegmentedButtonDefaults
+import androidx.compose.material3.SingleChoiceSegmentedButtonRow
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+
+internal enum class ProtectionMode { VpnTargets, AppHiding, PortHiding }
+
+@Composable
+fun ProtectionScreen(
+    searchQuery: String,
+    showSystem: Boolean,
+    showRussianOnly: Boolean,
+    showHelp: Boolean,
+    onDismissHelp: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    var mode by rememberSaveable { mutableStateOf(ProtectionMode.VpnTargets) }
+
+    if (showHelp) {
+        when (mode) {
+            ProtectionMode.VpnTargets -> AppsHelpDialog(onDismiss = onDismissHelp)
+            ProtectionMode.AppHiding -> AppHidingHelpDialog(onDismiss = onDismissHelp)
+            ProtectionMode.PortHiding -> onDismissHelp()
+        }
+    }
+
+    Column(modifier = modifier.fillMaxSize()) {
+        ProtectionModeSwitcher(
+            mode = mode,
+            onModeChange = { mode = it },
+        )
+        when (mode) {
+            ProtectionMode.VpnTargets -> {
+                AppPickerScreen(
+                    searchQuery = searchQuery,
+                    showSystem = showSystem,
+                    showRussianOnly = showRussianOnly,
+                    modifier = Modifier.fillMaxSize(),
+                )
+            }
+
+            ProtectionMode.AppHiding -> {
+                AppHidingScreen(
+                    searchQuery = searchQuery,
+                    showSystem = showSystem,
+                    showRussianOnly = showRussianOnly,
+                    modifier = Modifier.fillMaxSize(),
+                )
+            }
+
+            ProtectionMode.PortHiding -> {
+                ComingSoonPlaceholder()
+            }
+        }
+    }
+}
+
+@Composable
+private fun ProtectionModeSwitcher(
+    mode: ProtectionMode,
+    onModeChange: (ProtectionMode) -> Unit,
+) {
+    val options =
+        listOf(
+            ProtectionMode.VpnTargets to R.string.mode_vpn_targets,
+            ProtectionMode.AppHiding to R.string.mode_app_hiding,
+            ProtectionMode.PortHiding to R.string.mode_port_hiding,
+        )
+    SingleChoiceSegmentedButtonRow(
+        modifier =
+            Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 12.dp, vertical = 8.dp),
+    ) {
+        options.forEachIndexed { index, (m, labelRes) ->
+            SegmentedButton(
+                selected = m == mode,
+                onClick = { onModeChange(m) },
+                shape = SegmentedButtonDefaults.itemShape(index = index, count = options.size),
+                icon = {},
+            ) {
+                Text(stringResource(labelRes))
+            }
+        }
+    }
+}
+
+@Composable
+private fun ComingSoonPlaceholder() {
+    Box(
+        modifier = Modifier.fillMaxSize(),
+        contentAlignment = Alignment.Center,
+    ) {
+        Text(
+            text = stringResource(R.string.port_hiding_coming_soon),
+            style = MaterialTheme.typography.titleLarge,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+    }
+}

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/ShellUtils.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/ShellUtils.kt
@@ -14,6 +14,8 @@ internal const val ZYGISK_MODULE_TARGETS = "/data/adb/modules/vpnhide_zygisk/tar
 internal const val LSPOSED_TARGETS = "/data/adb/vpnhide_lsposed/targets.txt"
 internal const val PROC_TARGETS = "/proc/vpnhide_targets"
 internal const val SS_UIDS_FILE = "/data/system/vpnhide_uids.txt"
+internal const val SS_HIDDEN_PKGS_FILE = "/data/system/vpnhide_hidden_pkgs.txt"
+internal const val SS_OBSERVER_UIDS_FILE = "/data/system/vpnhide_observer_uids.txt"
 internal const val KMOD_MODULE_DIR = "/data/adb/modules/vpnhide_kmod"
 internal const val ZYGISK_MODULE_DIR = "/data/adb/modules/vpnhide_zygisk"
 internal const val ZYGISK_STATUS_FILE_NAME = "vpnhide_zygisk_active"
@@ -121,6 +123,25 @@ internal fun ensureSelfInTargets(selfPkg: String): Boolean {
     suExec("[ -d $ZYGISK_MODULE_DIR ] && cp $ZYGISK_TARGETS $ZYGISK_MODULE_TARGETS 2>/dev/null; true")
     suExec("mkdir -p /data/adb/vpnhide_lsposed")
     addIfMissing(LSPOSED_TARGETS, null)
+
+    // Always hide self via package visibility hooks — prevents observer apps from seeing us.
+    // File lives in /data/system/ (system_data_file), readable by system_server.
+    val (_, hiddenRaw) = suExec("cat $SS_HIDDEN_PKGS_FILE 2>/dev/null || true")
+    val hiddenExisting = hiddenRaw.lines().map { it.trim() }.filter { it.isNotEmpty() && !it.startsWith("#") }
+    if (selfPkg !in hiddenExisting) {
+        val body =
+            "# Managed by VPN Hide app\n" +
+                (hiddenExisting + selfPkg).sorted().joinToString("\n") + "\n"
+        val b64 = Base64.encodeToString(body.toByteArray(), Base64.NO_WRAP)
+        suExec(
+            "echo '$b64' | base64 -d > $SS_HIDDEN_PKGS_FILE" +
+                " && chmod 644 $SS_HIDDEN_PKGS_FILE" +
+                " && chcon u:object_r:system_data_file:s0 $SS_HIDDEN_PKGS_FILE 2>/dev/null; true",
+        )
+        Log.i(TAG, "ensureSelfInTargets: added $selfPkg to $SS_HIDDEN_PKGS_FILE")
+        // Don't flip `added`: PM hooks live in system_server and pick up the file change
+        // immediately via inotify — no app restart is needed, unlike native (zygisk) hooks.
+    }
 
     // Resolve UIDs so hooks pick us up immediately (kmod + lsposed support live reload)
     val uidCmd =

--- a/lsposed/app/src/main/res/values-ru/strings.xml
+++ b/lsposed/app/src/main/res/values-ru/strings.xml
@@ -4,8 +4,14 @@
 
     <!-- Navigation -->
     <string name="tab_dashboard">Обзор</string>
-    <string name="tab_apps">Приложения</string>
+    <string name="tab_protection">Защита</string>
     <string name="tab_diagnostics">Диагностика</string>
+
+    <!-- Protection modes (segmented button) -->
+    <string name="mode_vpn_targets">Туннели</string>
+    <string name="mode_app_hiding">Приложения</string>
+    <string name="mode_port_hiding">Порты</string>
+    <string name="port_hiding_coming_soon">Скоро</string>
 
     <!-- App picker -->
     <string name="selected_count">%d выбрано</string>
@@ -17,6 +23,13 @@
     <string name="apps_help_title">Как это работает</string>
     <string name="apps_hint_toggles">Нажимайте L, K, Z для переключения отдельных уровней защиты (LSPosed, модуль ядра, Zygisk). Нажмите на строку, чтобы переключить все уровни сразу.</string>
     <string name="apps_hint_zygisk">Некоторые приложения обнаруживают хуки Zygisk. Для таких приложений оставьте Z выключенным и используйте другие уровни защиты.</string>
+
+    <!-- App hiding -->
+    <string name="hiding_help_title">Как работает скрытие приложений</string>
+    <string name="hiding_hint_roles">Отметьте приложения как H (Hidden — скрытые) — приложения с меткой O (Observer — наблюдатели) не смогут их видеть. Наблюдатель не получит скрытое приложение ни в списке установленных, ни через intent-запросы, ни через resolve.</string>
+    <string name="hiding_hint_system">Системные вызовы (установщик, лаунчер, системные сервисы) всегда исключены — иначе сломается базовая функциональность Android.</string>
+    <string name="hiding_hint_reboot">Изменения применяются мгновенно, но приложения-наблюдатели могут кэшировать список — сделайте force-stop и перезапустите их, чтобы увидеть результат.</string>
+    <string name="hiding_save_success">Сохранено · %1$d скрыто, %2$d наблюдателей</string>
 
     <!-- Root status -->
     <string name="root_error_title">Требуется root-доступ</string>
@@ -62,8 +75,8 @@
     <string name="dashboard_issue_lsposed_config_unreadable">Не удалось прочитать конфигурацию LSPosed/Vector. Откройте LSPosed/Vector, проверьте что VPN Hide там включён, затем снова откройте VPN Hide.</string>
     <string name="dashboard_issue_lsposed_not_enabled">VPN Hide найден в LSPosed/Vector, но модуль выключен. Включите VPN Hide в LSPosed/Vector и оставьте в scope System Framework.</string>
     <string name="dashboard_issue_lsposed_no_system_scope">VPN Hide включён в LSPosed/Vector, но в его scope отсутствует System Framework. Добавьте System Framework в scope модуля VPN Hide в LSPosed/Vector.</string>
-    <string name="dashboard_issue_lsposed_extra_scope">VPN Hide в LSPosed/Vector должен быть включён только для System Framework. Уберите из scope модуля VPN Hide эти приложения: %1$s. Для фильтрации используйте вкладку «Приложения» в VPN Hide.</string>
-    <string name="dashboard_issue_no_targets">Целевые приложения не настроены. Перейдите во вкладку «Приложения».</string>
+    <string name="dashboard_issue_lsposed_extra_scope">VPN Hide в LSPosed/Vector должен быть включён только для System Framework. Уберите из scope модуля VPN Hide эти приложения: %1$s. Для фильтрации используйте Защита → Туннели в VPN Hide.</string>
+    <string name="dashboard_issue_no_targets">Целевые приложения не настроены. Перейдите в Защита → Туннели.</string>
     <string name="dashboard_issue_version_mismatch">Несоответствие версий LSPosed модуля: запущена %1$s, установлена %2$s. Перезагрузитесь для обновления.</string>
     <string name="dashboard_issue_update_kmod">Версия модуля ядра %1$s старее версии приложения %2$s. Откройте KernelSU/Magisk → Модули для обновления.</string>
     <string name="dashboard_issue_update_zygisk">Версия модуля Zygisk %1$s старее версии приложения %2$s. Откройте KernelSU/Magisk → Модули для обновления.</string>

--- a/lsposed/app/src/main/res/values/strings.xml
+++ b/lsposed/app/src/main/res/values/strings.xml
@@ -4,8 +4,14 @@
 
     <!-- Navigation -->
     <string name="tab_dashboard">Dashboard</string>
-    <string name="tab_apps">Apps</string>
+    <string name="tab_protection">Protection</string>
     <string name="tab_diagnostics">Diagnostics</string>
+
+    <!-- Protection modes (segmented button) -->
+    <string name="mode_vpn_targets">Tun</string>
+    <string name="mode_app_hiding">Apps</string>
+    <string name="mode_port_hiding">Ports</string>
+    <string name="port_hiding_coming_soon">Coming soon</string>
 
     <!-- App picker -->
     <string name="selected_count">%d selected</string>
@@ -17,6 +23,15 @@
     <string name="apps_help_title">How it works</string>
     <string name="apps_hint_toggles">Tap L, K, Z to toggle individual layers (LSPosed, Kernel module, Zygisk). Tap the row to toggle all layers at once.</string>
     <string name="apps_hint_zygisk">Some apps detect Zygisk hooks. For those apps, keep Z disabled and rely on other protection layers.</string>
+
+    <!-- App hiding -->
+    <string name="hiding_chip_hidden" translatable="false">H</string>
+    <string name="hiding_chip_observer" translatable="false">O</string>
+    <string name="hiding_help_title">How app hiding works</string>
+    <string name="hiding_hint_roles">Mark apps as H (Hidden) to remove them from the package manager for O (Observer) apps. Observers cannot list, resolve, or query any Hidden app.</string>
+    <string name="hiding_hint_system">System callers (installer, launcher, system services) are always exempt so core OS functionality keeps working.</string>
+    <string name="hiding_hint_reboot">Changes take effect immediately, but observer apps may cache the package list — force-stop and restart them to see results.</string>
+    <string name="hiding_save_success">Saved · %1$d hidden, %2$d observers</string>
 
     <!-- Root status -->
     <string name="root_error_title">Root access required</string>
@@ -82,8 +97,8 @@
     <string name="dashboard_issue_lsposed_config_unreadable">Failed to read LSPosed/Vector configuration. Reopen LSPosed/Vector, verify that VPN Hide is enabled there, and then reopen VPN Hide.</string>
     <string name="dashboard_issue_lsposed_not_enabled">VPN Hide is present in LSPosed/Vector, but the module is disabled. Enable VPN Hide in LSPosed/Vector and keep System Framework in its scope.</string>
     <string name="dashboard_issue_lsposed_no_system_scope">VPN Hide is enabled in LSPosed/Vector, but System Framework is missing from its scope. Add System Framework to the VPN Hide scope in LSPosed/Vector.</string>
-    <string name="dashboard_issue_lsposed_extra_scope">VPN Hide should stay scoped only to System Framework in LSPosed/Vector. Remove these apps from the VPN Hide scope: %1$s. Use the Apps tab in VPN Hide for filtering instead.</string>
-    <string name="dashboard_issue_no_targets">No target apps configured. Go to Apps tab to select apps.</string>
+    <string name="dashboard_issue_lsposed_extra_scope">VPN Hide should stay scoped only to System Framework in LSPosed/Vector. Remove these apps from the VPN Hide scope: %1$s. Use Protection → Tun in VPN Hide for filtering instead.</string>
+    <string name="dashboard_issue_no_targets">No target apps configured. Go to Protection → Tun to select apps.</string>
     <string name="dashboard_issue_version_mismatch">LSPosed module version mismatch: running %1$s, installed %2$s. Reboot to apply the update.</string>
     <string name="dashboard_issue_update_kmod">Kernel module version %1$s is older than app version %2$s. Open KernelSU/Magisk → Modules to update.</string>
     <string name="dashboard_issue_update_zygisk">Zygisk version %1$s is older than app version %2$s. Open KernelSU/Magisk → Modules to update.</string>


### PR DESCRIPTION
Extend the LSPosed module with a second, orthogonal privacy layer: hide selected packages from selected caller UIDs at the PackageManagerService Binder stub. Same philosophy as the existing VPN hiding — all hooks live in system_server, the target app's process stays untouched, so banking / anti-tamper apps that detect in-process injection remain unaffected. The Apps tab is renamed Protection and gains a segmented-button mode switcher so future privacy features (ports next) can slot in cleanly.

- Hook 14 methods on `com.android.server.pm.IPackageManagerBase` (with `PackageManagerService` fallback): `getInstalled{Packages,Applications}`, `queryIntent*`, `resolve{Intent,Service}`, `get{Package,Application}Info`, `getPackageUid`, `getPackagesForUid`, `getInstaller{PackageName,SourceInfo}`
- `ParceledListSlice<T>` results are unwrapped, filtered, rewrapped via reflection (class is `@hide` in SDK)
- Two-file config at `/data/system/vpnhide_hidden_pkgs.txt` and `/data/system/vpnhide_observer_uids.txt` with inotify live-reload; changes take effect without reboot
- Callers with `UID < 10000` are always exempt so installd, LauncherApps, StatusBar and other core services keep working regardless of what the user picks
- Self-package is always present in the hidden list — added by `ensureSelfInTargets` at startup and by the Save flow — so observer apps cannot even see the VPN Hide app itself
- Filtering runs post-AppsFilter (AOSP's built-in visibility layer) so we subtract further rather than undo its work
- Apps tab becomes Protection with a top segmented button: Tun (existing VPN target picker), Apps (new H / O chip picker), Ports (Coming soon placeholder)
- Help dialog becomes mode-aware; Russian labels spell out `H (Hidden)` / `O (Observer)` explicitly

Testing
- Pixel 8 Pro, Android 16 (API 36), LSPosed-Next
- Added Alfa-Bank and Avito to hidden, Floppa VPN (UID 10431) to observers
- Verified Floppa's split-tunnel app picker no longer shows either package
- Verified `adb shell pm list packages` (UID 2000, exempt) still shows both
- Verified self-package auto-add on fresh install via `cat /data/system/vpnhide_hidden_pkgs.txt`
- Verified all 14 hooks install cleanly via `/data/adb/lspd/log/modules_*.log`