### PR TITLE
Fix LinkProperties route filtering for app-visible snapshots

### DIFF
--- a/lsposed/app/src/main/assets/changelog.json
+++ b/lsposed/app/src/main/assets/changelog.json
@@ -1,21 +1,77 @@
 {
-  "version": "0.5.3",
+  "version": "0.6.0",
   "sections": [
     {
       "type": "added",
       "items": [
         {
-          "en": "Debug log export — open the Diagnostics tab and tap \"Collect debug log\" at the bottom. The app gathers dmesg, check results, device info, module status, kernel symbols, targets, interfaces, routing tables, and logcat into a zip. Save to disk or share directly.",
-          "ru": "Экспорт отладочного лога — откройте вкладку «Диагностика» и нажмите «Собрать отладочный лог» внизу экрана. Приложение собирает dmesg, результаты проверок, информацию об устройстве, статус модулей, символы ядра, список целей, интерфейсы, таблицы маршрутизации и logcat в zip-архив. Можно сохранить на диск или поделиться."
+          "en": "App hiding mode in Protection — hide selected apps from selected observer apps at the PackageManager level. Observer apps can no longer list, resolve, or query hidden apps.",
+          "ru": "Режим скрытия приложений в разделе «Защита» — скрывайте выбранные приложения от выбранных приложений-наблюдателей на уровне PackageManager. Наблюдатели больше не могут перечислять, находить или запрашивать скрытые приложения."
         },
         {
-          "en": "Kernel module debug logging toggle — all 6 kretprobe hooks now log detailed info (UID, target status, interface name, filter decisions) when debug mode is active. Enabled automatically during debug log collection.",
-          "ru": "Переключатель отладочного логирования модуля ядра — все 6 хуков kretprobe теперь логируют подробную информацию (UID, статус цели, имя интерфейса, решения фильтрации) при активном режиме отладки. Включается автоматически при сборе отладочного лога."
+          "en": "Ports hiding mode plus new vpnhide-ports.zip module — block selected apps from reaching 127.0.0.1 / ::1 ports to hide locally running VPN/proxy daemons (Clash, sing-box, V2Ray, Happ, etc.).",
+          "ru": "Режим скрытия портов и новый модуль vpnhide-ports.zip — блокируйте выбранным приложениям доступ к портам 127.0.0.1 / ::1, чтобы скрыть локально работающие VPN/прокси-демоны (Clash, sing-box, V2Ray, Happ и т. д.)."
+        },
+        {
+          "en": "Ports module integration in the dashboard — shows install state, active rules, observer count, and version mismatch/update warnings.",
+          "ru": "Интеграция модуля скрытия портов в панель — показывает статус установки, активность правил, число наблюдателей и предупреждения о несовпадении версий или доступных обновлениях."
+        }
+      ]
+    },
+    {
+      "type": "changed",
+      "items": [
+        {
+          "en": "The old Apps tab is now Protection, split into three modes: Tun, Apps, and Ports.",
+          "ru": "Прежняя вкладка «Приложения» теперь называется «Защита» и разделена на три режима: Tun, Apps и Ports."
+        },
+        {
+          "en": "Ports rules apply immediately on Save and are restored automatically on boot.",
+          "ru": "Правила скрытия портов применяются сразу после сохранения и автоматически восстанавливаются после загрузки устройства."
+        },
+        {
+          "en": "vpnhide-ports.zip is now included in the release/update pipeline with Magisk/KernelSU update metadata.",
+          "ru": "vpnhide-ports.zip теперь включён в пайплайн релизов и обновлений с метаданными для Magisk/KernelSU."
+        }
+      ]
+    },
+    {
+      "type": "fixed",
+      "items": [
+        {
+          "en": "Fixed LinkProperties filtering so VPN routes are stripped more reliably from app-visible network snapshots.",
+          "ru": "Исправлена фильтрация LinkProperties: VPN-маршруты теперь надёжнее удаляются из сетевых snapshot'ов, видимых приложению."
+        },
+        {
+          "en": "Fixed SIOCGIFCONF filtering on some Android 12/13 5.10 kernels where the previous hook could succeed but never fire.",
+          "ru": "Исправлена фильтрация SIOCGIFCONF на некоторых ядрах Android 12/13 5.10, где предыдущий хук мог успешно зарегистрироваться, но никогда не срабатывал."
+        },
+        {
+          "en": "Fixed debug log collection so app logcat entries are captured reliably on devices where logcat via su misses them.",
+          "ru": "Исправлен сбор отладочного лога: записи logcat самого приложения теперь надёжно попадают в архив на устройствах, где запуск logcat через su их пропускал."
         }
       ]
     }
   ],
   "history": [
+    {
+      "version": "0.5.3",
+      "sections": [
+        {
+          "type": "added",
+          "items": [
+            {
+              "en": "Debug log export — open the Diagnostics tab and tap \"Collect debug log\" at the bottom. The app gathers dmesg, check results, device info, module status, kernel symbols, targets, interfaces, routing tables, and logcat into a zip. Save to disk or share directly.",
+              "ru": "Экспорт отладочного лога — откройте вкладку «Диагностика» и нажмите «Собрать отладочный лог» внизу экрана. Приложение собирает dmesg, результаты проверок, информацию об устройстве, статус модулей, символы ядра, список целей, интерфейсы, таблицы маршрутизации и logcat в zip-архив. Можно сохранить на диск или поделиться."
+            },
+            {
+              "en": "Kernel module debug logging toggle — all 6 kretprobe hooks now log detailed info (UID, target status, interface name, filter decisions) when debug mode is active. Enabled automatically during debug log collection.",
+              "ru": "Переключатель отладочного логирования модуля ядра — все 6 хуков kretprobe теперь логируют подробную информацию (UID, статус цели, имя интерфейса, решения фильтрации) при активном режиме отладки. Включается автоматически при сборе отладочного лога."
+            }
+          ]
+        }
+      ]
+    },
     {
       "version": "0.5.2",
       "sections": [
@@ -74,68 +130,68 @@
               "en": "Built-in diagnostics merged into the main app (separate test app removed)",
               "ru": "Встроенная диагностика перенесена в основное приложение (отдельное тестовое приложение удалено)"
             },
-        {
-          "en": "New app icon and chameleon mascot branding",
-          "ru": "Новая иконка приложения и брендинг с маскотом-хамелеоном"
+            {
+              "en": "New app icon and chameleon mascot branding",
+              "ru": "Новая иконка приложения и брендинг с маскотом-хамелеоном"
+            },
+            {
+              "en": "Dashboard with module status, LSPosed config validation, version checks, and live protection verification",
+              "ru": "Панель обзора со статусом модулей, проверкой конфигурации LSPosed, проверкой версий и проверкой защиты в реальном времени"
+            },
+            {
+              "en": "Native module install recommendation — the app detects your kernel and tells you exactly which module to download",
+              "ru": "Рекомендация нативного модуля — приложение определяет ядро и подсказывает, какой модуль скачать"
+            },
+            {
+              "en": "Per-app protection layer toggles (L/K/Z) — control LSPosed, kernel module, and Zygisk independently for each app",
+              "ru": "Раздельное управление уровнями защиты (L/K/Z) — LSPosed, модуль ядра и Zygisk для каждого приложения отдельно"
+            },
+            {
+              "en": "Magisk/KSU auto-update for kmod and zygisk modules",
+              "ru": "Автообновление модулей kmod и zygisk через Magisk/KSU"
+            },
+            {
+              "en": "App update check via GitHub Releases",
+              "ru": "Проверка обновлений приложения через GitHub Releases"
+            },
+            {
+              "en": "Changelog with version history",
+              "ru": "Список изменений с историей версий"
+            }
+          ]
         },
         {
-          "en": "Dashboard with module status, LSPosed config validation, version checks, and live protection verification",
-          "ru": "Панель обзора со статусом модулей, проверкой конфигурации LSPosed, проверкой версий и проверкой защиты в реальном времени"
+          "type": "changed",
+          "items": [
+            {
+              "en": "Replaced WebUI with native Compose UI for module management",
+              "ru": "WebUI заменён нативным Compose UI для управления модулями"
+            },
+            {
+              "en": "Zygisk API lowered from v5 to v2 for Magisk v27 compatibility",
+              "ru": "Версия Zygisk API понижена с v5 до v2 для совместимости с Magisk v27"
+            },
+            {
+              "en": "Apps tab: search in top bar, filter menu, fast scroll with letter indicator, Russian apps filter",
+              "ru": "Вкладка приложений: поиск в верхней панели, меню фильтров, быстрая прокрутка с буквенным индикатором, фильтр российских приложений"
+            }
+          ]
         },
         {
-          "en": "Native module install recommendation — the app detects your kernel and tells you exactly which module to download",
-          "ru": "Рекомендация нативного модуля — приложение определяет ядро и подсказывает, какой модуль скачать"
-        },
-        {
-          "en": "Per-app protection layer toggles (L/K/Z) — control LSPosed, kernel module, and Zygisk independently for each app",
-          "ru": "Раздельное управление уровнями защиты (L/K/Z) — LSPosed, модуль ядра и Zygisk для каждого приложения отдельно"
-        },
-        {
-          "en": "Magisk/KSU auto-update for kmod and zygisk modules",
-          "ru": "Автообновление модулей kmod и zygisk через Magisk/KSU"
-        },
-        {
-          "en": "App update check via GitHub Releases",
-          "ru": "Проверка обновлений приложения через GitHub Releases"
-        },
-        {
-          "en": "Changelog with version history",
-          "ru": "Список изменений с историей версий"
+          "type": "fixed",
+          "items": [
+            {
+              "en": "Fixed potential system_server crash caused by race condition in writeToParcel hooks",
+              "ru": "Исправлен потенциальный краш system_server из-за race condition в хуках writeToParcel"
+            },
+            {
+              "en": "App no longer removes itself from target lists when saving",
+              "ru": "Приложение больше не удаляет себя из списков целей при сохранении"
+            }
+          ]
         }
       ]
     },
-    {
-      "type": "changed",
-      "items": [
-        {
-          "en": "Replaced WebUI with native Compose UI for module management",
-          "ru": "WebUI заменён нативным Compose UI для управления модулями"
-        },
-        {
-          "en": "Zygisk API lowered from v5 to v2 for Magisk v27 compatibility",
-          "ru": "Версия Zygisk API понижена с v5 до v2 для совместимости с Magisk v27"
-        },
-        {
-          "en": "Apps tab: search in top bar, filter menu, fast scroll with letter indicator, Russian apps filter",
-          "ru": "Вкладка приложений: поиск в верхней панели, меню фильтров, быстрая прокрутка с буквенным индикатором, фильтр российских приложений"
-        }
-      ]
-    },
-    {
-      "type": "fixed",
-      "items": [
-        {
-          "en": "Fixed potential system_server crash caused by race condition in writeToParcel hooks",
-          "ru": "Исправлен потенциальный краш system_server из-за race condition в хуках writeToParcel"
-        },
-        {
-          "en": "App no longer removes itself from target lists when saving",
-          "ru": "Приложение больше не удаляет себя из списков целей при сохранении"
-        }
-      ]
-    }
-  ]
-},
     {
       "version": "0.4.2",
       "sections": [

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/HookEntry.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/HookEntry.kt
@@ -3,6 +3,7 @@ package dev.okhsunrog.vpnhide
 import android.net.LinkProperties
 import android.net.NetworkCapabilities
 import android.net.NetworkInfo
+import android.net.RouteInfo
 import android.os.Binder
 import de.robv.android.xposed.IXposedHookLoadPackage
 import de.robv.android.xposed.XC_MethodHook
@@ -83,6 +84,73 @@ class HookEntry : IXposedHookLoadPackage {
             n.startsWith("l2tp") ||
             n.startsWith("gre") ||
             n.contains("vpn")
+    }
+
+    private fun sanitizeLinkProperties(copy: LinkProperties): Boolean {
+        var modified = false
+
+        val ifaceName = XposedHelpers.getObjectField(copy, "mIfaceName") as? String
+        if (ifaceName != null && isVpnInterfaceName(ifaceName)) {
+            XposedHelpers.setObjectField(copy, "mIfaceName", null)
+            modified = true
+        }
+
+        try {
+            @Suppress("UNCHECKED_CAST")
+            val routesField = XposedHelpers.getObjectField(copy, "mRoutes") as? MutableList<RouteInfo>
+            if (routesField != null) {
+                val filtered =
+                    routesField.filterNot { route ->
+                        val routeIface = route.`interface`
+                        routeIface != null && isVpnInterfaceName(routeIface)
+                    }
+                if (filtered.size != routesField.size) {
+                    routesField.clear()
+                    routesField.addAll(filtered)
+                    modified = true
+                }
+            }
+        } catch (t: Throwable) {
+            XposedBridge.log("VpnHide: failed to sanitize mRoutes: ${t.message}")
+        }
+
+        try {
+            @Suppress("UNCHECKED_CAST")
+            val stacked = XposedHelpers.getObjectField(copy, "mStackedLinks") as? MutableMap<String, LinkProperties>
+            if (stacked != null && stacked.isNotEmpty()) {
+                val filtered = LinkedHashMap<String, LinkProperties>()
+                for ((key, value) in stacked) {
+                    val stackedCopy =
+                        try {
+                            val ctor = LinkProperties::class.java.getDeclaredConstructor(LinkProperties::class.java)
+                            ctor.isAccessible = true
+                            ctor.newInstance(value) as LinkProperties
+                        } catch (_: Throwable) {
+                            value
+                        }
+                    val stackedModified = sanitizeLinkProperties(stackedCopy)
+                    val stackedIface = XposedHelpers.getObjectField(stackedCopy, "mIfaceName") as? String
+                    if (stackedIface == null && stackedCopy.routes.isEmpty()) {
+                        if (stackedModified || isVpnInterfaceName(key)) {
+                            modified = true
+                        } else {
+                            filtered[key] = stackedCopy
+                        }
+                    } else {
+                        if (stackedModified || stackedCopy !== value) modified = true
+                        filtered[key] = stackedCopy
+                    }
+                }
+                if (filtered.size != stacked.size || modified) {
+                    stacked.clear()
+                    stacked.putAll(filtered)
+                }
+            }
+        } catch (t: Throwable) {
+            XposedBridge.log("VpnHide: failed to sanitize mStackedLinks: ${t.message}")
+        }
+
+        return modified
     }
 
     // ==================================================================
@@ -316,19 +384,10 @@ class HookEntry : IXposedHookLoadPackage {
                     if (!isTargetCaller()) return
                     val lp = param.thisObject as LinkProperties
                     try {
-                        val ifname = XposedHelpers.getObjectField(lp, "mIfaceName") as? String ?: return
-                        if (!isVpnInterfaceName(ifname)) return
-
                         val ctor = LinkProperties::class.java.getDeclaredConstructor(LinkProperties::class.java)
                         ctor.isAccessible = true
                         val copy = ctor.newInstance(lp) as LinkProperties
-                        XposedHelpers.setObjectField(copy, "mIfaceName", null)
-                        try {
-                            @Suppress("UNCHECKED_CAST")
-                            val routes = XposedHelpers.getObjectField(copy, "mRoutes") as? MutableList<*>
-                            routes?.clear()
-                        } catch (_: Throwable) {
-                        }
+                        if (!sanitizeLinkProperties(copy)) return
 
                         val parcel = param.args[0] as android.os.Parcel
                         val flags = param.args[1] as Int

--- a/update-json/changelog.md
+++ b/update-json/changelog.md
@@ -1,3 +1,20 @@
+## v0.6.0
+
+### Added
+- App hiding mode in Protection — hide selected apps from selected observer apps at the PackageManager level. Observer apps can no longer list, resolve, or query hidden apps.
+- Ports hiding mode plus new `vpnhide-ports.zip` module — block selected apps from reaching `127.0.0.1` / `::1` ports to hide locally running VPN/proxy daemons (Clash, sing-box, V2Ray, Happ, etc.).
+- Ports module integration in the app dashboard — shows install state, active rules, observer count, and version mismatch/update warnings.
+
+### Changed
+- The old Apps tab is now Protection, split into three modes: Tun, Apps, and Ports.
+- Ports rules apply immediately on Save and are restored automatically on boot.
+- `vpnhide-ports.zip` is included in the release/update pipeline with Magisk/KernelSU update metadata.
+
+### Fixed
+- Fixed `LinkProperties` filtering so VPN routes are stripped more reliably from app-visible network snapshots.
+- Fixed `SIOCGIFCONF` filtering on some Android 12/13 `5.10` kernels where the previous hook could succeed but never fire.
+- Fixed debug log collection so app logcat entries are captured reliably on devices where `logcat` via `su` misses them.
+
 ## v0.5.3
 
 ### Added


### PR DESCRIPTION
## Summary
- sanitize `LinkProperties` more aggressively for target apps by stripping VPN-backed routes from app-visible snapshots
- keep filtering stacked `LinkProperties` entries so secondary snapshots do not leak VPN interfaces or routes
- update the `0.6.0` changelog entries in both Markdown and in-app JSON

## Why
Some app-visible network snapshots could still contain VPN route entries even when the top-level interface name was not VPN-like. That left route-based Java API detection paths exposed.

## Validation
- `lsposed/gradlew :app:compileDebugKotlin`
- built and installed the updated debug APK with `adb`
- reran the target detection app after reboot and confirmed the indirect route-based signals no longer reported VPN routes or split-tunnel patterns
