### PR TITLE
feat(diagnostics): full system logcat recording

### DIFF
--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DiagnosticsScreen.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DiagnosticsScreen.kt
@@ -14,8 +14,10 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.FiberManualRecord
 import androidx.compose.material.icons.filled.Save
 import androidx.compose.material.icons.filled.Share
+import androidx.compose.material.icons.filled.Stop
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
@@ -199,6 +201,10 @@ fun DiagnosticsScreen(
 
         Spacer(Modifier.height(16.dp))
 
+        LogcatRecordCard()
+
+        Spacer(Modifier.height(16.dp))
+
         // Collect button
         if (debugZipFile == null) {
             Button(
@@ -277,6 +283,149 @@ fun DiagnosticsScreen(
 
         Spacer(Modifier.height(16.dp))
     }
+}
+
+@Composable
+private fun LogcatRecordCard() {
+    val context = LocalContext.current
+    val scope = rememberCoroutineScope()
+    val state by LogcatRecorder.state.collectAsState()
+
+    // Tick every second while recording so the elapsed counter updates
+    // even when sizeBytes happens to hold steady.
+    var nowMs by remember { mutableStateOf(System.currentTimeMillis()) }
+    LaunchedEffect(state) {
+        if (state is LogcatRecorder.State.Recording) {
+            while (true) {
+                nowMs = System.currentTimeMillis()
+                kotlinx.coroutines.delay(1000)
+            }
+        }
+    }
+
+    Card(
+        shape = RoundedCornerShape(8.dp),
+        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceVariant),
+        modifier = Modifier.fillMaxWidth(),
+    ) {
+        Column(modifier = Modifier.padding(16.dp)) {
+            Text(
+                text = stringResource(R.string.logcat_card_title),
+                style = MaterialTheme.typography.titleSmall,
+                fontWeight = FontWeight.Bold,
+            )
+            Spacer(Modifier.height(4.dp))
+            Text(
+                text = stringResource(R.string.logcat_card_description),
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            Spacer(Modifier.height(12.dp))
+
+            when (val s = state) {
+                is LogcatRecorder.State.Recording -> {
+                    val elapsed = (nowMs - s.startMs).coerceAtLeast(0L) / 1000
+                    Text(
+                        text =
+                            stringResource(
+                                R.string.logcat_recording_status,
+                                formatElapsed(elapsed),
+                                formatSize(s.sizeBytes),
+                            ),
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.error,
+                        fontWeight = FontWeight.Bold,
+                    )
+                    Spacer(Modifier.height(12.dp))
+                    Button(
+                        onClick = {
+                            scope.launch { LogcatRecorder.stop() }
+                        },
+                        modifier = Modifier.fillMaxWidth(),
+                    ) {
+                        Icon(
+                            Icons.Default.Stop,
+                            contentDescription = null,
+                            modifier = Modifier.size(18.dp),
+                        )
+                        Spacer(Modifier.width(8.dp))
+                        Text(stringResource(R.string.logcat_btn_stop))
+                    }
+                }
+
+                is LogcatRecorder.State.Stopped -> {
+                    val last = s.lastFile
+                    Row(
+                        modifier = Modifier.fillMaxWidth(),
+                        horizontalArrangement = Arrangement.spacedBy(8.dp),
+                    ) {
+                        Button(
+                            onClick = {
+                                scope.launch { LogcatRecorder.start(context) }
+                            },
+                            modifier = Modifier.weight(1f),
+                        ) {
+                            Icon(
+                                Icons.Default.FiberManualRecord,
+                                contentDescription = null,
+                                modifier = Modifier.size(18.dp),
+                            )
+                            Spacer(Modifier.width(8.dp))
+                            Text(stringResource(R.string.logcat_btn_start))
+                        }
+                        if (last != null && last.exists()) {
+                            OutlinedButton(
+                                onClick = {
+                                    val uri =
+                                        FileProvider.getUriForFile(
+                                            context,
+                                            "${context.packageName}.fileprovider",
+                                            last,
+                                        )
+                                    val intent =
+                                        Intent(Intent.ACTION_SEND).apply {
+                                            type = "text/plain"
+                                            putExtra(Intent.EXTRA_STREAM, uri)
+                                            addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
+                                        }
+                                    context.startActivity(Intent.createChooser(intent, null))
+                                },
+                                modifier = Modifier.weight(1f),
+                            ) {
+                                Icon(
+                                    Icons.Default.Share,
+                                    contentDescription = null,
+                                    modifier = Modifier.size(18.dp),
+                                )
+                                Spacer(Modifier.width(8.dp))
+                                Text(
+                                    text =
+                                        stringResource(
+                                            R.string.logcat_btn_share_last,
+                                            formatSize(last.length()),
+                                        ),
+                                )
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+private fun formatElapsed(seconds: Long): String {
+    val m = seconds / 60
+    val s = seconds % 60
+    return "%d:%02d".format(m, s)
+}
+
+private fun formatSize(bytes: Long): String {
+    if (bytes < 1024) return "$bytes B"
+    val kb = bytes / 1024.0
+    if (kb < 1024.0) return "%.1f KB".format(kb)
+    val mb = kb / 1024.0
+    return "%.1f MB".format(mb)
 }
 
 @Composable

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/LogcatRecorder.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/LogcatRecorder.kt
@@ -1,0 +1,145 @@
+package dev.okhsunrog.vpnhide
+
+import android.content.Context
+import android.util.Log
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import java.io.File
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+
+/**
+ * Records an unfiltered `logcat -b all` stream to a file, driven by a
+ * single start/stop lifecycle. Used by the Diagnostics screen to capture
+ * everything happening during an issue reproduction — our own VpnHide
+ * tags, system_server, radio, crashes, anything.
+ *
+ * Requires root (READ_LOGS is not granted to third-party apps); we spawn
+ * `logcat` under `su` so the subprocess inherits CAP_SYSLOG.
+ *
+ * Only one recording may be active at a time. The process is intentionally
+ * spawned via `exec logcat ...` so `Process.destroy()` kills logcat, not
+ * just the wrapping shell.
+ */
+internal object LogcatRecorder {
+    private const val TAG = "VpnHide-Logcat"
+
+    sealed interface State {
+        data class Stopped(
+            val lastFile: File?,
+        ) : State
+
+        data class Recording(
+            val file: File,
+            val startMs: Long,
+            val sizeBytes: Long,
+        ) : State
+    }
+
+    private val _state = MutableStateFlow<State>(State.Stopped(null))
+    val state: StateFlow<State> = _state
+
+    private var process: Process? = null
+    private var scope: CoroutineScope? = null
+
+    /**
+     * Start recording. No-op if already recording.
+     *
+     * Output is a plain-text logcat capture at `-v threadtime` format,
+     * all buffers (`main system crash events radio`), written to a file
+     * in the app's cache directory. Returns the target file immediately;
+     * the process runs in the background until [stop] is called.
+     */
+    fun start(context: Context): File? {
+        if (_state.value is State.Recording) return (_state.value as State.Recording).file
+
+        val ts = SimpleDateFormat("yyyyMMdd_HHmmss", Locale.US).format(Date())
+        val file = File(context.cacheDir, "vpnhide_logcat_$ts.log")
+        try {
+            file.createNewFile()
+        } catch (t: Throwable) {
+            Log.w(TAG, "failed to create output file: ${t.message}")
+            return null
+        }
+
+        val proc =
+            try {
+                // `exec logcat` ensures the PID we hold is the logcat
+                // process itself — su destroy() would otherwise kill
+                // only the shell wrapper.
+                ProcessBuilder("su", "-c", "exec logcat -b all -v threadtime")
+                    .redirectErrorStream(true)
+                    .start()
+            } catch (t: Throwable) {
+                Log.w(TAG, "failed to spawn logcat via su: ${t.message}")
+                return null
+            }
+
+        process = proc
+        val newScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+        scope = newScope
+        val startMs = System.currentTimeMillis()
+        _state.value = State.Recording(file, startMs, 0L)
+
+        // Pipe stdout → file
+        newScope.launch {
+            try {
+                proc.inputStream.use { input ->
+                    file.outputStream().use { out ->
+                        val buf = ByteArray(8 * 1024)
+                        while (isActive) {
+                            val n = input.read(buf)
+                            if (n < 0) break
+                            if (n > 0) out.write(buf, 0, n)
+                        }
+                    }
+                }
+            } catch (t: Throwable) {
+                Log.w(TAG, "pipe error: ${t.message}")
+            }
+        }
+
+        // Periodic size refresh so the UI shows growing recording size
+        newScope.launch {
+            while (isActive) {
+                delay(500)
+                val current = _state.value
+                if (current is State.Recording) {
+                    _state.value = current.copy(sizeBytes = file.length())
+                }
+            }
+        }
+
+        return file
+    }
+
+    /**
+     * Stop recording. Returns the captured file, or null if nothing was
+     * recording. Safe to call multiple times.
+     */
+    suspend fun stop(): File? {
+        val current = _state.value as? State.Recording ?: return null
+
+        process?.destroy()
+        process = null
+        scope?.cancel()
+        scope = null
+
+        // Give the pipe a moment to flush, then publish final state.
+        withContext(Dispatchers.IO) {
+            // small grace period for the piping coroutine to finish writing
+            delay(120)
+        }
+        _state.value = State.Stopped(current.file)
+        return current.file
+    }
+}

--- a/lsposed/app/src/main/res/values-ru/strings.xml
+++ b/lsposed/app/src/main/res/values-ru/strings.xml
@@ -117,6 +117,12 @@
     <string name="btn_export_debug_running">Собираю отладочную информацию&#8230;</string>
     <string name="btn_save_debug">Сохранить</string>
     <string name="btn_share_debug">Поделиться</string>
+    <string name="logcat_card_title">Полный системный logcat</string>
+    <string name="logcat_card_description">Записывает неотфильтрованные логи из всех буферов (main/system/crash/events/radio) для диагностики проблем, которые не видны в стандартных проверках. Начните запись, воспроизведите баг, затем остановите.</string>
+    <string name="logcat_btn_start">Начать запись</string>
+    <string name="logcat_btn_stop">Остановить и сохранить</string>
+    <string name="logcat_btn_share_last">Последний (%1$s)</string>
+    <string name="logcat_recording_status">● Запись · %1$s · %2$s</string>
     <string name="summary_running">Выполняется&#8230;</string>
     <string name="summary_format">%1$d/%2$d пройдено</string>
     <string name="btn_run_all">Запустить все проверки</string>

--- a/lsposed/app/src/main/res/values/strings.xml
+++ b/lsposed/app/src/main/res/values/strings.xml
@@ -64,6 +64,12 @@
     <string name="btn_export_debug_running">Collecting debug info&#8230;</string>
     <string name="btn_save_debug">Save</string>
     <string name="btn_share_debug">Share</string>
+    <string name="logcat_card_title">Full system logcat</string>
+    <string name="logcat_card_description">Records unfiltered logs from all buffers (main/system/crash/events/radio) for debugging issues that aren\'t visible in the standard checks. Start recording, reproduce the bug, then stop.</string>
+    <string name="logcat_btn_start">Start recording</string>
+    <string name="logcat_btn_stop">Stop and save</string>
+    <string name="logcat_btn_share_last">Share last (%1$s)</string>
+    <string name="logcat_recording_status">● Recording · %1$s · %2$s</string>
     <string name="badge_pass">PASS</string>
     <string name="badge_fail">FAIL</string>
     <string name="badge_info">INFO</string>


### PR DESCRIPTION
Adds a start/stop logcat capture control on the Diagnostics screen that records unfiltered system logs from all buffers (`main system crash events radio`). Motivated by issue #16: the existing debug-zip collector only grabs lines tagged `VpnHide*`, which is useless when we need to see what other apps (Ozon, Home Assistant, Chrome, system_server) are doing around a zygisk-injected hang. A full logcat gives us the actual reproduction context.

- New `LogcatRecorder` singleton backed by a `StateFlow<State>`; spawns `logcat -b all -v threadtime` via `su` (READ_LOGS is not granted to third-party apps) and pipes the stream into a file in the app cache dir. The subprocess is intentionally spawned as `exec logcat ...` so `Process.destroy()` kills logcat itself, not the wrapping shell.
- New card on the Diagnostics screen with two states:
  - **Idle** — `Start recording` button, plus `Share last (N MB)` when a previous capture is still on disk.
  - **Recording** — `● Recording · m:ss · size` indicator that ticks every second, plus `Stop and save`.
- Stop produces the captured file and the user shares it via the standard Android share sheet (reusing the existing FileProvider authority, which already maps `cacheDir`).
- Strings added in `values/` and `values-ru/`.
- `./gradlew :app:compileReleaseKotlin` passes cleanly (only pre-existing deprecation warnings from unrelated files).

## Test plan

- [ ] Build APK, install on a rooted Pixel 4a, grant root.
- [ ] Press `Start recording`, confirm indicator shows growing elapsed / size.
- [ ] Cold-start a target app (e.g. Ozon), let it run ~30s, press `Stop and save`.
- [ ] Confirm share sheet opens with `vpnhide_logcat_<ts>.log`, inspect contents — should include `VpnHide:` zygisk injection lines plus logs from the target app and system_server.
- [ ] Close and reopen the app; `Share last` should still expose the previous recording.
- [ ] Start a second recording; confirm previous `lastFile` is replaced cleanly and there's no leaked logcat process (`ps | grep logcat`).