### PR TITLE
fix(service.sh): wait for PackageManager to index user apps before resolving UIDs

### DIFF
--- a/kmod/module/service.sh
+++ b/kmod/module/service.sh
@@ -14,9 +14,17 @@ for i in 1 2 3 4 5 6 7 8 9 10; do
     sleep 1
 done
 
-# Wait for PackageManager to be ready
-for i in $(seq 1 30); do
-    pm list packages >/dev/null 2>&1 && break
+# Wait until PackageManager has actually indexed user-installed apps.
+# `pm list packages` starts responding very early in boot but returns
+# only system packages for several more seconds — if we resolve during
+# that window, `dev.okhsunrog.vpnhide` (and any other user-installed
+# target) silently drops from the UID file and the LSPosed hook caches
+# an empty target set for the rest of the session. Gate on our own
+# package being visible, with a 60s budget.
+for i in $(seq 1 60); do
+    if pm list packages -U 2>/dev/null | grep -q "^package:dev.okhsunrog.vpnhide "; then
+        break
+    fi
     sleep 1
 done
 

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/HookEntry.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/HookEntry.kt
@@ -276,11 +276,24 @@ class HookEntry : IXposedHookLoadPackage {
             object : XC_MethodHook() {
                 override fun beforeHookedMethod(param: MethodHookParam) {
                     if (writingCopy.get() == true) return
-                    if (!loadTargetUids().contains(Binder.getCallingUid())) return
-
+                    val callerUid = Binder.getCallingUid()
+                    val targets = loadTargetUids()
+                    val isTarget = targets.contains(callerUid)
                     val nc = param.thisObject as NetworkCapabilities
+                    val transportTypes = XposedHelpers.getLongField(nc, "mTransportTypes")
+                    val hasVpn = (transportTypes and (1L shl TRANSPORT_VPN)) != 0L
+                    // Verbose diagnostic log — one line per NC.writeToParcel call.
+                    // Filter with `logcat -s LSPosed-Bridge:* | grep VpnHide-NC`.
+                    // Volume is low relative to other system_server activity but
+                    // high enough that we may want to gate it behind a setting
+                    // once the code stabilises.
+                    XposedBridge.log(
+                        "VpnHide-NC: uid=$callerUid target=$isTarget hasVpn=$hasVpn " +
+                            "transports=0x${transportTypes.toString(16)}",
+                    )
+                    if (!isTarget) return
+
                     try {
-                        val transportTypes = XposedHelpers.getLongField(nc, "mTransportTypes")
                         val vpnBit = 1L shl TRANSPORT_VPN
                         if (transportTypes and vpnBit == 0L) return
 
@@ -305,6 +318,7 @@ class HookEntry : IXposedHookLoadPackage {
                             writingCopy.set(false)
                         }
                         param.result = null
+                        XposedBridge.log("VpnHide-NC: uid=$callerUid STRIPPED VPN")
                     } catch (t: Throwable) {
                         XposedBridge.log("VpnHide: NC.writeToParcel error: ${t.message}")
                     }
@@ -329,11 +343,17 @@ class HookEntry : IXposedHookLoadPackage {
             object : XC_MethodHook() {
                 override fun beforeHookedMethod(param: MethodHookParam) {
                     if (writingCopy.get() == true) return
-                    if (!isTargetCaller()) return
+                    val callerUid = Binder.getCallingUid()
+                    val isTarget = loadTargetUids().contains(callerUid)
                     val ni = param.thisObject as NetworkInfo
+                    val type = XposedHelpers.getIntField(ni, "mNetworkType")
+                    val isVpn = type == TYPE_VPN
+                    XposedBridge.log(
+                        "VpnHide-NI: uid=$callerUid target=$isTarget isVpn=$isVpn type=$type",
+                    )
+                    if (!isTarget) return
                     try {
-                        val type = XposedHelpers.getIntField(ni, "mNetworkType")
-                        if (type != TYPE_VPN) return
+                        if (!isVpn) return
 
                         val ctor =
                             NetworkInfo::class.java.getDeclaredConstructor(
@@ -357,6 +377,7 @@ class HookEntry : IXposedHookLoadPackage {
                             writingCopy.set(false)
                         }
                         param.result = null
+                        XposedBridge.log("VpnHide-NI: uid=$callerUid STRIPPED VPN (disguised as WIFI)")
                     } catch (t: Throwable) {
                         XposedBridge.log("VpnHide: NI.writeToParcel error: ${t.message}")
                     }
@@ -381,8 +402,12 @@ class HookEntry : IXposedHookLoadPackage {
             object : XC_MethodHook() {
                 override fun beforeHookedMethod(param: MethodHookParam) {
                     if (writingCopy.get() == true) return
-                    if (!isTargetCaller()) return
+                    val callerUid = Binder.getCallingUid()
+                    val isTarget = loadTargetUids().contains(callerUid)
                     val lp = param.thisObject as LinkProperties
+                    val ifname = XposedHelpers.getObjectField(lp, "mIfaceName") as? String
+                    XposedBridge.log("VpnHide-LP: uid=$callerUid target=$isTarget ifname=$ifname")
+                    if (!isTarget) return
                     try {
                         val ctor = LinkProperties::class.java.getDeclaredConstructor(LinkProperties::class.java)
                         ctor.isAccessible = true
@@ -398,6 +423,7 @@ class HookEntry : IXposedHookLoadPackage {
                             writingCopy.set(false)
                         }
                         param.result = null
+                        XposedBridge.log("VpnHide-LP: uid=$callerUid STRIPPED VPN (ifname was $ifname)")
                     } catch (t: Throwable) {
                         XposedBridge.log("VpnHide: LP.writeToParcel error: ${t.message}")
                     }

--- a/zygisk/module/service.sh
+++ b/zygisk/module/service.sh
@@ -13,9 +13,17 @@ if [ -f "$ZYGISK_TARGETS" ]; then
     cp "$ZYGISK_TARGETS" "$MODULE_DIR/targets.txt" 2>/dev/null
 fi
 
-# Wait for PackageManager to be ready
-for i in $(seq 1 30); do
-    pm list packages >/dev/null 2>&1 && break
+# Wait until PackageManager has actually indexed user-installed apps.
+# `pm list packages` starts responding very early in boot but returns
+# only system packages for several more seconds — if we resolve during
+# that window, `dev.okhsunrog.vpnhide` (and any other user-installed
+# target) silently drops from the UID file and the LSPosed hook caches
+# an empty target set for the rest of the session. Gate on our own
+# package being visible, with a 60s budget.
+for i in $(seq 1 60); do
+    if pm list packages -U 2>/dev/null | grep -q "^package:dev.okhsunrog.vpnhide "; then
+        break
+    fi
     sleep 1
 done
 


### PR DESCRIPTION
## What was broken

On a clean boot of Pixel 4a (stock Android 13, Magisk Kitsune 27001, Zygisk Next 1.3.4, LSPosed/Vector 2.0), the Diagnostics screen's **getAllNetworks() VPN scan** check reliably failed (`1 network(s) with TRANSPORT_VPN`) even though every other Java-level check passed.

Cause: `service.sh` in the zygisk and kmod modules resolved package names → UIDs at the wrong moment of boot. `pm list packages` starts responding to IPC very early (while `package service` is up) but returns only the **system** package set for several seconds after that — user-installed packages (including `dev.okhsunrog.vpnhide` and whichever targets the user added) aren't in the list yet. The loop

```sh
for i in $(seq 1 30); do
    pm list packages >/dev/null 2>&1 && break
    sleep 1
done
```

was satisfied by the system-only response, then the subsequent `pm list packages -U | grep "^package:$pkg "` resolver returned nothing for every user-installed target. `/data/system/vpnhide_uids.txt` was written empty, the LSPosed hook in system_server lazily read that empty file on its first `NC.writeToParcel` call and cached `emptySet()`, and from that point on the hook's `isTargetCaller()` returned `false` for every caller — including the VPN Hide app itself. Java-level filtering silently no-op'd until the next reboot where we got lucky on timing.

The Diagnostic DIAG logs we added confirmed it directly:

```
VpnHide-NC: uid=10236 target=false hasVpn=true transports=0x12
```

UID 10236 = the VPN Hide app; it's supposed to be a target but the hook didn't think so.

## Fix

Gate the boot-time wait on **our own package being visible**, not just PM being up. Budget 60s (was 30s) since the wait is now for the full user-package indexing pass which takes longer than PM's initial wake-up.

```sh
for i in $(seq 1 60); do
    if pm list packages -U 2>/dev/null | grep -q "^package:dev.okhsunrog.vpnhide "; then
        break
    fi
    sleep 1
done
```

Applied to both `kmod/module/service.sh` and `zygisk/module/service.sh` (the same logic is duplicated in each — they ship separately, whichever happens to be installed runs the resolver).

## Also in this PR

Added per-call diagnostic logs to all three `writeToParcel` hooks in `HookEntry`:

- `VpnHide-NC: uid=… target=… hasVpn=… transports=0x…`
- `VpnHide-NI: uid=… target=… isVpn=… type=…`
- `VpnHide-LP: uid=… target=… ifname=…`

Plus `STRIPPED` confirmation lines when we actually modify a parcel. These turned out to be the decisive tool for pinning down this bug — the caller UID, target-list membership, and VPN bitmap are all visible on one log line, so the next variant of the bug will take minutes instead of hours. Volume is modest relative to system_server's own output and logs live inside the LSPosed bridge log. We can gate this behind a setting later when the code stabilises.

## Test plan

- [ ] Install on a fresh boot (simulate PM indexing window).
- [ ] Open VPN Hide → Diagnostics → Run all checks with VPN active → 27/27 pass (previously `getAllNetworks VPN scan` would fail with zygisk enabled).
- [ ] `adb shell su -c 'cat /data/system/vpnhide_uids.txt'` — should list all resolved UIDs from the LSPosed targets, including the app's own UID.
- [ ] `adb logcat -s LSPosed-Bridge:\* | grep VpnHide-NC` during a diagnostic run — should show `target=true` for the app's UID on VPN network requests, followed by `STRIPPED VPN` lines.