### PR TITLE
fix(zygisk): close module-dir fd before zygote forks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Magisk versions before v28 failed to install vpnhide-ports and vpnhide-kmod with an unpack error — restored the META-INF/com/google/android/{update-binary,updater-script} entries the older managers expect.
+- Ozon and other apps with root-detection scanning /proc/self/fd no longer hang when vpnhide-zygisk is installed. The module's zygote-side on_load was leaking the module-dir fd, which every forked app process inherited — root-tamper scans detected a descriptor pointing inside /data/adb/modules/ and refused to continue. The fd is now explicitly closed before any app fork.
 
 ## v0.6.0
 

--- a/lsposed/app/src/main/assets/changelog.json
+++ b/lsposed/app/src/main/assets/changelog.json
@@ -7,6 +7,10 @@
         {
           "en": "Magisk versions before v28 failed to install vpnhide-ports and vpnhide-kmod with an unpack error — restored the META-INF/com/google/android/{update-binary,updater-script} entries the older managers expect.",
           "ru": "Magisk до v28 не мог установить vpnhide-ports и vpnhide-kmod из-за ошибки распаковки — вернул файлы META-INF/com/google/android/{update-binary,updater-script}, которые требуются старыми менеджерами."
+        },
+        {
+          "en": "Ozon and other apps with root-detection scanning /proc/self/fd no longer hang when vpnhide-zygisk is installed. The module's zygote-side on_load was leaking the module-dir fd, which every forked app process inherited — root-tamper scans detected a descriptor pointing inside /data/adb/modules/ and refused to continue. The fd is now explicitly closed before any app fork.",
+          "ru": "Ozon и другие приложения, сканирующие /proc/self/fd на признаки root, больше не зависают при установленном vpnhide-zygisk. Модуль утекал fd на /data/adb/modules/ в зиготу, и каждое форкнутое приложение наследовало его — антирут-проверки детектили descriptor внутри /data/adb/ и отказывались запускаться. Теперь fd явно закрывается до первого форка."
         }
       ]
     },

--- a/update-json/changelog.md
+++ b/update-json/changelog.md
@@ -5,6 +5,7 @@
 
 ### Fixed
 - Magisk versions before v28 failed to install vpnhide-ports and vpnhide-kmod with an unpack error — restored the META-INF/com/google/android/{update-binary,updater-script} entries the older managers expect.
+- Ozon and other apps with root-detection scanning /proc/self/fd no longer hang when vpnhide-zygisk is installed. The module's zygote-side on_load was leaking the module-dir fd, which every forked app process inherited — root-tamper scans detected a descriptor pointing inside /data/adb/modules/ and refused to continue. The fd is now explicitly closed before any app fork.
 
 ## v0.6.0
 

--- a/zygisk/src/lib.rs
+++ b/zygisk/src/lib.rs
@@ -30,6 +30,7 @@ mod filter;
 mod hooks;
 mod shadowhook;
 
+use std::os::fd::{AsRawFd, FromRawFd, OwnedFd};
 use std::sync::Once;
 
 use jni::JNIEnv;
@@ -132,12 +133,20 @@ impl ZygiskModule for VpnHide {
 
     fn on_load(&self, api: ZygiskApi<'_, V2>, _env: JNIEnv<'_>) {
         init_logger();
-        let dir_fd = api.get_module_dir();
-        CACHED_TARGETS.get_or_init(|| load_targets_from_dir_fd(dir_fd));
+        // Zygisksu returns a raw fd to /data/adb/modules/<id> that we own.
+        // Wrap it in OwnedFd so the drop at the end of this function closes
+        // it before zygote forks any app. If we leak it, every app forked
+        // after us inherits an fd pointing inside /data/adb/ — and apps
+        // that scan /proc/self/fd for root-managed paths (e.g. Ozon's
+        // anti-tamper SDK) detect it and refuse to run, even though our
+        // .so is dlclosed for non-target apps.
+        let dir_fd = unsafe { OwnedFd::from_raw_fd(api.get_module_dir()) };
+        CACHED_TARGETS.get_or_init(|| load_targets_from_dir_fd(dir_fd.as_raw_fd()));
         debug!(
             "on_load: {} targets cached",
             CACHED_TARGETS.get().map_or(0, |v| v.len())
         );
+        // dir_fd drops here → closed before any app fork.
     }
 
     fn pre_app_specialize<'a>(


### PR DESCRIPTION
Fixes a critical fd leak where `api.get_module_dir()` returned a raw fd pointing to `/data/adb/modules/vpnhide_zygisk` that we never closed. Zygote kept it open across fork, so every app process inherited it via normal fd inheritance. Apps that scan `/proc/self/fd` for root-managed paths (Ozon's anti-tamper SDK, likely others) detected it and silently hung on their loading screen — even for non-target apps where our `.so` was already dlclosed.

The fix wraps the raw fd in `OwnedFd` so `Drop` closes it at the end of `on_load`, before zygote forks any app.

- `zygisk/src/lib.rs`: wrap `api.get_module_dir()` return in `OwnedFd` and pass `as_raw_fd()` to `load_targets_from_dir_fd`
- Changelog entry for v0.6.1

## Bisect trail

Reproduced on Pixel 4a + Magisk Kitsune 27001 + Zygisk Next 1.3.4 + Vector 2.0, Ozon 19.12.1:

| Configuration | Ozon |
|---|---|
| vpnhide_zygisk disabled | loads |
| enabled, Ozon NOT targeted | **hangs** |
| enabled, `on_load` empty | loads |
| enabled, `on_load` = `init_logger()` only | loads |
| enabled, `on_load` = `init_logger()` + `get_module_dir()` (no file read) | **hangs** |

Confirmed via `ls -l /proc/$(pidof ru.ozon.app.android)/fd/`:
```
lr-x------ 1 root root 64 fd/56 -> /data/adb/modules/vpnhide_zygisk
```

After the fix, Ozon's fd table has no `/data/adb/` descriptor, Ozon loads to main catalog with hooks active.

## Testing

- [x] Ozon loads without being targeted (vpnhide_zygisk module installed)
- [x] Ozon loads with being targeted (hooks install: `vpnhide_zygisk: hooks installed`)
- [x] No `/data/adb/` fd visible in `/proc/ozon_pid/fd`
- [x] Audit of other fd-opening code in the module — all paths properly close (see PR comment)
- [ ] Field confirmation from users on other devices (alessaly OxygenOS, new MIUI user)