### PR TITLE
fix(lsposed): skip version-mismatch warning for dev builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,8 @@ jobs:
         run: ktlint "lsposed/**/*.kt"
       - name: Android lint
         run: cd lsposed && ./gradlew --no-daemon :app:lint
+      - name: Kotlin unit tests
+        run: cd lsposed && ./gradlew --no-daemon :app:testDebugUnitTest
 
   kmod:
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Dashboard now shows a consistent version string for all modules. Kernel-module, Zygisk and Ports module cards used to display the Magisk-style 'vX.Y.Z' from their module.prop, while the LSPosed hook module card showed the Android-style 'X.Y.Z' from the APK's versionName — on the same screen, for the same version number. The 'v' prefix is now stripped at parse time so every card reads 'X.Y.Z' (or 'X.Y.Z-N-gSHA' for dev builds).
 - App Hiding: marking the same app as both H (Hidden) and O (Observer) caused it to crash on startup — the app would query its own PackageInfo, our system_server hook matched it as an observer and stripped its own package from the result, and the framework bailed. Roles are now mutually exclusive: toggling one clears the other, and existing H+O configs are migrated to O-only on first launch.
 - Protection toolbar: the filter icon indicator for "filter is applied" no longer blends into the topbar background on Material You palettes. Active state is now a FilledIconButton (primary / onPrimary pair, guaranteed contrast) instead of a plain icon tinted with primary on top of primaryContainer.
+- Dev builds of the app no longer trigger a false 'module version mismatch' warning on the Dashboard. The check now strips the git-describe dev suffix (e.g. 0.6.2-14-g1f2205e vs module 0.6.2) before comparing.
 
 ## v0.6.2
 

--- a/lsposed/app/src/main/assets/changelog.json
+++ b/lsposed/app/src/main/assets/changelog.json
@@ -41,6 +41,10 @@
           {
             "en": "Protection toolbar: the filter icon indicator for \"filter is applied\" no longer blends into the topbar background on Material You palettes. Active state is now a FilledIconButton (primary / onPrimary pair, guaranteed contrast) instead of a plain icon tinted with primary on top of primaryContainer.",
             "ru": "Панель защиты: индикатор активного фильтра на иконке в тулбаре больше не сливается с фоном на Material You палитрах. В активном состоянии вместо подкрашенной иконки теперь заливной FilledIconButton (пара primary / onPrimary, контраст гарантирован)."
+          },
+          {
+            "en": "Dev builds of the app no longer trigger a false 'module version mismatch' warning on the Dashboard. The check now strips the git-describe dev suffix (e.g. 0.6.2-14-g1f2205e vs module 0.6.2) before comparing.",
+            "ru": "Сборки приложения из ветки больше не вызывают ложное предупреждение «версия модуля не совпадает» в Обзоре. Теперь сравнение отбрасывает суффикс git describe (0.6.2-14-g1f2205e → 0.6.2)."
           }
         ]
       }

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DashboardData.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DashboardData.kt
@@ -593,13 +593,13 @@ internal fun loadDashboardState(
     val appVersion = BuildConfig.VERSION_NAME
     // Version mismatches are warnings — modules keep working, user just needs to
     // update the lagging side. Full coverage is not affected by a patch-level gap.
-    if (kmod is ModuleState.Installed && kmod.version != null && normalizeVersion(kmod.version) != normalizeVersion(appVersion)) {
+    if (kmod is ModuleState.Installed && kmod.version != null && versionsMismatch(kmod.version, appVersion)) {
         warn(buildModuleVersionIssue(NativeModuleKind.Kmod, kmod.version, appVersion))
     }
-    if (zygisk is ModuleState.Installed && zygisk.version != null && normalizeVersion(zygisk.version) != normalizeVersion(appVersion)) {
+    if (zygisk is ModuleState.Installed && zygisk.version != null && versionsMismatch(zygisk.version, appVersion)) {
         warn(buildModuleVersionIssue(NativeModuleKind.Zygisk, zygisk.version, appVersion))
     }
-    if (ports is ModuleState.Installed && ports.version != null && normalizeVersion(ports.version) != normalizeVersion(appVersion)) {
+    if (ports is ModuleState.Installed && ports.version != null && versionsMismatch(ports.version, appVersion)) {
         warn(buildModuleVersionIssue(NativeModuleKind.Ports, ports.version, appVersion))
     }
     val totalTargets = lsposedTargetCount + kmodTargetCount + zygiskTargetCount
@@ -611,7 +611,7 @@ internal fun loadDashboardState(
     }
     if (lsposed is LsposedState.Active) {
         val runningVersion = lsposed.version
-        if (runningVersion != null && runningVersion != appVersion) {
+        if (versionsMismatch(runningVersion, appVersion)) {
             VpnHideLog.w(TAG, "version mismatch: running=$runningVersion app=$appVersion")
             warn(res.getString(R.string.dashboard_issue_version_mismatch, runningVersion, appVersion))
         }

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DashboardData.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DashboardData.kt
@@ -69,7 +69,31 @@ sealed interface JavaResult {
     data object HooksInactive : JavaResult
 }
 
-private enum class NativeModuleKind { Kmod, Zygisk, Ports }
+internal enum class NativeModuleKind { Kmod, Zygisk, Ports }
+
+internal data class ModuleMismatch(
+    val kind: NativeModuleKind,
+    val moduleVersion: String,
+    val appVersion: String,
+)
+
+// Pure: given a list of (state, kind) pairs and the app version, returns
+// the subset whose base version disagrees with the app. Extracted so the
+// three kmod / zygisk / ports callsites in loadDashboardState share one
+// code path instead of three near-identical if-blocks.
+internal fun detectModuleMismatches(
+    modules: List<Pair<ModuleState, NativeModuleKind>>,
+    appVersion: String,
+): List<ModuleMismatch> =
+    modules.mapNotNull { (state, kind) ->
+        val installed = state as? ModuleState.Installed ?: return@mapNotNull null
+        val moduleVersion = installed.version ?: return@mapNotNull null
+        if (versionsMismatch(moduleVersion, appVersion)) {
+            ModuleMismatch(kind, moduleVersion, appVersion)
+        } else {
+            null
+        }
+    }
 
 private sealed interface LsposedRuntime {
     data object Inactive : LsposedRuntime
@@ -593,14 +617,17 @@ internal fun loadDashboardState(
     val appVersion = BuildConfig.VERSION_NAME
     // Version mismatches are warnings — modules keep working, user just needs to
     // update the lagging side. Full coverage is not affected by a patch-level gap.
-    if (kmod is ModuleState.Installed && kmod.version != null && versionsMismatch(kmod.version, appVersion)) {
-        warn(buildModuleVersionIssue(NativeModuleKind.Kmod, kmod.version, appVersion))
-    }
-    if (zygisk is ModuleState.Installed && zygisk.version != null && versionsMismatch(zygisk.version, appVersion)) {
-        warn(buildModuleVersionIssue(NativeModuleKind.Zygisk, zygisk.version, appVersion))
-    }
-    if (ports is ModuleState.Installed && ports.version != null && versionsMismatch(ports.version, appVersion)) {
-        warn(buildModuleVersionIssue(NativeModuleKind.Ports, ports.version, appVersion))
+    val moduleMismatches =
+        detectModuleMismatches(
+            listOf(
+                kmod to NativeModuleKind.Kmod,
+                zygisk to NativeModuleKind.Zygisk,
+                ports to NativeModuleKind.Ports,
+            ),
+            appVersion,
+        )
+    moduleMismatches.forEach { mismatch ->
+        warn(buildModuleVersionIssue(mismatch.kind, mismatch.moduleVersion, mismatch.appVersion))
     }
     val totalTargets = lsposedTargetCount + kmodTargetCount + zygiskTargetCount
     if (totalTargets == 0) {

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/UpdateChecker.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/UpdateChecker.kt
@@ -38,6 +38,25 @@ data class BilingualItem(
 
 internal fun normalizeVersion(version: String): String = version.trim().removePrefix("v")
 
+private val GIT_DESCRIBE_DEV_SUFFIX = Regex("""-\d+-g[0-9a-f]+$""")
+
+// Strip the `-<commits>-g<short-sha>` suffix that `git describe --tags`
+// appends when HEAD isn't on a tag, so a dev APK built on top of release
+// 0.6.2 compares equal to module.prop version 0.6.2. Pre-release tags
+// (-rc1, -beta, -alpha.2) are preserved.
+internal fun baseVersion(version: String): String = normalizeVersion(version).replace(GIT_DESCRIBE_DEV_SUFFIX, "")
+
+// True when a module's version is meaningfully different from the app's,
+// i.e. both have real base versions and the bases disagree. Dev APKs on
+// top of the same release do not count as mismatch.
+internal fun versionsMismatch(
+    moduleVersion: String?,
+    appVersion: String,
+): Boolean {
+    if (moduleVersion == null) return false
+    return baseVersion(moduleVersion) != baseVersion(appVersion)
+}
+
 internal fun compareSemver(
     left: String,
     right: String,

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/UpdateChecker.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/UpdateChecker.kt
@@ -38,12 +38,13 @@ data class BilingualItem(
 
 internal fun normalizeVersion(version: String): String = version.trim().removePrefix("v")
 
-private val GIT_DESCRIBE_DEV_SUFFIX = Regex("""-\d+-g[0-9a-f]+$""")
+// `git describe --tags --dirty` produces up to two extra suffixes:
+//   -<commits>-g<short-sha>   when HEAD is not on a tag
+//   -dirty                    when the working tree has uncommitted changes
+// Either or both are stripped. Pre-release tags (-rc1, -beta, -alpha.2)
+// are preserved because they don't match this shape.
+private val GIT_DESCRIBE_DEV_SUFFIX = Regex("""(?:-\d+-g[0-9a-f]+)?(?:-dirty)?$""")
 
-// Strip the `-<commits>-g<short-sha>` suffix that `git describe --tags`
-// appends when HEAD isn't on a tag, so a dev APK built on top of release
-// 0.6.2 compares equal to module.prop version 0.6.2. Pre-release tags
-// (-rc1, -beta, -alpha.2) are preserved.
 internal fun baseVersion(version: String): String = normalizeVersion(version).replace(GIT_DESCRIBE_DEV_SUFFIX, "")
 
 // True when a module's version is meaningfully different from the app's,

--- a/lsposed/app/src/test/kotlin/dev/okhsunrog/vpnhide/DetectModuleMismatchesTest.kt
+++ b/lsposed/app/src/test/kotlin/dev/okhsunrog/vpnhide/DetectModuleMismatchesTest.kt
@@ -1,0 +1,68 @@
+package dev.okhsunrog.vpnhide
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class DetectModuleMismatchesTest {
+    private fun installed(version: String?) = ModuleState.Installed(version = version, active = true, targetCount = 0)
+
+    @Test
+    fun `no modules produces no mismatches`() {
+        assertEquals(emptyList<ModuleMismatch>(), detectModuleMismatches(emptyList(), "0.6.2"))
+    }
+
+    @Test
+    fun `not-installed modules are skipped`() {
+        val modules =
+            listOf(
+                ModuleState.NotInstalled to NativeModuleKind.Kmod,
+                ModuleState.NotInstalled to NativeModuleKind.Zygisk,
+            )
+        assertEquals(emptyList<ModuleMismatch>(), detectModuleMismatches(modules, "0.6.2"))
+    }
+
+    @Test
+    fun `installed modules without a version are skipped`() {
+        val modules = listOf(installed(null) to NativeModuleKind.Kmod)
+        assertEquals(emptyList<ModuleMismatch>(), detectModuleMismatches(modules, "0.6.2"))
+    }
+
+    @Test
+    fun `matching base version does not mismatch`() {
+        val modules =
+            listOf(
+                installed("0.6.2") to NativeModuleKind.Kmod,
+                installed("v0.6.2") to NativeModuleKind.Zygisk,
+            )
+        assertEquals(emptyList<ModuleMismatch>(), detectModuleMismatches(modules, "0.6.2-14-g1f2205e"))
+    }
+
+    @Test
+    fun `different base version produces a mismatch per module`() {
+        val modules =
+            listOf(
+                installed("0.6.1") to NativeModuleKind.Kmod,
+                installed("0.6.2") to NativeModuleKind.Zygisk,
+                installed("0.5.0") to NativeModuleKind.Ports,
+            )
+        val result = detectModuleMismatches(modules, "0.6.2")
+        assertEquals(
+            listOf(
+                ModuleMismatch(NativeModuleKind.Kmod, "0.6.1", "0.6.2"),
+                ModuleMismatch(NativeModuleKind.Ports, "0.5.0", "0.6.2"),
+            ),
+            result,
+        )
+    }
+
+    @Test
+    fun `module kind and versions preserved in result`() {
+        val modules = listOf(installed("0.5.0") to NativeModuleKind.Ports)
+        val result = detectModuleMismatches(modules, "0.6.2")
+        assertEquals(1, result.size)
+        val only = result.single()
+        assertEquals(NativeModuleKind.Ports, only.kind)
+        assertEquals("0.5.0", only.moduleVersion)
+        assertEquals("0.6.2", only.appVersion)
+    }
+}

--- a/lsposed/app/src/test/kotlin/dev/okhsunrog/vpnhide/UpdateCheckerTest.kt
+++ b/lsposed/app/src/test/kotlin/dev/okhsunrog/vpnhide/UpdateCheckerTest.kt
@@ -1,0 +1,151 @@
+package dev.okhsunrog.vpnhide
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class NormalizeVersionTest {
+    @Test
+    fun `strips leading v prefix`() {
+        assertEquals("0.6.2", normalizeVersion("v0.6.2"))
+        assertEquals("0.6.2", normalizeVersion("0.6.2"))
+    }
+
+    @Test
+    fun `trims surrounding whitespace`() {
+        assertEquals("0.6.2", normalizeVersion("  0.6.2  "))
+        assertEquals("0.6.2", normalizeVersion("\n0.6.2\t"))
+    }
+
+    @Test
+    fun `does not strip inner v`() {
+        assertEquals("0.6.2-rcv1", normalizeVersion("0.6.2-rcv1"))
+    }
+
+    @Test
+    fun `preserves git-describe dev suffix`() {
+        // normalizeVersion is not responsible for stripping the dev suffix;
+        // baseVersion is.
+        assertEquals("0.6.2-14-g1f2205e", normalizeVersion("0.6.2-14-g1f2205e"))
+    }
+}
+
+class CompareSemverTest {
+    @Test
+    fun `equal versions return zero`() {
+        assertEquals(0, compareSemver("0.6.2", "0.6.2"))
+        assertEquals(0, compareSemver("v0.6.2", "0.6.2"))
+    }
+
+    @Test
+    fun `newer major beats older`() {
+        assertTrue((compareSemver("1.0.0", "0.9.9") ?: 0) > 0)
+        assertTrue((compareSemver("0.9.9", "1.0.0") ?: 0) < 0)
+    }
+
+    @Test
+    fun `newer minor and patch compare correctly`() {
+        assertTrue((compareSemver("0.7.0", "0.6.9") ?: 0) > 0)
+        assertTrue((compareSemver("0.6.3", "0.6.2") ?: 0) > 0)
+        assertTrue((compareSemver("0.6.2", "0.6.3") ?: 0) < 0)
+    }
+
+    @Test
+    fun `missing trailing components treated as zero`() {
+        assertEquals(0, compareSemver("0.6", "0.6.0"))
+        assertTrue((compareSemver("0.6.1", "0.6") ?: 0) > 0)
+    }
+
+    @Test
+    fun `non-numeric input returns null for the caller to handle`() {
+        // Contract: compareSemver does not attempt to parse suffixes like
+        // -rc1 or git-describe dev suffixes. Callers must normalize first
+        // (e.g. via baseVersion) if they want those compared.
+        assertNull(compareSemver("abc", "0.6.2"))
+        assertNull(compareSemver("", "0.6.2"))
+    }
+}
+
+class BaseVersionTest {
+    @Test
+    fun `release version passes through unchanged`() {
+        assertEquals("0.6.2", baseVersion("0.6.2"))
+        assertEquals("1.0.0", baseVersion("1.0.0"))
+    }
+
+    @Test
+    fun `v prefix still stripped`() {
+        assertEquals("0.6.2", baseVersion("v0.6.2"))
+    }
+
+    @Test
+    fun `git-describe dev suffix is stripped`() {
+        // `git describe --tags` appends -<commits>-g<short-sha> when HEAD
+        // isn't on a tag. Strip it so a dev APK on top of release v0.6.2
+        // compares equal to module.prop version 0.6.2.
+        assertEquals("0.6.2", baseVersion("0.6.2-14-g1f2205e"))
+        assertEquals("0.6.2", baseVersion("v0.6.2-1-gabcdef0"))
+        assertEquals("1.0.0", baseVersion("1.0.0-42-gdeadbee"))
+    }
+
+    @Test
+    fun `rc and other pre-release tags are preserved`() {
+        // Only the exact -N-gHASH shape is dev-build pollution. Pre-release
+        // markers like -rc1, -beta, -alpha.2 must survive so that real
+        // version comparisons between pre-releases stay meaningful.
+        assertEquals("0.6.2-rc1", baseVersion("0.6.2-rc1"))
+        assertEquals("0.6.2-beta", baseVersion("0.6.2-beta"))
+        assertEquals("0.6.2-alpha.2", baseVersion("0.6.2-alpha.2"))
+    }
+
+    @Test
+    fun `whitespace trimmed`() {
+        assertEquals("0.6.2", baseVersion("  0.6.2-14-g1f2205e  "))
+    }
+}
+
+class VersionsMismatchTest {
+    @Test
+    fun `identical versions do not mismatch`() {
+        assertFalse(versionsMismatch("0.6.2", "0.6.2"))
+    }
+
+    @Test
+    fun `v-prefix difference does not mismatch`() {
+        assertFalse(versionsMismatch("v0.6.2", "0.6.2"))
+    }
+
+    @Test
+    fun `dev-build app on top of release module does not mismatch`() {
+        // The false-warning bug: app is built from 14 commits past tag
+        // 0.6.2; module is the released 0.6.2. Base versions are equal,
+        // so no warning.
+        assertFalse(versionsMismatch("0.6.2", "0.6.2-14-g1f2205e"))
+        assertFalse(versionsMismatch("0.6.2-14-g1f2205e", "0.6.2"))
+    }
+
+    @Test
+    fun `two dev builds on same base do not mismatch`() {
+        assertFalse(versionsMismatch("0.6.2-3-gabc1234", "0.6.2-14-g1f2205e"))
+    }
+
+    @Test
+    fun `different release versions do mismatch`() {
+        assertTrue(versionsMismatch("0.6.1", "0.6.2"))
+        assertTrue(versionsMismatch("0.5.0", "0.6.2"))
+    }
+
+    @Test
+    fun `dev build on different base does mismatch`() {
+        assertTrue(versionsMismatch("0.6.1", "0.6.2-14-g1f2205e"))
+    }
+
+    @Test
+    fun `null module version never mismatches`() {
+        // Unknown/missing module version is handled upstream; don't emit
+        // a false mismatch when we simply don't have a module version.
+        assertFalse(versionsMismatch(null, "0.6.2"))
+    }
+}

--- a/lsposed/app/src/test/kotlin/dev/okhsunrog/vpnhide/UpdateCheckerTest.kt
+++ b/lsposed/app/src/test/kotlin/dev/okhsunrog/vpnhide/UpdateCheckerTest.kt
@@ -91,6 +91,21 @@ class BaseVersionTest {
     }
 
     @Test
+    fun `dirty suffix alone is stripped`() {
+        // build-version.sh emits `X.Y.Z-dirty` when HEAD is on a tag but
+        // the working tree has uncommitted changes.
+        assertEquals("0.6.2", baseVersion("0.6.2-dirty"))
+        assertEquals("0.6.2", baseVersion("v0.6.2-dirty"))
+    }
+
+    @Test
+    fun `dev suffix with dirty marker is stripped`() {
+        // Most common dev-build shape: -<commits>-g<sha>-dirty.
+        assertEquals("0.6.2", baseVersion("0.6.2-14-g1f2205e-dirty"))
+        assertEquals("1.0.0", baseVersion("v1.0.0-3-gdeadbee-dirty"))
+    }
+
+    @Test
     fun `rc and other pre-release tags are preserved`() {
         // Only the exact -N-gHASH shape is dev-build pollution. Pre-release
         // markers like -rc1, -beta, -alpha.2 must survive so that real
@@ -129,6 +144,12 @@ class VersionsMismatchTest {
     @Test
     fun `two dev builds on same base do not mismatch`() {
         assertFalse(versionsMismatch("0.6.2-3-gabc1234", "0.6.2-14-g1f2205e"))
+    }
+
+    @Test
+    fun `dirty dev build on same release does not mismatch`() {
+        assertFalse(versionsMismatch("0.6.2", "0.6.2-14-g1f2205e-dirty"))
+        assertFalse(versionsMismatch("0.6.2", "0.6.2-dirty"))
     }
 
     @Test


### PR DESCRIPTION
## Why

Dashboard was showing a false "module version mismatch" warning on every
dev build of the app. `BuildConfig.VERSION_NAME` carries the
`git describe --tags` suffix (`0.6.2-14-g1f2205e`), and the comparison
against `module.prop`'s plain `0.6.2` always returned inequality. The
CTA told the user to "update modules" when in fact nothing was wrong —
the app was just one ahead of the latest release.

Noticed on-device during #38 testing. Noted while we were here that CI
did not run `:app:testDebugUnitTest`, so `RussianAppFilterTest` had been
coasting unenforced; wired it up.

## Summary

- `UpdateChecker.kt`: new `baseVersion()` strips `-\d+-g[0-9a-f]+$`; new
  `versionsMismatch(module, app)` is the single predicate Dashboard
  callsites use. Pre-release tags (`-rc1`, `-beta`) are preserved.
- `DashboardData.kt`: four callsites (kmod / zygisk / ports / running
  LSPosed hook) switch to `versionsMismatch`.
- `UpdateCheckerTest.kt`: new — `NormalizeVersionTest`,
  `CompareSemverTest`, `BaseVersionTest`, `VersionsMismatchTest`.
- `.github/workflows/ci.yml`: adds `:app:testDebugUnitTest` step after
  Android lint.