### PR TITLE
feat(lsposed): experimentally lower minSdk to 28 for Android 9

### DIFF
--- a/changelog.d/changed-lower-minimum-android-version-to-9-82ba.md
+++ b/changelog.d/changed-lower-minimum-android-version-to-9-82ba.md
@@ -1,0 +1,9 @@
+_2026-04-20_
+
+## English
+
+Lower minimum Android version to 9 (API 28). Experimental — tested builds work on Android 10+, Android 9 support is unverified and needs community reports.
+
+## Русский
+
+Понижена минимальная версия Android до 9 (API 28). Экспериментально — сборки протестированы на Android 10+, работа на Android 9 не проверена и требует отчётов от пользователей.

--- a/lsposed/app/build.gradle.kts
+++ b/lsposed/app/build.gradle.kts
@@ -28,7 +28,7 @@ android {
 
     defaultConfig {
         applicationId = "dev.okhsunrog.vpnhide"
-        minSdk = 29
+        minSdk = 28
         targetSdk = 35
         versionCode = 700
         versionName = buildVersion

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DashboardData.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DashboardData.kt
@@ -1094,10 +1094,16 @@ private fun runJavaProtectionCheck(cm: ConnectivityManager): JavaResult {
     if (!notVpn) failed++
     VpnHideLog.d(TAG, "java: hasCapability(NOT_VPN)=$notVpn")
 
-    val info = caps.transportInfo
-    val isVpnTi = info?.javaClass?.name?.contains("VpnTransportInfo") == true
-    if (isVpnTi) failed++
-    VpnHideLog.d(TAG, "java: transportInfo=${info?.javaClass?.name} isVpn=$isVpnTi")
+    // NetworkCapabilities.getTransportInfo() was introduced in API 29;
+    // on API 28 (Android 9) the leak path does not exist, so skip the check.
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+        val info = caps.transportInfo
+        val isVpnTi = info?.javaClass?.name?.contains("VpnTransportInfo") == true
+        if (isVpnTi) failed++
+        VpnHideLog.d(TAG, "java: transportInfo=${info?.javaClass?.name} isVpn=$isVpnTi")
+    } else {
+        VpnHideLog.d(TAG, "java: transportInfo check skipped (API < 29)")
+    }
 
     val vpnNets =
         cm.allNetworks.count {

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DiagnosticsScreen.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DiagnosticsScreen.kt
@@ -732,6 +732,11 @@ private fun checkTransportInfo(
     cm: ConnectivityManager,
     name: String,
 ): CheckResult {
+    // NetworkCapabilities.getTransportInfo() is API 29+; the leak path does
+    // not exist on Android 9, so the check trivially passes.
+    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.Q) {
+        return CheckResult(name, true, "PASS: transportInfo unavailable (API < 29)")
+    }
     val net = cm.activeNetwork ?: return CheckResult(name, true, "PASS: no active network")
     val caps = cm.getNetworkCapabilities(net) ?: return CheckResult(name, true, "PASS: no capabilities")
     val info = caps.transportInfo

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/HookEntry.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/HookEntry.kt
@@ -239,9 +239,12 @@ class HookEntry : IXposedHookLoadPackage {
     private fun watchTargetUidsFile() {
         val dir = "/data/system"
         val filename = "vpnhide_uids.txt"
+
+        // FileObserver(File, Int) is API 29+; use the String-path form for API 28 compatibility.
+        @Suppress("DEPRECATION")
         val observer =
             object : android.os.FileObserver(
-                File(dir),
+                dir,
                 CREATE or CLOSE_WRITE or MOVED_TO or MODIFY,
             ) {
                 override fun onEvent(

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/HookLog.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/HookLog.kt
@@ -4,6 +4,9 @@ import android.os.FileObserver
 import de.robv.android.xposed.XposedBridge
 import java.io.File
 
+// FileObserver(File, Int) requires API 29; we stay compatible with API 28
+// (Android 9) by using the String-path constructor throughout.
+
 /**
  * [XposedBridge.log] wrapper gated by a filesystem flag set from the app.
  * Used by LSPosed hooks running inside `system_server`, where we don't
@@ -26,9 +29,10 @@ internal object HookLog {
     fun install() {
         reload()
         if (watcher != null) return
+        @Suppress("DEPRECATION")
         val observer =
             object : FileObserver(
-                File("/data/system"),
+                "/data/system",
                 CREATE or CLOSE_WRITE or MOVED_TO or MODIFY,
             ) {
                 override fun onEvent(

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/PackageVisibilityHooks.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/PackageVisibilityHooks.kt
@@ -164,8 +164,10 @@ internal object PackageVisibilityHooks {
         }
 
     private fun watchConfigFiles() {
+        // FileObserver(File, Int) is API 29+; use the String-path form for API 28 compatibility.
+        @Suppress("DEPRECATION")
         val observer =
-            object : FileObserver(File("/data/system"), CREATE or CLOSE_WRITE or MOVED_TO or MODIFY) {
+            object : FileObserver("/data/system", CREATE or CLOSE_WRITE or MOVED_TO or MODIFY) {
                 override fun onEvent(
                     event: Int,
                     path: String?,


### PR DESCRIPTION
Users on older devices have been asking for Android 9 support. The lsposed APK code had no fundamental dependency on API 29+, so this lowers `minSdk` to 28 and fixes the handful of call sites Android Lint flagged. Marked **experimental** — only Android 10+ builds have been verified locally, Android 9 behaviour depends on private `system_server` field layouts that may differ and needs confirmation from users on real devices. The kmod component still requires GKI 5.10+ (Android 12+); this PR only affects the lsposed path.

- `minSdk = 29` → `minSdk = 28` in `lsposed/app/build.gradle.kts`
- `HookEntry.kt`, `HookLog.kt`, `PackageVisibilityHooks.kt`: switch from `FileObserver(File, Int)` (API 29+) to `FileObserver(String, Int)`. Without this, hook installation throws `NoSuchMethodError` on Android 9.
- `DashboardData.kt`, `DiagnosticsScreen.kt`: gate `NetworkCapabilities.getTransportInfo()` (API 29+) behind `Build.VERSION.SDK_INT >= Q`. The `VpnTransportInfo` leak path does not exist pre-Android 10, so the self-check reports PASS / skipped there.
- Changelog entry under `unreleased` (changed, bilingual).

## Testing
- `./gradlew :app:lint` — 0 errors (was 4 after the initial `minSdk` drop).
- `ktlint "**/*.kt"` — clean.
- `./gradlew :app:assembleDebug` — builds.
- Runtime verification on Android 9: **not done**, relies on community testers. Android 10+ paths unchanged behaviourally.