### PR TITLE
perf(lsposed): cache installed-app list at startup

### DIFF
--- a/changelog.d/changed-installed-app-list-is-now-loaded-b3a2.md
+++ b/changelog.d/changed-installed-app-list-is-now-loaded-b3a2.md
@@ -1,0 +1,9 @@
+_2026-04-19_
+
+## English
+
+Installed-app list is now loaded once at app start and cached in RAM, so switching between Protection tabs is instant instead of waiting for the icon+label load every time. Added a refresh button in the top bar to force a reload (also re-reads the per-screen target/observer files).
+
+## Русский
+
+Список установленных приложений теперь загружается один раз при старте и кешируется, так что переключение между вкладками «Защита» происходит мгновенно. Добавлена кнопка «обновить» в верхнем баре для принудительной перезагрузки (заодно перечитывает per-screen файлы целей/наблюдателей).

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/AppHidingScreen.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/AppHidingScreen.kt
@@ -1,7 +1,5 @@
 package dev.okhsunrog.vpnhide
 
-import android.content.pm.ApplicationInfo
-import android.content.pm.PackageManager
 import android.graphics.drawable.Drawable
 import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.foundation.Image
@@ -35,6 +33,7 @@ import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -81,10 +80,13 @@ fun AppHidingScreen(
     modifier: Modifier = Modifier,
 ) {
     val context = LocalContext.current
-    val pm = context.packageManager
 
+    val cachedApps by AppListCache.apps.collectAsState()
+    val refreshCounter by AppListCache.refreshCounter.collectAsState()
+
+    var hiddenNames by remember { mutableStateOf<Set<String>?>(null) }
+    var observerNames by remember { mutableStateOf<Set<String>?>(null) }
     var allApps by remember { mutableStateOf<List<HidingEntry>>(emptyList()) }
-    var loading by remember { mutableStateOf(true) }
     var saving by remember { mutableStateOf(false) }
     var dirty by remember { mutableStateOf(false) }
     var snackMessage by remember { mutableStateOf<String?>(null) }
@@ -97,9 +99,10 @@ fun AppHidingScreen(
         }
     }
 
-    LaunchedEffect(Unit) {
+    // Per-screen root-files state (hidden packages + observer UIDs).
+    // Keyed on refreshCounter so the TopBar refresh re-reads these too.
+    LaunchedEffect(refreshCounter) {
         withContext(Dispatchers.IO) {
-            // Read hidden packages (by name) and observer UIDs → map back to names.
             fun readLines(path: String): Set<String> {
                 val (_, raw) = suExec("cat $path 2>/dev/null || true")
                 return raw
@@ -108,10 +111,9 @@ fun AppHidingScreen(
                     .filter { it.isNotEmpty() && !it.startsWith("#") }
                     .toSet()
             }
-            val hiddenNames = readLines(SS_HIDDEN_PKGS_FILE)
+            val hidden = readLines(SS_HIDDEN_PKGS_FILE)
             val observerUids = readLines(SS_OBSERVER_UIDS_FILE).mapNotNull { it.toIntOrNull() }.toSet()
 
-            // Resolve observer UIDs → package names via `pm list packages -U`.
             val (_, listing) = suExec("pm list packages -U 2>/dev/null")
             val uidToPkg =
                 listing
@@ -120,58 +122,51 @@ fun AppHidingScreen(
                         val pkgMatch = Regex("^package:(\\S+) uid:(\\d+)").find(line) ?: return@mapNotNull null
                         pkgMatch.groupValues[1] to pkgMatch.groupValues[2].toInt()
                     }.associate { (pkg, uid) -> uid to pkg }
-            val observerNames = observerUids.mapNotNull { uidToPkg[it] }.toSet()
+            val observers = observerUids.mapNotNull { uidToPkg[it] }.toSet()
 
-            val selfPkg = context.packageName
-            val installedApps = pm.getInstalledApplications(PackageManager.GET_META_DATA)
-            // Packages with both roles crash on startup: the app queries its own
-            // PackageInfo/ResolveInfo during init, we detect the observer caller
-            // (itself) and strip its own package from the result, so frameworks
-            // see a self-lookup NameNotFoundException and bail. Collapse to
-            // observer-only on load so the next Save persists the fix.
-            var autoFixedConflict = false
-            val entries =
-                installedApps
-                    .filter { it.packageName != selfPkg } // self is always hidden; managed invisibly
-                    .map { info ->
-                        val label =
-                            try {
-                                pm.getApplicationLabel(info).toString()
-                            } catch (_: Exception) {
-                                info.packageName
-                            }
-                        val icon =
-                            try {
-                                pm.getApplicationIcon(info)
-                            } catch (_: Exception) {
-                                null
-                            }
-                        val isSystem = (info.flags and ApplicationInfo.FLAG_SYSTEM) != 0
-                        val pkg = info.packageName
-                        val rawHidden = pkg in hiddenNames
-                        val rawObserver = pkg in observerNames
-                        val (hidden, observer) =
-                            if (rawHidden && rawObserver) {
-                                autoFixedConflict = true
-                                false to true
-                            } else {
-                                rawHidden to rawObserver
-                            }
-                        HidingEntry(
-                            packageName = pkg,
-                            label = label,
-                            icon = icon,
-                            isSystem = isSystem,
-                            hidden = hidden,
-                            observer = observer,
-                        )
-                    }.sortedBy { it.label.lowercase() }
-
-            allApps = entries
-            if (autoFixedConflict) dirty = true
-            loading = false
+            hiddenNames = hidden
+            observerNames = observers
         }
+        dirty = false
     }
+
+    // Packages with both roles crash on startup: the app queries its own
+    // PackageInfo/ResolveInfo during init, we detect the observer caller
+    // (itself) and strip its own package from the result, so frameworks
+    // see a self-lookup NameNotFoundException and bail. Collapse to
+    // observer-only on load so the next Save persists the fix.
+    LaunchedEffect(cachedApps, hiddenNames, observerNames) {
+        val apps = cachedApps ?: return@LaunchedEffect
+        val hidden = hiddenNames ?: return@LaunchedEffect
+        val observers = observerNames ?: return@LaunchedEffect
+        val selfPkg = context.packageName
+        var autoFixedConflict = false
+        allApps =
+            apps
+                .filter { it.packageName != selfPkg }
+                .map { app ->
+                    val rawHidden = app.packageName in hidden
+                    val rawObserver = app.packageName in observers
+                    val (finalHidden, finalObserver) =
+                        if (rawHidden && rawObserver) {
+                            autoFixedConflict = true
+                            false to true
+                        } else {
+                            rawHidden to rawObserver
+                        }
+                    HidingEntry(
+                        packageName = app.packageName,
+                        label = app.label,
+                        icon = app.icon,
+                        isSystem = app.isSystem,
+                        hidden = finalHidden,
+                        observer = finalObserver,
+                    )
+                }
+        if (autoFixedConflict) dirty = true
+    }
+
+    val loading = cachedApps == null || hiddenNames == null || observerNames == null
 
     val filteredApps =
         remember(allApps, searchQuery, showSystem, showRussianOnly) {

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/AppListCache.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/AppListCache.kt
@@ -1,0 +1,93 @@
+package dev.okhsunrog.vpnhide
+
+import android.content.Context
+import android.content.pm.ApplicationInfo
+import android.content.pm.PackageManager
+import android.graphics.drawable.Drawable
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+
+/**
+ * Common per-installed-app fields used by every Protection screen
+ * (Tun targets, App hiding, Ports). The three screens merge this with
+ * their own per-screen toggle state at render time.
+ */
+internal data class AppSummary(
+    val packageName: String,
+    val label: String,
+    val icon: Drawable?,
+    val isSystem: Boolean,
+)
+
+/**
+ * App-scoped cache for the installed-app list. Loaded asynchronously
+ * at startup; Protection screens subscribe to `apps` and render
+ * instantly on tab switch.
+ *
+ * [refreshCounter] increments on every refresh — screens that maintain
+ * their own per-screen state (targets.txt / observer files etc.) key
+ * their reload `LaunchedEffect` on it, so the TopBar refresh button
+ * rehydrates *everything*, not just the package+icon cache.
+ */
+internal object AppListCache {
+    private val _apps = MutableStateFlow<List<AppSummary>?>(null)
+    val apps: StateFlow<List<AppSummary>?> = _apps.asStateFlow()
+
+    private val _refreshCounter = MutableStateFlow(0)
+    val refreshCounter: StateFlow<Int> = _refreshCounter.asStateFlow()
+
+    private val _loading = MutableStateFlow(false)
+    val loading: StateFlow<Boolean> = _loading.asStateFlow()
+
+    private var inflight: Job? = null
+
+    /** Kick off an initial load if not already loaded or loading. */
+    fun ensureLoaded(
+        scope: CoroutineScope,
+        context: Context,
+    ) {
+        if (_apps.value != null || inflight?.isActive == true) return
+        inflight = scope.launch { reload(context.applicationContext) }
+    }
+
+    /** Force a reload and bump the refresh counter so screens re-read
+     * their per-screen state (targets.txt / observer files etc.) too.
+     */
+    fun refresh(
+        scope: CoroutineScope,
+        context: Context,
+    ) {
+        inflight?.cancel()
+        inflight = scope.launch { reload(context.applicationContext) }
+    }
+
+    private suspend fun reload(appContext: Context) {
+        _loading.value = true
+        try {
+            val loaded =
+                withContext(Dispatchers.IO) {
+                    val pm = appContext.packageManager
+                    pm
+                        .getInstalledApplications(0)
+                        .map { info ->
+                            AppSummary(
+                                packageName = info.packageName,
+                                label = info.loadLabel(pm).toString(),
+                                icon = runCatching { pm.getApplicationIcon(info) }.getOrNull(),
+                                isSystem = (info.flags and ApplicationInfo.FLAG_SYSTEM) != 0,
+                            )
+                        }.sortedBy { it.label.lowercase() }
+                }
+            _apps.value = loaded
+            _refreshCounter.value = _refreshCounter.value + 1
+        } finally {
+            _loading.value = false
+        }
+    }
+}

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/AppPickerScreen.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/AppPickerScreen.kt
@@ -1,7 +1,5 @@
 package dev.okhsunrog.vpnhide
 
-import android.content.pm.ApplicationInfo
-import android.content.pm.PackageManager
 import android.graphics.drawable.Drawable
 import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.foundation.Image
@@ -64,11 +62,13 @@ fun AppPickerScreen(
     modifier: Modifier = Modifier,
 ) {
     val context = LocalContext.current
-    val pm = context.packageManager
 
-    var allApps by remember { mutableStateOf<List<AppEntry>>(emptyList()) }
+    val cachedApps by AppListCache.apps.collectAsState()
+    val refreshCounter by AppListCache.refreshCounter.collectAsState()
+
     var installed by remember { mutableStateOf(InstalledModules()) }
-    var loading by remember { mutableStateOf(true) }
+    var targetSets by remember { mutableStateOf<Triple<Set<String>, Set<String>, Set<String>>?>(null) }
+    var allApps by remember { mutableStateOf<List<AppEntry>>(emptyList()) }
     var saving by remember { mutableStateOf(false) }
     var dirty by remember { mutableStateOf(false) }
     var snackMessage by remember { mutableStateOf<String?>(null) }
@@ -81,9 +81,11 @@ fun AppPickerScreen(
         }
     }
 
-    LaunchedEffect(Unit) {
+    // Per-screen state (installed modules + target sets) — re-read on
+    // every cache refresh. Dashboard wants these fresh after the user
+    // taps Refresh in the top bar, not stuck on whatever loaded first.
+    LaunchedEffect(refreshCounter) {
         withContext(Dispatchers.IO) {
-            // Detect which native modules are installed
             val (_, detectOut) =
                 suExec(
                     "echo kmod=\$([ -d $KMOD_MODULE_DIR ] && echo 1 || echo 0);" +
@@ -103,7 +105,6 @@ fun AppPickerScreen(
                     zygisk = flags["zygisk"] == true,
                 )
 
-            // Read 3 separate target lists
             fun readTargets(path: String): Set<String> {
                 val (_, raw) = suExec("cat $path 2>/dev/null || true")
                 return raw
@@ -112,45 +113,34 @@ fun AppPickerScreen(
                     .filter { it.isNotEmpty() && !it.startsWith("#") }
                     .toSet()
             }
-            val kmodTargets = readTargets(KMOD_TARGETS)
-            val zygiskTargets = readTargets(ZYGISK_TARGETS)
-            val lsposedTargets = readTargets(LSPOSED_TARGETS)
-
-            val selfPkg = context.packageName
-            val installedApps = pm.getInstalledApplications(PackageManager.GET_META_DATA)
-            val entries =
-                installedApps
-                    .filter { it.packageName != selfPkg }
-                    .map { info ->
-                        val label =
-                            try {
-                                pm.getApplicationLabel(info).toString()
-                            } catch (_: Exception) {
-                                info.packageName
-                            }
-                        val icon =
-                            try {
-                                pm.getApplicationIcon(info)
-                            } catch (_: Exception) {
-                                null
-                            }
-                        val isSystem = (info.flags and ApplicationInfo.FLAG_SYSTEM) != 0
-                        val pkg = info.packageName
-                        AppEntry(
-                            packageName = pkg,
-                            label = label,
-                            icon = icon,
-                            isSystem = isSystem,
-                            kmod = pkg in kmodTargets,
-                            zygisk = pkg in zygiskTargets,
-                            lsposed = pkg in lsposedTargets,
-                        )
-                    }.sortedBy { it.label.lowercase() }
-
-            allApps = entries
-            loading = false
+            targetSets = Triple(readTargets(KMOD_TARGETS), readTargets(ZYGISK_TARGETS), readTargets(LSPOSED_TARGETS))
         }
+        dirty = false
     }
+
+    // Merge cached app metadata with per-screen target flags. Runs
+    // cheaply whenever either side changes.
+    LaunchedEffect(cachedApps, targetSets) {
+        val apps = cachedApps ?: return@LaunchedEffect
+        val (kmodT, zygiskT, lsposedT) = targetSets ?: return@LaunchedEffect
+        val selfPkg = context.packageName
+        allApps =
+            apps
+                .filter { it.packageName != selfPkg }
+                .map { app ->
+                    AppEntry(
+                        packageName = app.packageName,
+                        label = app.label,
+                        icon = app.icon,
+                        isSystem = app.isSystem,
+                        kmod = app.packageName in kmodT,
+                        zygisk = app.packageName in zygiskT,
+                        lsposed = app.packageName in lsposedT,
+                    )
+                }
+    }
+
+    val loading = cachedApps == null || targetSets == null
 
     val filteredApps =
         remember(allApps, searchQuery, showSystem, showRussianOnly) {

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/MainActivity.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/MainActivity.kt
@@ -13,6 +13,7 @@ import androidx.compose.material.icons.filled.CheckCircle
 import androidx.compose.material.icons.filled.Clear
 import androidx.compose.material.icons.filled.FilterList
 import androidx.compose.material.icons.filled.Home
+import androidx.compose.material.icons.filled.Refresh
 import androidx.compose.material.icons.filled.Search
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
@@ -86,6 +87,7 @@ private enum class Tab { Dashboard, Protection, Diagnostics }
 @Composable
 private fun MainScreen() {
     val context = LocalContext.current
+    val scope = rememberCoroutineScope()
     var currentTab by remember { mutableStateOf(Tab.Dashboard) }
     var selfNeedsRestart by remember { mutableStateOf<Boolean?>(null) }
     var searchQuery by remember { mutableStateOf("") }
@@ -93,6 +95,7 @@ private fun MainScreen() {
     var showSystem by remember { mutableStateOf(false) }
     var showRussianOnly by remember { mutableStateOf(false) }
     var showFilterMenu by remember { mutableStateOf(false) }
+    val cacheLoading by AppListCache.loading.collectAsState()
 
     LaunchedEffect(Unit) {
         selfNeedsRestart =
@@ -100,6 +103,13 @@ private fun MainScreen() {
                 cleanupStaleZygiskStatus(context)
                 ensureSelfInTargets(context.packageName)
             }
+    }
+
+    // Kick off the app-list cache load as early as possible so tab
+    // switches into Protection render instantly instead of paying the
+    // per-screen pm + icon cost each time.
+    LaunchedEffect(Unit) {
+        AppListCache.ensureLoaded(scope, context)
     }
 
     LaunchedEffect(currentTab) {
@@ -146,6 +156,24 @@ private fun MainScreen() {
                         ),
                     actions = {
                         if (currentTab == Tab.Protection) {
+                            IconButton(
+                                onClick = { AppListCache.refresh(scope, context) },
+                                enabled = !cacheLoading,
+                            ) {
+                                if (cacheLoading) {
+                                    CircularProgressIndicator(
+                                        modifier = Modifier.size(20.dp),
+                                        strokeWidth = 2.dp,
+                                        color = MaterialTheme.colorScheme.onPrimaryContainer,
+                                    )
+                                } else {
+                                    Icon(
+                                        Icons.Default.Refresh,
+                                        contentDescription = stringResource(R.string.action_refresh_apps),
+                                        tint = MaterialTheme.colorScheme.onPrimaryContainer,
+                                    )
+                                }
+                            }
                             IconButton(onClick = { searchActive = true }) {
                                 Icon(
                                     Icons.Default.Search,

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/PortsHidingScreen.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/PortsHidingScreen.kt
@@ -1,7 +1,5 @@
 package dev.okhsunrog.vpnhide
 
-import android.content.pm.ApplicationInfo
-import android.content.pm.PackageManager
 import android.graphics.drawable.Drawable
 import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.foundation.Image
@@ -37,6 +35,7 @@ import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -78,11 +77,13 @@ fun PortsHidingScreen(
     modifier: Modifier = Modifier,
 ) {
     val context = LocalContext.current
-    val pm = context.packageManager
+
+    val cachedApps by AppListCache.apps.collectAsState()
+    val refreshCounter by AppListCache.refreshCounter.collectAsState()
 
     var moduleInstalled by remember { mutableStateOf<Boolean?>(null) }
+    var observerNames by remember { mutableStateOf<Set<String>?>(null) }
     var allApps by remember { mutableStateOf<List<PortsEntry>>(emptyList()) }
-    var loading by remember { mutableStateOf(true) }
     var saving by remember { mutableStateOf(false) }
     var dirty by remember { mutableStateOf(false) }
     var snackMessage by remember { mutableStateOf<String?>(null) }
@@ -95,7 +96,7 @@ fun PortsHidingScreen(
         }
     }
 
-    LaunchedEffect(Unit) {
+    LaunchedEffect(refreshCounter) {
         withContext(Dispatchers.IO) {
             // Read module.prop rather than [ -d ]: on KSU-Next a pending-removal
             // module keeps the directory with a `remove` flag file until reboot;
@@ -104,53 +105,42 @@ fun PortsHidingScreen(
             val installed = exitCode == 0
             moduleInstalled = installed
             if (!installed) {
-                loading = false
+                observerNames = emptySet()
                 return@withContext
             }
 
             // observers.txt stores package names (resolved to UIDs at apply time
             // inside the module script). Read them directly — no UID mapping needed.
             val (_, raw) = suExec("cat $PORTS_OBSERVERS_FILE 2>/dev/null || true")
-            val observerNames =
+            observerNames =
                 raw
                     .lines()
                     .map { it.trim() }
                     .filter { it.isNotEmpty() && !it.startsWith("#") }
                     .toSet()
-
-            val selfPkg = context.packageName
-            val installedApps = pm.getInstalledApplications(PackageManager.GET_META_DATA)
-            val entries =
-                installedApps
-                    .filter { it.packageName != selfPkg }
-                    .map { info ->
-                        val label =
-                            try {
-                                pm.getApplicationLabel(info).toString()
-                            } catch (_: Exception) {
-                                info.packageName
-                            }
-                        val icon =
-                            try {
-                                pm.getApplicationIcon(info)
-                            } catch (_: Exception) {
-                                null
-                            }
-                        val isSystem = (info.flags and ApplicationInfo.FLAG_SYSTEM) != 0
-                        val pkg = info.packageName
-                        PortsEntry(
-                            packageName = pkg,
-                            label = label,
-                            icon = icon,
-                            isSystem = isSystem,
-                            observer = pkg in observerNames,
-                        )
-                    }.sortedBy { it.label.lowercase() }
-
-            allApps = entries
-            loading = false
         }
+        dirty = false
     }
+
+    LaunchedEffect(cachedApps, observerNames) {
+        val apps = cachedApps ?: return@LaunchedEffect
+        val observers = observerNames ?: return@LaunchedEffect
+        val selfPkg = context.packageName
+        allApps =
+            apps
+                .filter { it.packageName != selfPkg }
+                .map { app ->
+                    PortsEntry(
+                        packageName = app.packageName,
+                        label = app.label,
+                        icon = app.icon,
+                        isSystem = app.isSystem,
+                        observer = app.packageName in observers,
+                    )
+                }
+    }
+
+    val loading = cachedApps == null || observerNames == null
 
     if (moduleInstalled == false) {
         NotInstalledCard(modifier = modifier)

--- a/lsposed/app/src/main/res/values-ru/strings.xml
+++ b/lsposed/app/src/main/res/values-ru/strings.xml
@@ -25,6 +25,7 @@
     <!-- App picker -->
     <string name="selected_count">%d выбрано</string>
     <string name="btn_save">Сохранить</string>
+    <string name="action_refresh_apps">Обновить список приложений</string>
     <string name="search_placeholder">Поиск приложений&#8230;</string>
     <string name="filter_system">Системные</string>
     <string name="filter_show_system">Показать системные приложения</string>

--- a/lsposed/app/src/main/res/values/strings.xml
+++ b/lsposed/app/src/main/res/values/strings.xml
@@ -27,6 +27,7 @@
     <!-- App picker -->
     <string name="selected_count">%d selected</string>
     <string name="btn_save">Save</string>
+    <string name="action_refresh_apps">Refresh app list</string>
     <string name="search_placeholder">Search apps&#8230;</string>
     <string name="filter_system">System</string>
     <string name="filter_show_system">Show system apps</string>


### PR DESCRIPTION
## Why

Switching to a Protection tab triggered a full
\`pm.getInstalledApplications\` + ~300 \`getApplicationIcon\` calls every
time. Icons dominate and the user stares at a spinner on every tab
change. The three screens each implemented their own loader
independently.

## Summary

- \`AppListCache\` \`object\` with \`StateFlow<List<AppSummary>?>\` +
  loading flag + refresh counter. Holds \`{packageName, label, icon,
  isSystem}\` — shared across the three screens.
- \`MainActivity\` calls \`AppListCache.ensureLoaded\` at composition so
  the cache is warming while the user is still on Dashboard.
- Refresh IconButton in the Protection TopBar (spinner while
  reloading). Refresh bumps the counter → each screen's own per-screen
  state (target/observer files) re-loads via
  \`LaunchedEffect(refreshCounter)\`. Full refresh, not just icons.
- \`AppPickerScreen\`, \`AppHidingScreen\`, \`PortsHidingScreen\`: drop
  inline \`pm\` loading; subscribe to \`AppListCache.apps\` via
  \`collectAsState\` and merge with their own target/observer set.
- New string \`action_refresh_apps\` (EN + RU).

Same pattern could be applied to Dashboard later — its
\`LaunchedEffect(Unit)\` blocks also re-fire on tab switch.