### PR TITLE
perf(lsposed): cache Dashboard state + update check

### DIFF
--- a/changelog.d/changed-dashboard-no-longer-re-runs-all-cbf4.md
+++ b/changelog.d/changed-dashboard-no-longer-re-runs-all-cbf4.md
@@ -1,0 +1,9 @@
+_2026-04-19_
+
+## English
+
+Dashboard no longer re-runs all checks (module detection, kprobes, SELinux, target counts, GitHub update check, etc.) on every tab switch. State is loaded once at startup and cached in RAM; the Refresh button in the top bar forces a reload. Update check is cached for 6 hours and re-runs when the app comes back to the foreground after sitting in the background longer than that — no background jobs, no notifications, just reactive to app lifecycle.
+
+## Русский
+
+Обзор больше не перезапускает все проверки (обнаружение модулей, kprobes, SELinux, счётчики целей, проверка обновлений на GitHub и т. д.) при каждом переключении вкладки. Состояние загружается один раз при старте и кэшируется в памяти; кнопка «Обновить» в верхнем баре принудительно перезагружает. Проверка обновлений кэшируется на 6 часов и перезапускается при возврате приложения из фона, если прошло больше — никаких фоновых задач, никаких уведомлений, только реакция на жизненный цикл приложения.

--- a/changelog.d/fixed-dev-builds-of-the-app-now-86b8.md
+++ b/changelog.d/fixed-dev-builds-of-the-app-now-86b8.md
@@ -1,0 +1,9 @@
+_2026-04-19_
+
+## English
+
+Dev builds of the app now correctly receive "new version available" notifications. The comparison used to bail on the git-describe suffix (0.6.2-14-gSHA) and silently treat it as "no update", so testers running dev APKs never saw release prompts.
+
+## Русский
+
+Dev-сборки приложения теперь корректно получают уведомления о новой версии. Раньше сравнение спотыкалось о git-describe-суффикс (0.6.2-14-gSHA) и молча трактовало это как «обновлений нет», поэтому тестеры на dev-APK не видели релизных уведомлений.

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/AppHidingScreen.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/AppHidingScreen.kt
@@ -364,6 +364,7 @@ fun AppHidingScreen(
                 if (exitCode == 0) {
                     snackMessage =
                         context.getString(R.string.hiding_save_success, hiddenPkgs.size, observerPkgs.size)
+                    DashboardCache.invalidate()
                 } else if (exitCode == -1) {
                     snackMessage = context.getString(R.string.save_failed_root)
                     dirty = true

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/AppPickerScreen.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/AppPickerScreen.kt
@@ -337,6 +337,10 @@ fun AppPickerScreen(
                 val totalSelected = allApps.count { it.anySelected }
                 if (exitCode == 0) {
                     snackMessage = context.getString(R.string.save_success, totalSelected)
+                    // Target counts shown on the Dashboard just changed;
+                    // invalidate so next open reflects them without a
+                    // manual refresh tap.
+                    DashboardCache.invalidate()
                 } else if (exitCode == -1) {
                     snackMessage = context.getString(R.string.save_failed_root)
                     dirty = true

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DashboardCache.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DashboardCache.kt
@@ -1,0 +1,78 @@
+package dev.okhsunrog.vpnhide
+
+import android.content.Context
+import android.net.ConnectivityManager
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+
+/**
+ * App-scoped cache for the Dashboard's computed state. Previously
+ * `DashboardScreen` ran `loadDashboardState()` in its own
+ * `LaunchedEffect(Unit)` on every composition — which means every
+ * tab switch re-ran all the module-prop / target / kprobes / SELinux
+ * checks via `suExec`. Cache them once at startup; refresh them
+ * explicitly on user action or after a Save.
+ *
+ * The Dashboard screen reads [state] and shows the previous value
+ * while a refresh is in flight so tab switches feel instant even when
+ * data changes underneath.
+ */
+internal object DashboardCache {
+    private val _state = MutableStateFlow<DashboardState?>(null)
+    val state: StateFlow<DashboardState?> = _state.asStateFlow()
+
+    private val _loading = MutableStateFlow(false)
+    val loading: StateFlow<Boolean> = _loading.asStateFlow()
+
+    private var inflight: Job? = null
+
+    fun ensureLoaded(
+        scope: CoroutineScope,
+        context: Context,
+        selfNeedsRestart: Boolean,
+    ) {
+        if (_state.value != null || inflight?.isActive == true) return
+        inflight = scope.launch { reload(context, selfNeedsRestart) }
+    }
+
+    fun refresh(
+        scope: CoroutineScope,
+        context: Context,
+        selfNeedsRestart: Boolean,
+    ) {
+        inflight?.cancel()
+        inflight = scope.launch { reload(context, selfNeedsRestart) }
+    }
+
+    /** Invalidate so the next `ensureLoaded` call reloads. Used after
+     * a Save on a Protection screen changes target-file contents so
+     * that the next Dashboard open reflects the fresh counts without
+     * the user having to tap Refresh.
+     */
+    fun invalidate() {
+        _state.value = null
+    }
+
+    private suspend fun reload(
+        context: Context,
+        selfNeedsRestart: Boolean,
+    ) {
+        _loading.value = true
+        try {
+            val cm = context.getSystemService(ConnectivityManager::class.java)
+            val next =
+                withContext(Dispatchers.IO) {
+                    loadDashboardState(cm, context.applicationContext, selfNeedsRestart)
+                }
+            _state.value = next
+        } finally {
+            _loading.value = false
+        }
+    }
+}

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DashboardScreen.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DashboardScreen.kt
@@ -1,7 +1,6 @@
 package dev.okhsunrog.vpnhide
 
 import android.content.Intent
-import android.net.ConnectivityManager
 import android.net.Uri
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.*
@@ -29,18 +28,19 @@ fun DashboardScreen(
     modifier: Modifier = Modifier,
 ) {
     val context = LocalContext.current
-    val cm = context.getSystemService(ConnectivityManager::class.java)
+    val scope = rememberCoroutineScope()
 
-    var state by remember { mutableStateOf<DashboardState?>(null) }
-    var updateInfo by remember { mutableStateOf<UpdateInfo?>(null) }
+    val state by DashboardCache.state.collectAsState()
+    val updateInfo by UpdateCheckCache.info.collectAsState()
     var showChangelog by remember { mutableStateOf(false) }
     var changelogData by remember { mutableStateOf<ChangelogData?>(null) }
 
+    // Both caches are reactive to tab switches without re-doing work:
+    // ensureLoaded / ensureFresh are no-ops if the data is already
+    // populated or an inflight job hasn't finished yet.
     LaunchedEffect(Unit) {
-        state = withContext(Dispatchers.IO) { loadDashboardState(cm, context, selfNeedsRestart) }
-    }
-    LaunchedEffect(Unit) {
-        updateInfo = withContext(Dispatchers.IO) { checkForUpdate(BuildConfig.VERSION_NAME) }
+        DashboardCache.ensureLoaded(scope, context, selfNeedsRestart)
+        UpdateCheckCache.ensureFresh(scope, BuildConfig.VERSION_NAME)
     }
     LaunchedEffect(Unit) {
         if (shouldShowChangelog(context)) {

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/MainActivity.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/MainActivity.kt
@@ -24,6 +24,9 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleEventObserver
+import androidx.lifecycle.compose.LocalLifecycleOwner
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 
@@ -83,6 +86,11 @@ fun VpnHideApp() {
 
 private enum class Tab { Dashboard, Protection, Diagnostics }
 
+private data class RefreshContext(
+    val loading: Boolean,
+    val onRefresh: () -> Unit,
+)
+
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 private fun MainScreen() {
@@ -95,7 +103,9 @@ private fun MainScreen() {
     var showSystem by remember { mutableStateOf(false) }
     var showRussianOnly by remember { mutableStateOf(false) }
     var showFilterMenu by remember { mutableStateOf(false) }
-    val cacheLoading by AppListCache.loading.collectAsState()
+    val appListLoading by AppListCache.loading.collectAsState()
+    val dashboardLoading by DashboardCache.loading.collectAsState()
+    val refreshRestart = selfNeedsRestart ?: false
 
     LaunchedEffect(Unit) {
         selfNeedsRestart =
@@ -110,6 +120,21 @@ private fun MainScreen() {
     // per-screen pm + icon cost each time.
     LaunchedEffect(Unit) {
         AppListCache.ensureLoaded(scope, context)
+    }
+
+    // Kick the update check once (silently) on first launch, and again
+    // on ON_RESUME if it's been a while. Listener lives as long as
+    // MainScreen is composed.
+    val lifecycleOwner = LocalLifecycleOwner.current
+    DisposableEffect(lifecycleOwner) {
+        val observer =
+            LifecycleEventObserver { _, event ->
+                if (event == Lifecycle.Event.ON_RESUME) {
+                    UpdateCheckCache.ensureFresh(scope, BuildConfig.VERSION_NAME)
+                }
+            }
+        lifecycleOwner.lifecycle.addObserver(observer)
+        onDispose { lifecycleOwner.lifecycle.removeObserver(observer) }
     }
 
     LaunchedEffect(currentTab) {
@@ -155,12 +180,39 @@ private fun MainScreen() {
                             titleContentColor = MaterialTheme.colorScheme.onPrimaryContainer,
                         ),
                     actions = {
-                        if (currentTab == Tab.Protection) {
+                        // Refresh is contextual: Protection refreshes
+                        // the app list, Dashboard refreshes the dashboard
+                        // state + update check. Diagnostics has its own
+                        // run buttons per-check, no top-bar refresh.
+                        val refreshContext =
+                            when (currentTab) {
+                                Tab.Dashboard -> {
+                                    RefreshContext(
+                                        loading = dashboardLoading,
+                                        onRefresh = {
+                                            DashboardCache.refresh(scope, context, refreshRestart)
+                                            UpdateCheckCache.refresh(scope, BuildConfig.VERSION_NAME)
+                                        },
+                                    )
+                                }
+
+                                Tab.Protection -> {
+                                    RefreshContext(
+                                        loading = appListLoading,
+                                        onRefresh = { AppListCache.refresh(scope, context) },
+                                    )
+                                }
+
+                                Tab.Diagnostics -> {
+                                    null
+                                }
+                            }
+                        refreshContext?.let { rc ->
                             IconButton(
-                                onClick = { AppListCache.refresh(scope, context) },
-                                enabled = !cacheLoading,
+                                onClick = rc.onRefresh,
+                                enabled = !rc.loading,
                             ) {
-                                if (cacheLoading) {
+                                if (rc.loading) {
                                     CircularProgressIndicator(
                                         modifier = Modifier.size(20.dp),
                                         strokeWidth = 2.dp,
@@ -174,6 +226,8 @@ private fun MainScreen() {
                                     )
                                 }
                             }
+                        }
+                        if (currentTab == Tab.Protection) {
                             IconButton(onClick = { searchActive = true }) {
                                 Icon(
                                     Icons.Default.Search,

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/PortsHidingScreen.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/PortsHidingScreen.kt
@@ -317,6 +317,7 @@ fun PortsHidingScreen(
                 val (exitCode, _) = suExecAsync(buildPortsSaveCommand(header, observerPkgs))
                 if (exitCode == 0) {
                     snackMessage = context.getString(R.string.ports_save_success, observerPkgs.size)
+                    DashboardCache.invalidate()
                 } else if (exitCode == -1) {
                     snackMessage = context.getString(R.string.save_failed_root)
                     dirty = true

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/UpdateCheckCache.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/UpdateCheckCache.kt
@@ -1,0 +1,66 @@
+package dev.okhsunrog.vpnhide
+
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+
+/**
+ * In-memory cache for the GitHub update-check result. Two jobs:
+ *
+ * 1. Avoid re-hitting the GitHub API on every Dashboard tab switch —
+ *    previously each composition re-ran `checkForUpdate`, so toggling
+ *    Dashboard ↔ Protection a few times burned through the 60/h
+ *    anonymous API rate limit.
+ * 2. Refresh quietly when the app comes back to the foreground after
+ *    sitting in the background long enough (see [STALE_MS]). Users who
+ *    keep the app minimized for a day still see a fresh state when
+ *    they come back.
+ *
+ * No WorkManager, no background alarms, no notifications — this is
+ * purely reactive to app lifecycle. If the app is actually killed the
+ * cache dies with it and the next launch re-checks as usual.
+ */
+internal object UpdateCheckCache {
+    /** 6 hours. Arbitrary — roughly matches how often a release cadence
+     * is meaningful. Not configurable on purpose; if you want newer,
+     * tap Refresh.
+     */
+    private const val STALE_MS = 6L * 60 * 60 * 1000
+
+    private val _info = MutableStateFlow<UpdateInfo?>(null)
+    val info: StateFlow<UpdateInfo?> = _info.asStateFlow()
+
+    // `null` = never checked this session. Timestamps are wall-clock
+    // millis; drift doesn't matter — all we need is "was X hours ago".
+    private var lastCheckMs: Long? = null
+    private var inflight: Job? = null
+
+    fun ensureFresh(
+        scope: CoroutineScope,
+        currentVersion: String,
+    ) {
+        val last = lastCheckMs
+        val fresh = last != null && System.currentTimeMillis() - last < STALE_MS
+        if (fresh || inflight?.isActive == true) return
+        inflight = scope.launch { run(currentVersion) }
+    }
+
+    fun refresh(
+        scope: CoroutineScope,
+        currentVersion: String,
+    ) {
+        inflight?.cancel()
+        inflight = scope.launch { run(currentVersion) }
+    }
+
+    private suspend fun run(currentVersion: String) {
+        val result = withContext(Dispatchers.IO) { checkForUpdate(currentVersion) }
+        _info.value = result
+        lastCheckMs = System.currentTimeMillis()
+    }
+}

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/UpdateChecker.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/UpdateChecker.kt
@@ -57,6 +57,19 @@ internal fun versionsMismatch(
     return baseVersion(moduleVersion) != baseVersion(appVersion)
 }
 
+// True when `remote` is a strictly newer release than `current` — used
+// to decide whether to offer an in-app update prompt. Both sides go
+// through baseVersion() so a dev APK built on top of 0.6.2 still gets
+// prompted when 0.6.3 lands (compareSemver by itself returns null for
+// the dev suffix, which the old code silently treated as "no update").
+internal fun isNewerVersion(
+    remote: String,
+    current: String,
+): Boolean {
+    val cmp = compareSemver(baseVersion(remote), baseVersion(current)) ?: return false
+    return cmp > 0
+}
+
 internal fun compareSemver(
     left: String,
     right: String,
@@ -100,8 +113,7 @@ fun checkForUpdate(currentVersion: String): UpdateInfo? {
             val body = conn.inputStream.bufferedReader().readText()
             val release = JSONObject(body)
             val remoteVersion = normalizeVersion(release.getString("tag_name"))
-            val cmp = compareSemver(remoteVersion, normalizeVersion(currentVersion))
-            if (cmp == null || cmp <= 0) {
+            if (!isNewerVersion(remoteVersion, currentVersion)) {
                 VpnHideLog.d(TAG, "No update: remote=$remoteVersion current=$currentVersion")
                 return null
             }

--- a/lsposed/app/src/test/kotlin/dev/okhsunrog/vpnhide/UpdateCheckerTest.kt
+++ b/lsposed/app/src/test/kotlin/dev/okhsunrog/vpnhide/UpdateCheckerTest.kt
@@ -170,3 +170,44 @@ class VersionsMismatchTest {
         assertFalse(versionsMismatch(null, "0.6.2"))
     }
 }
+
+class IsNewerVersionTest {
+    @Test
+    fun `newer release beats older release`() {
+        assertTrue(isNewerVersion("0.6.3", "0.6.2"))
+        assertTrue(isNewerVersion("v0.6.3", "0.6.2"))
+        assertTrue(isNewerVersion("1.0.0", "0.9.9"))
+    }
+
+    @Test
+    fun `equal releases are not newer`() {
+        assertFalse(isNewerVersion("0.6.2", "0.6.2"))
+        assertFalse(isNewerVersion("v0.6.2", "0.6.2"))
+    }
+
+    @Test
+    fun `older remote is not newer`() {
+        assertFalse(isNewerVersion("0.6.1", "0.6.2"))
+    }
+
+    @Test
+    fun `dev build on same release gets prompted for new release`() {
+        // The bug: without baseVersion() the comparator parses the dev
+        // suffix as garbage → returns null → caller treats as "no
+        // update" → dev builds never see release notifications.
+        assertTrue(isNewerVersion("0.6.3", "0.6.2-14-g1f2205e"))
+        assertTrue(isNewerVersion("0.6.3", "0.6.2-14-g1f2205e-dirty"))
+    }
+
+    @Test
+    fun `dev build on current release is not offered that same release`() {
+        // Local is "0.6.2 + 14 commits" — remote 0.6.2 is not newer.
+        assertFalse(isNewerVersion("0.6.2", "0.6.2-14-g1f2205e"))
+    }
+
+    @Test
+    fun `dev build ahead of remote is not offered a downgrade`() {
+        // Local is building toward 0.6.3; remote is still on 0.6.2.
+        assertFalse(isNewerVersion("0.6.2", "0.6.3-1-gabcdef0"))
+    }
+}


### PR DESCRIPTION
## Why

Every tab switch into Dashboard re-ran:
- \`loadDashboardState\` — multiple \`suExec\` calls (module.prop probes,
  kprobes / SELinux / root-manager detect, target counts).
- \`checkForUpdate\` — GitHub API call. Toggling tabs a few times eats
  into the 60/h anonymous rate limit.

Same fix pattern as #53 (AppListCache): load once at startup, cache in
RAM, explicit refresh button.

## Summary

- \`DashboardCache\` — \`StateFlow<DashboardState?>\` + loading flag.
  \`ensureLoaded\` on first Dashboard open; survives tab switches.
  \`invalidate()\` called from Save handlers so target counts refresh
  automatically after the user saves on a Protection screen.
- \`UpdateCheckCache\` — \`StateFlow<UpdateInfo?>\` with 6h TTL.
  \`ensureFresh\` is a no-op if the last check is < 6h old.
  \`DisposableEffect\` on \`LifecycleEventObserver\` re-runs \`ensureFresh\`
  on \`ON_RESUME\` so a user who keeps the app backgrounded for a day
  sees a fresh state on return. No WorkManager, no background alarms,
  no notification permissions.
- Refresh \`IconButton\` in the top bar now shows on Dashboard too.
  Dashboard refresh → \`DashboardCache.refresh\` +
  \`UpdateCheckCache.refresh\`. Protection refresh unchanged.
- \`DashboardScreen\` reads the caches via \`collectAsState\`; no more
  per-composition \`LaunchedEffect(Unit)\` loaders.
- Save handlers in \`AppPicker\` / \`AppHiding\` / \`PortsHiding\` call
  \`DashboardCache.invalidate()\` on success.