### PR TITLE
perf(lsposed): cache Diagnostics + Protection state for the session

### DIFF
--- a/changelog.d/changed-diagnostics-and-protection-tabs-now-open-924e.md
+++ b/changelog.d/changed-diagnostics-and-protection-tabs-now-open-924e.md
@@ -1,0 +1,9 @@
+_2026-04-20_
+
+## English
+
+Diagnostics and Protection tabs now open instantly after the first load. Previously each tab switch re-ran all root-shell probes (module detection, target/observer files, pm lookups, 500ms of check functions), now those results live in process-lifetime caches. Diagnostics specifically: checks run once when VPN is first detected active, then results are fixed for the process — hooks don't change mid-session, so re-running is pointless. When VPN is off, both Dashboard and Diagnostics show a shared "turn on VPN, then Retry" banner. Log-capture tools (debug logging toggle, logcat recorder, debug-zip export) are now always visible on Diagnostics, regardless of VPN state.
+
+## Русский
+
+Вкладки «Диагностика» и «Защита» открываются мгновенно после первой загрузки. Раньше каждый переход между вкладками заново гонял все root-запросы (детект модулей, target/observer файлы, pm-запросы, 500мс функций проверки) — теперь результаты живут в кэше до перезапуска процесса. Конкретно по диагностике: проверки запускаются один раз, когда VPN впервые обнаружен активным, дальше результат фиксируется на сессию — хуки не меняются в пределах процесса, прогонять заново бессмысленно. Когда VPN выключен, Обзор и Диагностика показывают общий баннер «включите VPN, нажмите Повторить». Инструменты сбора логов (переключатель отладочных логов, запись logcat, экспорт debug-зипа) теперь всегда доступны на Диагностике, независимо от состояния VPN.

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/AppHidingScreen.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/AppHidingScreen.kt
@@ -37,6 +37,7 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -80,12 +81,11 @@ fun AppHidingScreen(
     modifier: Modifier = Modifier,
 ) {
     val context = LocalContext.current
+    val scope = rememberCoroutineScope()
 
     val cachedApps by AppListCache.apps.collectAsState()
-    val refreshCounter by AppListCache.refreshCounter.collectAsState()
+    val targets by TargetsCache.snapshot.collectAsState()
 
-    var hiddenNames by remember { mutableStateOf<Set<String>?>(null) }
-    var observerNames by remember { mutableStateOf<Set<String>?>(null) }
     var allApps by remember { mutableStateOf<List<HidingEntry>>(emptyList()) }
     var saving by remember { mutableStateOf(false) }
     var dirty by remember { mutableStateOf(false) }
@@ -99,35 +99,8 @@ fun AppHidingScreen(
         }
     }
 
-    // Per-screen root-files state (hidden packages + observer UIDs).
-    // Keyed on refreshCounter so the TopBar refresh re-reads these too.
-    LaunchedEffect(refreshCounter) {
-        withContext(Dispatchers.IO) {
-            fun readLines(path: String): Set<String> {
-                val (_, raw) = suExec("cat $path 2>/dev/null || true")
-                return raw
-                    .lines()
-                    .map { it.trim() }
-                    .filter { it.isNotEmpty() && !it.startsWith("#") }
-                    .toSet()
-            }
-            val hidden = readLines(SS_HIDDEN_PKGS_FILE)
-            val observerUids = readLines(SS_OBSERVER_UIDS_FILE).mapNotNull { it.toIntOrNull() }.toSet()
-
-            val (_, listing) = suExec("pm list packages -U 2>/dev/null")
-            val uidToPkg =
-                listing
-                    .lines()
-                    .mapNotNull { line ->
-                        val pkgMatch = Regex("^package:(\\S+) uid:(\\d+)").find(line) ?: return@mapNotNull null
-                        pkgMatch.groupValues[1] to pkgMatch.groupValues[2].toInt()
-                    }.associate { (pkg, uid) -> uid to pkg }
-            val observers = observerUids.mapNotNull { uidToPkg[it] }.toSet()
-
-            hiddenNames = hidden
-            observerNames = observers
-        }
-        dirty = false
+    LaunchedEffect(Unit) {
+        TargetsCache.ensureLoaded(scope, context)
     }
 
     // Packages with both roles crash on startup: the app queries its own
@@ -135,10 +108,11 @@ fun AppHidingScreen(
     // (itself) and strip its own package from the result, so frameworks
     // see a self-lookup NameNotFoundException and bail. Collapse to
     // observer-only on load so the next Save persists the fix.
-    LaunchedEffect(cachedApps, hiddenNames, observerNames) {
+    LaunchedEffect(cachedApps, targets) {
         val apps = cachedApps ?: return@LaunchedEffect
-        val hidden = hiddenNames ?: return@LaunchedEffect
-        val observers = observerNames ?: return@LaunchedEffect
+        val t = targets ?: return@LaunchedEffect
+        val hidden = t.hiddenPkgs
+        val observers = t.observerNames
         val selfPkg = context.packageName
         var autoFixedConflict = false
         allApps =
@@ -163,10 +137,10 @@ fun AppHidingScreen(
                         observer = finalObserver,
                     )
                 }
-        if (autoFixedConflict) dirty = true
+        dirty = autoFixedConflict
     }
 
-    val loading = cachedApps == null || hiddenNames == null || observerNames == null
+    val loading = cachedApps == null || targets == null
 
     val filteredApps =
         remember(allApps, searchQuery, showSystem, showRussianOnly) {
@@ -365,6 +339,7 @@ fun AppHidingScreen(
                     snackMessage =
                         context.getString(R.string.hiding_save_success, hiddenPkgs.size, observerPkgs.size)
                     DashboardCache.invalidate()
+                    TargetsCache.refresh(scope, context)
                 } else if (exitCode == -1) {
                     snackMessage = context.getString(R.string.save_failed_root)
                     dirty = true

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/AppPickerScreen.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/AppPickerScreen.kt
@@ -62,12 +62,11 @@ fun AppPickerScreen(
     modifier: Modifier = Modifier,
 ) {
     val context = LocalContext.current
+    val scope = rememberCoroutineScope()
 
     val cachedApps by AppListCache.apps.collectAsState()
-    val refreshCounter by AppListCache.refreshCounter.collectAsState()
+    val targets by TargetsCache.snapshot.collectAsState()
 
-    var installed by remember { mutableStateOf(InstalledModules()) }
-    var targetSets by remember { mutableStateOf<Triple<Set<String>, Set<String>, Set<String>>?>(null) }
     var allApps by remember { mutableStateOf<List<AppEntry>>(emptyList()) }
     var saving by remember { mutableStateOf(false) }
     var dirty by remember { mutableStateOf(false) }
@@ -81,48 +80,25 @@ fun AppPickerScreen(
         }
     }
 
-    // Per-screen state (installed modules + target sets) — re-read on
-    // every cache refresh. Dashboard wants these fresh after the user
-    // taps Refresh in the top bar, not stuck on whatever loaded first.
-    LaunchedEffect(refreshCounter) {
-        withContext(Dispatchers.IO) {
-            val (_, detectOut) =
-                suExec(
-                    "echo kmod=\$([ -d $KMOD_MODULE_DIR ] && echo 1 || echo 0);" +
-                        "echo zygisk=\$([ -d $ZYGISK_MODULE_DIR ] && echo 1 || echo 0)",
-                )
-            val flags =
-                detectOut
-                    .lines()
-                    .filter { it.contains("=") }
-                    .associate {
-                        val (k, v) = it.split("=", limit = 2)
-                        k to (v == "1")
-                    }
-            installed =
-                InstalledModules(
-                    kmod = flags["kmod"] == true,
-                    zygisk = flags["zygisk"] == true,
-                )
-
-            fun readTargets(path: String): Set<String> {
-                val (_, raw) = suExec("cat $path 2>/dev/null || true")
-                return raw
-                    .lines()
-                    .map { it.trim() }
-                    .filter { it.isNotEmpty() && !it.startsWith("#") }
-                    .toSet()
-            }
-            targetSets = Triple(readTargets(KMOD_TARGETS), readTargets(ZYGISK_TARGETS), readTargets(LSPOSED_TARGETS))
-        }
-        dirty = false
+    LaunchedEffect(Unit) {
+        TargetsCache.ensureLoaded(scope, context)
     }
 
-    // Merge cached app metadata with per-screen target flags. Runs
-    // cheaply whenever either side changes.
-    LaunchedEffect(cachedApps, targetSets) {
+    val installed =
+        remember(targets) {
+            InstalledModules(
+                kmod = targets?.kmodModuleInstalled == true,
+                zygisk = targets?.zygiskModuleInstalled == true,
+            )
+        }
+
+    // Merge cached app metadata with per-screen target flags. Cheap —
+    // runs whenever either side of the cache changes. Resets local
+    // `dirty` when a fresh snapshot arrives, since that means disk
+    // state just synced (Save finished, or user tapped Refresh).
+    LaunchedEffect(cachedApps, targets) {
         val apps = cachedApps ?: return@LaunchedEffect
-        val (kmodT, zygiskT, lsposedT) = targetSets ?: return@LaunchedEffect
+        val t = targets ?: return@LaunchedEffect
         val selfPkg = context.packageName
         allApps =
             apps
@@ -133,14 +109,15 @@ fun AppPickerScreen(
                         label = app.label,
                         icon = app.icon,
                         isSystem = app.isSystem,
-                        kmod = app.packageName in kmodT,
-                        zygisk = app.packageName in zygiskT,
-                        lsposed = app.packageName in lsposedT,
+                        kmod = app.packageName in t.kmodTargets,
+                        zygisk = app.packageName in t.zygiskTargets,
+                        lsposed = app.packageName in t.lsposedTargets,
                     )
                 }
+        dirty = false
     }
 
-    val loading = cachedApps == null || targetSets == null
+    val loading = cachedApps == null || targets == null
 
     val filteredApps =
         remember(allApps, searchQuery, showSystem, showRussianOnly) {
@@ -341,6 +318,7 @@ fun AppPickerScreen(
                     // invalidate so next open reflects them without a
                     // manual refresh tap.
                     DashboardCache.invalidate()
+                    TargetsCache.refresh(scope, context)
                 } else if (exitCode == -1) {
                     snackMessage = context.getString(R.string.save_failed_root)
                     dirty = true

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DashboardScreen.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DashboardScreen.kt
@@ -126,10 +126,15 @@ fun DashboardScreen(
 
         when (val p = s.protection) {
             is ProtectionCheck.NoVpn -> {
-                StatusBanner(
-                    text = stringResource(R.string.dashboard_no_vpn),
-                    containerColor = MaterialTheme.colorScheme.surfaceVariant,
-                    contentColor = MaterialTheme.colorScheme.onSurfaceVariant,
+                VpnOffPrompt(
+                    onRetry = {
+                        // Re-read dashboard state (re-runs its own VPN
+                        // + protection probes) and re-run the diag
+                        // cache so both screens move to "Ready" when
+                        // VPN is back.
+                        DashboardCache.refresh(scope, context, selfNeedsRestart)
+                        DiagnosticsCache.retry(scope, context)
+                    },
                 )
             }
 

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DiagnosticsCache.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DiagnosticsCache.kt
@@ -1,0 +1,125 @@
+package dev.okhsunrog.vpnhide
+
+import android.content.Context
+import android.net.ConnectivityManager
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+
+/**
+ * Cache for `runAllChecks` results.
+ *
+ * Diagnostics answer one question: *do the hooks work for this app
+ * process right now?* The hooks themselves are fixed at process
+ * creation time — kmod loads at boot, LSPosed injects into
+ * system_server at its boot, Zygisk hooks fire at zygote fork —
+ * so a run's result is valid for the entire lifetime of this app
+ * process. Re-running every tab switch is pure waste.
+ *
+ * State machine:
+ * - [State.NotRun] — fresh, nothing attempted yet.
+ * - [State.Running] — a run is in flight.
+ * - [State.VpnOff] — last run aborted because no active VPN was
+ *   detected. User gets a "turn on VPN, then retry" banner.
+ * - [State.Ready] — results captured; exposed to both the Dashboard
+ *   protection panel and the Diagnostics screen.
+ *
+ * Once [State.Ready] is reached, [run] becomes a no-op — results don't
+ * change mid-process. The only path back to "please retry" requires
+ * killing the process (new launch = fresh cache) or calling [reset]
+ * (currently unused; reserved for explicit force-refresh flows, e.g.
+ * "new kernel module just installed, please verify from a fresh
+ * process" style prompts if we ever want them).
+ */
+internal object DiagnosticsCache {
+    sealed interface State {
+        data object NotRun : State
+
+        data object Running : State
+
+        data object VpnOff : State
+
+        data class Ready(
+            val results: CheckResults,
+        ) : State
+    }
+
+    private val _state = MutableStateFlow<State>(State.NotRun)
+    val state: StateFlow<State> = _state.asStateFlow()
+
+    private var inflight: Job? = null
+
+    /** Start a run if one isn't already in flight and we don't have a
+     * completed result yet. Idempotent — safe to call from both
+     * Dashboard and Diagnostics screens on every composition.
+     */
+    fun run(
+        scope: CoroutineScope,
+        context: Context,
+    ) {
+        when (_state.value) {
+            is State.Ready -> {
+                return
+            }
+
+            State.Running -> {
+                return
+            }
+
+            State.NotRun, State.VpnOff -> { /* proceed */ }
+        }
+        if (inflight?.isActive == true) return
+        inflight = scope.launch { doRun(context.applicationContext) }
+    }
+
+    /** Used by the retry button in the "VPN off" banner. Same as [run]
+     * but bypasses the `VpnOff` short-circuit (which [run] doesn't
+     * actually have — the guard above covers NotRun/VpnOff both — so
+     * this is really just a named alias for readability at the
+     * callsite).
+     */
+    fun retry(
+        scope: CoroutineScope,
+        context: Context,
+    ) = run(scope, context)
+
+    /** Drop any cached result. Next [run] will execute fresh.
+     * Not wired to any UI at the moment — reserved for scenarios like
+     * "user installed a new module and wants to force a re-run from the
+     * same process". Normal refreshes never need this because results
+     * are fixed for the process lifetime.
+     */
+    fun reset() {
+        inflight?.cancel()
+        _state.value = State.NotRun
+    }
+
+    private suspend fun doRun(appContext: Context) {
+        _state.value = State.Running
+        try {
+            val vpnActive = withContext(Dispatchers.IO) { isVpnActive() }
+            if (!vpnActive) {
+                _state.value = State.VpnOff
+                return
+            }
+            val results =
+                withContext(Dispatchers.IO) {
+                    val cm = appContext.getSystemService(ConnectivityManager::class.java)
+                    runAllChecks(cm, appContext)
+                }
+            _state.value = State.Ready(results)
+        } catch (e: Exception) {
+            // Failures leave us in VpnOff so the user sees the retry UI
+            // rather than a frozen spinner. Real-world causes here are
+            // transient (root dropped, shell exec failure) and a retry
+            // usually works.
+            _state.value = State.VpnOff
+            VpnHideLog.w("VpnHide-Diag", "runAllChecks failed: ${e.message}")
+        }
+    }
+}

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DiagnosticsScreen.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DiagnosticsScreen.kt
@@ -52,14 +52,14 @@ data class CheckResult(
     val detail: String,
 )
 
-private data class CheckResults(
+internal data class CheckResults(
     val native: List<CheckResult>,
     val java: List<CheckResult>,
 ) {
     val all get() = native + java
 }
 
-private suspend fun isVpnActive(): Boolean =
+internal suspend fun isVpnActive(): Boolean =
     withContext(Dispatchers.IO) {
         val (exitCode, output) = suExec("ls /sys/class/net/ 2>/dev/null")
         if (exitCode != 0) return@withContext false
@@ -87,14 +87,21 @@ fun DiagnosticsScreen(
     val cm = context.getSystemService(ConnectivityManager::class.java)
     val scope = rememberCoroutineScope()
 
-    var vpnDetected by remember { mutableStateOf<Boolean?>(null) }
-    var results by remember { mutableStateOf<CheckResults?>(null) }
-    var networkBlocked by remember { mutableStateOf(false) }
-    var summary by remember { mutableStateOf<String?>(null) }
+    val diagState by DiagnosticsCache.state.collectAsState()
     var exporting by remember { mutableStateOf(false) }
     var debugZipFile by remember { mutableStateOf<File?>(null) }
     var kmodTrace by remember { mutableStateOf<String?>(null) }
     val summaryFmt = stringResource(R.string.summary_format)
+
+    // Kick off the diagnostics run once per process. If selfNeedsRestart
+    // is true we skip — hooks aren't applied to this app yet, results
+    // would be meaningless. DiagnosticsCache.run is idempotent: no-op
+    // when Ready/Running.
+    LaunchedEffect(selfNeedsRestart) {
+        if (!selfNeedsRestart) {
+            DiagnosticsCache.run(scope, context)
+        }
+    }
 
     LaunchedEffect(Unit) {
         kmodTrace =
@@ -127,20 +134,14 @@ fun DiagnosticsScreen(
             }
         }
 
-    fun updateResults(r: CheckResults) {
-        results = r
-        networkBlocked = r.all.any { it.detail.startsWith("NETWORK_BLOCKED:") }
-        val scored = r.all.filter { it.passed != null }
-        val passed = scored.count { it.passed == true }
-        summary = String.format(summaryFmt, passed, scored.size)
-    }
-
-    LaunchedEffect(Unit) {
-        vpnDetected = isVpnActive()
-        if (vpnDetected == true && !selfNeedsRestart) {
-            updateResults(runAllChecks(cm, context))
+    val results = (diagState as? DiagnosticsCache.State.Ready)?.results
+    val networkBlocked = results?.all?.any { it.detail.startsWith("NETWORK_BLOCKED:") } == true
+    val summary =
+        results?.let { r ->
+            val scored = r.all.filter { it.passed != null }
+            val passed = scored.count { it.passed == true }
+            String.format(summaryFmt, passed, scored.size)
         }
-    }
 
     Column(
         modifier =
@@ -151,70 +152,83 @@ fun DiagnosticsScreen(
     ) {
         Spacer(Modifier.height(8.dp))
 
-        if (vpnDetected == false) {
-            Box(
-                modifier = Modifier.fillMaxSize().weight(1f),
-                contentAlignment = Alignment.Center,
-            ) {
+        // Protection check section — its content depends on cache state,
+        // but the bottom debug-tools section always renders below so
+        // users can collect logs / toggle verbose logging even when
+        // VPN is off or a run is in flight.
+        when {
+            selfNeedsRestart -> {
                 StatusBanner(
-                    text = stringResource(R.string.banner_no_vpn),
-                    containerColor = MaterialTheme.colorScheme.errorContainer,
-                    contentColor = MaterialTheme.colorScheme.onErrorContainer,
+                    text = stringResource(R.string.banner_added_self),
+                    containerColor = MaterialTheme.colorScheme.tertiaryContainer,
+                    contentColor = MaterialTheme.colorScheme.onTertiaryContainer,
                 )
             }
-            return@Column
-        }
 
-        if (selfNeedsRestart) {
-            StatusBanner(
-                text = stringResource(R.string.banner_added_self),
-                containerColor = MaterialTheme.colorScheme.tertiaryContainer,
-                contentColor = MaterialTheme.colorScheme.onTertiaryContainer,
-            )
-        } else {
-            StatusBanner(
-                text = stringResource(R.string.banner_ready),
-                containerColor = Color(0xFF1B5E20).copy(alpha = 0.15f),
-                contentColor = MaterialTheme.colorScheme.onSurface,
-            )
-        }
+            diagState is DiagnosticsCache.State.VpnOff -> {
+                VpnOffPrompt(
+                    onRetry = {
+                        DiagnosticsCache.retry(scope, context)
+                        DashboardCache.refresh(scope, context, selfNeedsRestart)
+                    },
+                )
+            }
 
-        if (networkBlocked) {
-            Spacer(Modifier.height(6.dp))
-            StatusBanner(
-                text = stringResource(R.string.banner_network_blocked),
-                containerColor = MaterialTheme.colorScheme.errorContainer,
-                contentColor = MaterialTheme.colorScheme.onErrorContainer,
-            )
-        }
-
-        if (summary != null) {
-            Spacer(Modifier.height(12.dp))
-            Text(
-                text = summary!!,
-                style = MaterialTheme.typography.titleMedium,
-                fontWeight = FontWeight.Bold,
-            )
-        }
-
-        results?.let { r ->
-            Spacer(Modifier.height(16.dp))
-
-            SectionHeader(stringResource(R.string.section_native))
-            Spacer(Modifier.height(6.dp))
-            Column(verticalArrangement = Arrangement.spacedBy(6.dp)) {
-                for (check in r.native) {
-                    CheckCard(check)
+            diagState is DiagnosticsCache.State.Running ||
+                diagState is DiagnosticsCache.State.NotRun -> {
+                Box(
+                    modifier = Modifier.fillMaxWidth().padding(vertical = 32.dp),
+                    contentAlignment = Alignment.Center,
+                ) {
+                    CircularProgressIndicator()
                 }
             }
 
-            Spacer(Modifier.height(16.dp))
+            diagState is DiagnosticsCache.State.Ready -> {
+                StatusBanner(
+                    text = stringResource(R.string.banner_ready),
+                    containerColor = Color(0xFF1B5E20).copy(alpha = 0.15f),
+                    contentColor = MaterialTheme.colorScheme.onSurface,
+                )
 
-            SectionHeader(stringResource(R.string.section_java))
-            Spacer(Modifier.height(6.dp))
-            Column(verticalArrangement = Arrangement.spacedBy(6.dp)) {
-                for (check in r.java) {
-                    CheckCard(check)
+                if (networkBlocked) {
+                    Spacer(Modifier.height(6.dp))
+                    StatusBanner(
+                        text = stringResource(R.string.banner_network_blocked),
+                        containerColor = MaterialTheme.colorScheme.errorContainer,
+                        contentColor = MaterialTheme.colorScheme.onErrorContainer,
+                    )
+                }
+
+                if (summary != null) {
+                    Spacer(Modifier.height(12.dp))
+                    Text(
+                        text = summary,
+                        style = MaterialTheme.typography.titleMedium,
+                        fontWeight = FontWeight.Bold,
+                    )
+                }
+
+                results?.let { r ->
+                    Spacer(Modifier.height(16.dp))
+
+                    SectionHeader(stringResource(R.string.section_native))
+                    Spacer(Modifier.height(6.dp))
+                    Column(verticalArrangement = Arrangement.spacedBy(6.dp)) {
+                        for (check in r.native) {
+                            CheckCard(check)
+                        }
+                    }
+
+                    Spacer(Modifier.height(16.dp))
+
+                    SectionHeader(stringResource(R.string.section_java))
+                    Spacer(Modifier.height(6.dp))
+                    Column(verticalArrangement = Arrangement.spacedBy(6.dp)) {
+                        for (check in r.java) {
+                            CheckCard(check)
+                        }
+                    }
                 }
             }
         }
@@ -664,7 +678,7 @@ private fun CheckCard(r: CheckResult) {
 //  Check runner — runs directly in the main process
 // ==========================================================================
 
-private fun runAllChecks(
+internal fun runAllChecks(
     cm: ConnectivityManager,
     context: android.content.Context,
 ): CheckResults {

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/MainActivity.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/MainActivity.kt
@@ -104,6 +104,7 @@ private fun MainScreen() {
     var showRussianOnly by remember { mutableStateOf(false) }
     var showFilterMenu by remember { mutableStateOf(false) }
     val appListLoading by AppListCache.loading.collectAsState()
+    val targetsLoading by TargetsCache.loading.collectAsState()
     val dashboardLoading by DashboardCache.loading.collectAsState()
     val refreshRestart = selfNeedsRestart ?: false
 
@@ -115,11 +116,12 @@ private fun MainScreen() {
             }
     }
 
-    // Kick off the app-list cache load as early as possible so tab
+    // Kick off both Protection caches as early as possible so tab
     // switches into Protection render instantly instead of paying the
-    // per-screen pm + icon cost each time.
+    // per-screen pm + icon + root-shell cost each time.
     LaunchedEffect(Unit) {
         AppListCache.ensureLoaded(scope, context)
+        TargetsCache.ensureLoaded(scope, context)
     }
 
     // Kick the update check once (silently) on first launch, and again
@@ -198,8 +200,11 @@ private fun MainScreen() {
 
                                 Tab.Protection -> {
                                     RefreshContext(
-                                        loading = appListLoading,
-                                        onRefresh = { AppListCache.refresh(scope, context) },
+                                        loading = appListLoading || targetsLoading,
+                                        onRefresh = {
+                                            AppListCache.refresh(scope, context)
+                                            TargetsCache.refresh(scope, context)
+                                        },
                                     )
                                 }
 

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/PortsHidingScreen.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/PortsHidingScreen.kt
@@ -39,6 +39,7 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -77,12 +78,11 @@ fun PortsHidingScreen(
     modifier: Modifier = Modifier,
 ) {
     val context = LocalContext.current
+    val scope = rememberCoroutineScope()
 
     val cachedApps by AppListCache.apps.collectAsState()
-    val refreshCounter by AppListCache.refreshCounter.collectAsState()
+    val targets by TargetsCache.snapshot.collectAsState()
 
-    var moduleInstalled by remember { mutableStateOf<Boolean?>(null) }
-    var observerNames by remember { mutableStateOf<Set<String>?>(null) }
     var allApps by remember { mutableStateOf<List<PortsEntry>>(emptyList()) }
     var saving by remember { mutableStateOf(false) }
     var dirty by remember { mutableStateOf(false) }
@@ -96,35 +96,13 @@ fun PortsHidingScreen(
         }
     }
 
-    LaunchedEffect(refreshCounter) {
-        withContext(Dispatchers.IO) {
-            // Read module.prop rather than [ -d ]: on KSU-Next a pending-removal
-            // module keeps the directory with a `remove` flag file until reboot;
-            // an unreadable module.prop signals "not really installed anymore".
-            val (exitCode, _) = suExec("cat $PORTS_MODULE_DIR/module.prop >/dev/null 2>&1")
-            val installed = exitCode == 0
-            moduleInstalled = installed
-            if (!installed) {
-                observerNames = emptySet()
-                return@withContext
-            }
-
-            // observers.txt stores package names (resolved to UIDs at apply time
-            // inside the module script). Read them directly — no UID mapping needed.
-            val (_, raw) = suExec("cat $PORTS_OBSERVERS_FILE 2>/dev/null || true")
-            observerNames =
-                raw
-                    .lines()
-                    .map { it.trim() }
-                    .filter { it.isNotEmpty() && !it.startsWith("#") }
-                    .toSet()
-        }
-        dirty = false
+    LaunchedEffect(Unit) {
+        TargetsCache.ensureLoaded(scope, context)
     }
 
-    LaunchedEffect(cachedApps, observerNames) {
+    LaunchedEffect(cachedApps, targets) {
         val apps = cachedApps ?: return@LaunchedEffect
-        val observers = observerNames ?: return@LaunchedEffect
+        val t = targets ?: return@LaunchedEffect
         val selfPkg = context.packageName
         allApps =
             apps
@@ -135,18 +113,18 @@ fun PortsHidingScreen(
                         label = app.label,
                         icon = app.icon,
                         isSystem = app.isSystem,
-                        observer = app.packageName in observers,
+                        observer = app.packageName in t.portsObservers,
                     )
                 }
+        dirty = false
     }
 
-    val loading = cachedApps == null || observerNames == null
+    val loading = cachedApps == null || targets == null
 
-    if (moduleInstalled == false) {
+    if (targets?.portsModuleInstalled == false) {
         NotInstalledCard(modifier = modifier)
         return
     }
-    // moduleInstalled == null → still detecting; the `loading` spinner below covers it.
 
     val filteredApps =
         remember(allApps, searchQuery, showSystem, showRussianOnly) {
@@ -318,6 +296,7 @@ fun PortsHidingScreen(
                 if (exitCode == 0) {
                     snackMessage = context.getString(R.string.ports_save_success, observerPkgs.size)
                     DashboardCache.invalidate()
+                    TargetsCache.refresh(scope, context)
                 } else if (exitCode == -1) {
                     snackMessage = context.getString(R.string.save_failed_root)
                     dirty = true

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/TargetsCache.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/TargetsCache.kt
@@ -1,0 +1,182 @@
+package dev.okhsunrog.vpnhide
+
+import android.content.Context
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+
+/**
+ * Per-screen protection state from root-owned files and package
+ * manager lookups, cached once for the lifetime of the app session.
+ *
+ * Without this cache, every tab switch into Protection triggered 3-4
+ * sequential `suExec` roundtrips per screen. Root shell roundtrips
+ * are ~50-100ms each on most devices, so a single tab switch added
+ * hundreds of milliseconds of "loading" time even after AppListCache
+ * made the package list itself instant. Bundling every read into a
+ * single batched shell invocation + caching the result means subsequent
+ * tab switches render immediately from memory.
+ *
+ * Invalidated when:
+ * - The user taps Save on any Protection screen (target files have
+ *   just been overwritten — need a fresh read next time).
+ * - The user taps the top-bar Refresh button on Protection.
+ */
+internal data class TargetsSnapshot(
+    val kmodModuleInstalled: Boolean,
+    val zygiskModuleInstalled: Boolean,
+    val portsModuleInstalled: Boolean,
+    val kmodTargets: Set<String>,
+    val zygiskTargets: Set<String>,
+    val lsposedTargets: Set<String>,
+    val hiddenPkgs: Set<String>,
+    val observerUids: Set<Int>,
+    val portsObservers: Set<String>,
+    val uidToPkg: Map<Int, String>,
+) {
+    /** Observer UIDs resolved back to current package names via
+     * `pm list packages -U`. UIDs that no longer map to an installed
+     * package (e.g. after an uninstall) silently drop out.
+     */
+    val observerNames: Set<String>
+        get() = observerUids.mapNotNull { uidToPkg[it] }.toSet()
+}
+
+internal object TargetsCache {
+    private val _snapshot = MutableStateFlow<TargetsSnapshot?>(null)
+    val snapshot: StateFlow<TargetsSnapshot?> = _snapshot.asStateFlow()
+
+    private val _loading = MutableStateFlow(false)
+    val loading: StateFlow<Boolean> = _loading.asStateFlow()
+
+    private var inflight: Job? = null
+
+    fun ensureLoaded(
+        scope: CoroutineScope,
+        context: Context,
+    ) {
+        if (_snapshot.value != null || inflight?.isActive == true) return
+        inflight = scope.launch { reload(context.applicationContext) }
+    }
+
+    fun refresh(
+        scope: CoroutineScope,
+        context: Context,
+    ) {
+        inflight?.cancel()
+        inflight = scope.launch { reload(context.applicationContext) }
+    }
+
+    /** Drop the cached snapshot so the next subscriber triggers a
+     * fresh load. Save handlers call this because they just mutated
+     * one of the files this cache mirrors.
+     */
+    fun invalidate() {
+        _snapshot.value = null
+    }
+
+    // Bundle every read into a single `suExec` call separated by
+    // distinctive banner lines. One root roundtrip beats 8 serial
+    // ones — PM + 7 cats typically take <100ms this way.
+    private const val SENTINEL = "===VPNHIDE-TARGETS-BOUNDARY==="
+    private const val END = "===VPNHIDE-TARGETS-END==="
+
+    private val BATCH_SCRIPT =
+        """
+        echo "$SENTINEL KMOD_MODULE_DIR"
+        [ -d $KMOD_MODULE_DIR ] && echo 1 || echo 0
+        echo "$SENTINEL ZYGISK_MODULE_DIR"
+        [ -d $ZYGISK_MODULE_DIR ] && echo 1 || echo 0
+        echo "$SENTINEL PORTS_MODULE_PROP"
+        cat $PORTS_MODULE_DIR/module.prop 2>/dev/null || true
+        echo "$SENTINEL KMOD_TARGETS"
+        cat $KMOD_TARGETS 2>/dev/null || true
+        echo "$SENTINEL ZYGISK_TARGETS"
+        cat $ZYGISK_TARGETS 2>/dev/null || true
+        echo "$SENTINEL LSPOSED_TARGETS"
+        cat $LSPOSED_TARGETS 2>/dev/null || true
+        echo "$SENTINEL HIDDEN_PKGS"
+        cat $SS_HIDDEN_PKGS_FILE 2>/dev/null || true
+        echo "$SENTINEL OBSERVER_UIDS"
+        cat $SS_OBSERVER_UIDS_FILE 2>/dev/null || true
+        echo "$SENTINEL PORTS_OBSERVERS"
+        cat $PORTS_OBSERVERS_FILE 2>/dev/null || true
+        echo "$SENTINEL PM_LIST"
+        pm list packages -U 2>/dev/null || true
+        echo "$END"
+        """.trimIndent()
+
+    private suspend fun reload(
+        @Suppress("UNUSED_PARAMETER") appContext: Context,
+    ) {
+        _loading.value = true
+        try {
+            val (_, out) =
+                withContext(Dispatchers.IO) { suExec(BATCH_SCRIPT) }
+            _snapshot.value = parse(out)
+        } finally {
+            _loading.value = false
+        }
+    }
+
+    private fun parse(out: String): TargetsSnapshot {
+        val sections = mutableMapOf<String, String>()
+        var currentKey: String? = null
+        val buf = StringBuilder()
+        for (line in out.lines()) {
+            when {
+                line.startsWith(SENTINEL) -> {
+                    currentKey?.let { sections[it] = buf.toString() }
+                    buf.clear()
+                    currentKey = line.removePrefix("$SENTINEL ").trim()
+                }
+
+                line.startsWith(END) -> {
+                    currentKey?.let { sections[it] = buf.toString() }
+                    currentKey = null
+                }
+
+                currentKey != null -> {
+                    buf.appendLine(line)
+                }
+            }
+        }
+
+        fun nonEmptyLines(raw: String?): Set<String> =
+            raw
+                ?.lines()
+                ?.map { it.trim() }
+                ?.filter { it.isNotEmpty() && !it.startsWith("#") }
+                ?.toSet() ?: emptySet()
+
+        val portsInstalled = sections["PORTS_MODULE_PROP"]?.isNotBlank() == true
+        val observerUids = nonEmptyLines(sections["OBSERVER_UIDS"]).mapNotNull { it.toIntOrNull() }.toSet()
+
+        val pmLine = Regex("^package:(\\S+) uid:(\\d+)")
+        val uidToPkg =
+            sections["PM_LIST"]
+                ?.lines()
+                ?.mapNotNull { line ->
+                    val m = pmLine.find(line) ?: return@mapNotNull null
+                    m.groupValues[2].toInt() to m.groupValues[1]
+                }?.toMap() ?: emptyMap()
+
+        return TargetsSnapshot(
+            kmodModuleInstalled = sections["KMOD_MODULE_DIR"]?.trim() == "1",
+            zygiskModuleInstalled = sections["ZYGISK_MODULE_DIR"]?.trim() == "1",
+            portsModuleInstalled = portsInstalled,
+            kmodTargets = nonEmptyLines(sections["KMOD_TARGETS"]),
+            zygiskTargets = nonEmptyLines(sections["ZYGISK_TARGETS"]),
+            lsposedTargets = nonEmptyLines(sections["LSPOSED_TARGETS"]),
+            hiddenPkgs = nonEmptyLines(sections["HIDDEN_PKGS"]),
+            observerUids = observerUids,
+            portsObservers = nonEmptyLines(sections["PORTS_OBSERVERS"]),
+            uidToPkg = uidToPkg,
+        )
+    }
+}

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/VpnOffPrompt.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/VpnOffPrompt.kt
@@ -1,0 +1,57 @@
+package dev.okhsunrog.vpnhide
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Button
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+
+/**
+ * Shared banner + retry button for the "VPN is not active, please turn
+ * it on and re-run the checks" state. Used both on the Dashboard
+ * protection panel and the Diagnostics screen so the UX is identical.
+ */
+@Composable
+internal fun VpnOffPrompt(
+    onRetry: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Card(
+        modifier = modifier.fillMaxWidth(),
+        shape = RoundedCornerShape(12.dp),
+        colors =
+            CardDefaults.cardColors(
+                containerColor = MaterialTheme.colorScheme.surfaceVariant,
+                contentColor = MaterialTheme.colorScheme.onSurfaceVariant,
+            ),
+    ) {
+        Column(
+            modifier = Modifier.padding(16.dp),
+            horizontalAlignment = Alignment.CenterHorizontally,
+        ) {
+            Text(
+                text = stringResource(R.string.vpn_off_prompt),
+                style = MaterialTheme.typography.bodyMedium,
+            )
+            Spacer(Modifier.height(12.dp))
+            Button(
+                onClick = onRetry,
+                modifier = Modifier.fillMaxWidth(),
+            ) {
+                Text(stringResource(R.string.vpn_off_retry))
+            }
+        }
+    }
+}

--- a/lsposed/app/src/main/res/values-ru/strings.xml
+++ b/lsposed/app/src/main/res/values-ru/strings.xml
@@ -78,6 +78,8 @@
     <string name="dashboard_protection_hooks_inactive">Хуки неактивны</string>
     <string name="dashboard_needs_restart">Приложение только что добавлено в список целей. Перезапустите приложение для проверки защиты.</string>
     <string name="dashboard_no_vpn">VPN не активен. Включите VPN для проверки защиты.</string>
+    <string name="vpn_off_prompt">VPN не активен. Включите его и нажмите «Повторить», чтобы запустить проверку защиты. Результаты кэшируются до перезапуска приложения — повторно гонять не нужно.</string>
+    <string name="vpn_off_retry">Повторить</string>
     <string name="dashboard_install_recommendation_title">Рекомендация по установке</string>
     <string name="dashboard_install_recommendation_device">Ваше устройство: %1$s, ядро %2$s</string>
     <string name="dashboard_install_recommendation_kmod">Рекомендуется модуль ядра. Скачайте %1$s.</string>

--- a/lsposed/app/src/main/res/values/strings.xml
+++ b/lsposed/app/src/main/res/values/strings.xml
@@ -109,6 +109,8 @@
     <string name="dashboard_protection_hooks_inactive">Hooks inactive</string>
     <string name="dashboard_needs_restart">App was just added to targets. Restart the app to check protection.</string>
     <string name="dashboard_no_vpn">No active VPN. Turn on VPN to check protection status.</string>
+    <string name="vpn_off_prompt">No active VPN. Turn it on, then tap Retry to run the protection checks. Results are cached for the rest of this app session — no need to re-run later.</string>
+    <string name="vpn_off_retry">Retry</string>
     <string name="dashboard_install_recommendation_title">Installation recommendation</string>
     <string name="dashboard_install_recommendation_device">Your device: %1$s, kernel %2$s</string>
     <string name="dashboard_install_recommendation_kmod">Kernel module is recommended. Download %1$s.</string>


### PR DESCRIPTION
## Why

Closing out the "instant tab switches" thread from #53 / #54. Before
this PR, Diagnostics re-ran every root-shell probe on each tab switch
(~500ms of check functions) and Protection re-ran 2-4 root roundtrips
per screen. Stacking up to noticeable lag every time you flipped tabs,
even though the underlying state only changes on explicit user actions
(Save) or a process restart (new module loaded, etc.).

## Summary

### DiagnosticsCache
State machine — NotRun → Running → Ready (or VpnOff). Once Ready the
result is fixed for the lifetime of the process; hooks (kmod at boot,
LSPosed in system_server, Zygisk at zygote fork) don't change
mid-session, so there's nothing to re-run. Both Dashboard's Protection
status section and the Diagnostics screen subscribe.

### TargetsCache
Every root read each Protection screen used to do individually — module
directory checks, kmod / zygisk / LSPosed targets, hidden packages,
observer UIDs, ports observers, \`pm list packages -U\`, module.prop
probes — collapsed into a single batched \`suExec\` collected at startup.
8 serial root roundtrips → 1. Invalidated on Save / top-bar Refresh.

### Shared VpnOffPrompt
Banner + Retry button used on both Dashboard (\`ProtectionCheck.NoVpn\`
case) and Diagnostics (\`State.VpnOff\` case). Retry refreshes both
caches so the state stays consistent across screens.

### Diagnostics layout
Split into two independent sections: protection checks on top (changes
with state), log-capture tools (debug logging toggle, logcat recorder,
debug-zip export) always below. Previously those tools vanished when
VPN was off — cutting users off from the tools they need to send a bug
report.

### Visibility changes
\`CheckResults\`, \`isVpnActive\`, \`runAllChecks\` promoted from \`private\`
to \`internal\` so \`DiagnosticsCache\` can call them.

### Save handlers
\`AppPicker\` / \`AppHiding\` / \`PortsHiding\` call
\`TargetsCache.refresh()\` after a successful save so the fresh
on-disk state is picked up without a tab-switch detour.