### PR TITLE
perf(lsposed): pre-warm DiagnosticsCache at app launch

### DIFF
--- a/changelog.d/changed-diagnostics-tab-opens-instantly-even-on-0580.md
+++ b/changelog.d/changed-diagnostics-tab-opens-instantly-even-on-0580.md
@@ -1,0 +1,9 @@
+_2026-04-20_
+
+## English
+
+Diagnostics tab opens instantly even on the first time you tap it. The cache that stores the protection-check results now starts running in the background as soon as the app launches, instead of waiting for you to navigate to the tab — by the time you switch from Dashboard to Diagnostics, the results are usually already there.
+
+## Русский
+
+Вкладка «Диагностика» открывается мгновенно даже при первом переходе. Кэш с результатами проверок защиты теперь запускается в фоне сразу при старте приложения, а не ждёт пока вы перейдёте на вкладку — к моменту переключения с «Обзор» на «Диагностику» результаты обычно уже готовы.

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/MainActivity.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/MainActivity.kt
@@ -124,6 +124,17 @@ private fun MainScreen() {
         TargetsCache.ensureLoaded(scope, context)
     }
 
+    // Pre-warm the Diagnostics cache once we know we're not in the
+    // selfNeedsRestart "just-added-myself, hooks not in this process
+    // yet" state. By the time the user switches to the Diagnostics
+    // tab, runAllChecks has already produced Ready — no spinner on
+    // first open of the tab.
+    LaunchedEffect(selfNeedsRestart) {
+        if (selfNeedsRestart == false) {
+            DiagnosticsCache.run(scope, context)
+        }
+    }
+
     // Kick the update check once (silently) on first launch, and again
     // on ON_RESUME if it's been a while. Listener lives as long as
     // MainScreen is composed.


### PR DESCRIPTION
## Why

\`DiagnosticsCache\` only kicked \`runAllChecks\` the first time the user
opened the Diagnostics tab. That left one stale spinner on first
navigation even after the rest of the caching work made the other tabs
instant.

## Summary

\`MainActivity\` now calls \`DiagnosticsCache.run(scope, context)\` from a
new \`LaunchedEffect(selfNeedsRestart)\` — fires as soon as we know
\`selfNeedsRestart == false\` (the same gate \`DiagnosticsScreen\` already
uses). \`run\` is idempotent (no-op when Ready or Running), so any later
call from the screen itself is harmless.

By the time the user switches from Dashboard to Diagnostics,
\`runAllChecks\` has typically finished and the tab renders with results
already in place — no spinner on first open.

If \`selfNeedsRestart\` is true, the pre-warm is skipped (hooks aren't in
this process yet, so a run would be meaningless).