### PR TITLE
fix(ci): fix docker image pull errors for forks with uppercase usernames

### DIFF
--- a/.github/workflows/ci-image.yml
+++ b/.github/workflows/ci-image.yml
@@ -30,19 +30,16 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Extract metadata
-        id: meta
-        uses: docker/metadata-action@v6
-        with:
-          images: ghcr.io/${{ github.repository }}/ci
-          tags: type=raw,value=latest
+      - id: img
+        env:
+          REPO: ${{ github.repository }}
+        run: echo "image=ghcr.io/${REPO,,}/ci:latest" >> "$GITHUB_OUTPUT"
 
       - name: Build and push
         uses: docker/build-push-action@v6
         with:
           context: .github/docker/ci
           push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
+          tags: ${{ steps.img.outputs.image }}
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/.github/workflows/ci-image.yml
+++ b/.github/workflows/ci-image.yml
@@ -30,17 +30,19 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Lowercase repository name
-        id: lower
-        run: |
-          REPO=$(echo "${{ github.repository }}" | tr '[:upper:]' '[:lower:]')
-          echo "repo=$REPO" >> "$GITHUB_OUTPUT"
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v6
+        with:
+          images: ghcr.io/${{ github.repository }}/ci
+          tags: type=raw,value=latest
 
       - name: Build and push
         uses: docker/build-push-action@v6
         with:
           context: .github/docker/ci
           push: true
-          tags: ghcr.io/${{ steps.lower.outputs.repo }}/ci:latest
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/.github/workflows/ci-image.yml
+++ b/.github/workflows/ci-image.yml
@@ -30,11 +30,17 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Lowercase repository name
+        id: lower
+        run: |
+          REPO=$(echo "${{ github.repository }}" | tr '[:upper:]' '[:lower:]')
+          echo "repo=$REPO" >> "$GITHUB_OUTPUT"
+
       - name: Build and push
         uses: docker/build-push-action@v6
         with:
           context: .github/docker/ci
           push: true
-          tags: ghcr.io/${{ github.repository }}/ci:latest
+          tags: ghcr.io/${{ steps.lower.outputs.repo }}/ci:latest
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,18 +15,20 @@ jobs:
   setup:
     runs-on: ubuntu-latest
     outputs:
-      image_name: ${{ steps.lower.outputs.repo }}
+      image_name: ${{ steps.meta.outputs.tags }}
     steps:
-      - id: lower
-        run: |
-          REPO=$(echo "${{ github.repository }}" | tr '[:upper:]' '[:lower:]')
-          echo "repo=$REPO" >> "$GITHUB_OUTPUT"
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v6
+        with:
+          images: ghcr.io/${{ github.repository }}/ci
+          tags: type=raw,value=latest
 
   lint:
     needs: setup
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/${{ needs.setup.outputs.image_name }}/ci:latest
+      image: ${{ needs.setup.outputs.image_name }}
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
@@ -121,7 +123,7 @@ jobs:
     needs: setup
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/${{ needs.setup.outputs.image_name }}/ci:latest
+      image: ${{ needs.setup.outputs.image_name }}
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
@@ -163,7 +165,7 @@ jobs:
     needs: setup
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/${{ needs.setup.outputs.image_name }}/ci:latest
+      image: ${{ needs.setup.outputs.image_name }}
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,20 +15,18 @@ jobs:
   setup:
     runs-on: ubuntu-latest
     outputs:
-      image_name: ${{ steps.meta.outputs.tags }}
+      image: ${{ steps.img.outputs.image }}
     steps:
-      - name: Extract metadata
-        id: meta
-        uses: docker/metadata-action@v6
-        with:
-          images: ghcr.io/${{ github.repository }}/ci
-          tags: type=raw,value=latest
+      - id: img
+        env:
+          REPO: ${{ github.repository }}
+        run: echo "image=ghcr.io/${REPO,,}/ci:latest" >> "$GITHUB_OUTPUT"
 
   lint:
     needs: setup
     runs-on: ubuntu-latest
     container:
-      image: ${{ needs.setup.outputs.image_name }}
+      image: ${{ needs.setup.outputs.image }}
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
@@ -123,7 +121,7 @@ jobs:
     needs: setup
     runs-on: ubuntu-latest
     container:
-      image: ${{ needs.setup.outputs.image_name }}
+      image: ${{ needs.setup.outputs.image }}
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
@@ -165,7 +163,7 @@ jobs:
     needs: setup
     runs-on: ubuntu-latest
     container:
-      image: ${{ needs.setup.outputs.image_name }}
+      image: ${{ needs.setup.outputs.image }}
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,10 +12,21 @@ permissions:
   packages: read
 
 jobs:
+  setup:
+    runs-on: ubuntu-latest
+    outputs:
+      image_name: ${{ steps.lower.outputs.repo }}
+    steps:
+      - id: lower
+        run: |
+          REPO=$(echo "${{ github.repository }}" | tr '[:upper:]' '[:lower:]')
+          echo "repo=$REPO" >> "$GITHUB_OUTPUT"
+
   lint:
+    needs: setup
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/${{ github.repository }}/ci:latest
+      image: ghcr.io/${{ needs.setup.outputs.image_name }}/ci:latest
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
@@ -107,9 +118,10 @@ jobs:
           if-no-files-found: error
 
   zygisk:
+    needs: setup
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/${{ github.repository }}/ci:latest
+      image: ghcr.io/${{ needs.setup.outputs.image_name }}/ci:latest
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
@@ -148,9 +160,10 @@ jobs:
           if-no-files-found: error
 
   lsposed:
+    needs: setup
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/${{ github.repository }}/ci:latest
+      image: ghcr.io/${{ needs.setup.outputs.image_name }}/ci:latest
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
When a user with capital letters in their username (e.g., `BlueGradientHorizon`) forks this repository, the CI workflows fail immediately with an `invalid reference format` error. This happens because GitHub Actions evaluates the `${{ github.repository }}` variable with its exact original casing, but Docker strictly requires all image references to be entirely lowercase. 

Instead of directly interpolating `${{ github.repository }}` into the `container:` and `tags:` fields, I implemented the official `docker/metadata-action`. 

This action automatically extracts the repository data and safely formats it (including lowercasing the repository name) to comply with Docker's strict naming rules. 
* In `ci-image.yml`, it dynamically generates the correct lowercase tags to build and push the image.
* In `ci.yml`, a lightweight `setup` job now uses the metadata action to generate the safe image string and passes it as an output to the `lint`, `zygisk`, and `lsposed` jobs.

This ensures that the CI workflows will run successfully out-of-the-box for all forks, regardless of the user's casing.