### PR TITLE
fix(lsposed): recommend kmod on custom kernels missing the GKI KMI tag

### DIFF
--- a/changelog.d/fixed-kmod-active-overrides-unsupported-708a.md
+++ b/changelog.d/fixed-kmod-active-overrides-unsupported-708a.md
@@ -1,0 +1,9 @@
+_2026-04-20_
+
+## English
+
+Kmod install recommendation no longer falsely pushes users to Zygisk on custom kernels whose `uname -r` lacks the GKI KMI tag (e.g. `android12`, `android13`). The heuristic now matches only the parsed KMI — not the phone's Android OS release, which is an unrelated label — and falls back on kernel series when the KMI is missing: 6.1 / 6.6 / 6.12 each ship a single KMI variant and are still unambiguous; 5.10 and 5.15 each have two candidates, both of which the app now surfaces (primary + alternative), with a dedicated banner when the installed variant fails to load so the user knows to try the other. An active kmod — `/proc/vpnhide_targets` present — also overrides any remaining heuristic-driven warning.
+
+## Русский
+
+Рекомендация установки модуля ядра больше не подталкивает ложно к Zygisk на кастомных ядрах, в `uname -r` которых нет GKI KMI-метки (`android12`, `android13` и т.д.). Эвристика теперь сопоставляет только распарсенный KMI — версия Android OS телефона к этому не относится — и при отсутствии KMI делает fallback по серии ядра: для 6.1, 6.6 и 6.12 существует по одному KMI-варианту, рекомендация однозначна; у 5.10 и 5.15 по два кандидата, приложение теперь показывает оба (основной + альтернативный) и отдельный баннер, когда установленный вариант не загрузился — чтобы было понятно, что нужно попробовать второй. Активный kmod (`/proc/vpnhide_targets` существует) также имеет приоритет над любыми эвристическими предупреждениями.

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DashboardData.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DashboardData.kt
@@ -681,18 +681,21 @@ internal fun loadDashboardState(
     //    all (non-GKI / unsupported combo) — we recommend zygisk instead so
     //    the user doesn't wait for the kmod to "just work".
     val recommendedKmi = kernelRecommendation?.recommendedGkiVariant
-    // Two cross-cutting gates on every heuristic-driven kmod warning:
+    // Two cross-cutting gates on kmod warnings:
     //   !kmodRaw.active — an active kmod (/proc/vpnhide_targets present)
-    //     is empirical proof the installation works, so a heuristic saying
-    //     otherwise is wrong.
-    //   kmodLoadStatus?.freshForCurrentBoot == true (on UnsupportedKernel /
-    //     AmbiguousLoadFailed) — only fire after post-fs-data has attempted
-    //     insmod this boot, so a freshly-installed-but-not-rebooted module
-    //     isn't prematurely flagged.
+    //     is empirical proof the installation works, so a heuristic
+    //     saying otherwise is wrong. Applied to every warning below.
+    //   kmodLoadStatus?.freshForCurrentBoot == true (AmbiguousLoadFailed
+    //     only) — that warning is specifically about "the module we
+    //     installed tried to insmod this boot and failed, pick the
+    //     other candidate", so it only makes sense once post-fs-data
+    //     has actually attempted a load. The other warnings are
+    //     deterministic from the variant stamp / kernel-series tables
+    //     and are valid even before the first post-install boot.
     // For an ambiguous recommendation (variantAmbiguous=true), either
-    // candidate is a valid install, so kmodVariantMismatch must check both
-    // recommendedGkiVariant AND alternativeGkiVariant before deciding it's
-    // a real mismatch.
+    // candidate is a valid install, so kmodVariantMismatch must check
+    // both recommendedGkiVariant AND alternativeGkiVariant before
+    // deciding it's a real mismatch.
     val kmodVariantMismatch =
         kmodRaw is ModuleState.Installed &&
             !kmodRaw.active &&
@@ -709,7 +712,6 @@ internal fun loadDashboardState(
     val kmodOnUnsupportedKernel =
         kmodRaw is ModuleState.Installed &&
             !kmodRaw.active &&
-            kmodLoadStatus?.freshForCurrentBoot == true &&
             kernelRecommendation != null &&
             !kernelRecommendation.preferKmod
     // User installed one of the two candidates for an ambiguous GKI series

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DashboardData.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DashboardData.kt
@@ -32,6 +32,7 @@ enum class KmodBrokenReason {
     UnsupportedKernel,
     MissingKprobes,
     UnknownVariantInactive,
+    AmbiguousLoadFailed,
 }
 
 sealed interface LsposedState {
@@ -162,6 +163,15 @@ internal data class NativeInstallRecommendation(
     val recommendedArtifact: String,
     val recommendedGkiVariant: String?,
     val preferKmod: Boolean,
+    // Set when the kernel's GKI KMI couldn't be parsed from uname -r but the
+    // kernel series ships with multiple KMI variants (5.10: android12 / 13;
+    // 5.15: android13 / 14). Both candidates are valid picks — the UI shows
+    // the primary plus "if it doesn't load, try the alternative". Series with
+    // a single shipping variant (6.1 / 6.6 / 6.12) stay unambiguous even
+    // without a KMI tag.
+    val variantAmbiguous: Boolean = false,
+    val alternativeArtifact: String? = null,
+    val alternativeGkiVariant: String? = null,
 )
 
 // Boot-time diagnostics written by kmod/module/post-fs-data.sh into
@@ -339,15 +349,22 @@ internal fun loadDashboardState(
         val (_, kernelRaw) = suExec("uname -r 2>/dev/null")
         val kernelVersion = kernelRaw.trim().ifBlank { return null }
         val kernelSeries = parseKernelSeries(kernelVersion)
-        val kernelBranch = parseKernelAndroidBranch(kernelVersion)
-        val artifactKeyVersion = kernelBranch ?: androidMajorVersionLabel()
+        val kernelBranch = parseKernelAndroidBranch(kernelVersion) // GKI KMI
+        // User-facing device label only — never used for KMI matching below.
+        val deviceAndroidLabel = androidMajorVersionLabel()
 
         data class KmiMatch(
             val kmi: String,
             val zip: String,
         )
-        val supported =
-            when (artifactKeyVersion to kernelSeries) {
+
+        // Try exact KMI × series match. kernelBranch here is the GKI KMI
+        // extracted from uname -r, NOT the phone's Android OS release —
+        // these are independent spaces (an Android 15 ROM commonly runs an
+        // android12 KMI kernel), so we must not fall back to
+        // Build.VERSION.RELEASE here.
+        val exact: KmiMatch? =
+            when (kernelBranch to kernelSeries) {
                 "Android 12" to "5.10" -> KmiMatch("android12-5.10", "vpnhide-kmod-android12-5.10.zip")
                 "Android 13" to "5.10" -> KmiMatch("android13-5.10", "vpnhide-kmod-android13-5.10.zip")
                 "Android 13" to "5.15" -> KmiMatch("android13-5.15", "vpnhide-kmod-android13-5.15.zip")
@@ -357,26 +374,75 @@ internal fun loadDashboardState(
                 "Android 16" to "6.12" -> KmiMatch("android16-6.12", "vpnhide-kmod-android16-6.12.zip")
                 else -> null
             }
-
-        return if (supported != null) {
-            NativeInstallRecommendation(
-                androidVersion = artifactKeyVersion,
+        if (exact != null) {
+            return NativeInstallRecommendation(
+                androidVersion = deviceAndroidLabel,
                 kernelVersion = kernelVersion,
                 kernelBranch = kernelBranch,
-                recommendedArtifact = supported.zip,
-                recommendedGkiVariant = supported.kmi,
+                recommendedArtifact = exact.zip,
+                recommendedGkiVariant = exact.kmi,
                 preferKmod = true,
             )
-        } else {
-            NativeInstallRecommendation(
-                androidVersion = artifactKeyVersion,
+        }
+
+        // No KMI in uname (custom kernel stripped it). Fall back on kernel
+        // series alone. For 6.1 / 6.6 / 6.12 we ship a single KMI variant —
+        // the recommendation is still deterministic. For 5.10 / 5.15 two
+        // variants ship, so we surface both via variantAmbiguous and let
+        // the UI tell the user to try the alternative if the primary fails.
+        val fallback: Pair<KmiMatch, KmiMatch?>? =
+            when (kernelSeries) {
+                "5.10" -> {
+                    KmiMatch("android12-5.10", "vpnhide-kmod-android12-5.10.zip") to
+                        KmiMatch("android13-5.10", "vpnhide-kmod-android13-5.10.zip")
+                }
+
+                "5.15" -> {
+                    KmiMatch("android13-5.15", "vpnhide-kmod-android13-5.15.zip") to
+                        KmiMatch("android14-5.15", "vpnhide-kmod-android14-5.15.zip")
+                }
+
+                "6.1" -> {
+                    KmiMatch("android14-6.1", "vpnhide-kmod-android14-6.1.zip") to null
+                }
+
+                "6.6" -> {
+                    KmiMatch("android15-6.6", "vpnhide-kmod-android15-6.6.zip") to null
+                }
+
+                "6.12" -> {
+                    KmiMatch("android16-6.12", "vpnhide-kmod-android16-6.12.zip") to null
+                }
+
+                else -> {
+                    null
+                }
+            }
+        if (fallback != null) {
+            val (primary, alternative) = fallback
+            return NativeInstallRecommendation(
+                androidVersion = deviceAndroidLabel,
                 kernelVersion = kernelVersion,
                 kernelBranch = kernelBranch,
-                recommendedArtifact = "vpnhide-zygisk.zip",
-                recommendedGkiVariant = null,
-                preferKmod = false,
+                recommendedArtifact = primary.zip,
+                recommendedGkiVariant = primary.kmi,
+                preferKmod = true,
+                variantAmbiguous = alternative != null,
+                alternativeArtifact = alternative?.zip,
+                alternativeGkiVariant = alternative?.kmi,
             )
         }
+
+        // Pre-GKI series (<5.10) or unparseable — kmod binaries we ship
+        // can't load against such kernels' Module.symvers. Recommend zygisk.
+        return NativeInstallRecommendation(
+            androidVersion = deviceAndroidLabel,
+            kernelVersion = kernelVersion,
+            kernelBranch = kernelBranch,
+            recommendedArtifact = "vpnhide-zygisk.zip",
+            recommendedGkiVariant = null,
+            preferKmod = false,
+        )
     }
 
     fun readKmodLoadStatus(currentBootId: String): KmodLoadStatus? {
@@ -615,12 +681,26 @@ internal fun loadDashboardState(
     //    all (non-GKI / unsupported combo) — we recommend zygisk instead so
     //    the user doesn't wait for the kmod to "just work".
     val recommendedKmi = kernelRecommendation?.recommendedGkiVariant
+    // Two cross-cutting gates on every heuristic-driven kmod warning:
+    //   !kmodRaw.active — an active kmod (/proc/vpnhide_targets present)
+    //     is empirical proof the installation works, so a heuristic saying
+    //     otherwise is wrong.
+    //   kmodLoadStatus?.freshForCurrentBoot == true (on UnsupportedKernel /
+    //     AmbiguousLoadFailed) — only fire after post-fs-data has attempted
+    //     insmod this boot, so a freshly-installed-but-not-rebooted module
+    //     isn't prematurely flagged.
+    // For an ambiguous recommendation (variantAmbiguous=true), either
+    // candidate is a valid install, so kmodVariantMismatch must check both
+    // recommendedGkiVariant AND alternativeGkiVariant before deciding it's
+    // a real mismatch.
     val kmodVariantMismatch =
         kmodRaw is ModuleState.Installed &&
+            !kmodRaw.active &&
             kernelRecommendation?.preferKmod == true &&
             recommendedKmi != null &&
             kmodRaw.gkiVariant != null &&
-            kmodRaw.gkiVariant != recommendedKmi
+            kmodRaw.gkiVariant != recommendedKmi &&
+            kmodRaw.gkiVariant != kernelRecommendation.alternativeGkiVariant
     val kmodUnknownVariantBroken =
         kmodRaw is ModuleState.Installed &&
             !kmodRaw.active &&
@@ -628,13 +708,30 @@ internal fun loadDashboardState(
             kernelRecommendation?.preferKmod == true
     val kmodOnUnsupportedKernel =
         kmodRaw is ModuleState.Installed &&
+            !kmodRaw.active &&
+            kmodLoadStatus?.freshForCurrentBoot == true &&
             kernelRecommendation != null &&
             !kernelRecommendation.preferKmod
+    // User installed one of the two candidates for an ambiguous GKI series
+    // (5.10 / 5.15) and it failed to load this boot — suggest the other.
+    val kmodAmbiguousLoadFailed =
+        kmodRaw is ModuleState.Installed &&
+            !kmodRaw.active &&
+            kmodLoadStatus?.freshForCurrentBoot == true &&
+            kernelRecommendation?.variantAmbiguous == true &&
+            kmodRaw.gkiVariant != null &&
+            (
+                kmodRaw.gkiVariant == kernelRecommendation.recommendedGkiVariant ||
+                    kmodRaw.gkiVariant == kernelRecommendation.alternativeGkiVariant
+            )
     val kprobesMissing =
         kmodLoadStatus?.freshForCurrentBoot == true && kmodLoadStatus.kretprobes == "n"
-    // Priority matches the Error emission below so the card color agrees with
-    // the banner: kprobes-missing first, then unsupported-kernel, then wrong-
-    // variant, then unknown-variant-inactive.
+    // Priority matches the Error emission below so the card color agrees
+    // with the banner: kprobes-missing first, then unsupported-kernel,
+    // then wrong-variant, then unknown-variant-inactive, then
+    // ambiguous-load-failed (falls to this only when the installed kmod is
+    // one of the ambiguous candidates — the mismatch branches above already
+    // excluded both candidates from "wrong variant").
     val kmodBrokenReason: KmodBrokenReason? =
         when {
             kmodRaw !is ModuleState.Installed -> null
@@ -642,6 +739,7 @@ internal fun loadDashboardState(
             kmodOnUnsupportedKernel -> KmodBrokenReason.UnsupportedKernel
             kmodVariantMismatch -> KmodBrokenReason.WrongVariant
             kmodUnknownVariantBroken -> KmodBrokenReason.UnknownVariantInactive
+            kmodAmbiguousLoadFailed -> KmodBrokenReason.AmbiguousLoadFailed
             else -> null
         }
     val kmod: ModuleState =
@@ -914,6 +1012,23 @@ internal fun loadDashboardState(
                     res.getString(
                         R.string.dashboard_issue_kmod_unknown_variant,
                         recommendedArtifact,
+                    ),
+                )
+            }
+
+            kmodAmbiguousLoadFailed -> {
+                val installed = (kmod as ModuleState.Installed).gkiVariant
+                val tryArtifact =
+                    if (installed == kernelRecommendation?.recommendedGkiVariant) {
+                        kernelRecommendation.alternativeArtifact
+                    } else {
+                        kernelRecommendation?.recommendedArtifact
+                    }
+                err(
+                    res.getString(
+                        R.string.dashboard_issue_kmod_ambiguous_try_alternative,
+                        installed ?: "?",
+                        tryArtifact ?: "?",
                     ),
                 )
             }

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DashboardScreen.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DashboardScreen.kt
@@ -231,6 +231,7 @@ private fun ModuleCard(
                     KmodBrokenReason.UnsupportedKernel -> R.string.dashboard_kmod_broken_unsupported_kernel
                     KmodBrokenReason.MissingKprobes -> R.string.dashboard_kmod_broken_no_kprobes
                     KmodBrokenReason.UnknownVariantInactive -> R.string.dashboard_kmod_broken_unknown_variant
+                    KmodBrokenReason.AmbiguousLoadFailed -> R.string.dashboard_kmod_broken_ambiguous
                     null -> null
                 }
             ModuleCardShell(
@@ -404,18 +405,31 @@ private fun NativeInstallRecommendationCard(recommendation: NativeInstallRecomme
                 style = MaterialTheme.typography.bodyMedium,
             )
             Spacer(Modifier.height(8.dp))
+            val alternative = recommendation.alternativeArtifact
             Text(
                 text =
-                    if (recommendation.preferKmod) {
-                        stringResource(
-                            R.string.dashboard_install_recommendation_kmod,
-                            recommendation.recommendedArtifact,
-                        )
-                    } else {
-                        stringResource(
-                            R.string.dashboard_install_recommendation_zygisk,
-                            recommendation.recommendedArtifact,
-                        )
+                    when {
+                        !recommendation.preferKmod -> {
+                            stringResource(
+                                R.string.dashboard_install_recommendation_zygisk,
+                                recommendation.recommendedArtifact,
+                            )
+                        }
+
+                        recommendation.variantAmbiguous && alternative != null -> {
+                            stringResource(
+                                R.string.dashboard_install_recommendation_kmod_ambiguous,
+                                recommendation.recommendedArtifact,
+                                alternative,
+                            )
+                        }
+
+                        else -> {
+                            stringResource(
+                                R.string.dashboard_install_recommendation_kmod,
+                                recommendation.recommendedArtifact,
+                            )
+                        }
                     },
                 style = MaterialTheme.typography.bodyMedium,
                 fontWeight = FontWeight.Medium,

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DashboardScreen.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DashboardScreen.kt
@@ -17,6 +17,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import kotlinx.coroutines.Dispatchers
@@ -404,6 +405,26 @@ private fun NativeInstallRecommendationCard(recommendation: NativeInstallRecomme
                     ),
                 style = MaterialTheme.typography.bodyMedium,
             )
+            // Disambiguate the GKI KMI tag baked into uname -r (e.g.
+            // "android12-5.10") from the device's Android OS release on
+            // devices where they differ — common on old Pixels still on
+            // an android12 KMI kernel under an Android 14/15 ROM. Hide
+            // the note when both match (would just be noise) or when
+            // uname -r carries no KMI tag at all.
+            val kmiBranch = recommendation.kernelBranch
+            if (kmiBranch != null && kmiBranch != recommendation.androidVersion) {
+                Spacer(Modifier.height(4.dp))
+                Text(
+                    text =
+                        stringResource(
+                            R.string.dashboard_install_recommendation_kmi_note,
+                            kmiBranch.replace(" ", "").lowercase(),
+                        ),
+                    style = MaterialTheme.typography.bodySmall,
+                    fontStyle = FontStyle.Italic,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
             Spacer(Modifier.height(8.dp))
             val alternative = recommendation.alternativeArtifact
             Text(

--- a/lsposed/app/src/main/res/values-ru/strings.xml
+++ b/lsposed/app/src/main/res/values-ru/strings.xml
@@ -119,7 +119,7 @@
     <!-- kmod variant / load diagnostics -->
     <string name="dashboard_issue_kmod_wrong_variant">Неправильный вариант модуля ядра: установлен %1$s, вашему ядру нужен %2$s. Удалите текущий kmod и установите %3$s из последнего релиза.</string>
     <string name="dashboard_issue_kmod_unknown_variant">Модуль ядра установлен, но не загружается, и в zip не указано, под какой GKI-вариант он собран. Переустановите %1$s из последнего релиза, чтобы убедиться, что он подходит вашему ядру.</string>
-    <string name="dashboard_issue_kmod_ambiguous_try_alternative">Модуль ядра %1$s не загрузился в эту сессию. GKI-ветку вашего ядра не удаётся определить из uname -r — установите %2$s вместо него.</string>
+    <string name="dashboard_issue_kmod_ambiguous_try_alternative">Модуль ядра %1$s не загрузился при текущей загрузке. GKI-ветку вашего ядра не удаётся определить из uname -r — установите %2$s вместо него.</string>
     <string name="dashboard_issue_kmod_load_failed">Модуль ядра не загрузился. Ошибка insmod: %1$s. Чтобы приложить полный вывод insmod к багрепорту, нажмите Диагностика → Собрать отладочный лог.</string>
     <string name="dashboard_issue_kmod_not_supported_kernel">Для вашего ядра (%1$s) нет подходящего варианта vpnhide-kmod. Удалите модуль kmod и установите вместо него %2$s.</string>
     <string name="dashboard_issue_kprobes_missing">Ваше ядро собрано без CONFIG_KRETPROBES. Модуль ядра VPN Hide не может работать на таком ядре. Удалите kmod и используйте vpnhide-zygisk.zip.</string>

--- a/lsposed/app/src/main/res/values-ru/strings.xml
+++ b/lsposed/app/src/main/res/values-ru/strings.xml
@@ -65,6 +65,7 @@
     <string name="dashboard_kmod_broken_unsupported_kernel">Установлен, ядро не поддерживается</string>
     <string name="dashboard_kmod_broken_no_kprobes">Установлен, ядро без kprobes</string>
     <string name="dashboard_kmod_broken_unknown_variant">Установлен, не загрузился</string>
+    <string name="dashboard_kmod_broken_ambiguous">Установлен, не загрузился — попробуйте второй GKI-вариант</string>
     <string name="dashboard_active_targets">Активен · целей: %d</string>
     <string name="dashboard_reboot_needed">Требуется перезагрузка устройства</string>
     <string name="dashboard_protection">Статус защиты</string>
@@ -83,6 +84,7 @@
     <string name="dashboard_install_recommendation_title">Рекомендация по установке</string>
     <string name="dashboard_install_recommendation_device">Ваше устройство: %1$s, ядро %2$s</string>
     <string name="dashboard_install_recommendation_kmod">Рекомендуется модуль ядра. Скачайте %1$s.</string>
+    <string name="dashboard_install_recommendation_kmod_ambiguous">Рекомендуется модуль ядра. GKI-ветку вашего ядра не удаётся определить из uname -r, поэтому сначала попробуйте %1$s; если после ребута он не загрузится — установите %2$s.</string>
     <string name="dashboard_install_recommendation_zygisk">Для вашего устройства модуль ядра не поддерживается. Установите %1$s.</string>
     <string name="dashboard_install_recommendation_zygisk_warning">Банковские и платёжные приложения обнаруживают Zygisk-хуки и крашатся при включённом Z. Для таких приложений оставьте Z выключенным и полагайтесь на LSPosed (Java-уровень) — native-уровень защиты для них работать не будет без поддержки kmod в ядре.</string>
     <string name="dashboard_issues">Ошибки (%d)</string>
@@ -116,6 +118,7 @@
     <!-- kmod variant / load diagnostics -->
     <string name="dashboard_issue_kmod_wrong_variant">Неправильный вариант модуля ядра: установлен %1$s, вашему ядру нужен %2$s. Удалите текущий kmod и установите %3$s из последнего релиза.</string>
     <string name="dashboard_issue_kmod_unknown_variant">Модуль ядра установлен, но не загружается, и в zip не указано, под какой GKI-вариант он собран. Переустановите %1$s из последнего релиза, чтобы убедиться, что он подходит вашему ядру.</string>
+    <string name="dashboard_issue_kmod_ambiguous_try_alternative">Модуль ядра %1$s не загрузился в эту сессию. GKI-ветку вашего ядра не удаётся определить из uname -r — установите %2$s вместо него.</string>
     <string name="dashboard_issue_kmod_load_failed">Модуль ядра не загрузился. Ошибка insmod: %1$s. Чтобы приложить полный вывод insmod к багрепорту, нажмите Диагностика → Собрать отладочный лог.</string>
     <string name="dashboard_issue_kmod_not_supported_kernel">Для вашего ядра (%1$s) нет подходящего варианта vpnhide-kmod. Удалите модуль kmod и установите вместо него %2$s.</string>
     <string name="dashboard_issue_kprobes_missing">Ваше ядро собрано без CONFIG_KRETPROBES. Модуль ядра VPN Hide не может работать на таком ядре. Удалите kmod и используйте vpnhide-zygisk.zip.</string>

--- a/lsposed/app/src/main/res/values-ru/strings.xml
+++ b/lsposed/app/src/main/res/values-ru/strings.xml
@@ -83,6 +83,7 @@
     <string name="vpn_off_retry">Повторить</string>
     <string name="dashboard_install_recommendation_title">Рекомендация по установке</string>
     <string name="dashboard_install_recommendation_device">Ваше устройство: %1$s, ядро %2$s</string>
+    <string name="dashboard_install_recommendation_kmi_note">«%1$s» в версии ядра — это GKI Kernel Module Interface, обозначающий бинарный интерфейс ядра для модулей, а не версию Android на устройстве.</string>
     <string name="dashboard_install_recommendation_kmod">Рекомендуется модуль ядра. Скачайте %1$s.</string>
     <string name="dashboard_install_recommendation_kmod_ambiguous">Рекомендуется модуль ядра. GKI-ветку вашего ядра не удаётся определить из uname -r, поэтому сначала попробуйте %1$s; если после ребута он не загрузится — установите %2$s.</string>
     <string name="dashboard_install_recommendation_zygisk">Для вашего устройства модуль ядра не поддерживается. Установите %1$s.</string>

--- a/lsposed/app/src/main/res/values/strings.xml
+++ b/lsposed/app/src/main/res/values/strings.xml
@@ -96,6 +96,7 @@
     <string name="dashboard_kmod_broken_unsupported_kernel">Installed, kernel not supported</string>
     <string name="dashboard_kmod_broken_no_kprobes">Installed, kernel has no kprobes</string>
     <string name="dashboard_kmod_broken_unknown_variant">Installed, did not load</string>
+    <string name="dashboard_kmod_broken_ambiguous">Installed, did not load — try the other GKI variant</string>
     <string name="dashboard_active_targets">Active · %d target(s)</string>
     <string name="dashboard_reboot_needed">Device reboot needed</string>
     <string name="dashboard_protection">Protection status</string>
@@ -114,6 +115,7 @@
     <string name="dashboard_install_recommendation_title">Installation recommendation</string>
     <string name="dashboard_install_recommendation_device">Your device: %1$s, kernel %2$s</string>
     <string name="dashboard_install_recommendation_kmod">Kernel module is recommended. Download %1$s.</string>
+    <string name="dashboard_install_recommendation_kmod_ambiguous">Kernel module is recommended. Your kernel\'s GKI branch isn\'t identifiable from uname -r, so try %1$s first; if it doesn\'t load after reboot, install %2$s instead.</string>
     <string name="dashboard_install_recommendation_zygisk">Kernel module is not supported for your device. Install %1$s.</string>
     <string name="dashboard_install_recommendation_zygisk_warning">Banking and payment apps detect Zygisk hooks and crash when Z is enabled for them. Leave Z off for those apps and rely on LSPosed (Java-level) hiding — native-level hiding won\'t work for them on a kernel without kmod support.</string>
     <string name="dashboard_issues">Errors (%d)</string>
@@ -147,6 +149,7 @@
     <!-- kmod variant / load diagnostics -->
     <string name="dashboard_issue_kmod_wrong_variant">Wrong kernel module variant: installed %1$s, your kernel needs %2$s. Uninstall the current kmod and install %3$s from the latest release.</string>
     <string name="dashboard_issue_kmod_unknown_variant">Kernel module is installed but not loading, and the zip doesn\'t identify which GKI variant it was built for. Reinstall %1$s from the latest release to make sure it matches your kernel.</string>
+    <string name="dashboard_issue_kmod_ambiguous_try_alternative">Kernel module %1$s failed to load this boot. Your kernel\'s GKI branch isn\'t identifiable from uname -r, so install %2$s instead.</string>
     <string name="dashboard_issue_kmod_load_failed">Kernel module failed to load. insmod error: %1$s. Use Diagnostics → Collect debug log to attach the full boot-time insmod output to a bug report.</string>
     <string name="dashboard_issue_kmod_not_supported_kernel">Your kernel (%1$s) has no matching vpnhide-kmod variant. Uninstall the kmod module and install %2$s instead.</string>
     <string name="dashboard_issue_kprobes_missing">Your kernel was built without CONFIG_KRETPROBES. The VPN Hide kernel module cannot work on this kernel. Uninstall kmod and use vpnhide-zygisk.zip instead.</string>

--- a/lsposed/app/src/main/res/values/strings.xml
+++ b/lsposed/app/src/main/res/values/strings.xml
@@ -114,6 +114,7 @@
     <string name="vpn_off_retry">Retry</string>
     <string name="dashboard_install_recommendation_title">Installation recommendation</string>
     <string name="dashboard_install_recommendation_device">Your device: %1$s, kernel %2$s</string>
+    <string name="dashboard_install_recommendation_kmi_note">\"%1$s\" in the kernel version is the GKI Kernel Module Interface tag — it identifies the kernel\'s binary interface to modules, not your Android OS release.</string>
     <string name="dashboard_install_recommendation_kmod">Kernel module is recommended. Download %1$s.</string>
     <string name="dashboard_install_recommendation_kmod_ambiguous">Kernel module is recommended. Your kernel\'s GKI branch isn\'t identifiable from uname -r, so try %1$s first; if it doesn\'t load after reboot, install %2$s instead.</string>
     <string name="dashboard_install_recommendation_zygisk">Kernel module is not supported for your device. Install %1$s.</string>


### PR DESCRIPTION
## Why

A user reported: on a custom 5.10 kernel (`uname -r` = `5.10.253-Glow-v4.7`), kmod is loaded and working (`/proc/vpnhide_targets` exists, Diagnostics → Native OK), but the Dashboard shows a red card "Установлен, ядро не поддерживается" and recommends uninstalling the kmod and switching to zygisk. 0.6.2 didn't show this because the wrong-variant-kmod diagnostic was added in 0.7.0.

Two orthogonal issues:

**1. KMI matching conflated GKI KMI with Android OS release.** `parseKernelAndroidBranch` extracts the `androidNN` KMI tag from `uname -r` (the GKI Kernel Module Interface identifier, encoded at kernel build time). When absent, the old code fell back to `Build.VERSION.RELEASE` — the ROM's Android version, a label that is unrelated to KMI. An Android 15 ROM commonly runs an `android12` KMI kernel; the old fallback matched `(Android 15, 5.10)`, which isn't in the GKI baseline table, and escalated to zygisk recommendation.

**2. No fallback when KMI is genuinely absent.** Custom kernels routinely strip the `androidNN` tag. Even though the kernel is GKI-compatible (series ≥5.10), the app had no way to suggest a kmod.

## Summary

- `DashboardData.kt` — `buildNativeInstallRecommendation`:
  - Exact match now uses only the parsed KMI (not Build.VERSION.RELEASE).
  - Series-only fallback when KMI absent: `6.1` / `6.6` / `6.12` → single deterministic variant; `5.10` / `5.15` → surface both candidates via new `variantAmbiguous` + `alternativeArtifact` + `alternativeGkiVariant` fields on `NativeInstallRecommendation`.
  - `androidMajorVersionLabel()` retained only for the user-facing `androidVersion` display field.
- `kmodVariantMismatch` — accept either candidate for ambiguous series (don't flag a legitimate alternative install as "wrong variant").
- New `kmodAmbiguousLoadFailed` predicate + new `KmodBrokenReason.AmbiguousLoadFailed` + banner: when the installed kmod is one of the two candidates and failed to load this boot, tell the user to try the other one.
- Defense-in-depth gates on heuristic-driven warnings:
  - `!kmodRaw.active` on `kmodVariantMismatch`, `kmodOnUnsupportedKernel`, `kmodAmbiguousLoadFailed` — an active kmod (`/proc/vpnhide_targets` present) is empirical proof the install works, overrides heuristic.
  - `kmodLoadStatus?.freshForCurrentBoot == true` on `kmodOnUnsupportedKernel` + `kmodAmbiguousLoadFailed` — don't flag a just-installed module before post-fs-data has had a chance to attempt insmod this boot.
- `DashboardScreen.kt` — install-recommendation card shows both candidates for ambiguous series; card subtitle for `AmbiguousLoadFailed`.
- New EN/RU strings:
  - `dashboard_kmod_broken_ambiguous` — card subtitle
  - `dashboard_install_recommendation_kmod_ambiguous` — install card
  - `dashboard_issue_kmod_ambiguous_try_alternative` — error banner

## Behaviour matrix after this PR

| Scenario | `preferKmod` | `variantAmbiguous` | Recommendation |
|---|---|---|---|
| KMI in uname, in matrix | true | false | exact variant |
| KMI absent, series ∈ {6.1, 6.6, 6.12} | true | false | single variant |
| KMI absent, series ∈ {5.10, 5.15} | true | **true** | primary + alternative |
| KMI absent, series < 5.10 or unparseable | false | false | zygisk |

Reported case (`5.10.253-Glow-v4.7`, Android 15 ROM): was → zygisk recommendation + red "kernel not supported"; now → `android12-5.10` primary with `android13-5.10` alternative, no red banner.

Verified locally: ktlint, `./gradlew :app:lint :app:testDebugUnitTest :app:assembleRelease` all green. Release APK builds under R8 (3.37 MB, unchanged).