### PR TITLE
fix(lsposed): polish multi-profile app list (follow-up to #66)

### DIFF
--- a/changelog.d/fixed-polish-multi-profile-app-list-the-408e.md
+++ b/changelog.d/fixed-polish-multi-profile-app-list-the-408e.md
@@ -1,0 +1,9 @@
+_2026-04-21_
+
+## English
+
+Polish multi-profile app list: the Show system filter now classifies apps installed only in a secondary profile correctly, and the user-ID suffix no longer appears on every row for users without a secondary profile
+
+## Русский
+
+Полировка мультипрофильного списка: фильтр System теперь корректно классифицирует приложения, установленные только во втором пространстве; суффикс user-ID больше не показывается в каждой строке у пользователей без второго пространства

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/AppHidingScreen.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/AppHidingScreen.kt
@@ -65,6 +65,7 @@ internal data class HidingEntry(
     val label: String,
     val icon: Drawable?,
     val isSystem: Boolean,
+    val userIds: List<Int> = emptyList(),
     val hidden: Boolean = false,
     val observer: Boolean = false,
 ) {
@@ -133,6 +134,7 @@ fun AppHidingScreen(
                         label = app.label,
                         icon = app.icon,
                         isSystem = app.isSystem,
+                        userIds = app.userIds,
                         hidden = finalHidden,
                         observer = finalObserver,
                     )
@@ -430,7 +432,7 @@ private fun HidingAppRow(
         }
         Column(modifier = Modifier.weight(1f)) {
             Text(
-                text = app.label,
+                text = labelWithUsers(app.label, app.userIds),
                 style = MaterialTheme.typography.bodyLarge,
                 fontWeight = FontWeight.Medium,
             )

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/AppListCache.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/AppListCache.kt
@@ -28,6 +28,23 @@ internal data class AppSummary(
 )
 
 /**
+ * Append the user-ID list to an app label so users can tell that
+ * Telegram-in-Second-Space and Telegram-in-main are the same target.
+ * Suppresses the suffix when the app is only in the current profile —
+ * otherwise every row in the list reads "Cromite (0)", "Chrome (0)",
+ * ... for users who don't even have a secondary profile.
+ */
+internal fun labelWithUsers(
+    label: String,
+    userIds: List<Int>,
+): String {
+    if (userIds.isEmpty()) return label
+    val currentUser = Process.myUid() / 100000
+    val onlyCurrent = userIds.size == 1 && userIds[0] == currentUser
+    return if (onlyCurrent) label else "$label (${userIds.joinToString(", ")})"
+}
+
+/**
  * App-scoped cache for the installed-app list. Loaded asynchronously
  * at startup; Protection screens subscribe to `apps` and render
  * instantly on tab switch.

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/AppListCache.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/AppListCache.kt
@@ -75,16 +75,13 @@ internal object AppListCache {
             val loaded =
                 withContext(Dispatchers.IO) {
                     val pm = appContext.packageManager
-                    val allUserPackages = loadAllUserPackageNamesViaRoot()
-                    val allUserIdsByPackage = loadAllUserIdsByPackageViaRoot()
-                    val allUserApkPaths = loadAllUserApkPathsViaRoot()
-                    if (allUserPackages.isNotEmpty()) {
-                        allUserPackages
-                            .map { pkg ->
+                    val packages = loadPackagesViaRoot()
+                    if (packages.isNotEmpty()) {
+                        packages.entries
+                            .map { (pkg, meta) ->
                                 val info = runCatching { pm.getApplicationInfo(pkg, 0) }.getOrNull()
-                                val userIds = allUserIdsByPackage[pkg] ?: emptyList()
                                 val archiveInfo =
-                                    if (info == null) loadArchiveApplicationInfo(pm, allUserApkPaths[pkg]) else null
+                                    if (info == null) loadArchiveApplicationInfo(pm, meta.apkPath) else null
                                 val effectiveInfo = info ?: archiveInfo
 
                                 AppSummary(
@@ -92,7 +89,7 @@ internal object AppListCache {
                                     label = effectiveInfo?.loadLabel(pm)?.toString() ?: pkg,
                                     icon = effectiveInfo?.let { runCatching { pm.getApplicationIcon(it) }.getOrNull() },
                                     isSystem = effectiveInfo?.let { (it.flags and ApplicationInfo.FLAG_SYSTEM) != 0 } ?: false,
-                                    userIds = userIds,
+                                    userIds = meta.userIds,
                                 )
                             }.sortedBy { it.label.lowercase() }
                     } else {
@@ -118,65 +115,60 @@ internal object AppListCache {
         }
     }
 
-    private fun loadAllUserIdsByPackageViaRoot(): Map<String, List<Int>> {
-        val (exitCode, raw) = suExec("pm list packages -U --user all 2>/dev/null")
+    private data class PkgMeta(
+        val apkPath: String,
+        val userIds: List<Int>,
+    )
+
+    /**
+     * Enumerate every installed package across every user profile (main +
+     * work profile / MIUI Second Space / Private Space / secondary users)
+     * in one `su` call. `-U -f --user all` gives both the APK path and
+     * the UID per (pkg, user) tuple, which was previously done with three
+     * separate root roundtrips (~150ms of wasted `su` spin-up per refresh).
+     *
+     * Output format is one of:
+     *   package:<apk_path>=<pkg> uid:<uid>            (single-user)
+     *   package:<apk_path>=<pkg> uid:<uid>,<uid>,...  (AOSP --user all)
+     *   package:<apk_path>=<pkg> uid:<uid>            (repeated per user
+     *                                                  on some ROMs)
+     * So the parser merges UIDs across duplicate lines for the same pkg.
+     */
+    private fun loadPackagesViaRoot(): Map<String, PkgMeta> {
+        val (exitCode, raw) = suExec("pm list packages -U -f --user all 2>/dev/null")
         if (exitCode != 0) return emptyMap()
-        val out = LinkedHashMap<String, List<Int>>()
-        raw
-            .lineSequence()
-            .map { it.trim() }
-            .filter { it.startsWith("package:") }
-            .forEach { line ->
-                val pkg = line.substringAfter("package:").substringBefore(" uid:").trim()
-                if (pkg.isEmpty()) return@forEach
-                val uidPart = line.substringAfter("uid:", "").trim()
-                if (uidPart.isEmpty()) {
-                    out[pkg] = emptyList()
-                    return@forEach
-                }
-
-                val userIds =
-                    uidPart
-                        .split(',')
-                        .mapNotNull { it.trim().toIntOrNull() }
-                        .map { it / 100000 }
-                        .distinct()
-                        .sorted()
-                out[pkg] = userIds
-            }
-        return out
-    }
-
-    private fun loadAllUserPackageNamesViaRoot(): List<String> {
-        val (exitCode, raw) = suExec("pm list packages --user all 2>/dev/null")
-        if (exitCode != 0) return emptyList()
-        return raw
-            .lineSequence()
-            .map { it.trim() }
-            .filter { it.startsWith("package:") }
-            .map { it.removePrefix("package:").trim() }
-            .filter { it.isNotEmpty() }
-            .distinct()
-            .toList()
-    }
-
-    private fun loadAllUserApkPathsViaRoot(): Map<String, String> {
-        val (exitCode, raw) = suExec("pm list packages -f --user all 2>/dev/null")
-        if (exitCode != 0) return emptyMap()
-        val out = LinkedHashMap<String, String>()
+        val out = LinkedHashMap<String, PkgMeta>()
         raw
             .lineSequence()
             .map { it.trim() }
             .filter { it.startsWith("package:") }
             .forEach { line ->
                 val body = line.removePrefix("package:")
-                val eq = body.lastIndexOf('=')
-                if (eq <= 0 || eq >= body.lastIndex) return@forEach
-                val apkPath = body.substring(0, eq).trim()
-                val pkg = body.substring(eq + 1).trim()
-                if (apkPath.isNotEmpty() && pkg.isNotEmpty() && out[pkg] == null) {
-                    out[pkg] = apkPath
-                }
+                val uidMarker = body.lastIndexOf(" uid:")
+                if (uidMarker <= 0) return@forEach
+                val pathAndPkg = body.substring(0, uidMarker)
+                val uidPart = body.substring(uidMarker + " uid:".length).trim()
+                val eq = pathAndPkg.lastIndexOf('=')
+                if (eq <= 0 || eq >= pathAndPkg.lastIndex) return@forEach
+                val apkPath = pathAndPkg.substring(0, eq).trim()
+                val pkg = pathAndPkg.substring(eq + 1).trim()
+                if (apkPath.isEmpty() || pkg.isEmpty()) return@forEach
+
+                val userIds =
+                    uidPart
+                        .split(',')
+                        .mapNotNull { it.trim().toIntOrNull() }
+                        .map { it / 100000 }
+
+                val existing = out[pkg]
+                out[pkg] =
+                    if (existing == null) {
+                        PkgMeta(apkPath, userIds.distinct().sorted())
+                    } else {
+                        existing.copy(
+                            userIds = (existing.userIds + userIds).distinct().sorted(),
+                        )
+                    }
             }
         return out
     }

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/AppListCache.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/AppListCache.kt
@@ -84,11 +84,26 @@ internal object AppListCache {
                                     if (info == null) loadArchiveApplicationInfo(pm, meta.apkPath) else null
                                 val effectiveInfo = info ?: archiveInfo
 
+                                // Archive-parsed ApplicationInfo doesn't carry
+                                // FLAG_SYSTEM (that bit is attached by PM at
+                                // install time, not stored in the manifest), so
+                                // for secondary-only packages we'd misclassify
+                                // every system app as user-installed. Fall back
+                                // to the APK path: /data/app/... is user-
+                                // installed, everything else is baked into the
+                                // system image.
+                                val isSystem =
+                                    if (info != null) {
+                                        (info.flags and ApplicationInfo.FLAG_SYSTEM) != 0
+                                    } else {
+                                        !meta.apkPath.startsWith("/data/app/")
+                                    }
+
                                 AppSummary(
                                     packageName = pkg,
                                     label = effectiveInfo?.loadLabel(pm)?.toString() ?: pkg,
                                     icon = effectiveInfo?.let { runCatching { pm.getApplicationIcon(it) }.getOrNull() },
-                                    isSystem = effectiveInfo?.let { (it.flags and ApplicationInfo.FLAG_SYSTEM) != 0 } ?: false,
+                                    isSystem = isSystem,
                                     userIds = meta.userIds,
                                 )
                             }.sortedBy { it.label.lowercase() }

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/AppPickerScreen.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/AppPickerScreen.kt
@@ -45,8 +45,6 @@ data class AppEntry(
     val lsposed: Boolean = false,
 ) {
     val anySelected get() = kmod || zygisk || lsposed
-    val labelWithUsers: String
-        get() = if (userIds.isEmpty()) label else "$label (${userIds.joinToString(", ")})"
 }
 
 /** Which installed modules are present (detected once at load). */
@@ -436,7 +434,7 @@ private fun AppRow(
         }
         Column(modifier = Modifier.weight(1f)) {
             Text(
-                text = app.labelWithUsers,
+                text = labelWithUsers(app.label, app.userIds),
                 style = MaterialTheme.typography.bodyLarge,
                 fontWeight = FontWeight.Medium,
             )

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/PortsHidingScreen.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/PortsHidingScreen.kt
@@ -67,6 +67,7 @@ internal data class PortsEntry(
     val label: String,
     val icon: Drawable?,
     val isSystem: Boolean,
+    val userIds: List<Int> = emptyList(),
     val observer: Boolean = false,
 )
 
@@ -113,6 +114,7 @@ fun PortsHidingScreen(
                         label = app.label,
                         icon = app.icon,
                         isSystem = app.isSystem,
+                        userIds = app.userIds,
                         observer = app.packageName in t.portsObservers,
                     )
                 }
@@ -381,7 +383,7 @@ private fun PortsAppRow(
         }
         Column(modifier = Modifier.weight(1f)) {
             Text(
-                text = app.label,
+                text = labelWithUsers(app.label, app.userIds),
                 style = MaterialTheme.typography.bodyLarge,
                 fontWeight = FontWeight.Medium,
             )


### PR DESCRIPTION
Follow-up polish to #66. Two user-visible regressions: apps installed only in a secondary profile were misclassified as user-installed (the archive-parsed `ApplicationInfo` doesn't carry `FLAG_SYSTEM`), so the "Show system apps" filter ignored all of them; and the user-ID suffix rendered as `"(0)"` on every row for users without a secondary profile, because the check for "only-current-user" was missing. Also consolidates three `su` roundtrips into one.

- Merge `pm list packages`, `-U`, `-f` root calls into a single `pm list packages -U -f --user all` — saves ~150ms on every refresh.
- Classify archive-parsed apps via APK path heuristic: `/data/app/...` is user-installed, everything else is system.
- Extract top-level `labelWithUsers(label, userIds)` helper that suppresses the suffix when the only listed user is the current one.
- Apply the suffix consistently across Tun targets, App hiding, and Ports (previously only Tun rendered it).