### PR TITLE
test(lsposed): unit-test buildNativeInstallRecommendation

### DIFF
--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DashboardData.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DashboardData.kt
@@ -196,6 +196,130 @@ internal data class KmodLoadStatus(
 
 private const val TAG = "VpnHide-Dashboard"
 
+internal fun parseKernelSeries(raw: String): String? = Regex("""\b(\d+\.\d+)""").find(raw)?.groupValues?.get(1)
+
+internal fun parseKernelAndroidBranch(raw: String): String? =
+    Regex("""android(\d+)""")
+        .find(raw)
+        ?.groupValues
+        ?.get(1)
+        ?.let { "Android $it" }
+
+/**
+ * Pick the right native-module artifact for the device based on its
+ * kernel version (from `uname -r`) and Android OS label (from
+ * `Build.VERSION.RELEASE`). Pulled out as a pure top-level function
+ * so it can be unit-tested without a real device — the `uname -r`
+ * read and `Build.VERSION` probe happen in the caller.
+ *
+ * Strategy, in order:
+ *  1. Exact `(GKI KMI × kernel series)` match from the supported
+ *     shipping matrix → specific kmod zip, preferKmod=true.
+ *  2. KMI tag missing from `uname -r` (custom kernel stripped it)
+ *     but the kernel series is GKI-shipping:
+ *       - 6.1 / 6.6 / 6.12 have a single shipping variant each →
+ *         deterministic kmod recommendation, preferKmod=true.
+ *       - 5.10 / 5.15 have two shipping variants each → return the
+ *         primary plus an alternative via `variantAmbiguous=true`;
+ *         the UI shows "try primary, if it doesn't load try alt".
+ *  3. Pre-GKI series (<5.10) or unparseable kernel version → fall
+ *     back to zygisk (preferKmod=false) since we have no kmod
+ *     binaries that can load against such kernels' Module.symvers.
+ *
+ * Returns `null` only if [kernelRaw] is blank (no uname output).
+ * `deviceAndroidLabel` is only reflected back in the returned
+ * `androidVersion` for display — it's never used for KMI matching
+ * (those spaces are independent: an Android 15 ROM routinely runs
+ * an android12 KMI kernel).
+ */
+internal fun buildNativeInstallRecommendation(
+    kernelRaw: String,
+    deviceAndroidLabel: String,
+): NativeInstallRecommendation? {
+    val kernelVersion = kernelRaw.trim().ifBlank { return null }
+    val kernelSeries = parseKernelSeries(kernelVersion)
+    val kernelBranch = parseKernelAndroidBranch(kernelVersion) // GKI KMI
+
+    data class KmiMatch(
+        val kmi: String,
+        val zip: String,
+    )
+
+    val exact: KmiMatch? =
+        when (kernelBranch to kernelSeries) {
+            "Android 12" to "5.10" -> KmiMatch("android12-5.10", "vpnhide-kmod-android12-5.10.zip")
+            "Android 13" to "5.10" -> KmiMatch("android13-5.10", "vpnhide-kmod-android13-5.10.zip")
+            "Android 13" to "5.15" -> KmiMatch("android13-5.15", "vpnhide-kmod-android13-5.15.zip")
+            "Android 14" to "5.15" -> KmiMatch("android14-5.15", "vpnhide-kmod-android14-5.15.zip")
+            "Android 14" to "6.1" -> KmiMatch("android14-6.1", "vpnhide-kmod-android14-6.1.zip")
+            "Android 15" to "6.6" -> KmiMatch("android15-6.6", "vpnhide-kmod-android15-6.6.zip")
+            "Android 16" to "6.12" -> KmiMatch("android16-6.12", "vpnhide-kmod-android16-6.12.zip")
+            else -> null
+        }
+    if (exact != null) {
+        return NativeInstallRecommendation(
+            androidVersion = deviceAndroidLabel,
+            kernelVersion = kernelVersion,
+            kernelBranch = kernelBranch,
+            recommendedArtifact = exact.zip,
+            recommendedGkiVariant = exact.kmi,
+            preferKmod = true,
+        )
+    }
+
+    val fallback: Pair<KmiMatch, KmiMatch?>? =
+        when (kernelSeries) {
+            "5.10" -> {
+                KmiMatch("android12-5.10", "vpnhide-kmod-android12-5.10.zip") to
+                    KmiMatch("android13-5.10", "vpnhide-kmod-android13-5.10.zip")
+            }
+
+            "5.15" -> {
+                KmiMatch("android13-5.15", "vpnhide-kmod-android13-5.15.zip") to
+                    KmiMatch("android14-5.15", "vpnhide-kmod-android14-5.15.zip")
+            }
+
+            "6.1" -> {
+                KmiMatch("android14-6.1", "vpnhide-kmod-android14-6.1.zip") to null
+            }
+
+            "6.6" -> {
+                KmiMatch("android15-6.6", "vpnhide-kmod-android15-6.6.zip") to null
+            }
+
+            "6.12" -> {
+                KmiMatch("android16-6.12", "vpnhide-kmod-android16-6.12.zip") to null
+            }
+
+            else -> {
+                null
+            }
+        }
+    if (fallback != null) {
+        val (primary, alternative) = fallback
+        return NativeInstallRecommendation(
+            androidVersion = deviceAndroidLabel,
+            kernelVersion = kernelVersion,
+            kernelBranch = kernelBranch,
+            recommendedArtifact = primary.zip,
+            recommendedGkiVariant = primary.kmi,
+            preferKmod = true,
+            variantAmbiguous = alternative != null,
+            alternativeArtifact = alternative?.zip,
+            alternativeGkiVariant = alternative?.kmi,
+        )
+    }
+
+    return NativeInstallRecommendation(
+        androidVersion = deviceAndroidLabel,
+        kernelVersion = kernelVersion,
+        kernelBranch = kernelBranch,
+        recommendedArtifact = "vpnhide-zygisk.zip",
+        recommendedGkiVariant = null,
+        preferKmod = false,
+    )
+}
+
 internal fun loadDashboardState(
     cm: ConnectivityManager,
     context: android.content.Context,
@@ -334,115 +458,6 @@ internal fun loadDashboardState(
                 Build.VERSION.RELEASE
             }.substringBefore('.')
         return "Android $release"
-    }
-
-    fun parseKernelSeries(raw: String): String? = Regex("""\b(\d+\.\d+)""").find(raw)?.groupValues?.get(1)
-
-    fun parseKernelAndroidBranch(raw: String): String? =
-        Regex("""android(\d+)""")
-            .find(raw)
-            ?.groupValues
-            ?.get(1)
-            ?.let { "Android $it" }
-
-    fun buildNativeInstallRecommendation(): NativeInstallRecommendation? {
-        val (_, kernelRaw) = suExec("uname -r 2>/dev/null")
-        val kernelVersion = kernelRaw.trim().ifBlank { return null }
-        val kernelSeries = parseKernelSeries(kernelVersion)
-        val kernelBranch = parseKernelAndroidBranch(kernelVersion) // GKI KMI
-        // User-facing device label only — never used for KMI matching below.
-        val deviceAndroidLabel = androidMajorVersionLabel()
-
-        data class KmiMatch(
-            val kmi: String,
-            val zip: String,
-        )
-
-        // Try exact KMI × series match. kernelBranch here is the GKI KMI
-        // extracted from uname -r, NOT the phone's Android OS release —
-        // these are independent spaces (an Android 15 ROM commonly runs an
-        // android12 KMI kernel), so we must not fall back to
-        // Build.VERSION.RELEASE here.
-        val exact: KmiMatch? =
-            when (kernelBranch to kernelSeries) {
-                "Android 12" to "5.10" -> KmiMatch("android12-5.10", "vpnhide-kmod-android12-5.10.zip")
-                "Android 13" to "5.10" -> KmiMatch("android13-5.10", "vpnhide-kmod-android13-5.10.zip")
-                "Android 13" to "5.15" -> KmiMatch("android13-5.15", "vpnhide-kmod-android13-5.15.zip")
-                "Android 14" to "5.15" -> KmiMatch("android14-5.15", "vpnhide-kmod-android14-5.15.zip")
-                "Android 14" to "6.1" -> KmiMatch("android14-6.1", "vpnhide-kmod-android14-6.1.zip")
-                "Android 15" to "6.6" -> KmiMatch("android15-6.6", "vpnhide-kmod-android15-6.6.zip")
-                "Android 16" to "6.12" -> KmiMatch("android16-6.12", "vpnhide-kmod-android16-6.12.zip")
-                else -> null
-            }
-        if (exact != null) {
-            return NativeInstallRecommendation(
-                androidVersion = deviceAndroidLabel,
-                kernelVersion = kernelVersion,
-                kernelBranch = kernelBranch,
-                recommendedArtifact = exact.zip,
-                recommendedGkiVariant = exact.kmi,
-                preferKmod = true,
-            )
-        }
-
-        // No KMI in uname (custom kernel stripped it). Fall back on kernel
-        // series alone. For 6.1 / 6.6 / 6.12 we ship a single KMI variant —
-        // the recommendation is still deterministic. For 5.10 / 5.15 two
-        // variants ship, so we surface both via variantAmbiguous and let
-        // the UI tell the user to try the alternative if the primary fails.
-        val fallback: Pair<KmiMatch, KmiMatch?>? =
-            when (kernelSeries) {
-                "5.10" -> {
-                    KmiMatch("android12-5.10", "vpnhide-kmod-android12-5.10.zip") to
-                        KmiMatch("android13-5.10", "vpnhide-kmod-android13-5.10.zip")
-                }
-
-                "5.15" -> {
-                    KmiMatch("android13-5.15", "vpnhide-kmod-android13-5.15.zip") to
-                        KmiMatch("android14-5.15", "vpnhide-kmod-android14-5.15.zip")
-                }
-
-                "6.1" -> {
-                    KmiMatch("android14-6.1", "vpnhide-kmod-android14-6.1.zip") to null
-                }
-
-                "6.6" -> {
-                    KmiMatch("android15-6.6", "vpnhide-kmod-android15-6.6.zip") to null
-                }
-
-                "6.12" -> {
-                    KmiMatch("android16-6.12", "vpnhide-kmod-android16-6.12.zip") to null
-                }
-
-                else -> {
-                    null
-                }
-            }
-        if (fallback != null) {
-            val (primary, alternative) = fallback
-            return NativeInstallRecommendation(
-                androidVersion = deviceAndroidLabel,
-                kernelVersion = kernelVersion,
-                kernelBranch = kernelBranch,
-                recommendedArtifact = primary.zip,
-                recommendedGkiVariant = primary.kmi,
-                preferKmod = true,
-                variantAmbiguous = alternative != null,
-                alternativeArtifact = alternative?.zip,
-                alternativeGkiVariant = alternative?.kmi,
-            )
-        }
-
-        // Pre-GKI series (<5.10) or unparseable — kmod binaries we ship
-        // can't load against such kernels' Module.symvers. Recommend zygisk.
-        return NativeInstallRecommendation(
-            androidVersion = deviceAndroidLabel,
-            kernelVersion = kernelVersion,
-            kernelBranch = kernelBranch,
-            recommendedArtifact = "vpnhide-zygisk.zip",
-            recommendedGkiVariant = null,
-            preferKmod = false,
-        )
     }
 
     fun readKmodLoadStatus(currentBootId: String): KmodLoadStatus? {
@@ -666,7 +681,8 @@ internal fun loadDashboardState(
     // Recommendation based purely on the kernel — used by the install card,
     // the "kmod-capable kernel, only zygisk installed" warning (W1), and the
     // wrong-variant detection below.
-    val kernelRecommendation = buildNativeInstallRecommendation()
+    val (_, kernelRaw) = suExec("uname -r 2>/dev/null")
+    val kernelRecommendation = buildNativeInstallRecommendation(kernelRaw, androidMajorVersionLabel())
     val kmodLoadStatus = readKmodLoadStatus(currentBootId.trim())
     VpnHideLog.i(TAG, "kmodLoadStatus=$kmodLoadStatus")
 

--- a/lsposed/app/src/test/kotlin/dev/okhsunrog/vpnhide/BuildNativeInstallRecommendationTest.kt
+++ b/lsposed/app/src/test/kotlin/dev/okhsunrog/vpnhide/BuildNativeInstallRecommendationTest.kt
@@ -1,0 +1,204 @@
+package dev.okhsunrog.vpnhide
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Covers the `(kernel KMI × series)` → (kmod zip, variant, zygisk?)
+ * decision table in [buildNativeInstallRecommendation]. Deliberately
+ * paranoid about the reported edge cases — a custom kernel whose
+ * `uname -r` lacks the `androidNN` tag, the Android 15 ROM over an
+ * `android12-5.10` kernel regression, pre-GKI kernels, etc.
+ *
+ * `deviceAndroidLabel` is only reflected back in `androidVersion`
+ * for display; it is never used for KMI matching. The tests pass
+ * both plausible ("Android 12") and mismatched ("Android 15")
+ * labels where relevant to prove that invariant.
+ */
+class BuildNativeInstallRecommendationTest {
+    // ── 1. Exact KMI × series matches ─────────────────────────
+
+    @Test
+    fun `exact match android12-5_10`() {
+        val r = buildNativeInstallRecommendation("5.10.149-android12-foo-g123abc", "Android 12")!!
+        assertTrue(r.preferKmod)
+        assertFalse(r.variantAmbiguous)
+        assertEquals("android12-5.10", r.recommendedGkiVariant)
+        assertEquals("vpnhide-kmod-android12-5.10.zip", r.recommendedArtifact)
+        assertNull(r.alternativeArtifact)
+        assertEquals("Android 12", r.kernelBranch)
+        assertEquals("Android 12", r.androidVersion)
+    }
+
+    @Test
+    fun `exact match covers the full shipping matrix`() {
+        data class Case(
+            val kernel: String,
+            val expectedKmi: String,
+        )
+        listOf(
+            Case("5.10.149-android12-g123abc", "android12-5.10"),
+            Case("5.10.149-android13-g123abc", "android13-5.10"),
+            Case("5.15.60-android13-g123abc", "android13-5.15"),
+            Case("5.15.60-android14-g123abc", "android14-5.15"),
+            Case("6.1.25-android14-g123abc", "android14-6.1"),
+            Case("6.6.10-android15-g123abc", "android15-6.6"),
+            Case("6.12.0-android16-g123abc", "android16-6.12"),
+        ).forEach { case ->
+            val r = buildNativeInstallRecommendation(case.kernel, "Android 14")
+            assertEquals("kernel ${case.kernel}", case.expectedKmi, r?.recommendedGkiVariant)
+            assertEquals("kernel ${case.kernel}", true, r?.preferKmod)
+            assertEquals("kernel ${case.kernel}", false, r?.variantAmbiguous)
+        }
+    }
+
+    @Test
+    fun `Android 15 ROM on android12-5_10 kernel — reporter's scenario`() {
+        // Previous regression: the Android-release fallback turned this
+        // into (Android 15, 5.10), which isn't in the shipping table,
+        // so the app recommended zygisk. With the KMI-only match it
+        // correctly lands on android12-5.10.
+        val r = buildNativeInstallRecommendation("5.10.253-android12-Glow-v4.7", "Android 15")!!
+        assertTrue(r.preferKmod)
+        assertEquals("android12-5.10", r.recommendedGkiVariant)
+        // androidVersion reflects the device OS, not the KMI — so the
+        // UI shows "Your device: Android 15" with the italic KMI note
+        // disambiguating the android12 fragment.
+        assertEquals("Android 15", r.androidVersion)
+        assertEquals("Android 12", r.kernelBranch)
+    }
+
+    // ── 2. Ambiguous fallback (KMI missing, series has 2 shipping variants) ─
+
+    @Test
+    fun `no KMI 5_10 returns ambiguous android12 plus android13 alternative`() {
+        val r = buildNativeInstallRecommendation("5.10.253-Glow-v4.7", "Android 15")!!
+        assertTrue(r.preferKmod)
+        assertTrue(r.variantAmbiguous)
+        assertEquals("android12-5.10", r.recommendedGkiVariant)
+        assertEquals("vpnhide-kmod-android12-5.10.zip", r.recommendedArtifact)
+        assertEquals("android13-5.10", r.alternativeGkiVariant)
+        assertEquals("vpnhide-kmod-android13-5.10.zip", r.alternativeArtifact)
+        assertNull(r.kernelBranch) // no `androidNN` in uname → null
+    }
+
+    @Test
+    fun `no KMI 5_15 returns ambiguous android13 plus android14 alternative`() {
+        val r = buildNativeInstallRecommendation("5.15.104-custom", "Android 14")!!
+        assertTrue(r.preferKmod)
+        assertTrue(r.variantAmbiguous)
+        assertEquals("android13-5.15", r.recommendedGkiVariant)
+        assertEquals("android14-5.15", r.alternativeGkiVariant)
+    }
+
+    // ── 3. Deterministic fallback (single shipping variant per series) ────
+
+    @Test
+    fun `no KMI 6_1 is deterministic not ambiguous`() {
+        val r = buildNativeInstallRecommendation("6.1.55-custom-clear", "Android 14")!!
+        assertTrue(r.preferKmod)
+        assertFalse(r.variantAmbiguous)
+        assertEquals("android14-6.1", r.recommendedGkiVariant)
+        assertNull(r.alternativeArtifact)
+    }
+
+    @Test
+    fun `no KMI 6_6 is deterministic`() {
+        val r = buildNativeInstallRecommendation("6.6.0-custom", "Android 15")!!
+        assertFalse(r.variantAmbiguous)
+        assertEquals("android15-6.6", r.recommendedGkiVariant)
+        assertNull(r.alternativeGkiVariant)
+    }
+
+    @Test
+    fun `no KMI 6_12 is deterministic`() {
+        val r = buildNativeInstallRecommendation("6.12.1-custom", "Android 16")!!
+        assertFalse(r.variantAmbiguous)
+        assertEquals("android16-6.12", r.recommendedGkiVariant)
+    }
+
+    // ── 4. KMI present but combo not shipping → series fallback ────────────
+
+    @Test
+    fun `android14 KMI on 5_10 falls to ambiguous 5_10 — no such shipping combo`() {
+        // Android 14 + 5.10 is not a real GKI combo (A14 shipped with
+        // 5.15 / 6.1). A kernel carrying that tag is most likely custom;
+        // the 5.10 series fallback gives the user both plausible picks.
+        val r = buildNativeInstallRecommendation("5.10.100-android14-custom", "Android 14")!!
+        assertTrue(r.variantAmbiguous)
+        assertEquals("android12-5.10", r.recommendedGkiVariant)
+        assertEquals("android13-5.10", r.alternativeGkiVariant)
+        // kernelBranch is still parsed — the card can quote "android14" in the note.
+        assertEquals("Android 14", r.kernelBranch)
+    }
+
+    // ── 5. Pre-GKI / unsupported → zygisk ─────────────────────────────────
+
+    @Test
+    fun `pre-GKI 4_14 recommends zygisk`() {
+        val r = buildNativeInstallRecommendation("4.14.302-g92e0d94b6cba", "Android 13")!!
+        assertFalse(r.preferKmod)
+        assertFalse(r.variantAmbiguous)
+        assertEquals("vpnhide-zygisk.zip", r.recommendedArtifact)
+        assertNull(r.recommendedGkiVariant)
+        assertEquals("Android 13", r.androidVersion)
+    }
+
+    @Test
+    fun `5_4 recommends zygisk`() {
+        val r = buildNativeInstallRecommendation("5.4.188-custom", "Android 12")!!
+        assertFalse(r.preferKmod)
+        assertEquals("vpnhide-zygisk.zip", r.recommendedArtifact)
+    }
+
+    @Test
+    fun `6_3 recommends zygisk — no shipping variant for this series`() {
+        // We only ship for 6.1, 6.6, 6.12 — a 6.3 kernel is rare but
+        // shouldn't silently pick one of those.
+        val r = buildNativeInstallRecommendation("6.3.0-something", "Android 14")!!
+        assertFalse(r.preferKmod)
+        assertEquals("vpnhide-zygisk.zip", r.recommendedArtifact)
+    }
+
+    @Test
+    fun `unparseable kernel string recommends zygisk`() {
+        // parseKernelSeries would not find a `\d+\.\d+` token — the
+        // function must not crash, just recommend zygisk.
+        val r = buildNativeInstallRecommendation("garbage-no-numbers", "Android 12")!!
+        assertFalse(r.preferKmod)
+        assertEquals("vpnhide-zygisk.zip", r.recommendedArtifact)
+    }
+
+    // ── 6. Null / blank input ─────────────────────────────────────────────
+
+    @Test
+    fun `empty kernel string returns null`() {
+        assertNull(buildNativeInstallRecommendation("", "Android 14"))
+    }
+
+    @Test
+    fun `blank kernel string returns null`() {
+        assertNull(buildNativeInstallRecommendation("   \n  ", "Android 14"))
+    }
+
+    // ── 7. Helper parsers ─────────────────────────────────────────────────
+
+    @Test
+    fun `parseKernelSeries extracts major minor`() {
+        assertEquals("5.10", parseKernelSeries("5.10.253-android12-Glow-v4.7"))
+        assertEquals("6.12", parseKernelSeries("6.12.0-something"))
+        assertEquals("4.14", parseKernelSeries("4.14.302-g92e0d94b6cba"))
+        assertNull(parseKernelSeries("no-version-here"))
+    }
+
+    @Test
+    fun `parseKernelAndroidBranch finds androidNN anywhere`() {
+        assertEquals("Android 12", parseKernelAndroidBranch("5.10.149-android12-Glow"))
+        assertEquals("Android 16", parseKernelAndroidBranch("6.12-android16-whatever"))
+        assertNull(parseKernelAndroidBranch("5.10.253-Glow-v4.7")) // KMI stripped
+        assertNull(parseKernelAndroidBranch("4.14.302-g92e0d94b6cba"))
+    }
+}


### PR DESCRIPTION
Follow-up to #71. The KMI × kernel-series decision table was untested because the matching logic lived as a local function inside `loadDashboardState` and called `suExec` / `Build.VERSION.RELEASE` inline. After the regression that #71 fixed, it's worth having tests before touching the table again.

- Extracts `buildNativeInstallRecommendation(kernelRaw, deviceAndroidLabel)` as a pure top-level internal function, plus the `parseKernelSeries` / `parseKernelAndroidBranch` helpers. The `suExec` and `Build.VERSION` probes move to the call site in `loadDashboardState`. No behaviour change.
- 17 JUnit 4 tests covering every branch: full exact-match matrix, reporter's Android-15-on-android12-5.10 scenario, ambiguous 5.10 / 5.15 fallbacks, deterministic 6.1 / 6.6 / 6.12 fallbacks, pre-GKI (4.14, 5.4, 6.3) → zygisk, unparseable / blank / empty kernel strings, and the two helper parsers.

All tests pass locally (`./gradlew :app:testDebugUnitTest`).