### PR TITLE
fix(lsposed): exclude self package from snack counter

### DIFF
--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/AppHidingScreen.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/AppHidingScreen.kt
@@ -341,7 +341,7 @@ fun AppHidingScreen(
                     suExecAsync(buildHidingSaveCommand(header, hiddenPkgs, observerPkgs))
                 if (exitCode == 0) {
                     snackMessage =
-                        context.getString(R.string.hiding_save_success, hiddenPkgs.size, observerPkgs.size)
+                        context.getString(R.string.hiding_save_success, hiddenPkgs.size - 1, observerPkgs.size)
                     DashboardCache.invalidate()
                     TargetsCache.refresh(scope, context)
                 } else if (exitCode == -1) {


### PR DESCRIPTION
### Why
The 0.7.1 release APK has a bug where hidden apps counter in snack message includes self package

### Summary
Fix to show correct number of hidden apps

Closes #79 