### PR TITLE
fix(build): tighten the python build-script port

### DIFF
--- a/kmod/build-zip.py
+++ b/kmod/build-zip.py
@@ -21,7 +21,7 @@ import sys
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts"))
-from build_lib import get_build_version, make_zip  # type: ignore[import-not-found]
+from build_lib import get_build_version, make_zip, version_sort_key  # type: ignore[import-not-found]
 
 
 # Module file names
@@ -102,7 +102,10 @@ def main() -> int:
             # Auto-detect: In CI, clang is at /opt/ddk/clang/clang-r*/bin
             clang_base = Path("/opt/ddk/clang")
             if clang_base.exists():
-                clang_dirs = sorted(d for d in clang_base.iterdir() if d.is_dir() and d.name.startswith("clang-"))
+                clang_dirs = sorted(
+                    (d for d in clang_base.iterdir() if d.is_dir() and d.name.startswith("clang-")),
+                    key=lambda p: version_sort_key(p.name),
+                )
                 if clang_dirs:
                     clang_dir = str(clang_dirs[-1] / "bin")
                     clang_dir_src = "auto-detected from /opt/ddk/clang"
@@ -112,13 +115,11 @@ def main() -> int:
     else:
         print("Warning: clang-dir not set, using system PATH", file=sys.stderr)
 
-    # Build the kernel module (env vars loaded by direnv from .env)
-    kmod_c = kmod_dir / KMOD_C
-    kmod_ko = kmod_dir / KMOD_KO
-
-    if not kmod_ko.exists() or kmod_c.stat().st_mtime > kmod_ko.stat().st_mtime:
-        print("Building kernel module...")
-        subprocess.run(["make", "strip"], check=True)
+    # Build the kernel module — let make decide whether anything needs
+    # rebuilding; its dependency tracking covers all sources, headers,
+    # and the kernel .config, not just vpnhide_kmod.c.
+    print("Building kernel module...")
+    subprocess.run(["make", "strip"], check=True)
 
     # Assemble the module staging directory so the committed module.prop
     # stays at its release version while the zip carries the actual build

--- a/scripts/build_lib.py
+++ b/scripts/build_lib.py
@@ -1,18 +1,20 @@
 """Shared helpers for build scripts.
 
-Used by kmod/build-zip.py, portshide/build-zip.py, and zygisk/build-zip.py.
+Used by kmod/build-zip.py, portshide/build-zip.py, zygisk/build-zip.py,
+and scripts/build-version.py.
+
+Stdlib-only on purpose: scripts/build-version.py is invoked from
+lsposed/app/build.gradle.kts on every Gradle build, so adding pip/uv
+dependencies here would break the APK build for anyone without those
+tools available.
 """
 
 from __future__ import annotations
 
-import os
+import re
+import subprocess
 import zipfile
 from pathlib import Path
-
-
-def get_python_exe() -> str:
-    """Return 'python' on Windows, 'python3' elsewhere."""
-    return "python" if os.name == "nt" else "python3"
 
 
 def make_zip(source_dir: Path, output_zip: Path) -> None:
@@ -24,6 +26,16 @@ def make_zip(source_dir: Path, output_zip: Path) -> None:
                 zf.write(file_path, arcname)
 
 
+def version_sort_key(name: str) -> tuple[int, ...]:
+    """Sort key that orders strings by their embedded integer runs.
+
+    Used to pick the highest version when multiple toolchain directories
+    coexist (NDK 25.0.1 vs 100.0.0, clang-r450b vs clang-r498344b) where
+    plain lexicographic sort gives the wrong answer.
+    """
+    return tuple(int(part) for part in re.findall(r"\d+", name))
+
+
 def get_build_version(repo_root: Path | None = None) -> str:
     """Get the effective build version for vpnhide artifacts.
 
@@ -32,8 +44,6 @@ def get_build_version(repo_root: Path | None = None) -> str:
     - working tree dirty          -> additional "-dirty" suffix
     - no git / no matching tag    -> falls back to VERSION file
     """
-    import subprocess
-
     if repo_root is None:
         repo_root = Path(__file__).resolve().parent.parent
 

--- a/zygisk/build-zip.py
+++ b/zygisk/build-zip.py
@@ -18,7 +18,7 @@ import sys
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts"))
-from build_lib import get_build_version, make_zip  # type: ignore[import-not-found]
+from build_lib import get_build_version, make_zip, version_sort_key  # type: ignore[import-not-found]
 
 
 def main() -> int:
@@ -31,7 +31,8 @@ def main() -> int:
         ndk_base = Path.home() / "Android" / "Sdk" / "ndk"
         if ndk_base.exists():
             ndk_versions = sorted(
-                d.name for d in ndk_base.iterdir() if d.is_dir()
+                (d.name for d in ndk_base.iterdir() if d.is_dir()),
+                key=version_sort_key,
             )
             if ndk_versions:
                 android_ndk_home = str(ndk_base / ndk_versions[-1])


### PR DESCRIPTION
## Why

Five small follow-ups to #83 caught while reviewing the merged changes.
Two are correctness (NDK / clang version sort regression vs the old
`.sh` and an over-eager mtime gate that hides incremental rebuilds);
the rest are cleanup / load-bearing comments.

## Summary

- `scripts/build_lib.py`: spell out the **stdlib-only** invariant in the
  module docstring (Gradle calls `build-version.py` on every APK build —
  no pip/uv deps allowed).
- `scripts/build_lib.py`: add `version_sort_key()` and use it from
  `zygisk/build-zip.py` (NDK auto-detect) and `kmod/build-zip.py` (clang
  auto-detect). The previous `sorted()` was lexicographic — `100.0.0`
  ended up below `25.0.1`, `clang-r9` ended up above `clang-r498344b`.
  `zygisk/build-zip.sh` had `sort -V` pre-port, so this is a regression
  fix; `kmod` is a safety net (DDK containers ship one clang today).
- `scripts/build_lib.py`: drop unused `get_python_exe()` (no callers).
- `scripts/build_lib.py`: hoist `import subprocess` to module scope.
- `kmod/build-zip.py`: drop the `kmod_c.stat().st_mtime > kmod_ko...`
  gate before `make strip`. It only watched `vpnhide_kmod.c`, so edits
  to the `Makefile`, kernel headers, or `.config` wouldn't trigger a
  rebuild. Let make's own dep tracking decide.