### PR TITLE
fix(lsposed): show user-app hidden count in save snackbar

### DIFF
--- a/changelog.d/fixed-save-snackbar-on-the-app-hiding-fcab.md
+++ b/changelog.d/fixed-save-snackbar-on-the-app-hiding-fcab.md
@@ -1,0 +1,9 @@
+_2026-04-25_
+
+## English
+
+Save snackbar on the App Hiding screen no longer counts vpnhide itself in the hidden total.
+
+## Русский
+
+Snackbar после сохранения на экране скрытия приложений больше не учитывает сам vpnhide в счётчике скрытых.

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/AppHidingScreen.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/AppHidingScreen.kt
@@ -341,7 +341,7 @@ fun AppHidingScreen(
                     suExecAsync(buildHidingSaveCommand(header, hiddenPkgs, observerPkgs))
                 if (exitCode == 0) {
                     snackMessage =
-                        context.getString(R.string.hiding_save_success, hiddenPkgs.size, observerPkgs.size)
+                        context.getString(R.string.hiding_save_success, hiddenCount, observerCount)
                     DashboardCache.invalidate()
                     TargetsCache.refresh(scope, context)
                 } else if (exitCode == -1) {


### PR DESCRIPTION
## Why

Reported in #79: after pressing Save on the App Hiding screen, the
snackbar reports one more hidden app than the user actually selected.
The cause is that \`hiddenPkgs\` (passed to the shell command) always
has the vpnhide package itself appended so the kernel-side list keeps
self in scope, and the snackbar was reading \`hiddenPkgs.size\` directly.

Alternative fix to #81 — that PR uses \`hiddenPkgs.size - 1\`, which
also works today but bakes a magic offset into the UI that breaks
silently if the assembly of \`hiddenPkgs\` ever changes again.

## Summary

- \`AppHidingScreen.kt:344\`: switch the save-success snackbar from
  \`hiddenPkgs.size, observerPkgs.size\` to \`hiddenCount, observerCount\`
  — the same values already used by the header (\`H: \$hiddenCount · O: \$observerCount\`, \`:309\`),
  computed via \`allApps.count { it.hidden / it.observer }\` (\`:158-159\`).
- Header and snackbar now agree on the count, and both ignore self
  consistently.
- \`AppPickerScreen\` already uses this pattern (\`:322\` —
  \`allApps.count { it.anySelected }\`); this brings the hiding screen
  in line.

Closes #79.