### PR TITLE
fix(lsposed): increase time of notifications

### DIFF
--- a/changelog.d/fixed-notification-time-increased-to-make-it-fc9a.md
+++ b/changelog.d/fixed-notification-time-increased-to-make-it-fc9a.md
@@ -1,0 +1,9 @@
+gi_2026-04-25_
+
+## English
+
+Notification time increased to make it readable
+
+## Русский
+
+Увеличено время отображения уведомления о сохранении

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/AppHidingScreen.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/AppHidingScreen.kt
@@ -27,6 +27,7 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Button
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.SnackbarDuration
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Surface
@@ -96,7 +97,10 @@ fun AppHidingScreen(
 
     LaunchedEffect(snackMessage) {
         snackMessage?.let {
-            snackbarHostState.showSnackbar(it)
+            snackbarHostState.showSnackbar(
+                message = it,
+                duration = SnackbarDuration.Long,
+            )
             snackMessage = null
         }
     }
@@ -298,33 +302,41 @@ fun AppHidingScreen(
                 )
             }
             Surface(tonalElevation = 3.dp) {
-                Row(
-                    modifier =
-                        Modifier
-                            .fillMaxWidth()
-                            .padding(horizontal = 16.dp, vertical = 12.dp),
-                    verticalAlignment = Alignment.CenterVertically,
-                ) {
-                    Text(
-                        text = "H: $hiddenCount · O: $observerCount",
-                        style = MaterialTheme.typography.bodyMedium,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant,
-                        modifier = Modifier.weight(1f),
-                    )
-                    Button(
-                        onClick = {
-                            saving = true
-                            dirty = false
-                        },
-                        enabled = dirty && !saving,
+                Box {
+                    Row(
+                        modifier =
+                            Modifier
+                                .fillMaxWidth()
+                                .padding(horizontal = 16.dp, vertical = 12.dp),
+                        verticalAlignment = Alignment.CenterVertically,
                     ) {
-                        Text(stringResource(R.string.btn_save))
+                        Text(
+                            text = "H: $hiddenCount · O: $observerCount",
+                            style = MaterialTheme.typography.bodyMedium,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            modifier = Modifier.weight(1f),
+                        )
+                        Button(
+                            onClick = {
+                                saving = true
+                                dirty = false
+                            },
+                            enabled = dirty && !saving,
+                        ) {
+                            Text(stringResource(R.string.btn_save))
+                        }
                     }
+
+                    SnackbarHost(
+                        hostState = snackbarHostState,
+                        modifier =
+                            Modifier
+                                .fillMaxWidth()
+                                .align(Alignment.TopCenter),
+                    )
                 }
             }
         }
-
-        SnackbarHost(snackbarHostState)
     }
 
     if (saving) {

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/AppPickerScreen.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/AppPickerScreen.kt
@@ -77,7 +77,10 @@ fun AppPickerScreen(
 
     LaunchedEffect(snackMessage) {
         snackMessage?.let {
-            snackbarHostState.showSnackbar(it)
+            snackbarHostState.showSnackbar(
+                message = it,
+                duration = SnackbarDuration.Long,
+            )
             snackMessage = null
         }
     }
@@ -275,33 +278,41 @@ fun AppPickerScreen(
                 )
             }
             Surface(tonalElevation = 3.dp) {
-                Row(
-                    modifier =
-                        Modifier
-                            .fillMaxWidth()
-                            .padding(horizontal = 16.dp, vertical = 12.dp),
-                    verticalAlignment = Alignment.CenterVertically,
-                ) {
-                    Text(
-                        text = stringResource(R.string.selected_count, selectedCount),
-                        style = MaterialTheme.typography.bodyMedium,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant,
-                        modifier = Modifier.weight(1f),
-                    )
-                    Button(
-                        onClick = {
-                            saving = true
-                            dirty = false
-                        },
-                        enabled = dirty && !saving,
+                Box {
+                    Row(
+                        modifier =
+                            Modifier
+                                .fillMaxWidth()
+                                .padding(horizontal = 16.dp, vertical = 12.dp),
+                        verticalAlignment = Alignment.CenterVertically,
                     ) {
-                        Text(stringResource(R.string.btn_save))
+                        Text(
+                            text = stringResource(R.string.selected_count, selectedCount),
+                            style = MaterialTheme.typography.bodyMedium,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            modifier = Modifier.weight(1f),
+                        )
+                        Button(
+                            onClick = {
+                                saving = true
+                                dirty = false
+                            },
+                            enabled = dirty && !saving,
+                        ) {
+                            Text(stringResource(R.string.btn_save))
+                        }
                     }
+
+                    SnackbarHost(
+                        hostState = snackbarHostState,
+                        modifier =
+                            Modifier
+                                .fillMaxWidth()
+                                .align(Alignment.TopCenter),
+                    )
                 }
             }
         }
-
-        SnackbarHost(snackbarHostState)
     }
 
     // Save effect

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/PortsHidingScreen.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/PortsHidingScreen.kt
@@ -291,12 +291,6 @@ fun PortsHidingScreen(
                         }
                     }
 
-//                    SnackbarHost(
-//                        hostState = snackbarHostState,
-//                        modifier = Modifier
-//                            .fillMaxWidth()
-//                            .align(Alignment.TopCenter),
-//                    )
                     SnackbarHost(
                         hostState = snackbarHostState,
                         modifier =

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/PortsHidingScreen.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/PortsHidingScreen.kt
@@ -29,6 +29,7 @@ import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.SnackbarDuration
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Surface
@@ -93,7 +94,10 @@ fun PortsHidingScreen(
 
     LaunchedEffect(snackMessage) {
         snackMessage?.let {
-            snackbarHostState.showSnackbar(it)
+            snackbarHostState.showSnackbar(
+                message = it,
+                duration = SnackbarDuration.Long,
+            )
             snackMessage = null
         }
     }
@@ -262,33 +266,47 @@ fun PortsHidingScreen(
                 )
             }
             Surface(tonalElevation = 3.dp) {
-                Row(
-                    modifier =
-                        Modifier
-                            .fillMaxWidth()
-                            .padding(horizontal = 16.dp, vertical = 12.dp),
-                    verticalAlignment = Alignment.CenterVertically,
-                ) {
-                    Text(
-                        text = stringResource(R.string.ports_count, observerCount),
-                        style = MaterialTheme.typography.bodyMedium,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant,
-                        modifier = Modifier.weight(1f),
-                    )
-                    Button(
-                        onClick = {
-                            saving = true
-                            dirty = false
-                        },
-                        enabled = dirty && !saving,
+                Box {
+                    Row(
+                        modifier =
+                            Modifier
+                                .fillMaxWidth()
+                                .padding(horizontal = 16.dp, vertical = 12.dp),
+                        verticalAlignment = Alignment.CenterVertically,
                     ) {
-                        Text(stringResource(R.string.btn_save))
+                        Text(
+                            text = stringResource(R.string.ports_count, observerCount),
+                            style = MaterialTheme.typography.bodyMedium,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            modifier = Modifier.weight(1f),
+                        )
+                        Button(
+                            onClick = {
+                                saving = true
+                                dirty = false
+                            },
+                            enabled = dirty && !saving,
+                        ) {
+                            Text(stringResource(R.string.btn_save))
+                        }
                     }
+
+//                    SnackbarHost(
+//                        hostState = snackbarHostState,
+//                        modifier = Modifier
+//                            .fillMaxWidth()
+//                            .align(Alignment.TopCenter),
+//                    )
+                    SnackbarHost(
+                        hostState = snackbarHostState,
+                        modifier =
+                            Modifier
+                                .fillMaxWidth()
+                                .align(Alignment.TopCenter),
+                    )
                 }
             }
         }
-
-        SnackbarHost(snackbarHostState)
     }
 
     if (saving) {


### PR DESCRIPTION
### Why
When saving, a request is sent to Magisk, which responds with a "root access granted" notification. At the same time, the app shows its own notification confirming the save. These two notifications overlap, making the text unreadable.

### Summary
- Notification time increased to make it readable

Closes #82 