### PR TITLE
refactor: drive VPN-iface matching from a single TOML source of truth

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,16 @@ jobs:
       - name: Mark workspace safe
         run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
 
+      # Codegen
+      - name: Verify generated iface lists are up to date
+        run: |
+          python3 scripts/codegen-interfaces.py
+          if ! git diff --quiet; then
+            echo "::error::data/interfaces.toml is out of sync with generated files. Run scripts/codegen-interfaces.py and commit the result." >&2
+            git --no-pager diff
+            exit 1
+          fi
+
       # Rust
       - name: rustfmt
         run: |

--- a/changelog.d/fixed-native-diagnostics-now-recognize-utun-l2tp-5a82.md
+++ b/changelog.d/fixed-native-diagnostics-now-recognize-utun-l2tp-5a82.md
@@ -1,0 +1,9 @@
+_2026-04-25_
+
+## English
+
+Native diagnostics now recognize utun*, l2tp*, gre* and renamed *vpn* interfaces as VPN tunnels (matching the rest of the hooks).
+
+## Русский
+
+Нативная диагностика теперь распознаёт utun*, l2tp*, gre* и переименованные *vpn* интерфейсы как VPN-туннели (соответствует поведению остальных хуков).

--- a/data/interfaces.toml
+++ b/data/interfaces.toml
@@ -1,0 +1,58 @@
+# Single source of truth for VPN-like network interface name patterns.
+# A name matching any rule below is treated as a tunnel and hidden from
+# target apps (kmod) / from the calling process (zygisk + lsposed).
+#
+# Read at codegen time by scripts/codegen-interfaces.py, which renders
+# four matchers (kmod C, zygisk Rust, lsposed-native Rust, lsposed
+# Kotlin). Sync between platforms is enforced by a CI lint step that
+# re-runs the codegen and fails if the generated files drift.
+#
+# Match grammar (intentionally tiny so all four targets implement it
+# identically without depending on a regex engine — kernel C has none):
+#
+#   { exact   = "lo"     }                  name == "lo"
+#   { prefix  = "rmnet"  }                  name.starts_with("rmnet")
+#   { prefix  = "wlan", suffix = "digits" } starts_with + rest is all ASCII digits
+#   { contains = "vpn"   }                  needle anywhere in name
+#
+# All matches are ASCII case-insensitive.
+
+[[vpn]]
+match = { prefix = "tun" }
+note = "OpenVPN, WireGuard userspace, Tailscale, generic tunneling"
+
+[[vpn]]
+match = { prefix = "tap" }
+note = "OpenVPN bridged"
+
+[[vpn]]
+match = { prefix = "wg" }
+note = "WireGuard kernel"
+
+[[vpn]]
+match = { prefix = "ppp" }
+note = "PPTP / L2TP PPP tunnels"
+
+[[vpn]]
+match = { prefix = "ipsec" }
+note = "Android built-in IPsec VPN"
+
+[[vpn]]
+match = { prefix = "xfrm" }
+note = "kernel IPsec XFRM framework"
+
+[[vpn]]
+match = { prefix = "utun" }
+note = "Apple-style, rare on Android"
+
+[[vpn]]
+match = { prefix = "l2tp" }
+note = "L2TP"
+
+[[vpn]]
+match = { prefix = "gre" }
+note = "GRE tunnels"
+
+[[vpn]]
+match = { contains = "vpn" }
+note = "catch-all for renamed clients (myvpn0, vpn-client, xvpn1, ...)"

--- a/kmod/generated/iface_lists.h
+++ b/kmod/generated/iface_lists.h
@@ -1,0 +1,110 @@
+/* AUTO-GENERATED from data/interfaces.toml — do not edit by hand. Regenerate with: python3 scripts/codegen-interfaces.py */
+#ifndef VPNHIDE_GENERATED_IFACE_LISTS_H
+#define VPNHIDE_GENERATED_IFACE_LISTS_H
+
+#include <linux/string.h>
+#include <linux/ctype.h>
+#include <linux/types.h>
+
+static inline bool vpnhide_iface_starts_with_ci(
+	const char *name, const char *prefix)
+{
+	size_t i;
+	for (i = 0; prefix[i]; i++) {
+		if (!name[i])
+			return false;
+		if (tolower((unsigned char)name[i]) !=
+		    (unsigned char)prefix[i])
+			return false;
+	}
+	return true;
+}
+
+static inline bool vpnhide_iface_starts_with_then_digits_ci(
+	const char *name, const char *prefix)
+{
+	size_t i;
+	if (!vpnhide_iface_starts_with_ci(name, prefix))
+		return false;
+	i = strlen(prefix);
+	if (!name[i])
+		return false;
+	for (; name[i]; i++)
+		if (name[i] < '0' || name[i] > '9')
+			return false;
+	return true;
+}
+
+static inline bool vpnhide_iface_equals_ci(
+	const char *name, const char *other)
+{
+	size_t i;
+	for (i = 0; other[i]; i++) {
+		if (!name[i])
+			return false;
+		if (tolower((unsigned char)name[i]) !=
+		    (unsigned char)other[i])
+			return false;
+	}
+	return name[i] == '\0';
+}
+
+static inline bool vpnhide_iface_contains_ci(
+	const char *name, const char *needle)
+{
+	size_t nlen = strlen(needle);
+	size_t i, j;
+	if (nlen == 0)
+		return true;
+	for (i = 0; name[i]; i++) {
+		for (j = 0; j < nlen; j++) {
+			if (!name[i + j])
+				return false;
+			if (tolower((unsigned char)name[i + j]) !=
+			    (unsigned char)needle[j])
+				break;
+		}
+		if (j == nlen)
+			return true;
+	}
+	return false;
+}
+
+static inline bool vpnhide_iface_is_vpn(const char *name)
+{
+	if (!name || !name[0])
+		return false;
+	/* OpenVPN, WireGuard userspace, Tailscale, generic tunneling */
+	if (vpnhide_iface_starts_with_ci(name, "tun"))
+		return true;
+	/* OpenVPN bridged */
+	if (vpnhide_iface_starts_with_ci(name, "tap"))
+		return true;
+	/* WireGuard kernel */
+	if (vpnhide_iface_starts_with_ci(name, "wg"))
+		return true;
+	/* PPTP / L2TP PPP tunnels */
+	if (vpnhide_iface_starts_with_ci(name, "ppp"))
+		return true;
+	/* Android built-in IPsec VPN */
+	if (vpnhide_iface_starts_with_ci(name, "ipsec"))
+		return true;
+	/* kernel IPsec XFRM framework */
+	if (vpnhide_iface_starts_with_ci(name, "xfrm"))
+		return true;
+	/* Apple-style, rare on Android */
+	if (vpnhide_iface_starts_with_ci(name, "utun"))
+		return true;
+	/* L2TP */
+	if (vpnhide_iface_starts_with_ci(name, "l2tp"))
+		return true;
+	/* GRE tunnels */
+	if (vpnhide_iface_starts_with_ci(name, "gre"))
+		return true;
+	/* catch-all for renamed clients (myvpn0, vpn-client, xvpn1, ...) */
+	if (vpnhide_iface_contains_ci(name, "vpn"))
+		return true;
+	return false;
+}
+
+#endif /* VPNHIDE_GENERATED_IFACE_LISTS_H */

--- a/kmod/vpnhide_kmod.c
+++ b/kmod/vpnhide_kmod.c
@@ -37,6 +37,8 @@
 #include <linux/inetdevice.h>
 #include <net/if_inet6.h>
 
+#include "generated/iface_lists.h"
+
 #define MODNAME "vpnhide"
 #define MAX_TARGET_UIDS 64
 
@@ -53,30 +55,10 @@ static bool debug_enabled;
 	} while (0)
 
 /* ------------------------------------------------------------------ */
-/*  VPN interface name matching                                       */
+/*  VPN interface name matching — see data/interfaces.toml            */
 /* ------------------------------------------------------------------ */
 
-static const char *const vpn_prefixes[] = {
-	"tun", "ppp", "tap", "wg", "ipsec", "xfrm", "utun", "l2tp", "gre",
-};
-
-static bool is_vpn_ifname(const char *name)
-{
-	int i;
-
-	if (!name || !*name)
-		return false;
-
-	for (i = 0; i < ARRAY_SIZE(vpn_prefixes); i++) {
-		if (strncmp(name, vpn_prefixes[i], strlen(vpn_prefixes[i])) ==
-		    0)
-			return true;
-	}
-	if (strstr(name, "vpn") || strstr(name, "VPN"))
-		return true;
-
-	return false;
-}
+#define is_vpn_ifname(name) vpnhide_iface_is_vpn(name)
 
 /* ------------------------------------------------------------------ */
 /*  Target UID list                                                   */

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DiagnosticsScreen.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DiagnosticsScreen.kt
@@ -30,6 +30,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.core.content.FileProvider
+import dev.okhsunrog.vpnhide.generated.IfaceLists
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
@@ -44,7 +45,6 @@ import java.util.zip.ZipEntry
 import java.util.zip.ZipOutputStream
 
 private const val TAG = "VPNHideTest"
-private val VPN_PREFIXES = listOf("tun", "wg", "ppp", "tap", "ipsec", "xfrm")
 
 data class CheckResult(
     val name: String,
@@ -67,9 +67,7 @@ internal suspend fun isVpnActive(): Boolean =
             output
                 .lines()
                 .map { it.trim() }
-                .filter { name ->
-                    name.isNotEmpty() && VPN_PREFIXES.any { name.startsWith(it) }
-                }
+                .filter { name -> IfaceLists.isVpnIface(name) }
         if (vpnIfaces.isEmpty()) return@withContext false
         vpnIfaces.any { iface ->
             val (_, state) =
@@ -750,7 +748,7 @@ private fun checkNetworkInterfaceEnum(name: String): CheckResult =
         val vpnNames = mutableListOf<String>()
         for (iface in ifaces) {
             allNames.add(iface.name)
-            if (VPN_PREFIXES.any { iface.name.startsWith(it) }) vpnNames.add(iface.name)
+            if (IfaceLists.isVpnIface(iface.name)) vpnNames.add(iface.name)
         }
         val detail =
             if (vpnNames.isEmpty()) {
@@ -817,7 +815,7 @@ private fun checkLinkPropertiesIfname(
     val ifname = lp.interfaceName ?: "(null)"
     val routes = lp.routes.map { "${it.destination} via ${it.gateway} dev ${it.`interface`}" }
     val dns = lp.dnsServers.map { it.hostAddress ?: "?" }
-    val isVpn = VPN_PREFIXES.any { ifname.startsWith(it) }
+    val isVpn = IfaceLists.isVpnIface(ifname)
     val detail =
         if (!isVpn) {
             "PASS: ifname=$ifname, ${routes.size} routes, dns=[${dns.joinToString()}]"
@@ -837,7 +835,7 @@ private fun checkLinkPropertiesRoutes(
     val vpnRoutes =
         routes.filter { route ->
             val iface = route.`interface` ?: return@filter false
-            VPN_PREFIXES.any { iface.startsWith(it) }
+            IfaceLists.isVpnIface(iface)
         }
     val detail =
         if (vpnRoutes.isEmpty()) {
@@ -871,7 +869,12 @@ private fun checkProcNetRouteJava(name: String): CheckResult =
             var line: String?
             while (br.readLine().also { line = it } != null) {
                 allLines.add(line!!)
-                if (VPN_PREFIXES.any { line!!.startsWith(it) }) vpnLines.add(line!!.take(60))
+                // /proc/net/route is whitespace-separated; check
+                // each token instead of just startsWith on the raw
+                // line so we don't match e.g. an IP-as-hex by chance.
+                if (line!!.split(Regex("\\s+")).any(IfaceLists::isVpnIface)) {
+                    vpnLines.add(line!!.take(60))
+                }
             }
         }
         val detail =

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/HookEntry.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/HookEntry.kt
@@ -9,6 +9,7 @@ import de.robv.android.xposed.IXposedHookLoadPackage
 import de.robv.android.xposed.XC_MethodHook
 import de.robv.android.xposed.XposedHelpers
 import de.robv.android.xposed.callbacks.XC_LoadPackage
+import dev.okhsunrog.vpnhide.generated.IfaceLists
 import java.io.File
 import java.util.concurrent.atomic.AtomicBoolean
 
@@ -71,20 +72,7 @@ class HookEntry : IXposedHookLoadPackage {
     //  Helpers
     // ------------------------------------------------------------------
 
-    private fun isVpnInterfaceName(name: String): Boolean {
-        if (name.isEmpty()) return false
-        val n = name.lowercase()
-        return n.startsWith("tun") ||
-            n.startsWith("ppp") ||
-            n.startsWith("tap") ||
-            n.startsWith("wg") ||
-            n.startsWith("ipsec") ||
-            n.startsWith("xfrm") ||
-            n.startsWith("utun") ||
-            n.startsWith("l2tp") ||
-            n.startsWith("gre") ||
-            n.contains("vpn")
-    }
+    private fun isVpnInterfaceName(name: String): Boolean = IfaceLists.isVpnIface(name)
 
     private fun sanitizeLinkProperties(copy: LinkProperties): Boolean {
         var modified = false

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/generated/IfaceLists.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/generated/IfaceLists.kt
@@ -1,0 +1,32 @@
+// AUTO-GENERATED from data/interfaces.toml — do not edit by hand. Regenerate with: python3 scripts/codegen-interfaces.py
+
+package dev.okhsunrog.vpnhide.generated
+
+internal object IfaceLists {
+    /** True if `name` looks like a VPN tunnel per data/interfaces.toml. */
+    fun isVpnIface(name: String): Boolean {
+        if (name.isEmpty()) return false
+        val n = name.lowercase()
+        // OpenVPN, WireGuard userspace, Tailscale, generic tunneling
+        if (n.startsWith("tun")) return true
+        // OpenVPN bridged
+        if (n.startsWith("tap")) return true
+        // WireGuard kernel
+        if (n.startsWith("wg")) return true
+        // PPTP / L2TP PPP tunnels
+        if (n.startsWith("ppp")) return true
+        // Android built-in IPsec VPN
+        if (n.startsWith("ipsec")) return true
+        // kernel IPsec XFRM framework
+        if (n.startsWith("xfrm")) return true
+        // Apple-style, rare on Android
+        if (n.startsWith("utun")) return true
+        // L2TP
+        if (n.startsWith("l2tp")) return true
+        // GRE tunnels
+        if (n.startsWith("gre")) return true
+        // catch-all for renamed clients (myvpn0, vpn-client, xvpn1, ...)
+        if (n.contains("vpn")) return true
+        return false
+    }
+}

--- a/lsposed/native/Cargo.lock
+++ b/lsposed/native/Cargo.lock
@@ -184,7 +184,7 @@ checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
 name = "vpnhide_checks"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "android_logger",
  "jni",

--- a/lsposed/native/src/generated/iface_lists.rs
+++ b/lsposed/native/src/generated/iface_lists.rs
@@ -1,0 +1,100 @@
+// AUTO-GENERATED from data/interfaces.toml — do not edit by hand. Regenerate with: python3 scripts/codegen-interfaces.py
+
+#![allow(dead_code)]
+
+fn starts_with_ci(name: &[u8], prefix: &[u8]) -> bool {
+    if name.len() < prefix.len() {
+        return false;
+    }
+    for (i, &p) in prefix.iter().enumerate() {
+        if name[i].to_ascii_lowercase() != p {
+            return false;
+        }
+    }
+    true
+}
+
+fn starts_with_then_digits_ci(name: &[u8], prefix: &[u8]) -> bool {
+    if !starts_with_ci(name, prefix) {
+        return false;
+    }
+    let rest = &name[prefix.len()..];
+    !rest.is_empty() && rest.iter().all(|b| b.is_ascii_digit())
+}
+
+fn equals_ci(name: &[u8], other: &[u8]) -> bool {
+    if name.len() != other.len() {
+        return false;
+    }
+    name.iter()
+        .zip(other.iter())
+        .all(|(a, b)| a.to_ascii_lowercase() == *b)
+}
+
+fn contains_ci(haystack: &[u8], needle: &[u8]) -> bool {
+    if needle.is_empty() {
+        return true;
+    }
+    if needle.len() > haystack.len() {
+        return false;
+    }
+    for start in 0..=haystack.len() - needle.len() {
+        let window = &haystack[start..start + needle.len()];
+        if window
+            .iter()
+            .zip(needle.iter())
+            .all(|(a, b)| a.eq_ignore_ascii_case(b))
+        {
+            return true;
+        }
+    }
+    false
+}
+
+/// True if the name matches any VPN-iface rule from data/interfaces.toml.
+pub fn matches_vpn(name: &[u8]) -> bool {
+    if name.is_empty() {
+        return false;
+    }
+    // OpenVPN, WireGuard userspace, Tailscale, generic tunneling
+    if starts_with_ci(name, b"tun") {
+        return true;
+    }
+    // OpenVPN bridged
+    if starts_with_ci(name, b"tap") {
+        return true;
+    }
+    // WireGuard kernel
+    if starts_with_ci(name, b"wg") {
+        return true;
+    }
+    // PPTP / L2TP PPP tunnels
+    if starts_with_ci(name, b"ppp") {
+        return true;
+    }
+    // Android built-in IPsec VPN
+    if starts_with_ci(name, b"ipsec") {
+        return true;
+    }
+    // kernel IPsec XFRM framework
+    if starts_with_ci(name, b"xfrm") {
+        return true;
+    }
+    // Apple-style, rare on Android
+    if starts_with_ci(name, b"utun") {
+        return true;
+    }
+    // L2TP
+    if starts_with_ci(name, b"l2tp") {
+        return true;
+    }
+    // GRE tunnels
+    if starts_with_ci(name, b"gre") {
+        return true;
+    }
+    // catch-all for renamed clients (myvpn0, vpn-client, xvpn1, ...)
+    if contains_ci(name, b"vpn") {
+        return true;
+    }
+    false
+}

--- a/lsposed/native/src/generated/mod.rs
+++ b/lsposed/native/src/generated/mod.rs
@@ -1,0 +1,4 @@
+//! Auto-generated modules. Hand-edit nothing under here — see
+//! `scripts/codegen-interfaces.py`.
+
+pub mod iface_lists;

--- a/lsposed/native/src/lib.rs
+++ b/lsposed/native/src/lib.rs
@@ -1,14 +1,15 @@
+mod generated;
+
 use jni::JNIEnv;
 use jni::objects::JClass;
 use jni::sys::jstring;
 use std::ffi::CStr;
 use std::io::ErrorKind;
 
-const VPN_PREFIXES: &[&str] = &["tun", "wg", "ppp", "tap", "ipsec", "xfrm"];
+use crate::generated::iface_lists::matches_vpn;
 
 fn is_vpn_iface(name: &str) -> bool {
-    let n = name.to_ascii_lowercase();
-    VPN_PREFIXES.iter().any(|p| n.starts_with(p)) || n.contains("vpn")
+    matches_vpn(name.as_bytes())
 }
 
 fn logi(msg: &str) {
@@ -267,7 +268,12 @@ fn check_proc_file(path: &str) -> String {
                 }
                 total += 1;
                 logi(&format!("  {path} line: {}", &line[..line.len().min(120)]));
-                if VPN_PREFIXES.iter().any(|p| line.contains(p)) {
+                // /proc/net/route and /proc/net/ipv6_route are
+                // whitespace-separated; an iface name is one of the
+                // tokens. Token-by-token check avoids the false
+                // positive of substring "tun" or "gre" appearing
+                // inside a hex-encoded IP address.
+                if line.split_whitespace().any(is_vpn_iface) {
                     vpn_lines.push(line[..line.len().min(80)].to_string());
                 }
             }

--- a/scripts/codegen-interfaces.py
+++ b/scripts/codegen-interfaces.py
@@ -1,0 +1,402 @@
+#!/usr/bin/env python3
+"""Render the four iface-list matchers from data/interfaces.toml.
+
+Generates one match function per target (kmod C, zygisk Rust,
+lsposed/native Rust, lsposed Kotlin) so all four platforms agree on
+which interface names are VPN tunnels. Re-run this script after
+editing data/interfaces.toml and commit the regenerated files
+alongside the toml change. CI's lint job re-runs the codegen and fails
+on drift.
+
+Stdlib only: tomllib (Python 3.11+) is the only non-builtin import,
+and that's stdlib too.
+"""
+
+from __future__ import annotations
+
+import sys
+import tomllib
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+TOML_PATH = REPO_ROOT / "data" / "interfaces.toml"
+
+# Output paths — kept next to the code that consumes them so include /
+# import paths stay short and obvious.
+OUT_KMOD = REPO_ROOT / "kmod" / "generated" / "iface_lists.h"
+OUT_ZYGISK = REPO_ROOT / "zygisk" / "src" / "generated" / "iface_lists.rs"
+OUT_LSP_NATIVE = REPO_ROOT / "lsposed" / "native" / "src" / "generated" / "iface_lists.rs"
+OUT_LSP_KT = (
+    REPO_ROOT
+    / "lsposed"
+    / "app"
+    / "src"
+    / "main"
+    / "kotlin"
+    / "dev"
+    / "okhsunrog"
+    / "vpnhide"
+    / "generated"
+    / "IfaceLists.kt"
+)
+
+GENERATED_HEADER_LINE = (
+    "AUTO-GENERATED from data/interfaces.toml — do not edit by hand. "
+    "Regenerate with: python3 scripts/codegen-interfaces.py"
+)
+
+
+# ---------------------------------------------------------------------------
+# rule normalization
+# ---------------------------------------------------------------------------
+
+
+class Rule:
+    """One match rule from the toml, normalized to a known kind.
+
+    kind ∈ {"exact", "prefix", "prefix_digits", "contains"}.
+    needle is the literal string (already lowercased — all targets
+    fold case at match time).
+    note is the human comment from the toml, copied into the
+    generated source so reviewers see why each rule is there.
+    """
+
+    __slots__ = ("kind", "needle", "note")
+
+    def __init__(self, kind: str, needle: str, note: str) -> None:
+        self.kind = kind
+        self.needle = needle
+        self.note = note
+
+
+def parse_rule(entry: dict[str, Any]) -> Rule:
+    match = entry.get("match")
+    if not isinstance(match, dict):
+        raise SystemExit(f"entry missing or malformed `match`: {entry!r}")
+    note = str(entry.get("note", "")).strip()
+
+    keys = set(match.keys())
+    if keys == {"exact"}:
+        needle = str(match["exact"])
+        kind = "exact"
+    elif keys == {"prefix"}:
+        needle = str(match["prefix"])
+        kind = "prefix"
+    elif keys == {"prefix", "suffix"}:
+        if match["suffix"] != "digits":
+            raise SystemExit(
+                f"unsupported suffix {match['suffix']!r}; only 'digits' is implemented"
+            )
+        needle = str(match["prefix"])
+        kind = "prefix_digits"
+    elif keys == {"contains"}:
+        needle = str(match["contains"])
+        kind = "contains"
+    else:
+        raise SystemExit(f"unsupported match shape {keys!r} in entry {entry!r}")
+
+    if not needle:
+        raise SystemExit(f"empty needle in entry {entry!r}")
+    if not all(0x20 <= ord(c) < 0x7F for c in needle):
+        raise SystemExit(f"non-ASCII needle {needle!r} in entry {entry!r}")
+    return Rule(kind, needle.lower(), note)
+
+
+def load_rules() -> list[Rule]:
+    with TOML_PATH.open("rb") as f:
+        data = tomllib.load(f)
+    raw = data.get("vpn") or []
+    if not isinstance(raw, list) or not raw:
+        raise SystemExit(f"{TOML_PATH}: missing or empty [[vpn]] table")
+    return [parse_rule(e) for e in raw]
+
+
+# ---------------------------------------------------------------------------
+# emitters
+# ---------------------------------------------------------------------------
+
+
+def c_byte_lit(s: str) -> str:
+    """Render a Python str as a C string literal, ASCII only."""
+    return '"' + "".join(c if c not in '"\\' else "\\" + c for c in s) + '"'
+
+
+def emit_kmod(rules: list[Rule]) -> str:
+    """Render an inline header for the kernel module.
+
+    Provides:
+      static inline bool vpnhide_iface_is_vpn(const char *name);
+    """
+    lines: list[str] = []
+    lines.append(f"/* {GENERATED_HEADER_LINE} */")
+    lines.append("#ifndef VPNHIDE_GENERATED_IFACE_LISTS_H")
+    lines.append("#define VPNHIDE_GENERATED_IFACE_LISTS_H")
+    lines.append("")
+    lines.append("#include <linux/string.h>")
+    lines.append("#include <linux/ctype.h>")
+    lines.append("#include <linux/types.h>")
+    lines.append("")
+    lines.append("static inline bool vpnhide_iface_starts_with_ci(")
+    lines.append("\tconst char *name, const char *prefix)")
+    lines.append("{")
+    lines.append("\tsize_t i;")
+    lines.append("\tfor (i = 0; prefix[i]; i++) {")
+    lines.append("\t\tif (!name[i])")
+    lines.append("\t\t\treturn false;")
+    lines.append("\t\tif (tolower((unsigned char)name[i]) !=")
+    lines.append("\t\t    (unsigned char)prefix[i])")
+    lines.append("\t\t\treturn false;")
+    lines.append("\t}")
+    lines.append("\treturn true;")
+    lines.append("}")
+    lines.append("")
+    lines.append("static inline bool vpnhide_iface_starts_with_then_digits_ci(")
+    lines.append("\tconst char *name, const char *prefix)")
+    lines.append("{")
+    lines.append("\tsize_t i;")
+    lines.append("\tif (!vpnhide_iface_starts_with_ci(name, prefix))")
+    lines.append("\t\treturn false;")
+    lines.append("\ti = strlen(prefix);")
+    lines.append("\tif (!name[i])")
+    lines.append("\t\treturn false;")
+    lines.append("\tfor (; name[i]; i++)")
+    lines.append("\t\tif (name[i] < '0' || name[i] > '9')")
+    lines.append("\t\t\treturn false;")
+    lines.append("\treturn true;")
+    lines.append("}")
+    lines.append("")
+    lines.append("static inline bool vpnhide_iface_equals_ci(")
+    lines.append("\tconst char *name, const char *other)")
+    lines.append("{")
+    lines.append("\tsize_t i;")
+    lines.append("\tfor (i = 0; other[i]; i++) {")
+    lines.append("\t\tif (!name[i])")
+    lines.append("\t\t\treturn false;")
+    lines.append("\t\tif (tolower((unsigned char)name[i]) !=")
+    lines.append("\t\t    (unsigned char)other[i])")
+    lines.append("\t\t\treturn false;")
+    lines.append("\t}")
+    lines.append("\treturn name[i] == '\\0';")
+    lines.append("}")
+    lines.append("")
+    lines.append("static inline bool vpnhide_iface_contains_ci(")
+    lines.append("\tconst char *name, const char *needle)")
+    lines.append("{")
+    lines.append("\tsize_t nlen = strlen(needle);")
+    lines.append("\tsize_t i, j;")
+    lines.append("\tif (nlen == 0)")
+    lines.append("\t\treturn true;")
+    lines.append("\tfor (i = 0; name[i]; i++) {")
+    lines.append("\t\tfor (j = 0; j < nlen; j++) {")
+    lines.append("\t\t\tif (!name[i + j])")
+    lines.append("\t\t\t\treturn false;")
+    lines.append("\t\t\tif (tolower((unsigned char)name[i + j]) !=")
+    lines.append("\t\t\t    (unsigned char)needle[j])")
+    lines.append("\t\t\t\tbreak;")
+    lines.append("\t\t}")
+    lines.append("\t\tif (j == nlen)")
+    lines.append("\t\t\treturn true;")
+    lines.append("\t}")
+    lines.append("\treturn false;")
+    lines.append("}")
+    lines.append("")
+    lines.append("static inline bool vpnhide_iface_is_vpn(const char *name)")
+    lines.append("{")
+    lines.append("\tif (!name || !name[0])")
+    lines.append("\t\treturn false;")
+    for r in rules:
+        comment = f"\t/* {r.note} */" if r.note else ""
+        if comment:
+            lines.append(comment)
+        if r.kind == "exact":
+            lines.append(
+                f"\tif (vpnhide_iface_equals_ci(name, {c_byte_lit(r.needle)}))"
+            )
+        elif r.kind == "prefix":
+            lines.append(
+                f"\tif (vpnhide_iface_starts_with_ci(name, {c_byte_lit(r.needle)}))"
+            )
+        elif r.kind == "prefix_digits":
+            lines.append(
+                f"\tif (vpnhide_iface_starts_with_then_digits_ci(name, {c_byte_lit(r.needle)}))"
+            )
+        elif r.kind == "contains":
+            lines.append(
+                f"\tif (vpnhide_iface_contains_ci(name, {c_byte_lit(r.needle)}))"
+            )
+        lines.append("\t\treturn true;")
+    lines.append("\treturn false;")
+    lines.append("}")
+    lines.append("")
+    lines.append("#endif /* VPNHIDE_GENERATED_IFACE_LISTS_H */")
+    lines.append("")
+    return "\n".join(lines)
+
+
+def rust_byte_lit(s: str) -> str:
+    return 'b"' + "".join(c if c not in '"\\' else "\\" + c for c in s) + '"'
+
+
+def emit_rust(rules: list[Rule]) -> str:
+    """Render a Rust module exporting `pub fn matches_vpn(name: &[u8]) -> bool`.
+
+    Used by both zygisk and lsposed/native (identical body) so that
+    self-test and the actual hooks share one definition.
+    """
+    lines: list[str] = []
+    lines.append(f"// {GENERATED_HEADER_LINE}")
+    lines.append("")
+    lines.append("#![allow(dead_code)]")
+    lines.append("")
+    lines.append("fn starts_with_ci(name: &[u8], prefix: &[u8]) -> bool {")
+    lines.append("    if name.len() < prefix.len() {")
+    lines.append("        return false;")
+    lines.append("    }")
+    lines.append("    for (i, &p) in prefix.iter().enumerate() {")
+    lines.append("        if name[i].to_ascii_lowercase() != p {")
+    lines.append("            return false;")
+    lines.append("        }")
+    lines.append("    }")
+    lines.append("    true")
+    lines.append("}")
+    lines.append("")
+    lines.append("fn starts_with_then_digits_ci(name: &[u8], prefix: &[u8]) -> bool {")
+    lines.append("    if !starts_with_ci(name, prefix) {")
+    lines.append("        return false;")
+    lines.append("    }")
+    lines.append("    let rest = &name[prefix.len()..];")
+    lines.append("    !rest.is_empty() && rest.iter().all(|b| b.is_ascii_digit())")
+    lines.append("}")
+    lines.append("")
+    lines.append("fn equals_ci(name: &[u8], other: &[u8]) -> bool {")
+    lines.append("    if name.len() != other.len() {")
+    lines.append("        return false;")
+    lines.append("    }")
+    lines.append("    name.iter()")
+    lines.append("        .zip(other.iter())")
+    lines.append("        .all(|(a, b)| a.to_ascii_lowercase() == *b)")
+    lines.append("}")
+    lines.append("")
+    lines.append("fn contains_ci(haystack: &[u8], needle: &[u8]) -> bool {")
+    lines.append("    if needle.is_empty() {")
+    lines.append("        return true;")
+    lines.append("    }")
+    lines.append("    if needle.len() > haystack.len() {")
+    lines.append("        return false;")
+    lines.append("    }")
+    lines.append("    for start in 0..=haystack.len() - needle.len() {")
+    lines.append("        let window = &haystack[start..start + needle.len()];")
+    lines.append("        if window")
+    lines.append("            .iter()")
+    lines.append("            .zip(needle.iter())")
+    lines.append("            .all(|(a, b)| a.eq_ignore_ascii_case(b))")
+    lines.append("        {")
+    lines.append("            return true;")
+    lines.append("        }")
+    lines.append("    }")
+    lines.append("    false")
+    lines.append("}")
+    lines.append("")
+    lines.append("/// True if the name matches any VPN-iface rule from data/interfaces.toml.")
+    lines.append("pub fn matches_vpn(name: &[u8]) -> bool {")
+    lines.append("    if name.is_empty() {")
+    lines.append("        return false;")
+    lines.append("    }")
+    for r in rules:
+        if r.note:
+            lines.append(f"    // {r.note}")
+        if r.kind == "exact":
+            fn = "equals_ci"
+        elif r.kind == "prefix":
+            fn = "starts_with_ci"
+        elif r.kind == "prefix_digits":
+            fn = "starts_with_then_digits_ci"
+        elif r.kind == "contains":
+            fn = "contains_ci"
+        lines.append(f"    if {fn}(name, {rust_byte_lit(r.needle)}) {{")
+        lines.append("        return true;")
+        lines.append("    }")
+    lines.append("    false")
+    lines.append("}")
+    lines.append("")
+    return "\n".join(lines)
+
+
+def kt_str_lit(s: str) -> str:
+    return '"' + "".join(c if c not in '"\\' else "\\" + c for c in s) + '"'
+
+
+def emit_kotlin(rules: list[Rule]) -> str:
+    """Render a Kotlin singleton with `IfaceLists.isVpnIface(name)`."""
+    lines: list[str] = []
+    lines.append(f"// {GENERATED_HEADER_LINE}")
+    lines.append("")
+    lines.append("package dev.okhsunrog.vpnhide.generated")
+    lines.append("")
+    lines.append("internal object IfaceLists {")
+    lines.append("    /** True if `name` looks like a VPN tunnel per data/interfaces.toml. */")
+    lines.append("    fun isVpnIface(name: String): Boolean {")
+    lines.append("        if (name.isEmpty()) return false")
+    lines.append("        val n = name.lowercase()")
+    for r in rules:
+        if r.note:
+            lines.append(f"        // {r.note}")
+        if r.kind == "exact":
+            cond = f"n == {kt_str_lit(r.needle)}"
+        elif r.kind == "prefix":
+            cond = f"n.startsWith({kt_str_lit(r.needle)})"
+        elif r.kind == "prefix_digits":
+            lit = kt_str_lit(r.needle)
+            cond = (
+                f"n.startsWith({lit}) && "
+                f"n.length > {len(r.needle)} && "
+                f"n.substring({len(r.needle)}).all {{ it.isDigit() }}"
+            )
+        elif r.kind == "contains":
+            cond = f"n.contains({kt_str_lit(r.needle)})"
+        lines.append(f"        if ({cond}) return true")
+    lines.append("        return false")
+    lines.append("    }")
+    lines.append("}")
+    lines.append("")
+    return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# main
+# ---------------------------------------------------------------------------
+
+
+def write_if_changed(path: Path, content: str) -> bool:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    if path.exists() and path.read_text(encoding="utf-8") == content:
+        return False
+    path.write_text(content, encoding="utf-8")
+    return True
+
+
+def main() -> int:
+    rules = load_rules()
+    outputs = {
+        OUT_KMOD: emit_kmod(rules),
+        OUT_ZYGISK: emit_rust(rules),
+        OUT_LSP_NATIVE: emit_rust(rules),
+        OUT_LSP_KT: emit_kotlin(rules),
+    }
+    changed = []
+    for path, content in outputs.items():
+        if write_if_changed(path, content):
+            changed.append(path.relative_to(REPO_ROOT))
+
+    if changed:
+        print("Regenerated:")
+        for p in changed:
+            print(f"  {p}")
+    else:
+        print("All generated files already up to date.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/zygisk/Cargo.lock
+++ b/zygisk/Cargo.lock
@@ -241,7 +241,7 @@ checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
 name = "vpnhide_zygisk"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "android_logger",
  "cmake",

--- a/zygisk/src/filter.rs
+++ b/zygisk/src/filter.rs
@@ -1,84 +1,31 @@
 //! Pure logic: is a given interface name a VPN tunnel?
 //!
-//! Kept as a leaf module with no dependencies so it's easy to unit-test on
-//! the host. The set of prefixes must stay in sync with the Kotlin LSPosed
-//! module's `isVpnInterfaceName`.
+//! Kept as a leaf module so it's easy to unit-test on the host. The
+//! actual rules live in `data/interfaces.toml` and are rendered into
+//! `generated::iface_lists::matches_vpn` by
+//! `scripts/codegen-interfaces.py`; this file is just the public API
+//! plus the NUL-trim that `ifr_name`-style buffers need.
 
 use core::ffi::CStr;
 
-/// Interface name prefixes we treat as "this is a VPN tunnel". Any name
-/// starting with one of these, or containing the substring `"vpn"`, is
-/// hidden from the target app.
-const VPN_PREFIXES: &[&[u8]] = &[
-    b"tun",   // OpenVPN / WireGuard user-space / Tailscale / most tunneling
-    b"ppp",   // PPTP / L2TP PPP tunnels
-    b"tap",   // OpenVPN bridged mode
-    b"wg",    // in-kernel WireGuard
-    b"ipsec", // Android built-in IPsec VPN
-    b"xfrm",  // kernel IPsec XFRM framework interfaces
-    b"utun",  // Apple-style, rare on Android
-    b"l2tp",  // L2TP
-    b"gre",   // GRE tunnels
-];
-
-const VPN_SUBSTRING: &[u8] = b"vpn";
+use crate::generated::iface_lists::matches_vpn;
 
 /// True if the bytes look like a VPN tunnel interface name.
 ///
-/// Case-insensitive, works on raw `&[u8]` so we can call it straight from
-/// a `libc::ifreq.ifr_name` buffer (which is `[c_char; IFNAMSIZ]`) without
+/// Works on raw `&[u8]` so we can call it straight from a
+/// `libc::ifreq.ifr_name` buffer (which is `[c_char; IFNAMSIZ]`) without
 /// having to copy into a String.
 pub fn is_vpn_iface_bytes(name: &[u8]) -> bool {
     // Trim at the first NUL — ifr_name is a fixed-size buffer with a NUL
     // terminator somewhere inside it.
     let end = name.iter().position(|&b| b == 0).unwrap_or(name.len());
-    let name = &name[..end];
-    if name.is_empty() {
-        return false;
-    }
-
-    // Ascii-lowercase compare for the prefix check
-    let matches_prefix = VPN_PREFIXES.iter().any(|prefix| {
-        name.len() >= prefix.len()
-            && name[..prefix.len()]
-                .iter()
-                .zip(prefix.iter())
-                .all(|(a, b)| a.to_ascii_lowercase() == *b)
-    });
-    if matches_prefix {
-        return true;
-    }
-
-    // Substring check: "vpn" anywhere in the name
-    contains_ignore_ascii_case(name, VPN_SUBSTRING)
+    matches_vpn(&name[..end])
 }
 
 /// Convenience wrapper: takes a `CStr` and dispatches to `is_vpn_iface_bytes`.
 #[allow(dead_code)]
 pub fn is_vpn_iface_cstr(name: &CStr) -> bool {
     is_vpn_iface_bytes(name.to_bytes())
-}
-
-/// Case-insensitive substring search for ASCII. Avoids pulling in regex or
-/// heavy helpers so the library stays tiny.
-fn contains_ignore_ascii_case(haystack: &[u8], needle: &[u8]) -> bool {
-    if needle.is_empty() {
-        return true;
-    }
-    if needle.len() > haystack.len() {
-        return false;
-    }
-    for start in 0..=haystack.len() - needle.len() {
-        let window = &haystack[start..start + needle.len()];
-        if window
-            .iter()
-            .zip(needle.iter())
-            .all(|(a, b)| a.eq_ignore_ascii_case(b))
-        {
-            return true;
-        }
-    }
-    false
 }
 
 /// Filter `/proc/net/route` content in-place, removing lines whose

--- a/zygisk/src/generated/iface_lists.rs
+++ b/zygisk/src/generated/iface_lists.rs
@@ -1,0 +1,100 @@
+// AUTO-GENERATED from data/interfaces.toml — do not edit by hand. Regenerate with: python3 scripts/codegen-interfaces.py
+
+#![allow(dead_code)]
+
+fn starts_with_ci(name: &[u8], prefix: &[u8]) -> bool {
+    if name.len() < prefix.len() {
+        return false;
+    }
+    for (i, &p) in prefix.iter().enumerate() {
+        if name[i].to_ascii_lowercase() != p {
+            return false;
+        }
+    }
+    true
+}
+
+fn starts_with_then_digits_ci(name: &[u8], prefix: &[u8]) -> bool {
+    if !starts_with_ci(name, prefix) {
+        return false;
+    }
+    let rest = &name[prefix.len()..];
+    !rest.is_empty() && rest.iter().all(|b| b.is_ascii_digit())
+}
+
+fn equals_ci(name: &[u8], other: &[u8]) -> bool {
+    if name.len() != other.len() {
+        return false;
+    }
+    name.iter()
+        .zip(other.iter())
+        .all(|(a, b)| a.to_ascii_lowercase() == *b)
+}
+
+fn contains_ci(haystack: &[u8], needle: &[u8]) -> bool {
+    if needle.is_empty() {
+        return true;
+    }
+    if needle.len() > haystack.len() {
+        return false;
+    }
+    for start in 0..=haystack.len() - needle.len() {
+        let window = &haystack[start..start + needle.len()];
+        if window
+            .iter()
+            .zip(needle.iter())
+            .all(|(a, b)| a.eq_ignore_ascii_case(b))
+        {
+            return true;
+        }
+    }
+    false
+}
+
+/// True if the name matches any VPN-iface rule from data/interfaces.toml.
+pub fn matches_vpn(name: &[u8]) -> bool {
+    if name.is_empty() {
+        return false;
+    }
+    // OpenVPN, WireGuard userspace, Tailscale, generic tunneling
+    if starts_with_ci(name, b"tun") {
+        return true;
+    }
+    // OpenVPN bridged
+    if starts_with_ci(name, b"tap") {
+        return true;
+    }
+    // WireGuard kernel
+    if starts_with_ci(name, b"wg") {
+        return true;
+    }
+    // PPTP / L2TP PPP tunnels
+    if starts_with_ci(name, b"ppp") {
+        return true;
+    }
+    // Android built-in IPsec VPN
+    if starts_with_ci(name, b"ipsec") {
+        return true;
+    }
+    // kernel IPsec XFRM framework
+    if starts_with_ci(name, b"xfrm") {
+        return true;
+    }
+    // Apple-style, rare on Android
+    if starts_with_ci(name, b"utun") {
+        return true;
+    }
+    // L2TP
+    if starts_with_ci(name, b"l2tp") {
+        return true;
+    }
+    // GRE tunnels
+    if starts_with_ci(name, b"gre") {
+        return true;
+    }
+    // catch-all for renamed clients (myvpn0, vpn-client, xvpn1, ...)
+    if contains_ci(name, b"vpn") {
+        return true;
+    }
+    false
+}

--- a/zygisk/src/generated/mod.rs
+++ b/zygisk/src/generated/mod.rs
@@ -1,0 +1,4 @@
+//! Auto-generated modules. Hand-edit nothing under here — see
+//! `scripts/codegen-interfaces.py`.
+
+pub mod iface_lists;

--- a/zygisk/src/lib.rs
+++ b/zygisk/src/lib.rs
@@ -27,6 +27,7 @@
 //! ensures we only actually do work for targeted apps.
 
 mod filter;
+mod generated;
 mod hooks;
 mod shadowhook;
 


### PR DESCRIPTION
## Why

The kernel module, zygisk, lsposed-native, and the LSPosed Kotlin
module each had their own hand-written list of VPN interface name
prefixes — and the four had drifted. \`kmod\` / \`zygisk\` /
\`HookEntry.kt\` knew \`utun\` / \`l2tp\` / \`gre\`; \`lsposed/native/lib.rs\`
and \`DiagnosticsScreen.kt\` only knew the original six. So the native
self-test could PASS while the hooks were silently hiding more
interfaces than the diagnostic ever checked for.

This is also the prerequisite for #86 (whitelist-based detection): no
point switching to a longer whitelist while the four lists are still
hand-synced.

## Summary

- New \`data/interfaces.toml\` — the single source of truth for VPN
  iface name patterns.
- \`scripts/codegen-interfaces.py\` (stdlib only) renders four
  matchers, one per target language:
  - \`kmod/generated/iface_lists.h\` — \`vpnhide_iface_is_vpn(name)\`
  - \`zygisk/src/generated/iface_lists.rs\` — \`matches_vpn(&[u8])\`
  - \`lsposed/native/src/generated/iface_lists.rs\` — same
  - \`lsposed/app/.../generated/IfaceLists.kt\` — \`isVpnIface(name)\`
- Hand-written matchers in \`kmod/vpnhide_kmod.c\`,
  \`zygisk/src/filter.rs\`, \`lsposed/native/src/lib.rs\`,
  \`HookEntry.kt\`, \`DiagnosticsScreen.kt\` deleted in favor of thin
  wrappers around the generated function.
- Match grammar (intentionally tiny — kernel C has no regex):
  \`exact\` / \`prefix\` / \`prefix+digits\` / \`contains\`. All ASCII
  case-insensitive.
- New \`lint\` step \"Verify generated iface lists are up to date\":
  re-runs the codegen and fails if anything drifts, with a clear
  remediation message.
- \`/proc/net/route\` self-check (in lsposed-native and
  DiagnosticsScreen) moved from raw \`line.contains(prefix)\` to
  whitespace-token matching, which avoids matching VPN-prefix
  substrings that show up by chance inside hex-encoded IP addresses.
- Changelog: \`fixed\` — native diagnostics now agree with the hooks
  (utun/l2tp/gre/*vpn* are recognized in the self-test, previously
  silently PASS'd).

## Notes

- All 17 existing zygisk \`filter::tests\` pass unchanged — the public
  API \`is_vpn_iface_bytes\` / \`is_vpn_iface_cstr\` is preserved, only
  the body now delegates to \`matches_vpn()\`.
- \`Cargo.lock\` files updated incidentally (sync with the 0.7.1
  manifest versions; codegen ran via \`cargo check\` / \`cargo test\`).
- Generated files are committed (with an \`AUTO-GENERATED\` banner) so
  the build doesn't depend on Python being available; CI guards
  against drift.
- This PR is **infra only** — the rule set in \`data/interfaces.toml\`
  is the union of the existing four lists, no behavior change for
  hooks. Whitelist-based detection (the #86 fix) lands in a follow-up
  once the upstream research finishes.