### PR TITLE
feat(codegen): grammar forms digits_optional / any + generated tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,6 +63,11 @@ jobs:
       # C (kernel module)
       - name: clang-format
         run: clang-format --dry-run --Werror kmod/vpnhide_kmod.c
+      - name: kmod iface-list test (host build)
+        run: |
+          cd kmod
+          gcc -O2 -Wall -Werror -o /tmp/test_iface_lists test_iface_lists.c
+          /tmp/test_iface_lists
 
       # Kotlin
       - name: ktlint

--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,7 @@ kmod/vpnhide_kmod.ko
 kmod/module/vpnhide_kmod.ko
 kmod/.env
 kmod/*.lds
+kmod/test_iface_lists
 
 # General
 *.swp

--- a/data/interfaces.toml
+++ b/data/interfaces.toml
@@ -10,12 +10,18 @@
 # Match grammar (intentionally tiny so all four targets implement it
 # identically without depending on a regex engine — kernel C has none):
 #
-#   { exact   = "lo"     }                  name == "lo"
-#   { prefix  = "rmnet"  }                  name.starts_with("rmnet")
-#   { prefix  = "wlan", suffix = "digits" } starts_with + rest is all ASCII digits
-#   { contains = "vpn"   }                  needle anywhere in name
+#   { exact   = "lo"     }                          name == "lo"
+#   { prefix  = "rmnet"  }                          name.starts_with("rmnet")
+#   { prefix  = "wlan", suffix = "digits" }         starts_with + rest is 1+ ASCII digits
+#   { prefix  = "seth_lte", suffix = "digits_optional" }  starts_with + rest is 0+ ASCII digits
+#   { prefix  = "v4-", suffix = "any" }             starts_with + rest is 1+ any chars
+#   { contains = "vpn"   }                          needle anywhere in name
 #
 # All matches are ASCII case-insensitive.
+#
+# [[test]] entries below feed into the generated unit tests in each
+# language target — they verify that all four matchers agree on a fixed
+# set of inputs. CI runs them on every PR.
 
 [[vpn]]
 match = { prefix = "tun" }
@@ -56,3 +62,165 @@ note = "GRE tunnels"
 [[vpn]]
 match = { contains = "vpn" }
 note = "catch-all for renamed clients (myvpn0, vpn-client, xvpn1, ...)"
+
+
+# ── Test vectors ──────────────────────────────────────────────────────
+# Array of {name, is_vpn} fixtures. Codegen renders these into per-
+# language unit tests so all four matchers stay in lockstep.
+
+[[test]]
+name = "tun0"
+is_vpn = true
+
+[[test]]
+name = "tun"          # bare prefix, no digits — still matches
+is_vpn = true
+
+[[test]]
+name = "tun1234"
+is_vpn = true
+
+[[test]]
+name = "tap0"
+is_vpn = true
+
+[[test]]
+name = "wg0"
+is_vpn = true
+
+[[test]]
+name = "wg-client"    # prefix wg, then any suffix
+is_vpn = true
+
+[[test]]
+name = "ppp0"
+is_vpn = true
+
+[[test]]
+name = "ipsec0"
+is_vpn = true
+
+[[test]]
+name = "xfrm0"
+is_vpn = true
+
+[[test]]
+name = "utun3"
+is_vpn = true
+
+[[test]]
+name = "l2tp0"
+is_vpn = true
+
+[[test]]
+name = "gre0"
+is_vpn = true
+
+# Case-insensitivity
+
+[[test]]
+name = "TUN0"
+is_vpn = true
+
+[[test]]
+name = "Wg99"
+is_vpn = true
+
+[[test]]
+name = "MyVPN"
+is_vpn = true
+
+[[test]]
+name = "custom_VPN_42"
+is_vpn = true
+
+# Substring catch-all
+
+[[test]]
+name = "myvpn0"
+is_vpn = true
+
+[[test]]
+name = "vpn"
+is_vpn = true
+
+[[test]]
+name = "xvpn1"
+is_vpn = true
+
+# Real physical / system interfaces — must NOT match
+
+[[test]]
+name = "lo"
+is_vpn = false
+
+[[test]]
+name = "wlan0"
+is_vpn = false
+
+[[test]]
+name = "wlan"
+is_vpn = false
+
+[[test]]
+name = "rmnet0"
+is_vpn = false
+
+[[test]]
+name = "rmnet_data0"
+is_vpn = false
+
+[[test]]
+name = "rmnet_ipa0"
+is_vpn = false
+
+[[test]]
+name = "eth0"
+is_vpn = false
+
+[[test]]
+name = "ccmni0"
+is_vpn = false
+
+[[test]]
+name = "seth_lte8"
+is_vpn = false
+
+[[test]]
+name = "dummy0"
+is_vpn = false
+
+[[test]]
+name = "bnep0"
+is_vpn = false
+
+[[test]]
+name = "rndis0"
+is_vpn = false
+
+# The renamed-tun trick from issue #86 — name-only matching cannot
+# catch this; here just confirms the matcher does not over-match on a
+# generic prefix.
+
+[[test]]
+name = "if33"
+is_vpn = false
+
+# Edge cases
+
+[[test]]
+name = ""             # empty
+is_vpn = false
+
+[[test]]
+name = "tunl"         # 'tun' prefix matches even with non-digit suffix
+is_vpn = true
+
+[[test]]
+name = "atun0"        # prefix only matches at start of name
+is_vpn = false
+
+[[test]]
+name = "VPN"          # full name is the substring
+is_vpn = true
+

--- a/kmod/generated/iface_lists.h
+++ b/kmod/generated/iface_lists.h
@@ -2,9 +2,16 @@
 #ifndef VPNHIDE_GENERATED_IFACE_LISTS_H
 #define VPNHIDE_GENERATED_IFACE_LISTS_H
 
-#include <linux/string.h>
-#include <linux/ctype.h>
-#include <linux/types.h>
+#ifdef __KERNEL__
+# include <linux/string.h>
+# include <linux/ctype.h>
+# include <linux/types.h>
+#else
+# include <ctype.h>
+# include <stdbool.h>
+# include <stddef.h>
+# include <string.h>
+#endif
 
 static inline bool vpnhide_iface_starts_with_ci(
 	const char *name, const char *prefix)
@@ -33,6 +40,26 @@ static inline bool vpnhide_iface_starts_with_then_digits_ci(
 		if (name[i] < '0' || name[i] > '9')
 			return false;
 	return true;
+}
+
+static inline bool vpnhide_iface_starts_with_then_digits_optional_ci(
+	const char *name, const char *prefix)
+{
+	size_t i;
+	if (!vpnhide_iface_starts_with_ci(name, prefix))
+		return false;
+	for (i = strlen(prefix); name[i]; i++)
+		if (name[i] < '0' || name[i] > '9')
+			return false;
+	return true;
+}
+
+static inline bool vpnhide_iface_starts_with_then_any_ci(
+	const char *name, const char *prefix)
+{
+	if (!vpnhide_iface_starts_with_ci(name, prefix))
+		return false;
+	return name[strlen(prefix)] != '\0';
 }
 
 static inline bool vpnhide_iface_equals_ci(

--- a/kmod/test_iface_lists.c
+++ b/kmod/test_iface_lists.c
@@ -1,0 +1,70 @@
+/* AUTO-GENERATED from data/interfaces.toml — do not edit by hand. Regenerate with: python3 scripts/codegen-interfaces.py */
+/*
+ * Userspace test driver for generated/iface_lists.h.
+ * Build: gcc -O2 -Wall -Werror -o test_iface_lists test_iface_lists.c
+ * Run: ./test_iface_lists  (exit 0 on success, 1 on failure)
+ */
+
+#include <stdbool.h>
+#include <stdio.h>
+
+#include "generated/iface_lists.h"
+
+static int failures;
+
+static void check(const char *name, bool expected)
+{
+	bool got = vpnhide_iface_is_vpn(name);
+	if (got != expected) {
+		fprintf(stderr, "FAIL: vpnhide_iface_is_vpn(\"%s\") = %s, expected %s\n",
+			name, got ? "true" : "false", expected ? "true" : "false");
+		failures++;
+	}
+}
+
+int main(void)
+{
+	check("tun0", true);
+	check("tun", true);
+	check("tun1234", true);
+	check("tap0", true);
+	check("wg0", true);
+	check("wg-client", true);
+	check("ppp0", true);
+	check("ipsec0", true);
+	check("xfrm0", true);
+	check("utun3", true);
+	check("l2tp0", true);
+	check("gre0", true);
+	check("TUN0", true);
+	check("Wg99", true);
+	check("MyVPN", true);
+	check("custom_VPN_42", true);
+	check("myvpn0", true);
+	check("vpn", true);
+	check("xvpn1", true);
+	check("lo", false);
+	check("wlan0", false);
+	check("wlan", false);
+	check("rmnet0", false);
+	check("rmnet_data0", false);
+	check("rmnet_ipa0", false);
+	check("eth0", false);
+	check("ccmni0", false);
+	check("seth_lte8", false);
+	check("dummy0", false);
+	check("bnep0", false);
+	check("rndis0", false);
+	check("if33", false);
+	check("", false);
+	check("tunl", true);
+	check("atun0", false);
+	check("VPN", true);
+
+	if (failures) {
+		fprintf(stderr, "%d test(s) failed\n", failures);
+		return 1;
+	}
+	printf("OK: 36 vectors passed\n");
+	return 0;
+}

--- a/lsposed/app/src/test/kotlin/dev/okhsunrog/vpnhide/generated/IfaceListsGeneratedTest.kt
+++ b/lsposed/app/src/test/kotlin/dev/okhsunrog/vpnhide/generated/IfaceListsGeneratedTest.kt
@@ -1,0 +1,48 @@
+// AUTO-GENERATED from data/interfaces.toml — do not edit by hand. Regenerate with: python3 scripts/codegen-interfaces.py
+
+package dev.okhsunrog.vpnhide.generated
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class IfaceListsGeneratedTest {
+    @Test
+    fun `generated vectors`() {
+        assertEquals("tun0", true, IfaceLists.isVpnIface("tun0"))
+        assertEquals("tun", true, IfaceLists.isVpnIface("tun"))
+        assertEquals("tun1234", true, IfaceLists.isVpnIface("tun1234"))
+        assertEquals("tap0", true, IfaceLists.isVpnIface("tap0"))
+        assertEquals("wg0", true, IfaceLists.isVpnIface("wg0"))
+        assertEquals("wg-client", true, IfaceLists.isVpnIface("wg-client"))
+        assertEquals("ppp0", true, IfaceLists.isVpnIface("ppp0"))
+        assertEquals("ipsec0", true, IfaceLists.isVpnIface("ipsec0"))
+        assertEquals("xfrm0", true, IfaceLists.isVpnIface("xfrm0"))
+        assertEquals("utun3", true, IfaceLists.isVpnIface("utun3"))
+        assertEquals("l2tp0", true, IfaceLists.isVpnIface("l2tp0"))
+        assertEquals("gre0", true, IfaceLists.isVpnIface("gre0"))
+        assertEquals("TUN0", true, IfaceLists.isVpnIface("TUN0"))
+        assertEquals("Wg99", true, IfaceLists.isVpnIface("Wg99"))
+        assertEquals("MyVPN", true, IfaceLists.isVpnIface("MyVPN"))
+        assertEquals("custom_VPN_42", true, IfaceLists.isVpnIface("custom_VPN_42"))
+        assertEquals("myvpn0", true, IfaceLists.isVpnIface("myvpn0"))
+        assertEquals("vpn", true, IfaceLists.isVpnIface("vpn"))
+        assertEquals("xvpn1", true, IfaceLists.isVpnIface("xvpn1"))
+        assertEquals("lo", false, IfaceLists.isVpnIface("lo"))
+        assertEquals("wlan0", false, IfaceLists.isVpnIface("wlan0"))
+        assertEquals("wlan", false, IfaceLists.isVpnIface("wlan"))
+        assertEquals("rmnet0", false, IfaceLists.isVpnIface("rmnet0"))
+        assertEquals("rmnet_data0", false, IfaceLists.isVpnIface("rmnet_data0"))
+        assertEquals("rmnet_ipa0", false, IfaceLists.isVpnIface("rmnet_ipa0"))
+        assertEquals("eth0", false, IfaceLists.isVpnIface("eth0"))
+        assertEquals("ccmni0", false, IfaceLists.isVpnIface("ccmni0"))
+        assertEquals("seth_lte8", false, IfaceLists.isVpnIface("seth_lte8"))
+        assertEquals("dummy0", false, IfaceLists.isVpnIface("dummy0"))
+        assertEquals("bnep0", false, IfaceLists.isVpnIface("bnep0"))
+        assertEquals("rndis0", false, IfaceLists.isVpnIface("rndis0"))
+        assertEquals("if33", false, IfaceLists.isVpnIface("if33"))
+        assertEquals("", false, IfaceLists.isVpnIface(""))
+        assertEquals("tunl", true, IfaceLists.isVpnIface("tunl"))
+        assertEquals("atun0", false, IfaceLists.isVpnIface("atun0"))
+        assertEquals("VPN", true, IfaceLists.isVpnIface("VPN"))
+    }
+}

--- a/lsposed/native/src/generated/iface_lists.rs
+++ b/lsposed/native/src/generated/iface_lists.rs
@@ -22,6 +22,17 @@ fn starts_with_then_digits_ci(name: &[u8], prefix: &[u8]) -> bool {
     !rest.is_empty() && rest.iter().all(|b| b.is_ascii_digit())
 }
 
+fn starts_with_then_digits_optional_ci(name: &[u8], prefix: &[u8]) -> bool {
+    if !starts_with_ci(name, prefix) {
+        return false;
+    }
+    name[prefix.len()..].iter().all(|b| b.is_ascii_digit())
+}
+
+fn starts_with_then_any_ci(name: &[u8], prefix: &[u8]) -> bool {
+    starts_with_ci(name, prefix) && name.len() > prefix.len()
+}
+
 fn equals_ci(name: &[u8], other: &[u8]) -> bool {
     if name.len() != other.len() {
         return false;
@@ -97,4 +108,67 @@ pub fn matches_vpn(name: &[u8]) -> bool {
         return true;
     }
     false
+}
+
+#[cfg(test)]
+#[rustfmt::skip]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn generated_vectors() {
+        assert_eq!(matches_vpn(b"tun0"), true, "matches_vpn('tun0')");
+        assert_eq!(matches_vpn(b"tun"), true, "matches_vpn('tun')");
+        assert_eq!(matches_vpn(b"tun1234"), true, "matches_vpn('tun1234')");
+        assert_eq!(matches_vpn(b"tap0"), true, "matches_vpn('tap0')");
+        assert_eq!(matches_vpn(b"wg0"), true, "matches_vpn('wg0')");
+        assert_eq!(matches_vpn(b"wg-client"), true, "matches_vpn('wg-client')");
+        assert_eq!(matches_vpn(b"ppp0"), true, "matches_vpn('ppp0')");
+        assert_eq!(matches_vpn(b"ipsec0"), true, "matches_vpn('ipsec0')");
+        assert_eq!(matches_vpn(b"xfrm0"), true, "matches_vpn('xfrm0')");
+        assert_eq!(matches_vpn(b"utun3"), true, "matches_vpn('utun3')");
+        assert_eq!(matches_vpn(b"l2tp0"), true, "matches_vpn('l2tp0')");
+        assert_eq!(matches_vpn(b"gre0"), true, "matches_vpn('gre0')");
+        assert_eq!(matches_vpn(b"TUN0"), true, "matches_vpn('TUN0')");
+        assert_eq!(matches_vpn(b"Wg99"), true, "matches_vpn('Wg99')");
+        assert_eq!(matches_vpn(b"MyVPN"), true, "matches_vpn('MyVPN')");
+        assert_eq!(matches_vpn(b"custom_VPN_42"), true, "matches_vpn('custom_VPN_42')");
+        assert_eq!(matches_vpn(b"myvpn0"), true, "matches_vpn('myvpn0')");
+        assert_eq!(matches_vpn(b"vpn"), true, "matches_vpn('vpn')");
+        assert_eq!(matches_vpn(b"xvpn1"), true, "matches_vpn('xvpn1')");
+        assert_eq!(matches_vpn(b"lo"), false, "matches_vpn('lo')");
+        assert_eq!(matches_vpn(b"wlan0"), false, "matches_vpn('wlan0')");
+        assert_eq!(matches_vpn(b"wlan"), false, "matches_vpn('wlan')");
+        assert_eq!(matches_vpn(b"rmnet0"), false, "matches_vpn('rmnet0')");
+        assert_eq!(matches_vpn(b"rmnet_data0"), false, "matches_vpn('rmnet_data0')");
+        assert_eq!(matches_vpn(b"rmnet_ipa0"), false, "matches_vpn('rmnet_ipa0')");
+        assert_eq!(matches_vpn(b"eth0"), false, "matches_vpn('eth0')");
+        assert_eq!(matches_vpn(b"ccmni0"), false, "matches_vpn('ccmni0')");
+        assert_eq!(matches_vpn(b"seth_lte8"), false, "matches_vpn('seth_lte8')");
+        assert_eq!(matches_vpn(b"dummy0"), false, "matches_vpn('dummy0')");
+        assert_eq!(matches_vpn(b"bnep0"), false, "matches_vpn('bnep0')");
+        assert_eq!(matches_vpn(b"rndis0"), false, "matches_vpn('rndis0')");
+        assert_eq!(matches_vpn(b"if33"), false, "matches_vpn('if33')");
+        assert_eq!(matches_vpn(b""), false, "matches_vpn('')");
+        assert_eq!(matches_vpn(b"tunl"), true, "matches_vpn('tunl')");
+        assert_eq!(matches_vpn(b"atun0"), false, "matches_vpn('atun0')");
+        assert_eq!(matches_vpn(b"VPN"), true, "matches_vpn('VPN')");
+    }
+
+    #[test]
+    fn helper_starts_with_then_digits_optional() {
+        assert!(starts_with_then_digits_optional_ci(b"foo", b"foo"));
+        assert!(starts_with_then_digits_optional_ci(b"foo0", b"foo"));
+        assert!(starts_with_then_digits_optional_ci(b"foo123", b"foo"));
+        assert!(!starts_with_then_digits_optional_ci(b"foox", b"foo"));
+        assert!(!starts_with_then_digits_optional_ci(b"fo", b"foo"));
+    }
+
+    #[test]
+    fn helper_starts_with_then_any() {
+        assert!(starts_with_then_any_ci(b"v4-x", b"v4-"));
+        assert!(starts_with_then_any_ci(b"v4-rmnet0", b"v4-"));
+        assert!(!starts_with_then_any_ci(b"v4-", b"v4-"));
+        assert!(!starts_with_then_any_ci(b"v3-x", b"v4-"));
+    }
 }

--- a/scripts/codegen-interfaces.py
+++ b/scripts/codegen-interfaces.py
@@ -1,12 +1,14 @@
 #!/usr/bin/env python3
-"""Render the four iface-list matchers from data/interfaces.toml.
+"""Render the four iface-list matchers + their unit tests from
+data/interfaces.toml.
 
 Generates one match function per target (kmod C, zygisk Rust,
 lsposed/native Rust, lsposed Kotlin) so all four platforms agree on
-which interface names are VPN tunnels. Re-run this script after
-editing data/interfaces.toml and commit the regenerated files
-alongside the toml change. CI's lint job re-runs the codegen and fails
-on drift.
+which interface names are VPN tunnels, plus per-language test files
+seeded from the same [[test]] vectors so CI catches drift instantly.
+
+Re-run after editing data/interfaces.toml and commit the regenerated
+files. CI's lint job re-runs the codegen and fails on drift.
 
 Stdlib only: tomllib (Python 3.11+) is the only non-builtin import,
 and that's stdlib too.
@@ -25,6 +27,7 @@ TOML_PATH = REPO_ROOT / "data" / "interfaces.toml"
 # Output paths — kept next to the code that consumes them so include /
 # import paths stay short and obvious.
 OUT_KMOD = REPO_ROOT / "kmod" / "generated" / "iface_lists.h"
+OUT_KMOD_TEST = REPO_ROOT / "kmod" / "test_iface_lists.c"
 OUT_ZYGISK = REPO_ROOT / "zygisk" / "src" / "generated" / "iface_lists.rs"
 OUT_LSP_NATIVE = REPO_ROOT / "lsposed" / "native" / "src" / "generated" / "iface_lists.rs"
 OUT_LSP_KT = (
@@ -40,6 +43,19 @@ OUT_LSP_KT = (
     / "generated"
     / "IfaceLists.kt"
 )
+OUT_LSP_KT_TEST = (
+    REPO_ROOT
+    / "lsposed"
+    / "app"
+    / "src"
+    / "test"
+    / "kotlin"
+    / "dev"
+    / "okhsunrog"
+    / "vpnhide"
+    / "generated"
+    / "IfaceListsGeneratedTest.kt"
+)
 
 GENERATED_HEADER_LINE = (
     "AUTO-GENERATED from data/interfaces.toml — do not edit by hand. "
@@ -52,10 +68,13 @@ GENERATED_HEADER_LINE = (
 # ---------------------------------------------------------------------------
 
 
+VALID_KINDS = ("exact", "prefix", "prefix_digits", "prefix_digits_optional", "prefix_any", "contains")
+
+
 class Rule:
     """One match rule from the toml, normalized to a known kind.
 
-    kind ∈ {"exact", "prefix", "prefix_digits", "contains"}.
+    kind ∈ VALID_KINDS.
     needle is the literal string (already lowercased — all targets
     fold case at match time).
     note is the human comment from the toml, copied into the
@@ -68,6 +87,14 @@ class Rule:
         self.kind = kind
         self.needle = needle
         self.note = note
+
+
+class TestVector:
+    __slots__ = ("name", "is_vpn")
+
+    def __init__(self, name: str, is_vpn: bool) -> None:
+        self.name = name
+        self.is_vpn = is_vpn
 
 
 def parse_rule(entry: dict[str, Any]) -> Rule:
@@ -84,12 +111,18 @@ def parse_rule(entry: dict[str, Any]) -> Rule:
         needle = str(match["prefix"])
         kind = "prefix"
     elif keys == {"prefix", "suffix"}:
-        if match["suffix"] != "digits":
+        suffix = str(match["suffix"])
+        if suffix == "digits":
+            kind = "prefix_digits"
+        elif suffix == "digits_optional":
+            kind = "prefix_digits_optional"
+        elif suffix == "any":
+            kind = "prefix_any"
+        else:
             raise SystemExit(
-                f"unsupported suffix {match['suffix']!r}; only 'digits' is implemented"
+                f"unsupported suffix {suffix!r}; expected digits / digits_optional / any"
             )
         needle = str(match["prefix"])
-        kind = "prefix_digits"
     elif keys == {"contains"}:
         needle = str(match["contains"])
         kind = "contains"
@@ -103,39 +136,106 @@ def parse_rule(entry: dict[str, Any]) -> Rule:
     return Rule(kind, needle.lower(), note)
 
 
-def load_rules() -> list[Rule]:
+def parse_test(entry: dict[str, Any]) -> TestVector:
+    if "name" not in entry or "is_vpn" not in entry:
+        raise SystemExit(f"[[test]] entry needs name and is_vpn: {entry!r}")
+    name = str(entry["name"])
+    if not all(c == "" or 0x20 <= ord(c) < 0x7F for c in name):
+        raise SystemExit(f"non-ASCII test name {name!r}; the matcher itself is ASCII-only")
+    return TestVector(name=name, is_vpn=bool(entry["is_vpn"]))
+
+
+def load() -> tuple[list[Rule], list[TestVector]]:
     with TOML_PATH.open("rb") as f:
         data = tomllib.load(f)
-    raw = data.get("vpn") or []
-    if not isinstance(raw, list) or not raw:
+    raw_rules = data.get("vpn") or []
+    if not isinstance(raw_rules, list) or not raw_rules:
         raise SystemExit(f"{TOML_PATH}: missing or empty [[vpn]] table")
-    return [parse_rule(e) for e in raw]
+    rules = [parse_rule(e) for e in raw_rules]
+    tests = [parse_test(e) for e in (data.get("test") or [])]
+    return rules, tests
 
 
 # ---------------------------------------------------------------------------
-# emitters
+# escape helpers
 # ---------------------------------------------------------------------------
 
 
-def c_byte_lit(s: str) -> str:
-    """Render a Python str as a C string literal, ASCII only."""
-    return '"' + "".join(c if c not in '"\\' else "\\" + c for c in s) + '"'
+def c_str_lit(s: str) -> str:
+    out = ['"']
+    for c in s:
+        if c == '"':
+            out.append('\\"')
+        elif c == "\\":
+            out.append("\\\\")
+        elif 0x20 <= ord(c) < 0x7F:
+            out.append(c)
+        else:
+            out.append(f"\\x{ord(c):02x}")
+    out.append('"')
+    return "".join(out)
+
+
+def rust_byte_lit(s: str) -> str:
+    # Use byte-string with escapes so non-printable / quotes survive.
+    out = ['b"']
+    for c in s:
+        if c == '"':
+            out.append('\\"')
+        elif c == "\\":
+            out.append("\\\\")
+        elif 0x20 <= ord(c) < 0x7F:
+            out.append(c)
+        else:
+            out.append(f"\\x{ord(c):02x}")
+    out.append('"')
+    return "".join(out)
+
+
+def kt_str_lit(s: str) -> str:
+    out = ['"']
+    for c in s:
+        if c == '"':
+            out.append('\\"')
+        elif c == "\\":
+            out.append("\\\\")
+        elif c == "$":
+            out.append("\\$")
+        elif 0x20 <= ord(c) < 0x7F:
+            out.append(c)
+        else:
+            out.append(f"\\u{ord(c):04x}")
+    out.append('"')
+    return "".join(out)
+
+
+# ---------------------------------------------------------------------------
+# C emitter (kmod)
+# ---------------------------------------------------------------------------
 
 
 def emit_kmod(rules: list[Rule]) -> str:
     """Render an inline header for the kernel module.
 
-    Provides:
-      static inline bool vpnhide_iface_is_vpn(const char *name);
+    Header is dual-target: builds in kernel (default) AND in userspace
+    when __VPNHIDE_HOST_TEST is defined, so test_iface_lists.c can link
+    the same matcher.
     """
     lines: list[str] = []
     lines.append(f"/* {GENERATED_HEADER_LINE} */")
     lines.append("#ifndef VPNHIDE_GENERATED_IFACE_LISTS_H")
     lines.append("#define VPNHIDE_GENERATED_IFACE_LISTS_H")
     lines.append("")
-    lines.append("#include <linux/string.h>")
-    lines.append("#include <linux/ctype.h>")
-    lines.append("#include <linux/types.h>")
+    lines.append("#ifdef __KERNEL__")
+    lines.append("# include <linux/string.h>")
+    lines.append("# include <linux/ctype.h>")
+    lines.append("# include <linux/types.h>")
+    lines.append("#else")
+    lines.append("# include <ctype.h>")
+    lines.append("# include <stdbool.h>")
+    lines.append("# include <stddef.h>")
+    lines.append("# include <string.h>")
+    lines.append("#endif")
     lines.append("")
     lines.append("static inline bool vpnhide_iface_starts_with_ci(")
     lines.append("\tconst char *name, const char *prefix)")
@@ -164,6 +264,26 @@ def emit_kmod(rules: list[Rule]) -> str:
     lines.append("\t\tif (name[i] < '0' || name[i] > '9')")
     lines.append("\t\t\treturn false;")
     lines.append("\treturn true;")
+    lines.append("}")
+    lines.append("")
+    lines.append("static inline bool vpnhide_iface_starts_with_then_digits_optional_ci(")
+    lines.append("\tconst char *name, const char *prefix)")
+    lines.append("{")
+    lines.append("\tsize_t i;")
+    lines.append("\tif (!vpnhide_iface_starts_with_ci(name, prefix))")
+    lines.append("\t\treturn false;")
+    lines.append("\tfor (i = strlen(prefix); name[i]; i++)")
+    lines.append("\t\tif (name[i] < '0' || name[i] > '9')")
+    lines.append("\t\t\treturn false;")
+    lines.append("\treturn true;")
+    lines.append("}")
+    lines.append("")
+    lines.append("static inline bool vpnhide_iface_starts_with_then_any_ci(")
+    lines.append("\tconst char *name, const char *prefix)")
+    lines.append("{")
+    lines.append("\tif (!vpnhide_iface_starts_with_ci(name, prefix))")
+    lines.append("\t\treturn false;")
+    lines.append("\treturn name[strlen(prefix)] != '\\0';")
     lines.append("}")
     lines.append("")
     lines.append("static inline bool vpnhide_iface_equals_ci(")
@@ -206,25 +326,21 @@ def emit_kmod(rules: list[Rule]) -> str:
     lines.append("\tif (!name || !name[0])")
     lines.append("\t\treturn false;")
     for r in rules:
-        comment = f"\t/* {r.note} */" if r.note else ""
-        if comment:
-            lines.append(comment)
+        if r.note:
+            lines.append(f"\t/* {r.note} */")
         if r.kind == "exact":
-            lines.append(
-                f"\tif (vpnhide_iface_equals_ci(name, {c_byte_lit(r.needle)}))"
-            )
+            fn = "vpnhide_iface_equals_ci"
         elif r.kind == "prefix":
-            lines.append(
-                f"\tif (vpnhide_iface_starts_with_ci(name, {c_byte_lit(r.needle)}))"
-            )
+            fn = "vpnhide_iface_starts_with_ci"
         elif r.kind == "prefix_digits":
-            lines.append(
-                f"\tif (vpnhide_iface_starts_with_then_digits_ci(name, {c_byte_lit(r.needle)}))"
-            )
+            fn = "vpnhide_iface_starts_with_then_digits_ci"
+        elif r.kind == "prefix_digits_optional":
+            fn = "vpnhide_iface_starts_with_then_digits_optional_ci"
+        elif r.kind == "prefix_any":
+            fn = "vpnhide_iface_starts_with_then_any_ci"
         elif r.kind == "contains":
-            lines.append(
-                f"\tif (vpnhide_iface_contains_ci(name, {c_byte_lit(r.needle)}))"
-            )
+            fn = "vpnhide_iface_contains_ci"
+        lines.append(f"\tif ({fn}(name, {c_str_lit(r.needle)}))")
         lines.append("\t\treturn true;")
     lines.append("\treturn false;")
     lines.append("}")
@@ -234,16 +350,61 @@ def emit_kmod(rules: list[Rule]) -> str:
     return "\n".join(lines)
 
 
-def rust_byte_lit(s: str) -> str:
-    return 'b"' + "".join(c if c not in '"\\' else "\\" + c for c in s) + '"'
+def emit_kmod_test(tests: list[TestVector]) -> str:
+    """Render a userspace test driver.
 
-
-def emit_rust(rules: list[Rule]) -> str:
-    """Render a Rust module exporting `pub fn matches_vpn(name: &[u8]) -> bool`.
-
-    Used by both zygisk and lsposed/native (identical body) so that
-    self-test and the actual hooks share one definition.
+    Built in CI's lint job (gcc on the host). Includes the same
+    iface_lists.h that the kernel module uses, but compiles with
+    libc headers via the !__KERNEL__ branch of the header guard.
     """
+    lines: list[str] = []
+    lines.append(f"/* {GENERATED_HEADER_LINE} */")
+    lines.append("/*")
+    lines.append(" * Userspace test driver for generated/iface_lists.h.")
+    lines.append(" * Build: gcc -O2 -Wall -Werror -o test_iface_lists test_iface_lists.c")
+    lines.append(" * Run: ./test_iface_lists  (exit 0 on success, 1 on failure)")
+    lines.append(" */")
+    lines.append("")
+    lines.append("#include <stdbool.h>")
+    lines.append("#include <stdio.h>")
+    lines.append("")
+    lines.append('#include "generated/iface_lists.h"')
+    lines.append("")
+    lines.append("static int failures;")
+    lines.append("")
+    lines.append("static void check(const char *name, bool expected)")
+    lines.append("{")
+    lines.append("\tbool got = vpnhide_iface_is_vpn(name);")
+    lines.append("\tif (got != expected) {")
+    lines.append('\t\tfprintf(stderr, "FAIL: vpnhide_iface_is_vpn(\\"%s\\") = %s, expected %s\\n",')
+    lines.append('\t\t\tname, got ? "true" : "false", expected ? "true" : "false");')
+    lines.append("\t\tfailures++;")
+    lines.append("\t}")
+    lines.append("}")
+    lines.append("")
+    lines.append("int main(void)")
+    lines.append("{")
+    for t in tests:
+        expected = "true" if t.is_vpn else "false"
+        lines.append(f"\tcheck({c_str_lit(t.name)}, {expected});")
+    lines.append("")
+    lines.append("\tif (failures) {")
+    lines.append('\t\tfprintf(stderr, "%d test(s) failed\\n", failures);')
+    lines.append("\t\treturn 1;")
+    lines.append("\t}")
+    lines.append(f'\tprintf("OK: {len(tests)} vectors passed\\n");')
+    lines.append("\treturn 0;")
+    lines.append("}")
+    lines.append("")
+    return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# Rust emitter (zygisk + lsposed/native — same body)
+# ---------------------------------------------------------------------------
+
+
+def emit_rust(rules: list[Rule], tests: list[TestVector]) -> str:
     lines: list[str] = []
     lines.append(f"// {GENERATED_HEADER_LINE}")
     lines.append("")
@@ -267,6 +428,17 @@ def emit_rust(rules: list[Rule]) -> str:
     lines.append("    }")
     lines.append("    let rest = &name[prefix.len()..];")
     lines.append("    !rest.is_empty() && rest.iter().all(|b| b.is_ascii_digit())")
+    lines.append("}")
+    lines.append("")
+    lines.append("fn starts_with_then_digits_optional_ci(name: &[u8], prefix: &[u8]) -> bool {")
+    lines.append("    if !starts_with_ci(name, prefix) {")
+    lines.append("        return false;")
+    lines.append("    }")
+    lines.append("    name[prefix.len()..].iter().all(|b| b.is_ascii_digit())")
+    lines.append("}")
+    lines.append("")
+    lines.append("fn starts_with_then_any_ci(name: &[u8], prefix: &[u8]) -> bool {")
+    lines.append("    starts_with_ci(name, prefix) && name.len() > prefix.len()")
     lines.append("}")
     lines.append("")
     lines.append("fn equals_ci(name: &[u8], other: &[u8]) -> bool {")
@@ -312,6 +484,10 @@ def emit_rust(rules: list[Rule]) -> str:
             fn = "starts_with_ci"
         elif r.kind == "prefix_digits":
             fn = "starts_with_then_digits_ci"
+        elif r.kind == "prefix_digits_optional":
+            fn = "starts_with_then_digits_optional_ci"
+        elif r.kind == "prefix_any":
+            fn = "starts_with_then_any_ci"
         elif r.kind == "contains":
             fn = "contains_ci"
         lines.append(f"    if {fn}(name, {rust_byte_lit(r.needle)}) {{")
@@ -320,15 +496,50 @@ def emit_rust(rules: list[Rule]) -> str:
     lines.append("    false")
     lines.append("}")
     lines.append("")
+    # Test module — generated assertions are wide; skip rustfmt rather
+    # than wrap each assertion across 5 lines.
+    lines.append("#[cfg(test)]")
+    lines.append("#[rustfmt::skip]")
+    lines.append("mod tests {")
+    lines.append("    use super::*;")
+    lines.append("")
+    lines.append("    #[test]")
+    lines.append("    fn generated_vectors() {")
+    for t in tests:
+        expected = "true" if t.is_vpn else "false"
+        lines.append(
+            f"        assert_eq!(matches_vpn({rust_byte_lit(t.name)}), {expected}, "
+            f"\"matches_vpn({t.name!r})\");"
+        )
+    lines.append("    }")
+    lines.append("")
+    lines.append("    #[test]")
+    lines.append("    fn helper_starts_with_then_digits_optional() {")
+    lines.append('        assert!(starts_with_then_digits_optional_ci(b"foo", b"foo"));')
+    lines.append('        assert!(starts_with_then_digits_optional_ci(b"foo0", b"foo"));')
+    lines.append('        assert!(starts_with_then_digits_optional_ci(b"foo123", b"foo"));')
+    lines.append('        assert!(!starts_with_then_digits_optional_ci(b"foox", b"foo"));')
+    lines.append('        assert!(!starts_with_then_digits_optional_ci(b"fo", b"foo"));')
+    lines.append("    }")
+    lines.append("")
+    lines.append("    #[test]")
+    lines.append("    fn helper_starts_with_then_any() {")
+    lines.append('        assert!(starts_with_then_any_ci(b"v4-x", b"v4-"));')
+    lines.append('        assert!(starts_with_then_any_ci(b"v4-rmnet0", b"v4-"));')
+    lines.append('        assert!(!starts_with_then_any_ci(b"v4-", b"v4-"));')
+    lines.append('        assert!(!starts_with_then_any_ci(b"v3-x", b"v4-"));')
+    lines.append("    }")
+    lines.append("}")
+    lines.append("")
     return "\n".join(lines)
 
 
-def kt_str_lit(s: str) -> str:
-    return '"' + "".join(c if c not in '"\\' else "\\" + c for c in s) + '"'
+# ---------------------------------------------------------------------------
+# Kotlin emitter (production code + separate test class)
+# ---------------------------------------------------------------------------
 
 
 def emit_kotlin(rules: list[Rule]) -> str:
-    """Render a Kotlin singleton with `IfaceLists.isVpnIface(name)`."""
     lines: list[str] = []
     lines.append(f"// {GENERATED_HEADER_LINE}")
     lines.append("")
@@ -353,10 +564,43 @@ def emit_kotlin(rules: list[Rule]) -> str:
                 f"n.length > {len(r.needle)} && "
                 f"n.substring({len(r.needle)}).all {{ it.isDigit() }}"
             )
+        elif r.kind == "prefix_digits_optional":
+            lit = kt_str_lit(r.needle)
+            cond = (
+                f"n.startsWith({lit}) && "
+                f"n.substring({len(r.needle)}).all {{ it.isDigit() }}"
+            )
+        elif r.kind == "prefix_any":
+            lit = kt_str_lit(r.needle)
+            cond = f"n.startsWith({lit}) && n.length > {len(r.needle)}"
         elif r.kind == "contains":
             cond = f"n.contains({kt_str_lit(r.needle)})"
         lines.append(f"        if ({cond}) return true")
     lines.append("        return false")
+    lines.append("    }")
+    lines.append("}")
+    lines.append("")
+    return "\n".join(lines)
+
+
+def emit_kotlin_test(tests: list[TestVector]) -> str:
+    lines: list[str] = []
+    lines.append(f"// {GENERATED_HEADER_LINE}")
+    lines.append("")
+    lines.append("package dev.okhsunrog.vpnhide.generated")
+    lines.append("")
+    lines.append("import org.junit.Assert.assertEquals")
+    lines.append("import org.junit.Test")
+    lines.append("")
+    lines.append("class IfaceListsGeneratedTest {")
+    lines.append("    @Test")
+    lines.append("    fun `generated vectors`() {")
+    for t in tests:
+        expected = "true" if t.is_vpn else "false"
+        lines.append(
+            f"        assertEquals({kt_str_lit(t.name)}, {expected}, "
+            f"IfaceLists.isVpnIface({kt_str_lit(t.name)}))"
+        )
     lines.append("    }")
     lines.append("}")
     lines.append("")
@@ -377,12 +621,15 @@ def write_if_changed(path: Path, content: str) -> bool:
 
 
 def main() -> int:
-    rules = load_rules()
+    rules, tests = load()
+    rust_body = emit_rust(rules, tests)
     outputs = {
         OUT_KMOD: emit_kmod(rules),
-        OUT_ZYGISK: emit_rust(rules),
-        OUT_LSP_NATIVE: emit_rust(rules),
+        OUT_KMOD_TEST: emit_kmod_test(tests),
+        OUT_ZYGISK: rust_body,
+        OUT_LSP_NATIVE: rust_body,
         OUT_LSP_KT: emit_kotlin(rules),
+        OUT_LSP_KT_TEST: emit_kotlin_test(tests),
     }
     changed = []
     for path, content in outputs.items():

--- a/zygisk/src/generated/iface_lists.rs
+++ b/zygisk/src/generated/iface_lists.rs
@@ -22,6 +22,17 @@ fn starts_with_then_digits_ci(name: &[u8], prefix: &[u8]) -> bool {
     !rest.is_empty() && rest.iter().all(|b| b.is_ascii_digit())
 }
 
+fn starts_with_then_digits_optional_ci(name: &[u8], prefix: &[u8]) -> bool {
+    if !starts_with_ci(name, prefix) {
+        return false;
+    }
+    name[prefix.len()..].iter().all(|b| b.is_ascii_digit())
+}
+
+fn starts_with_then_any_ci(name: &[u8], prefix: &[u8]) -> bool {
+    starts_with_ci(name, prefix) && name.len() > prefix.len()
+}
+
 fn equals_ci(name: &[u8], other: &[u8]) -> bool {
     if name.len() != other.len() {
         return false;
@@ -97,4 +108,67 @@ pub fn matches_vpn(name: &[u8]) -> bool {
         return true;
     }
     false
+}
+
+#[cfg(test)]
+#[rustfmt::skip]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn generated_vectors() {
+        assert_eq!(matches_vpn(b"tun0"), true, "matches_vpn('tun0')");
+        assert_eq!(matches_vpn(b"tun"), true, "matches_vpn('tun')");
+        assert_eq!(matches_vpn(b"tun1234"), true, "matches_vpn('tun1234')");
+        assert_eq!(matches_vpn(b"tap0"), true, "matches_vpn('tap0')");
+        assert_eq!(matches_vpn(b"wg0"), true, "matches_vpn('wg0')");
+        assert_eq!(matches_vpn(b"wg-client"), true, "matches_vpn('wg-client')");
+        assert_eq!(matches_vpn(b"ppp0"), true, "matches_vpn('ppp0')");
+        assert_eq!(matches_vpn(b"ipsec0"), true, "matches_vpn('ipsec0')");
+        assert_eq!(matches_vpn(b"xfrm0"), true, "matches_vpn('xfrm0')");
+        assert_eq!(matches_vpn(b"utun3"), true, "matches_vpn('utun3')");
+        assert_eq!(matches_vpn(b"l2tp0"), true, "matches_vpn('l2tp0')");
+        assert_eq!(matches_vpn(b"gre0"), true, "matches_vpn('gre0')");
+        assert_eq!(matches_vpn(b"TUN0"), true, "matches_vpn('TUN0')");
+        assert_eq!(matches_vpn(b"Wg99"), true, "matches_vpn('Wg99')");
+        assert_eq!(matches_vpn(b"MyVPN"), true, "matches_vpn('MyVPN')");
+        assert_eq!(matches_vpn(b"custom_VPN_42"), true, "matches_vpn('custom_VPN_42')");
+        assert_eq!(matches_vpn(b"myvpn0"), true, "matches_vpn('myvpn0')");
+        assert_eq!(matches_vpn(b"vpn"), true, "matches_vpn('vpn')");
+        assert_eq!(matches_vpn(b"xvpn1"), true, "matches_vpn('xvpn1')");
+        assert_eq!(matches_vpn(b"lo"), false, "matches_vpn('lo')");
+        assert_eq!(matches_vpn(b"wlan0"), false, "matches_vpn('wlan0')");
+        assert_eq!(matches_vpn(b"wlan"), false, "matches_vpn('wlan')");
+        assert_eq!(matches_vpn(b"rmnet0"), false, "matches_vpn('rmnet0')");
+        assert_eq!(matches_vpn(b"rmnet_data0"), false, "matches_vpn('rmnet_data0')");
+        assert_eq!(matches_vpn(b"rmnet_ipa0"), false, "matches_vpn('rmnet_ipa0')");
+        assert_eq!(matches_vpn(b"eth0"), false, "matches_vpn('eth0')");
+        assert_eq!(matches_vpn(b"ccmni0"), false, "matches_vpn('ccmni0')");
+        assert_eq!(matches_vpn(b"seth_lte8"), false, "matches_vpn('seth_lte8')");
+        assert_eq!(matches_vpn(b"dummy0"), false, "matches_vpn('dummy0')");
+        assert_eq!(matches_vpn(b"bnep0"), false, "matches_vpn('bnep0')");
+        assert_eq!(matches_vpn(b"rndis0"), false, "matches_vpn('rndis0')");
+        assert_eq!(matches_vpn(b"if33"), false, "matches_vpn('if33')");
+        assert_eq!(matches_vpn(b""), false, "matches_vpn('')");
+        assert_eq!(matches_vpn(b"tunl"), true, "matches_vpn('tunl')");
+        assert_eq!(matches_vpn(b"atun0"), false, "matches_vpn('atun0')");
+        assert_eq!(matches_vpn(b"VPN"), true, "matches_vpn('VPN')");
+    }
+
+    #[test]
+    fn helper_starts_with_then_digits_optional() {
+        assert!(starts_with_then_digits_optional_ci(b"foo", b"foo"));
+        assert!(starts_with_then_digits_optional_ci(b"foo0", b"foo"));
+        assert!(starts_with_then_digits_optional_ci(b"foo123", b"foo"));
+        assert!(!starts_with_then_digits_optional_ci(b"foox", b"foo"));
+        assert!(!starts_with_then_digits_optional_ci(b"fo", b"foo"));
+    }
+
+    #[test]
+    fn helper_starts_with_then_any() {
+        assert!(starts_with_then_any_ci(b"v4-x", b"v4-"));
+        assert!(starts_with_then_any_ci(b"v4-rmnet0", b"v4-"));
+        assert!(!starts_with_then_any_ci(b"v4-", b"v4-"));
+        assert!(!starts_with_then_any_ci(b"v3-x", b"v4-"));
+    }
 }


### PR DESCRIPTION
## Why

Two follow-ups to #90, prerequisite for the upcoming whitelist work
(#86):

1. The whitelist needs match forms our grammar didn't have —
   \`seth_lte\d*\` (Spreadtrum cellular) and \`v4-.+\` (Android CLAT).
   Adding them now keeps the whitelist PR focused on data, not
   infrastructure.
2. Four hand-written matchers in three languages and one cross-compile
   target are exactly the place where silent drift is easy. Test
   vectors driven from the same toml as the rules let CI catch any
   disagreement on the next push.

## Summary

**Grammar**

- Two new \`suffix\` values:
  - \`digits_optional\` — prefix + 0+ ASCII digits (for \`seth_lte\d*\`)
  - \`any\` — prefix + 1+ any chars (for \`v4-.+\`)
- New helper functions in each codegen target
  (\`starts_with_then_digits_optional_ci\`, \`starts_with_then_any_ci\`).
  Not used by current \`[[vpn]]\` rules, exercised by direct unit tests.

**Test vectors**

- New \`[[test]]\` array in \`data/interfaces.toml\` — 36 fixtures
  covering plain prefix hits, case-insensitivity, the \`vpn\` substring
  catch-all, real physical interfaces (lo, wlan, rmnet*, eth, ccmni,
  seth_lte, dummy, bnep, rndis), the \`if33\` rename trick from #86,
  and edge cases (empty, prefix-only, prefix-not-at-start).
- Codegen renders these into:
  - \`zygisk/src/generated/iface_lists.rs\` — \`#[cfg(test)] mod tests\`
    (run via existing \`cargo test\` in lint job).
  - \`lsposed/native/src/generated/iface_lists.rs\` — same.
  - \`lsposed/app/src/test/kotlin/.../IfaceListsGeneratedTest.kt\` — new
    JUnit class (picked up by existing \`:app:testDebugUnitTest\` step).
  - \`kmod/test_iface_lists.c\` — new userspace test driver. The
    generated header now has \`__KERNEL__\`-guarded includes so the same
    matcher compiles against either \`<linux/string.h>\` or libc.

**CI**

- New lint step \`kmod iface-list test (host build)\`: \`gcc -O2 -Wall
  -Werror\` builds \`test_iface_lists.c\` against the generated header,
  runs it, fails on any wrong vector.
- Existing \"Verify generated iface lists are up to date\" step (from
  #90) already covers the two new generated files.

## Notes

- No production behavior change. \`matches_vpn\` /
  \`vpnhide_iface_is_vpn\` / \`IfaceLists.isVpnIface\` bodies are
  byte-identical to main; only helpers and test modules grew.
- All four matchers verified locally:
  - \`cargo test --lib\` zygisk: 20 passed (17 prior + 3 generated).
  - \`gcc + ./test_iface_lists\`: \"OK: 36 vectors passed\".
  - \`cargo fmt --check\` clean both crates (test mod marked
    \`#[rustfmt::skip]\` — generated assertions are wide and wrapping
    each across 5 lines makes diffs unreadable).
  - \`ktlint\` clean on the new test class.