### PR TITLE
ci(lsposed/native): make `cargo test` build on host

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,6 +59,8 @@ jobs:
         run: cd lsposed/native && cargo ndk -t arm64-v8a clippy -- -D warnings
       - name: cargo test (zygisk)
         run: cd zygisk && cargo test
+      - name: cargo test (lsposed native)
+        run: cd lsposed/native && cargo test
 
       # C (kernel module)
       - name: clang-format

--- a/lsposed/native/src/lib.rs
+++ b/lsposed/native/src/lib.rs
@@ -113,7 +113,7 @@ fn check_ioctl_siocgifflags() -> String {
         let name = b"tun0\0";
         ifr.ifr_name[..name.len()].copy_from_slice(&name.map(|b| b as libc::c_char));
 
-        let ret = libc::ioctl(fd, libc::SIOCGIFFLAGS as i32, &ifr);
+        let ret = libc::ioctl(fd, libc::SIOCGIFFLAGS as _, &ifr);
         let err = last_os_errno();
         libc::close(fd);
 
@@ -152,7 +152,7 @@ fn check_ioctl_siocgifmtu() -> String {
         let name = b"tun0\0";
         ifr.ifr_name[..name.len()].copy_from_slice(&name.map(|b| b as libc::c_char));
 
-        let ret = libc::ioctl(fd, libc::SIOCGIFMTU as i32, &ifr);
+        let ret = libc::ioctl(fd, libc::SIOCGIFMTU as _, &ifr);
         let err = last_os_errno();
         libc::close(fd);
 
@@ -186,7 +186,7 @@ fn check_ioctl_siocgifconf() -> String {
         ifc.ifc_len = buf.len() as libc::c_int;
         ifc.ifc_ifcu.ifcu_buf = buf.as_mut_ptr().cast();
 
-        if libc::ioctl(fd, libc::SIOCGIFCONF as i32, &mut ifc) < 0 {
+        if libc::ioctl(fd, libc::SIOCGIFCONF as _, &mut ifc) < 0 {
             let e = last_os_error();
             libc::close(fd);
             return format!("FAIL: ioctl error: {e}");


### PR DESCRIPTION
## Why

\`libc::ioctl\` second-arg type \`Ioctl\` is \`c_int\` on android-arm64 but \`c_ulong\` on linux x86_64. The hardcoded \`as i32\` casts in \`lsposed/native/src/lib.rs\` made \`cargo test --lib\` fail to compile on host, so the generated \`iface_lists\` unit tests in this crate never actually ran — locally or in CI (CI did only \`cargo fmt\` + \`cargo ndk clippy\` for this crate, not \`cargo test\`). Pre-existing dead test coverage.

## Summary

- \`lsposed/native/src/lib.rs\`: 3 × \`as i32\` → \`as _\` on \`SIOCGIFFLAGS\` / \`SIOCGIFMTU\` / \`SIOCGIFCONF\`. Compiler picks the right width per target.
- \`.github/workflows/ci.yml\`: add \`cargo test (lsposed native)\` step right after the existing zygisk step, so the codegen \`iface_lists\` tests in this crate actually run on every PR.
- Verified locally: \`cargo test --lib\` passes 3/3 on host; \`cargo ndk -t arm64-v8a build --release\` still builds for android.