### PR TITLE
fix(lsposed): restore zygisk debug-logging flag on app start

### DIFF
--- a/changelog.d/fixed-restore-debug-logging-flag-for-the-dcb2.md
+++ b/changelog.d/fixed-restore-debug-logging-flag-for-the-dcb2.md
@@ -1,0 +1,9 @@
+_2026-04-26_
+
+## English
+
+Restore debug-logging flag for the zygisk module on app start. KSU/Magisk replace the module dir wholesale on reinstall, wiping the runtime flag file even though the user's preference is still ON; the app now re-applies the persisted preference to disk on every start so logs stay enabled.
+
+## Русский
+
+Восстанавливаем флаг отладочного логирования для zygisk-модуля при старте приложения. KSU/Magisk при переустановке модуля заменяют его папку целиком, удаляя runtime-файл флага, хотя в настройках логирование всё ещё включено; приложение теперь переписывает сохранённое значение на диск при каждом старте, так что логи остаются включёнными.

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/MainActivity.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/MainActivity.kt
@@ -28,7 +28,9 @@ import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
 import androidx.lifecycle.compose.LocalLifecycleOwner
+import androidx.lifecycle.lifecycleScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import java.util.concurrent.atomic.AtomicBoolean
 
@@ -42,6 +44,16 @@ class MainActivity : ComponentActivity() {
         // Load the user's debug-logging preference before anything else
         // runs so the first suExec + Dashboard reload honor it.
         VpnHideLog.init(applicationContext)
+        // Re-propagate the persisted flag to the on-disk sinks. Reinstalling
+        // a native module wipes its /data/adb/modules/<id>/ tree wholesale
+        // (KSU/Magisk replace it from the zip), so the zygisk-side
+        // debug_logging file disappears even though SharedPrefs still says
+        // ON. Without this re-write zygisk would silently default to
+        // error-only logging until the user toggled off-then-on. Cheap —
+        // two `su` roundtrips on a background dispatcher.
+        lifecycleScope.launch(Dispatchers.IO) {
+            applyDebugLoggingRuntime(VpnHideLog.enabled)
+        }
         setContent { VpnHideApp(onReady = { splashReady.set(true) }) }
     }
 }


### PR DESCRIPTION
## Why

Reinstalling a native module via KSU/Magisk replaces \`/data/adb/modules/<id>/\` wholesale with the contents of the new zip — so the runtime flag file \`debug_logging\` (a per-user setting that's not part of the zip) gets wiped. The persisted preference in SharedPrefs still says ON, but zygisk on next boot reads the missing flag file as OFF and drops its log filter to error-only. The user has to toggle the setting off-then-on in the app to restore logs.

## Summary

- \`MainActivity.onCreate\`: after \`VpnHideLog.init\`, kick \`applyDebugLoggingRuntime(VpnHideLog.enabled)\` on \`Dispatchers.IO\` via \`lifecycleScope.launch\`. Re-writes both disk sinks (\`/data/system/vpnhide_debug_logging\` for system_server, \`/data/adb/modules/vpnhide_zygisk/debug_logging\` for zygisk) from the persisted preference.
- Two \`su\` roundtrips per app start, on a background dispatcher. Only meaningful work when the user had logging enabled in the first place.