### PR TITLE
fix(lsposed/app): unify VPN-active detection on codegen matcher

### DIFF
--- a/changelog.d/fixed-dashboard-vpn-active-detection-now-matches-5f3a.md
+++ b/changelog.d/fixed-dashboard-vpn-active-detection-now-matches-5f3a.md
@@ -1,0 +1,9 @@
+_2026-04-26_
+
+## English
+
+Dashboard 'VPN active' detection now matches the kmod/zygisk filter for renamed interfaces (if<N> from issue #86, MyVPN, wg-client, ...).
+
+## Русский
+
+Определение 'VPN активен' на дашборде теперь совпадает с правилами фильтра kmod/zygisk для переименованных интерфейсов (if<N> из issue #86, MyVPN, wg-client и т. п.).

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DashboardData.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DashboardData.kt
@@ -25,6 +25,7 @@ import dev.okhsunrog.vpnhide.checks.checkProcNetTcp6
 import dev.okhsunrog.vpnhide.checks.checkProcNetUdp
 import dev.okhsunrog.vpnhide.checks.checkProcNetUdp6
 import dev.okhsunrog.vpnhide.checks.checkSysClassNet
+import dev.okhsunrog.vpnhide.generated.IfaceLists
 import java.io.File
 
 // ── Domain types — invalid states are unrepresentable ────────────────────
@@ -1084,7 +1085,7 @@ internal fun loadDashboardState(
     }
 
     // ── Protection checks ──
-    val vpnActive = isVpnActiveSync()
+    val vpnActive = isVpnActiveBlocking()
     VpnHideLog.i(TAG, "vpnActive=$vpnActive selfNeedsRestart=$selfNeedsRestart")
 
     val protection: ProtectionCheck =
@@ -1131,26 +1132,6 @@ internal fun loadDashboardState(
         protection = protection,
         issues = issues,
     )
-}
-
-private fun isVpnActiveSync(): Boolean {
-    val (exitCode, output) = suExec("ls /sys/class/net/ 2>/dev/null")
-    if (exitCode != 0) return false
-    val vpnPrefixes = listOf("tun", "wg", "ppp", "tap", "ipsec", "xfrm")
-    val vpnIfaces =
-        output.lines().map { it.trim() }.filter { name ->
-            name.isNotEmpty() && vpnPrefixes.any { name.startsWith(it) }
-        }
-    if (vpnIfaces.isEmpty()) {
-        VpnHideLog.d(TAG, "isVpnActive: no VPN interfaces found")
-        return false
-    }
-    return vpnIfaces.any { iface ->
-        val (_, state) = suExec("cat /sys/class/net/$iface/operstate 2>/dev/null")
-        val up = state.trim() == "unknown" || state.trim() == "up"
-        VpnHideLog.d(TAG, "isVpnActive: $iface operstate=${state.trim()} up=$up")
-        up
-    }
 }
 
 private fun runNativeProtectionCheck(): NativeResult {
@@ -1255,8 +1236,7 @@ private fun runJavaProtectionCheck(cm: ConnectivityManager): JavaResult {
 
     val lp = cm.getLinkProperties(net)
     val ifname = lp?.interfaceName
-    val vpnPrefixes = listOf("tun", "wg", "ppp", "tap", "ipsec", "xfrm")
-    val vpnIfname = ifname != null && vpnPrefixes.any { ifname.startsWith(it) }
+    val vpnIfname = ifname != null && IfaceLists.isVpnIface(ifname)
     if (vpnIfname) failed++
     VpnHideLog.d(TAG, "java: linkProperties ifname=$ifname isVpn=$vpnIfname")
 

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DiagnosticsScreen.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DiagnosticsScreen.kt
@@ -78,22 +78,7 @@ internal data class CheckResults(
     val all get() = native + java
 }
 
-internal suspend fun isVpnActive(): Boolean =
-    withContext(Dispatchers.IO) {
-        val (exitCode, output) = suExec("ls /sys/class/net/ 2>/dev/null")
-        if (exitCode != 0) return@withContext false
-        val vpnIfaces =
-            output
-                .lines()
-                .map { it.trim() }
-                .filter { name -> IfaceLists.isVpnIface(name) }
-        if (vpnIfaces.isEmpty()) return@withContext false
-        vpnIfaces.any { iface ->
-            val (_, state) =
-                suExec("cat /sys/class/net/$iface/operstate 2>/dev/null")
-            state.trim() == "unknown" || state.trim() == "up"
-        }
-    }
+internal suspend fun isVpnActive(): Boolean = withContext(Dispatchers.IO) { isVpnActiveBlocking() }
 
 @Composable
 fun DiagnosticsScreen(

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/ShellUtils.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/ShellUtils.kt
@@ -2,6 +2,7 @@ package dev.okhsunrog.vpnhide
 
 import android.util.Base64
 import android.util.Log
+import dev.okhsunrog.vpnhide.generated.IfaceLists
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import java.io.File
@@ -48,6 +49,31 @@ internal fun suExec(cmd: String): Pair<Int, String> =
     }
 
 internal suspend fun suExecAsync(cmd: String): Pair<Int, String> = withContext(Dispatchers.IO) { suExec(cmd) }
+
+/**
+ * Single source of truth for "is a VPN currently up?". Both the dashboard
+ * (sync, off the main thread already) and the diagnostics screen (suspend,
+ * via `withContext(Dispatchers.IO)`) call this so the answer doesn't drift
+ * — a previous version of the dashboard hard-coded a prefix list and missed
+ * names the codegen-driven `IfaceLists.isVpnIface` catches (e.g. `if<N>`
+ * from issue #86, `MyVPN`, `wg-client`).
+ */
+internal fun isVpnActiveBlocking(): Boolean {
+    val (exitCode, output) = suExec("ls /sys/class/net/ 2>/dev/null")
+    if (exitCode != 0) return false
+    val vpnIfaces =
+        output.lines().map { it.trim() }.filter { name -> IfaceLists.isVpnIface(name) }
+    if (vpnIfaces.isEmpty()) {
+        VpnHideLog.d(TAG, "isVpnActive: no VPN interfaces found")
+        return false
+    }
+    return vpnIfaces.any { iface ->
+        val (_, state) = suExec("cat /sys/class/net/$iface/operstate 2>/dev/null")
+        val up = state.trim() == "unknown" || state.trim() == "up"
+        VpnHideLog.d(TAG, "isVpnActive: $iface operstate=${state.trim()} up=$up")
+        up
+    }
+}
 
 internal fun cleanupStaleZygiskStatus(context: android.content.Context) {
     val statusFile = File(context.filesDir, ZYGISK_STATUS_FILE_NAME)


### PR DESCRIPTION
## Why

Dashboard reported "VPN not active" while the kmod/zygisk filter was
happily hiding the tunnel. Two functions in `DashboardData.kt`
(`isVpnActiveSync` and `runJavaProtectionCheck`) carried their own
`listOf("tun", "wg", ...)` + `startsWith` lists that diverged from
the codegen-driven `IfaceLists.isVpnIface` everything else uses.
That misses `if<N>` from issue #86, `MyVPN`, `wg-client`, the
substring catch-all — exactly the cases the codegen exists to cover.

## Summary

- New `isVpnActiveBlocking()` in `ShellUtils.kt` — single source of truth, uses `IfaceLists.isVpnIface` + keeps the existing `VpnHideLog.d` calls.
- `DashboardData.isVpnActiveSync` deleted; callsite calls the helper directly.
- `DiagnosticsScreen.isVpnActive` collapses to `withContext(IO) { isVpnActiveBlocking() }`.
- `runJavaProtectionCheck` link-properties ifname check switches to `IfaceLists.isVpnIface`.
- Changelog fragment added.