### PR TITLE
ci: cache cargo registry + lsposed/native target

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -181,6 +181,16 @@ jobs:
       - name: Mark workspace safe
         run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
 
+      - name: Cache cargo
+        uses: actions/cache@v5
+        with:
+          path: |
+            /usr/local/cargo/registry
+            /usr/local/cargo/git
+            lsposed/native/target
+          key: cargo-${{ runner.os }}-lsposed-${{ hashFiles('lsposed/native/Cargo.lock') }}
+          restore-keys: cargo-${{ runner.os }}-lsposed-
+
       - name: Set up keystore
         env:
           KEYSTORE_BASE64: ${{ secrets.ANDROID_KEYSTORE_BASE64 }}


### PR DESCRIPTION
## Why

The zygisk job has cached `~/.cargo/{registry,git}` + `zygisk/target`
since forever; the lsposed job rebuilds `lsposed/native` from
scratch every run, which now means the full uniffi/serde/quinn
dep tree on every PR. Cheap fix.

## Summary

- New `actions/cache@v5` step in the lsposed job, keyed on
  `lsposed/native/Cargo.lock`. Separate cache key from zygisk so the
  two don't clobber each other's `target/`.