### PR TITLE
chore(codegen): drop unused suffix forms `digits_optional` / `any`

### DIFF
--- a/data/interfaces.toml
+++ b/data/interfaces.toml
@@ -13,8 +13,6 @@
 #   { exact   = "lo"     }                          name == "lo"
 #   { prefix  = "rmnet"  }                          name.starts_with("rmnet")
 #   { prefix  = "wlan", suffix = "digits" }         starts_with + rest is 1+ ASCII digits
-#   { prefix  = "seth_lte", suffix = "digits_optional" }  starts_with + rest is 0+ ASCII digits
-#   { prefix  = "v4-", suffix = "any" }             starts_with + rest is 1+ any chars
 #   { contains = "vpn"   }                          needle anywhere in name
 #
 # All matches are ASCII case-insensitive.

--- a/kmod/generated/iface_lists.h
+++ b/kmod/generated/iface_lists.h
@@ -42,26 +42,6 @@ static inline bool vpnhide_iface_starts_with_then_digits_ci(
 	return true;
 }
 
-static inline bool vpnhide_iface_starts_with_then_digits_optional_ci(
-	const char *name, const char *prefix)
-{
-	size_t i;
-	if (!vpnhide_iface_starts_with_ci(name, prefix))
-		return false;
-	for (i = strlen(prefix); name[i]; i++)
-		if (name[i] < '0' || name[i] > '9')
-			return false;
-	return true;
-}
-
-static inline bool vpnhide_iface_starts_with_then_any_ci(
-	const char *name, const char *prefix)
-{
-	if (!vpnhide_iface_starts_with_ci(name, prefix))
-		return false;
-	return name[strlen(prefix)] != '\0';
-}
-
 static inline bool vpnhide_iface_equals_ci(
 	const char *name, const char *other)
 {

--- a/lsposed/native/src/generated/iface_lists.rs
+++ b/lsposed/native/src/generated/iface_lists.rs
@@ -22,17 +22,6 @@ fn starts_with_then_digits_ci(name: &[u8], prefix: &[u8]) -> bool {
     !rest.is_empty() && rest.iter().all(|b| b.is_ascii_digit())
 }
 
-fn starts_with_then_digits_optional_ci(name: &[u8], prefix: &[u8]) -> bool {
-    if !starts_with_ci(name, prefix) {
-        return false;
-    }
-    name[prefix.len()..].iter().all(|b| b.is_ascii_digit())
-}
-
-fn starts_with_then_any_ci(name: &[u8], prefix: &[u8]) -> bool {
-    starts_with_ci(name, prefix) && name.len() > prefix.len()
-}
-
 fn equals_ci(name: &[u8], other: &[u8]) -> bool {
     if name.len() != other.len() {
         return false;
@@ -163,22 +152,5 @@ mod tests {
         assert_eq!(matches_vpn(b"tunl"), true, "matches_vpn('tunl')");
         assert_eq!(matches_vpn(b"atun0"), false, "matches_vpn('atun0')");
         assert_eq!(matches_vpn(b"VPN"), true, "matches_vpn('VPN')");
-    }
-
-    #[test]
-    fn helper_starts_with_then_digits_optional() {
-        assert!(starts_with_then_digits_optional_ci(b"foo", b"foo"));
-        assert!(starts_with_then_digits_optional_ci(b"foo0", b"foo"));
-        assert!(starts_with_then_digits_optional_ci(b"foo123", b"foo"));
-        assert!(!starts_with_then_digits_optional_ci(b"foox", b"foo"));
-        assert!(!starts_with_then_digits_optional_ci(b"fo", b"foo"));
-    }
-
-    #[test]
-    fn helper_starts_with_then_any() {
-        assert!(starts_with_then_any_ci(b"v4-x", b"v4-"));
-        assert!(starts_with_then_any_ci(b"v4-rmnet0", b"v4-"));
-        assert!(!starts_with_then_any_ci(b"v4-", b"v4-"));
-        assert!(!starts_with_then_any_ci(b"v3-x", b"v4-"));
     }
 }

--- a/scripts/codegen-interfaces.py
+++ b/scripts/codegen-interfaces.py
@@ -68,7 +68,7 @@ GENERATED_HEADER_LINE = (
 # ---------------------------------------------------------------------------
 
 
-VALID_KINDS = ("exact", "prefix", "prefix_digits", "prefix_digits_optional", "prefix_any", "contains")
+VALID_KINDS = ("exact", "prefix", "prefix_digits", "contains")
 
 
 class Rule:
@@ -114,14 +114,8 @@ def parse_rule(entry: dict[str, Any]) -> Rule:
         suffix = str(match["suffix"])
         if suffix == "digits":
             kind = "prefix_digits"
-        elif suffix == "digits_optional":
-            kind = "prefix_digits_optional"
-        elif suffix == "any":
-            kind = "prefix_any"
         else:
-            raise SystemExit(
-                f"unsupported suffix {suffix!r}; expected digits / digits_optional / any"
-            )
+            raise SystemExit(f"unsupported suffix {suffix!r}; expected digits")
         needle = str(match["prefix"])
     elif keys == {"contains"}:
         needle = str(match["contains"])
@@ -266,26 +260,6 @@ def emit_kmod(rules: list[Rule]) -> str:
     lines.append("\treturn true;")
     lines.append("}")
     lines.append("")
-    lines.append("static inline bool vpnhide_iface_starts_with_then_digits_optional_ci(")
-    lines.append("\tconst char *name, const char *prefix)")
-    lines.append("{")
-    lines.append("\tsize_t i;")
-    lines.append("\tif (!vpnhide_iface_starts_with_ci(name, prefix))")
-    lines.append("\t\treturn false;")
-    lines.append("\tfor (i = strlen(prefix); name[i]; i++)")
-    lines.append("\t\tif (name[i] < '0' || name[i] > '9')")
-    lines.append("\t\t\treturn false;")
-    lines.append("\treturn true;")
-    lines.append("}")
-    lines.append("")
-    lines.append("static inline bool vpnhide_iface_starts_with_then_any_ci(")
-    lines.append("\tconst char *name, const char *prefix)")
-    lines.append("{")
-    lines.append("\tif (!vpnhide_iface_starts_with_ci(name, prefix))")
-    lines.append("\t\treturn false;")
-    lines.append("\treturn name[strlen(prefix)] != '\\0';")
-    lines.append("}")
-    lines.append("")
     lines.append("static inline bool vpnhide_iface_equals_ci(")
     lines.append("\tconst char *name, const char *other)")
     lines.append("{")
@@ -334,10 +308,6 @@ def emit_kmod(rules: list[Rule]) -> str:
             fn = "vpnhide_iface_starts_with_ci"
         elif r.kind == "prefix_digits":
             fn = "vpnhide_iface_starts_with_then_digits_ci"
-        elif r.kind == "prefix_digits_optional":
-            fn = "vpnhide_iface_starts_with_then_digits_optional_ci"
-        elif r.kind == "prefix_any":
-            fn = "vpnhide_iface_starts_with_then_any_ci"
         elif r.kind == "contains":
             fn = "vpnhide_iface_contains_ci"
         lines.append(f"\tif ({fn}(name, {c_str_lit(r.needle)}))")
@@ -430,17 +400,6 @@ def emit_rust(rules: list[Rule], tests: list[TestVector]) -> str:
     lines.append("    !rest.is_empty() && rest.iter().all(|b| b.is_ascii_digit())")
     lines.append("}")
     lines.append("")
-    lines.append("fn starts_with_then_digits_optional_ci(name: &[u8], prefix: &[u8]) -> bool {")
-    lines.append("    if !starts_with_ci(name, prefix) {")
-    lines.append("        return false;")
-    lines.append("    }")
-    lines.append("    name[prefix.len()..].iter().all(|b| b.is_ascii_digit())")
-    lines.append("}")
-    lines.append("")
-    lines.append("fn starts_with_then_any_ci(name: &[u8], prefix: &[u8]) -> bool {")
-    lines.append("    starts_with_ci(name, prefix) && name.len() > prefix.len()")
-    lines.append("}")
-    lines.append("")
     lines.append("fn equals_ci(name: &[u8], other: &[u8]) -> bool {")
     lines.append("    if name.len() != other.len() {")
     lines.append("        return false;")
@@ -484,10 +443,6 @@ def emit_rust(rules: list[Rule], tests: list[TestVector]) -> str:
             fn = "starts_with_ci"
         elif r.kind == "prefix_digits":
             fn = "starts_with_then_digits_ci"
-        elif r.kind == "prefix_digits_optional":
-            fn = "starts_with_then_digits_optional_ci"
-        elif r.kind == "prefix_any":
-            fn = "starts_with_then_any_ci"
         elif r.kind == "contains":
             fn = "contains_ci"
         lines.append(f"    if {fn}(name, {rust_byte_lit(r.needle)}) {{")
@@ -511,23 +466,6 @@ def emit_rust(rules: list[Rule], tests: list[TestVector]) -> str:
             f"        assert_eq!(matches_vpn({rust_byte_lit(t.name)}), {expected}, "
             f"\"matches_vpn({t.name!r})\");"
         )
-    lines.append("    }")
-    lines.append("")
-    lines.append("    #[test]")
-    lines.append("    fn helper_starts_with_then_digits_optional() {")
-    lines.append('        assert!(starts_with_then_digits_optional_ci(b"foo", b"foo"));')
-    lines.append('        assert!(starts_with_then_digits_optional_ci(b"foo0", b"foo"));')
-    lines.append('        assert!(starts_with_then_digits_optional_ci(b"foo123", b"foo"));')
-    lines.append('        assert!(!starts_with_then_digits_optional_ci(b"foox", b"foo"));')
-    lines.append('        assert!(!starts_with_then_digits_optional_ci(b"fo", b"foo"));')
-    lines.append("    }")
-    lines.append("")
-    lines.append("    #[test]")
-    lines.append("    fn helper_starts_with_then_any() {")
-    lines.append('        assert!(starts_with_then_any_ci(b"v4-x", b"v4-"));')
-    lines.append('        assert!(starts_with_then_any_ci(b"v4-rmnet0", b"v4-"));')
-    lines.append('        assert!(!starts_with_then_any_ci(b"v4-", b"v4-"));')
-    lines.append('        assert!(!starts_with_then_any_ci(b"v3-x", b"v4-"));')
     lines.append("    }")
     lines.append("}")
     lines.append("")
@@ -564,15 +502,6 @@ def emit_kotlin(rules: list[Rule]) -> str:
                 f"n.length > {len(r.needle)} && "
                 f"n.substring({len(r.needle)}).all {{ it.isDigit() }}"
             )
-        elif r.kind == "prefix_digits_optional":
-            lit = kt_str_lit(r.needle)
-            cond = (
-                f"n.startsWith({lit}) && "
-                f"n.substring({len(r.needle)}).all {{ it.isDigit() }}"
-            )
-        elif r.kind == "prefix_any":
-            lit = kt_str_lit(r.needle)
-            cond = f"n.startsWith({lit}) && n.length > {len(r.needle)}"
         elif r.kind == "contains":
             cond = f"n.contains({kt_str_lit(r.needle)})"
         lines.append(f"        if ({cond}) return true")

--- a/zygisk/src/generated/iface_lists.rs
+++ b/zygisk/src/generated/iface_lists.rs
@@ -22,17 +22,6 @@ fn starts_with_then_digits_ci(name: &[u8], prefix: &[u8]) -> bool {
     !rest.is_empty() && rest.iter().all(|b| b.is_ascii_digit())
 }
 
-fn starts_with_then_digits_optional_ci(name: &[u8], prefix: &[u8]) -> bool {
-    if !starts_with_ci(name, prefix) {
-        return false;
-    }
-    name[prefix.len()..].iter().all(|b| b.is_ascii_digit())
-}
-
-fn starts_with_then_any_ci(name: &[u8], prefix: &[u8]) -> bool {
-    starts_with_ci(name, prefix) && name.len() > prefix.len()
-}
-
 fn equals_ci(name: &[u8], other: &[u8]) -> bool {
     if name.len() != other.len() {
         return false;
@@ -163,22 +152,5 @@ mod tests {
         assert_eq!(matches_vpn(b"tunl"), true, "matches_vpn('tunl')");
         assert_eq!(matches_vpn(b"atun0"), false, "matches_vpn('atun0')");
         assert_eq!(matches_vpn(b"VPN"), true, "matches_vpn('VPN')");
-    }
-
-    #[test]
-    fn helper_starts_with_then_digits_optional() {
-        assert!(starts_with_then_digits_optional_ci(b"foo", b"foo"));
-        assert!(starts_with_then_digits_optional_ci(b"foo0", b"foo"));
-        assert!(starts_with_then_digits_optional_ci(b"foo123", b"foo"));
-        assert!(!starts_with_then_digits_optional_ci(b"foox", b"foo"));
-        assert!(!starts_with_then_digits_optional_ci(b"fo", b"foo"));
-    }
-
-    #[test]
-    fn helper_starts_with_then_any() {
-        assert!(starts_with_then_any_ci(b"v4-x", b"v4-"));
-        assert!(starts_with_then_any_ci(b"v4-rmnet0", b"v4-"));
-        assert!(!starts_with_then_any_ci(b"v4-", b"v4-"));
-        assert!(!starts_with_then_any_ci(b"v3-x", b"v4-"));
     }
 }


### PR DESCRIPTION
## Why

Both suffix forms landed with the codegen split (#91) but no
\`[[vpn]]\` rule has ever used them. The only \`suffix=\` consumer
is \`digits\` (the original \`wlan\` test vector and the \`if\` rule
from #93). Carrying the unused forms costs ~150 lines of
generated C/Rust helpers plus their helper tests, and it makes
the documented grammar in the toml header lie to readers.

## Summary

- \`scripts/codegen-interfaces.py\`: drop \`prefix_digits_optional\`
  and \`prefix_any\` from \`VALID_KINDS\`, the suffix parser, the
  three emitters (kmod C, Rust, Kotlin), and the two helper-only
  Rust unit tests.
- \`data/interfaces.toml\`: drop the two example lines from the
  grammar header that documented the now-removed forms.
- Regenerated outputs: \`kmod/generated/iface_lists.h\`,
  \`zygisk/src/generated/iface_lists.rs\`,
  \`lsposed/native/src/generated/iface_lists.rs\`.
- \`cargo test\` (zygisk + lsposed/native) and \`test_iface_lists\`
  (kmod host build) pass.

If a future rule needs \`digits_optional\` or \`any\`, reintroduce
alongside it.