### PR TITLE
fix: code-review cheap-batch — 10 small correctness/hardening fixes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: write
+  contents: read
   packages: read
 
 jobs:
@@ -260,6 +260,11 @@ jobs:
     needs: [kmod, zygisk, lsposed, portshide]
     if: startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
+    # Only the release job needs write — used by softprops/action-gh-release
+    # below to create the draft GitHub release. lint/build jobs run on the
+    # workflow-level `contents: read`.
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v6
         with:

--- a/kmod/module/service.sh
+++ b/kmod/module/service.sh
@@ -56,7 +56,10 @@ resolve_uids() {
         pkg="$(echo "$line" | tr -d '[:space:]')"
         [ -z "$pkg" ] && continue
         case "$pkg" in \#*) continue ;; esac
-        uid_csv="$(echo "$ALL_PACKAGES" | grep "^package:${pkg} " | sed 's/.*uid://')"
+        # Literal match on $1 — grep would treat dots in `pkg` as regex
+        # wildcards (e.g. `com.x.y` matching `comXxXy` if such a package
+        # ever existed). awk's `$1 == p` compares fields literally.
+        uid_csv="$(echo "$ALL_PACKAGES" | awk -v p="package:${pkg}" '$1 == p { sub(/uid:/, "", $2); print $2; exit }')"
         if [ -n "$uid_csv" ]; then
             expanded="$(echo "$uid_csv" | tr ',' '\n')"
             if [ -z "$uids" ]; then uids="$expanded"; else uids="${uids}

--- a/kmod/vpnhide_kmod.c
+++ b/kmod/vpnhide_kmod.c
@@ -774,7 +774,21 @@ static int __init vpnhide_init(void)
 	 * and the VPN Hide app (both root). Apps must not see the target list. */
 	targets_entry =
 		proc_create("vpnhide_targets", 0600, NULL, &targets_proc_ops);
+	if (!targets_entry) {
+		/* Without /proc/vpnhide_targets userspace cannot configure
+		 * the target UID list, so the module would silently filter
+		 * nothing — fail loudly instead of pretending to work. */
+		pr_err(MODNAME
+		       ": proc_create(vpnhide_targets) failed; aborting\n");
+		for (i = 0; i < ARRAY_SIZE(probes); i++)
+			if (probes[i].registered)
+				unregister_kretprobe(probes[i].krp);
+		return -ENOMEM;
+	}
 	debug_entry = proc_create("vpnhide_debug", 0600, NULL, &debug_proc_ops);
+	if (!debug_entry)
+		pr_warn(MODNAME
+			": proc_create(vpnhide_debug) failed; debug toggle unavailable\n");
 
 	pr_info(MODNAME ": loaded — write UIDs to /proc/vpnhide_targets\n");
 	return 0;

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/AppHidingScreen.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/AppHidingScreen.kt
@@ -411,11 +411,15 @@ private fun buildHidingUidResolver(
         // `--user all` emits comma-separated UIDs for multi-profile
         // packages (e.g. work profile). `tr ',' '\n'` splits them so
         // each profile's observer gets matched by the system_server
-        // hook, not just the primary-user one.
+        // hook, not just the primary-user one. Literal field match via
+        // awk — grep would treat dots in `pkg` as regex wildcards.
         append("ALL_PKGS=\"\$(pm list packages -U --user all 2>/dev/null)\"")
         append("; UIDS=\"\"")
         for (pkg in packages) {
-            append("; U=\$(echo \"\$ALL_PKGS\" | grep '^package:$pkg ' | sed 's/.*uid://' | tr ',' '\\n')")
+            append(
+                "; U=\$(echo \"\$ALL_PKGS\" | awk -v p=\"package:$pkg\" " +
+                    "'\$1 == p { sub(/uid:/, \"\", \$2); print \$2; exit }' | tr ',' '\\n')",
+            )
             append("; if [ -n \"\$U\" ]; then if [ -z \"\$UIDS\" ]; then UIDS=\"\$U\"; else UIDS=\"\$UIDS")
             append("\n")
             append("\$U\"; fi; fi")

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/AppPickerScreen.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/AppPickerScreen.kt
@@ -410,10 +410,16 @@ private fun buildUidResolver(
         //   package:com.android.chrome uid:10187,1010187
         // `tr ',' '\n'` expands each to its own line so every profile's
         // copy of the target is individually filtered by the hooks.
+        // Literal field match via awk — grep would treat dots in `pkg`
+        // as regex wildcards, occasionally cross-matching distinct
+        // packages.
         append("ALL_PKGS=\"\$(pm list packages -U --user all 2>/dev/null)\"")
         append("; UIDS=\"\"")
         for (pkg in packages) {
-            append("; U=\$(echo \"\$ALL_PKGS\" | grep '^package:$pkg ' | sed 's/.*uid://' | tr ',' '\\n')")
+            append(
+                "; U=\$(echo \"\$ALL_PKGS\" | awk -v p=\"package:$pkg\" " +
+                    "'\$1 == p { sub(/uid:/, \"\", \$2); print \$2; exit }' | tr ',' '\\n')",
+            )
             append("; if [ -n \"\$U\" ]; then if [ -z \"\$UIDS\" ]; then UIDS=\"\$U\"; else UIDS=\"\$UIDS")
             append("\n")
             append("\$U\"; fi; fi")

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DashboardData.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DashboardData.kt
@@ -993,8 +993,13 @@ internal fun loadDashboardState(
     // profile (PackageManager.getInstalledApplications is per-user). A
     // Save from a profile that doesn't see all the targets would silently
     // drop them. Recommend uninstalling everywhere except the main profile.
+    // Literal field match via awk — grep would treat dots in `selfPkg`
+    // as regex wildcards.
     val (_, selfPmRaw) =
-        suExec("pm list packages -U --user all 2>/dev/null | grep '^package:$selfPkg '")
+        suExec(
+            "pm list packages -U --user all 2>/dev/null | " +
+                "awk -v p=\"package:$selfPkg\" '\$1 == p'",
+        )
     val selfUidCount =
         selfPmRaw
             .lines()

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DiagnosticsScreen.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DiagnosticsScreen.kt
@@ -1147,6 +1147,12 @@ private suspend fun exportDebugZip(
                                 "VPNHideTest:*",
                                 "VpnHide:*",
                                 "VpnHide-Dashboard:*",
+                                // zygisk's android_logger uses this tag (see
+                                // zygisk/src/lib.rs:LOG_TAG); without it the
+                                // exported zip is missing all native-side
+                                // hook logs, which is the half users most
+                                // need to debug.
+                                "vpnhide-zygisk:*",
                             ),
                         )
                     val output = proc.inputStream.bufferedReader().readText()

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/HookEntry.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/HookEntry.kt
@@ -212,7 +212,10 @@ class HookEntry : IXposedHookLoadPackage {
             val content = "version=$version\nboot_id=$bootId\ntimestamp=$timestamp\n"
             val statusFile = File(HOOK_STATUS_FILE)
             statusFile.writeText(content)
-            statusFile.setReadable(true, false)
+            // Don't expose this file to untrusted apps — anti-tamper SDKs
+            // scan /data/system/ for known marker filenames. The VPN Hide
+            // app reads it via root (`suExec("cat ...")`), see
+            // DashboardData.kt — same pattern as vpnhide_uids.txt.
             HookLog.i("VpnHide: wrote hook status file (version=$version, boot_id=$bootId)")
         } catch (t: Throwable) {
             HookLog.e("VpnHide: failed to write hook status: ${t.message}")

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/HookEntry.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/HookEntry.kt
@@ -233,7 +233,12 @@ class HookEntry : IXposedHookLoadPackage {
         val observer =
             object : android.os.FileObserver(
                 File(dir),
-                CREATE or CLOSE_WRITE or MOVED_TO or MODIFY,
+                // CLOSE_WRITE + MOVED_TO is enough: the writers we control
+                // either do a single short `> file` redirect (one write +
+                // close) or atomic-rename via `mv`. MODIFY would fire
+                // mid-write on multi-write writers and let the hook read
+                // a partially-populated file before the writer closes.
+                CREATE or CLOSE_WRITE or MOVED_TO,
             ) {
                 override fun onEvent(
                     event: Int,

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/HookEntry.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/HookEntry.kt
@@ -125,7 +125,13 @@ class HookEntry : IXposedHookLoadPackage {
                             filtered[key] = stackedCopy
                         }
                     } else {
-                        if (stackedModified || stackedCopy !== value) modified = true
+                        // Only mark `modified` if sanitization actually
+                        // changed something. The previous condition also
+                        // tripped on `stackedCopy !== value`, which is
+                        // true after every successful clone — so any
+                        // non-empty stacked map forced a clear+putAll
+                        // even when no VPN data was present.
+                        if (stackedModified) modified = true
                         filtered[key] = stackedCopy
                     }
                 }

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/PackageVisibilityHooks.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/PackageVisibilityHooks.kt
@@ -165,7 +165,9 @@ internal object PackageVisibilityHooks {
 
     private fun watchConfigFiles() {
         val observer =
-            object : FileObserver(File("/data/system"), CREATE or CLOSE_WRITE or MOVED_TO or MODIFY) {
+            // CLOSE_WRITE + MOVED_TO only — see HookEntry.watchTargetUidsFile
+            // for why MODIFY is intentionally absent.
+            object : FileObserver(File("/data/system"), CREATE or CLOSE_WRITE or MOVED_TO) {
                 override fun onEvent(
                     event: Int,
                     path: String?,

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/ShellUtils.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/ShellUtils.kt
@@ -149,9 +149,16 @@ internal fun ensureSelfInTargets(selfPkg: String): Boolean {
 
     addIfMissing(KMOD_TARGETS, "/data/adb/vpnhide_kmod")
     addIfMissing(ZYGISK_TARGETS, "/data/adb/vpnhide_zygisk")
-    // Zygisk reads targets from module dir (via get_module_dir() fd), not from persistent dir.
-    // Must sync after adding self, otherwise zygisk won't hook us on next launch.
-    suExec("[ -d $ZYGISK_MODULE_DIR ] && cp $ZYGISK_TARGETS $ZYGISK_MODULE_TARGETS 2>/dev/null; true")
+    // Zygisk reads targets from module dir (via get_module_dir() fd), not
+    // from persistent dir. Must sync after adding self, otherwise zygisk
+    // won't hook us on next launch. Surface real `cp` failures (read-only
+    // mount, SELinux denial) — silent failure here used to manifest as
+    // "I edited targets in the app but zygisk didn't pick it up".
+    val (cpExit, cpOut) =
+        suExec("if [ -d $ZYGISK_MODULE_DIR ]; then cp $ZYGISK_TARGETS $ZYGISK_MODULE_TARGETS 2>&1; fi")
+    if (cpExit != 0 && cpOut.isNotBlank()) {
+        VpnHideLog.w(TAG, "ensureSelfInTargets: zygisk module dir copy failed (exit=$cpExit): ${cpOut.trim()}")
+    }
     suExec("mkdir -p /data/adb/vpnhide_lsposed")
     addIfMissing(LSPOSED_TARGETS, null)
 

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/ShellUtils.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/ShellUtils.kt
@@ -181,9 +181,12 @@ internal fun ensureSelfInTargets(selfPkg: String): Boolean {
     // the existing file content.
     val uidCmd =
         buildString {
+            // Literal field match via awk — grep would treat dots in
+            // `selfPkg` as regex wildcards.
             append("ALL_PKGS=\"\$(pm list packages -U --user all 2>/dev/null)\"")
             append(
-                "; SELF_UIDS=\$(echo \"\$ALL_PKGS\" | grep '^package:$selfPkg ' | sed 's/.*uid://' | tr ',' '\\n')",
+                "; SELF_UIDS=\$(echo \"\$ALL_PKGS\" | awk -v p=\"package:$selfPkg\" " +
+                    "'\$1 == p { sub(/uid:/, \"\", \$2); print \$2; exit }' | tr ',' '\\n')",
             )
             append("; if [ -n \"\$SELF_UIDS\" ]; then")
             append("   for U in \$SELF_UIDS; do")

--- a/scripts/codegen-interfaces.py
+++ b/scripts/codegen-interfaces.py
@@ -134,7 +134,7 @@ def parse_test(entry: dict[str, Any]) -> TestVector:
     if "name" not in entry or "is_vpn" not in entry:
         raise SystemExit(f"[[test]] entry needs name and is_vpn: {entry!r}")
     name = str(entry["name"])
-    if not all(c == "" or 0x20 <= ord(c) < 0x7F for c in name):
+    if not all(0x20 <= ord(c) < 0x7F for c in name):
         raise SystemExit(f"non-ASCII test name {name!r}; the matcher itself is ASCII-only")
     return TestVector(name=name, is_vpn=bool(entry["is_vpn"]))
 

--- a/zygisk/module/service.sh
+++ b/zygisk/module/service.sh
@@ -50,7 +50,9 @@ resolve_uids() {
         pkg="$(echo "$line" | tr -d '[:space:]')"
         [ -z "$pkg" ] && continue
         case "$pkg" in \#*) continue ;; esac
-        uid_csv="$(echo "$ALL_PACKAGES" | grep "^package:${pkg} " | sed 's/.*uid://')"
+        # Literal match on $1 — grep would treat dots in `pkg` as regex
+        # wildcards. awk's `$1 == p` compares fields literally.
+        uid_csv="$(echo "$ALL_PACKAGES" | awk -v p="package:${pkg}" '$1 == p { sub(/uid:/, "", $2); print $2; exit }')"
         if [ -n "$uid_csv" ]; then
             expanded="$(echo "$uid_csv" | tr ',' '\n')"
             if [ -z "$uids" ]; then uids="$expanded"; else uids="${uids}

--- a/zygisk/src/filter.rs
+++ b/zygisk/src/filter.rs
@@ -23,7 +23,6 @@ pub fn is_vpn_iface_bytes(name: &[u8]) -> bool {
 }
 
 /// Convenience wrapper: takes a `CStr` and dispatches to `is_vpn_iface_bytes`.
-#[allow(dead_code)]
 pub fn is_vpn_iface_cstr(name: &CStr) -> bool {
     is_vpn_iface_bytes(name.to_bytes())
 }


### PR DESCRIPTION
## Why

Pull together a stack of small fixes that surfaced during a code-review
sweep. Each is independent of the rest and one (or two) lines of real
change — not worth a PR per fix, but folding them into unrelated work
would lose the audit trail.

## Summary

* `fix:` swap `grep "^package:${pkg} "` for `awk '$1 == p'` in six
  places (`kmod/module/service.sh`, `zygisk/module/service.sh`,
  `AppPickerScreen.kt`, `AppHidingScreen.kt`, `ShellUtils.kt`,
  `DashboardData.kt`). Dots in `pkg` were treated as regex wildcards.
* `fix(kmod):` abort init when `proc_create(/proc/vpnhide_targets)`
  returns NULL — silent failure used to leave the module loaded but
  filtering nothing.
* `chore(zygisk):` drop `#[allow(dead_code)]` on `is_vpn_iface_cstr`
  (used at `hooks.rs:329` and `:636`).
* `chore(codegen):` drop dead `c == ""` disjunct in `parse_test()`'s
  ASCII validation.
* `fix(lsposed):` stop making `/data/system/vpnhide_hook_active`
  world-readable — the app reads it via root anyway, the
  `setReadable(true, false)` was just a discoverable marker.
* `fix(lsposed):` drop `MODIFY` from the `FileObserver` mask on both
  config-file watchers; `CLOSE_WRITE | MOVED_TO` covers our writers
  without the mid-write race.
* `refactor(lsposed):` `sanitizeLinkProperties` no longer triggers a
  `mStackedLinks` clear+putAll on every successful clone — flag
  `modified` only when sanitization actually changed something.
* `fix(lsposed):` log zygisk-module-dir `cp` failures instead of
  swallowing stderr+exit. Silent failure used to manifest as "I
  edited targets in the app but zygisk didn't pick it up".
* `chore(lsposed):` include `vpnhide-zygisk:*` in the diagnostics
  logcat capture so the export bundle covers the native side too.
* `ci:` narrow workflow-level `contents` permission to `read`; grant
  `write` only on the `release` job (used by
  `softprops/action-gh-release@v2`).

CI lints and host-side tests pass locally (`cargo clippy`, `cargo test`,
`clang-format`, `python3 scripts/codegen-interfaces.py` clean,
`ktlint` on touched files clean, kmod `test_iface_lists` passes).