### PR TITLE
fix: tighten /data/system/vpnhide_*.txt to 0640 root:system

### DIFF
--- a/kmod/module/service.sh
+++ b/kmod/module/service.sh
@@ -86,17 +86,36 @@ fi
 # Resolve lsposed targets → /data/system/vpnhide_uids.txt
 # Create persist dir if needed (for first-time installs)
 mkdir -p /data/adb/vpnhide_lsposed 2>/dev/null
+# Mode 0640 + group=system: system_server (UID 1000, in group `system`)
+# reads via the group bit; untrusted apps fall to "other" and get EACCES.
+# Default 0644 was a fingerprint vector — `/data/system/` itself is mode
+# 0775 traversable by untrusted, so any o+r file is enumerable + readable.
 if [ -f "$LSPOSED_TARGETS" ]; then
     LSPOSED_UIDS="$(resolve_uids "$LSPOSED_TARGETS")"
     if [ -n "$LSPOSED_UIDS" ]; then
         echo "$LSPOSED_UIDS" > "$SS_UIDS_FILE"
-        chmod 644 "$SS_UIDS_FILE"
+        chmod 640 "$SS_UIDS_FILE"
+        chown root:system "$SS_UIDS_FILE"
         chcon u:object_r:system_data_file:s0 "$SS_UIDS_FILE" 2>/dev/null
         count="$(echo "$LSPOSED_UIDS" | wc -l)"
         log -t vpnhide "lsposed: wrote $count UIDs to $SS_UIDS_FILE"
     else
         echo > "$SS_UIDS_FILE"
-        chmod 644 "$SS_UIDS_FILE"
+        chmod 640 "$SS_UIDS_FILE"
+        chown root:system "$SS_UIDS_FILE"
         log -t vpnhide "lsposed: no UIDs resolved"
     fi
 fi
+
+# Migrate pre-PR files written by older versions with mode 0644: any
+# vpnhide_*.txt the lsposed app may have left in /data/system/. Touch
+# only files that already exist; don't create new ones here.
+for f in "$SS_UIDS_FILE" \
+         /data/system/vpnhide_hidden_pkgs.txt \
+         /data/system/vpnhide_observer_uids.txt; do
+    if [ -f "$f" ]; then
+        chmod 640 "$f"
+        chown root:system "$f"
+        chcon u:object_r:system_data_file:s0 "$f" 2>/dev/null
+    fi
+done

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/AppHidingScreen.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/AppHidingScreen.kt
@@ -382,21 +382,29 @@ private fun buildHidingSaveCommand(
     val parts = mutableListOf<String>()
 
     // Hidden list: package names, one per line.
+    // Mode 0640 + group=system: system_server reads via the group bit;
+    // untrusted apps get EACCES because /data/system/ is mode 0775 (the
+    // file's "other" bits decide reachability). Prevents apps from
+    // enumerating the hidden-package list to fingerprint vpnhide.
     val hiddenBody = "$header\n" + hiddenPkgs.joinToString("\n") + if (hiddenPkgs.isNotEmpty()) "\n" else ""
     val hiddenB64 = encode(hiddenBody)
     parts +=
-        "echo '$hiddenB64' | base64 -d > $SS_HIDDEN_PKGS_FILE && chmod 644 $SS_HIDDEN_PKGS_FILE" +
+        "echo '$hiddenB64' | base64 -d > $SS_HIDDEN_PKGS_FILE" +
+        " && chmod 640 $SS_HIDDEN_PKGS_FILE" +
+        " && chown root:system $SS_HIDDEN_PKGS_FILE" +
         " && chcon u:object_r:system_data_file:s0 $SS_HIDDEN_PKGS_FILE 2>/dev/null; true"
 
-    // Observer list: resolved UIDs.
+    // Observer list: resolved UIDs. Same 0640 root:system rationale.
     if (observerPkgs.isNotEmpty()) {
         parts += buildHidingUidResolver(observerPkgs, SS_OBSERVER_UIDS_FILE)
-        parts += "chmod 644 $SS_OBSERVER_UIDS_FILE 2>/dev/null"
+        parts += "chmod 640 $SS_OBSERVER_UIDS_FILE 2>/dev/null"
+        parts += "chown root:system $SS_OBSERVER_UIDS_FILE 2>/dev/null"
         parts += "chcon u:object_r:system_data_file:s0 $SS_OBSERVER_UIDS_FILE 2>/dev/null; true"
     } else {
         parts +=
             "echo > $SS_OBSERVER_UIDS_FILE 2>/dev/null;" +
-            " chmod 644 $SS_OBSERVER_UIDS_FILE 2>/dev/null;" +
+            " chmod 640 $SS_OBSERVER_UIDS_FILE 2>/dev/null;" +
+            " chown root:system $SS_OBSERVER_UIDS_FILE 2>/dev/null;" +
             " chcon u:object_r:system_data_file:s0 $SS_OBSERVER_UIDS_FILE 2>/dev/null; true"
     }
 

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/AppPickerScreen.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/AppPickerScreen.kt
@@ -389,12 +389,20 @@ private fun buildSaveCommand(
     }
 
     // Resolve lsposed UIDs -> /data/system/vpnhide_uids.txt
+    // Mode 0640 + group=system: system_server reads via the group bit;
+    // untrusted apps get EACCES because /data/system/ is mode 0775 (parent
+    // is traversable, file's "other" bits decide). Prevents apps from
+    // enumerating the target UID list to fingerprint vpnhide.
     if (lsposedPkgs.isNotEmpty()) {
         parts += buildUidResolver(lsposedPkgs, SS_UIDS_FILE)
-        parts += "chmod 644 $SS_UIDS_FILE 2>/dev/null"
+        parts += "chmod 640 $SS_UIDS_FILE 2>/dev/null"
+        parts += "chown root:system $SS_UIDS_FILE 2>/dev/null"
         parts += "chcon u:object_r:system_data_file:s0 $SS_UIDS_FILE 2>/dev/null"
     } else {
-        parts += "echo > $SS_UIDS_FILE 2>/dev/null; true"
+        parts +=
+            "echo > $SS_UIDS_FILE 2>/dev/null" +
+            " && chmod 640 $SS_UIDS_FILE 2>/dev/null" +
+            " && chown root:system $SS_UIDS_FILE 2>/dev/null; true"
     }
 
     return parts.joinToString(" ; ")

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/ShellUtils.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/ShellUtils.kt
@@ -172,8 +172,13 @@ internal fun ensureSelfInTargets(selfPkg: String): Boolean {
                 (hiddenExisting + selfPkg).sorted().joinToString("\n") + "\n"
         val b64 = Base64.encodeToString(body.toByteArray(), Base64.NO_WRAP)
         suExec(
+            // Mode 0640 + group=system: system_server reads via the group
+            // bit; untrusted apps fall to "other" and get EACCES.
+            // /data/system/ itself is mode 0775 traversable by untrusted —
+            // a plain 0644 here used to be enumerable + readable.
             "echo '$b64' | base64 -d > $SS_HIDDEN_PKGS_FILE" +
-                " && chmod 644 $SS_HIDDEN_PKGS_FILE" +
+                " && chmod 640 $SS_HIDDEN_PKGS_FILE" +
+                " && chown root:system $SS_HIDDEN_PKGS_FILE" +
                 " && chcon u:object_r:system_data_file:s0 $SS_HIDDEN_PKGS_FILE 2>/dev/null; true",
         )
         VpnHideLog.i(TAG, "ensureSelfInTargets: added $selfPkg to $SS_HIDDEN_PKGS_FILE")
@@ -203,7 +208,7 @@ internal fun ensureSelfInTargets(selfPkg: String): Boolean {
             append("     ; fi")
             append("   ; EXISTING2=\$(cat $SS_UIDS_FILE 2>/dev/null)")
             append(
-                "   ; echo \"\$EXISTING2\" | grep -q \"^\$U\$\" || { echo \"\$U\" >> $SS_UIDS_FILE; chmod 644 $SS_UIDS_FILE; chcon u:object_r:system_data_file:s0 $SS_UIDS_FILE 2>/dev/null; }",
+                "   ; echo \"\$EXISTING2\" | grep -q \"^\$U\$\" || { echo \"\$U\" >> $SS_UIDS_FILE; chmod 640 $SS_UIDS_FILE; chown root:system $SS_UIDS_FILE; chcon u:object_r:system_data_file:s0 $SS_UIDS_FILE 2>/dev/null; }",
             )
             append("   ; done")
             append("; fi")

--- a/zygisk/module/service.sh
+++ b/zygisk/module/service.sh
@@ -69,15 +69,34 @@ ${expanded}"; fi
 mkdir -p /data/adb/vpnhide_lsposed 2>/dev/null
 if [ -f "$LSPOSED_TARGETS" ]; then
     LSPOSED_UIDS="$(resolve_uids "$LSPOSED_TARGETS")"
+    # Mode 0640 + group=system: system_server (UID 1000, in group `system`)
+    # reads via the group bit; untrusted apps fall to "other" and get EACCES.
+    # Default 0644 was a fingerprint vector — `/data/system/` itself is mode
+    # 0775 traversable by untrusted, so any o+r file is enumerable + readable.
     if [ -n "$LSPOSED_UIDS" ]; then
         echo "$LSPOSED_UIDS" > "$SS_UIDS_FILE"
-        chmod 644 "$SS_UIDS_FILE"
+        chmod 640 "$SS_UIDS_FILE"
+        chown root:system "$SS_UIDS_FILE"
         chcon u:object_r:system_data_file:s0 "$SS_UIDS_FILE" 2>/dev/null
         count="$(echo "$LSPOSED_UIDS" | wc -l)"
         log -t vpnhide "zygisk: wrote $count lsposed UIDs to $SS_UIDS_FILE"
     else
         echo > "$SS_UIDS_FILE"
-        chmod 644 "$SS_UIDS_FILE"
+        chmod 640 "$SS_UIDS_FILE"
+        chown root:system "$SS_UIDS_FILE"
         log -t vpnhide "zygisk: no lsposed UIDs resolved"
     fi
 fi
+
+# Migrate pre-PR files written by older versions with mode 0644: any
+# vpnhide_*.txt the lsposed app may have left in /data/system/. Touch
+# only files that already exist; don't create new ones here.
+for f in "$SS_UIDS_FILE" \
+         /data/system/vpnhide_hidden_pkgs.txt \
+         /data/system/vpnhide_observer_uids.txt; do
+    if [ -f "$f" ]; then
+        chmod 640 "$f"
+        chown root:system "$f"
+        chcon u:object_r:system_data_file:s0 "$f" 2>/dev/null
+    fi
+done


### PR DESCRIPTION
## Why

Empirical follow-up to PR #100. While verifying the `vpnhide_hook_active`
permission fix on a real Pixel device I noticed that
`/data/system/` itself is mode `0775 system:system` — untrusted apps
can `ls` it and `open()` any file there whose mode allows "other" read.
The three coordination files under it,

  /data/system/vpnhide_uids.txt          — target UIDs read by the
                                           system_server LSPosed hook
  /data/system/vpnhide_hidden_pkgs.txt   — package-visibility hide list
  /data/system/vpnhide_observer_uids.txt — package-visibility observers

were all written as `0644 root:root`, so any app could `cat` them.
Reading `vpnhide_uids.txt` and finding your own UID in it is a strictly
stronger fingerprint than "the marker file exists" — it positively
confirms vpnhide is filtering this specific app *right now*.

## Summary

* All three files now end up `0640 root:system`. `system_server`
  matches via its `system` group → still reads. Untrusted apps fall
  to the `o---` octet → EACCES on `open()`.
* Touched: `kmod/module/service.sh`, `zygisk/module/service.sh`,
  `ShellUtils.ensureSelfInTargets`, `AppPickerScreen.buildSaveCommand`,
  `AppHidingScreen.buildHidingSaveCommand`. Six call sites total.
* Both boot scripts also gained a small idempotent migration loop —
  `for f in vpnhide_uids vpnhide_hidden_pkgs vpnhide_observer_uids;
  do [ -f $f ] && chmod 640 + chown root:system + chcon; done` — so
  files left by older versions get re-stamped on the next boot
  without waiting for the user to hit Save.

## Empirical verification (Pixel, Apr 2026)

Before this PR — files I had on the device from the released app:
```
mode=644 owner=root:root  /data/system/vpnhide_uids.txt
mode=644 owner=root:root  /data/system/vpnhide_hidden_pkgs.txt
mode=644 owner=root:root  /data/system/vpnhide_observer_uids.txt
```

`adb shell cat ...` (untrusted-shell UID): reads succeed.

After running the migration block manually:
```
mode=640 owner=root:system  /data/system/vpnhide_uids.txt
mode=640 owner=root:system  /data/system/vpnhide_hidden_pkgs.txt
mode=640 owner=root:system  /data/system/vpnhide_observer_uids.txt
```

`adb shell cat ...`: `Permission denied`.
`adb shell su system -c "cat ..."` (uid=1000, the same UID
system_server runs under): reads the contents fine, confirming the
group-bit access path that LSPosed hooks rely on.