### PR TITLE
fix(kmod): rtnl_fill_ifinfo skb_trim instead of -EMSGSIZE

### DIFF
--- a/changelog.d/fixed-kmod-stop-hanging-rtm-getlink-dumps-171a.md
+++ b/changelog.d/fixed-kmod-stop-hanging-rtm-getlink-dumps-171a.md
@@ -1,0 +1,9 @@
+_2026-04-26_
+
+## English
+
+kmod: stop hanging RTM_GETLINK dumps when SELinux is Permissive — replaced -EMSGSIZE return in rtnl_fill_ifinfo with the same skb_trim+return-0 trick already used for inet6_fill_ifaddr
+
+## Русский
+
+kmod: больше не зависает RTM_GETLINK при Permissive SELinux — в rtnl_fill_ifinfo вместо -EMSGSIZE теперь skb_trim+return 0, как уже было в inet6_fill_ifaddr

--- a/kmod/vpnhide_kmod.c
+++ b/kmod/vpnhide_kmod.c
@@ -404,12 +404,18 @@ static struct kretprobe sock_ioctl_krp = {
 /*                                                                    */
 /*  rtnl_fill_ifinfo fills one interface's data into a netlink skb    */
 /*  during a RTM_GETLINK dump. If the device is a VPN and the caller  */
-/*  is a target UID, we make it return -EMSGSIZE which tells the      */
-/*  dump iterator to skip this entry (it thinks the skb is full for   */
-/*  this entry and moves on, but the entry never gets added).         */
+/*  is a target UID, we hide the entry from the dump.                 */
+/*                                                                    */
+/*  We can't return -EMSGSIZE (causes infinite retry of the same      */
+/*  entry on android14-6.1, hanging RTM_GETLINK dumps). Instead use   */
+/*  the same skb_trim approach as inet6_fill_ifaddr below: save       */
+/*  skb->len before the fill, trim back on return, return 0. The      */
+/*  iterator then sees a successful entry of zero bytes and advances. */
 /* ================================================================== */
 
 struct rtnl_fill_data {
+	struct sk_buff *skb;
+	unsigned int saved_len;
 	bool should_filter;
 };
 
@@ -435,6 +441,8 @@ static int rtnl_fill_entry(struct kretprobe_instance *ri, struct pt_regs *regs)
 	 * belt-and-suspenders — same rationale as inet6_fill_entry. */
 	rcu_read_lock();
 	if (dev && is_vpn_ifname(dev->name)) {
+		data->skb = (struct sk_buff *)regs->regs[0];
+		data->saved_len = data->skb ? data->skb->len : 0;
 		data->should_filter = true;
 		vpnhide_dbg(
 			"rtnl_fill_entry: uid=%u target=1 iface=%s -> filter\n",
@@ -454,11 +462,14 @@ static int rtnl_fill_ret(struct kretprobe_instance *ri, struct pt_regs *regs)
 {
 	struct rtnl_fill_data *data = (void *)ri->data;
 
-	if (data->should_filter) {
-		vpnhide_dbg("rtnl_fill_ret: returning -EMSGSIZE\n");
-		regs_set_return_value(regs, -EMSGSIZE);
-	}
+	if (!data->should_filter || !data->skb)
+		return 0;
 
+	vpnhide_dbg("rtnl_fill_ret: trimming skb %u -> %u\n", data->skb->len,
+		    data->saved_len);
+	/* Undo whatever the fill function wrote to the skb */
+	skb_trim(data->skb, data->saved_len);
+	regs_set_return_value(regs, 0);
 	return 0;
 }
 


### PR DESCRIPTION
## Why

\`rtnl_fill_ifinfo\` returned \`-EMSGSIZE\` for VPN devs to "skip" the entry in
RTM_GETLINK dumps. On android14-6.1 (Pixel 6–9a) the dump iterator instead
retries the same entry forever on an empty skb, hanging any caller doing
\`getifaddrs()\` / RTM_GETLINK from a target UID — most visibly the
\`netlink_getlink\` self-check in \`dev.okhsunrog.vpnhide\` froze on splash
screen when SELinux was Permissive (issue #38, reported on 4pda).

\`inet6_fill_ifaddr\`/\`inet_fill_ifaddr\` in the same file already documented
this kernel quirk and worked around it with \`skb_trim\` + \`return 0\`. The
same trick fits \`rtnl_fill_ifinfo\` 1:1.

## Summary

- \`kmod/vpnhide_kmod.c\`: \`struct rtnl_fill_data\` gains \`skb\` + \`saved_len\`,
  entry handler stashes them, ret handler does \`skb_trim(skb, saved_len)\` +
  \`regs_set_return_value(regs, 0)\` instead of \`-EMSGSIZE\`. Comment block
  updated.
- \`changelog.d/fixed-kmod-stop-hanging-rtm-getlink-dumps-171a.md\`.

Verified on Pixel 8 Pro (husky, \`android14-6.1\`, kernel
\`6.1.145-android14-11\`) with the rebuilt module: \`getifaddrs\`,
\`netlink_getlink\`, \`netlink_getroute\` all PASS in Permissive within
~700 ms; previously \`netlink_getlink\` hung indefinitely.