### PR TITLE
ci: shave another ~80s off lint/lsposed jobs

### DIFF
--- a/.github/docker/ci/Dockerfile
+++ b/.github/docker/ci/Dockerfile
@@ -53,6 +53,11 @@ RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | \
     rustup target add aarch64-linux-android && \
     rustup component add rustfmt clippy && \
     cargo install cargo-ndk --locked && \
+    # Pre-built uniffi-bindgen so Gobley's :app:installUniffiBindgen task
+    # finds it ready (instead of running `cargo install uniffi-bindgen` on
+    # every CI build — that took ~50 s of the lsposed/lint job each run).
+    # Version range matches lsposed/native/Cargo.toml's `uniffi = "0.29"`.
+    cargo install uniffi-bindgen --version "^0.29" --locked && \
     chmod -R a+w /usr/local/rustup /usr/local/cargo
 
 # ── Android NDK (for zygisk) ─────────────────────────────────────────

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,7 +112,10 @@ jobs:
       # of twice. ANDROID_NDK_ROOT is baked into the CI image
       # (Dockerfile ENV), no manual export needed.
       - name: Android lint + Kotlin unit tests
-        run: cd lsposed && ./gradlew :app:lint :app:testDebugUnitTest
+        # `:app:lintDebug` (not `:app:lint`) runs Lint on the debug
+        # variant only — release-variant Lint covers R8/ProGuard issues
+        # and is reserved for ad-hoc local runs / future tag CI.
+        run: cd lsposed && ./gradlew :app:lintDebug :app:testDebugUnitTest
 
   kmod:
     runs-on: ubuntu-latest

--- a/docs/development.md
+++ b/docs/development.md
@@ -120,7 +120,7 @@ gcc -O2 -Wall -Werror -o /tmp/test_iface_lists kmod/test_iface_lists.c && /tmp/t
 
 # Kotlin
 ktlint "lsposed/**/*.kt"
-cd lsposed && ./gradlew :app:lint :app:testDebugUnitTest
+cd lsposed && ./gradlew :app:lintDebug :app:testDebugUnitTest
 ```
 
 ## Build versions

--- a/lsposed/app/build.gradle.kts
+++ b/lsposed/app/build.gradle.kts
@@ -110,6 +110,20 @@ android {
     packaging {
         resources.excludes += "META-INF/*.kotlin_module"
     }
+
+    // Skip Android Lint on test source sets. Our `src/test/` is pure JVM
+    // unit-test logic (filter/recommendation builders) — no Android
+    // lifecycle, no layouts, no context misuse. Functional bugs are
+    // caught by `:app:testDebugUnitTest`. Saves ~15–20 s of
+    // `lintAnalyze*Test` per Lint run.
+    //
+    // We deliberately leave `checkReleaseBuilds` at its default (true):
+    // CI invokes `:app:lintDebug` on PRs (so the release variant isn't
+    // analysed there), but ad-hoc `./gradlew :app:lint` on a release
+    // build still catches R8/ProGuard-specific issues like MissingRules.
+    lint {
+        checkTestSources = false
+    }
 }
 
 dependencies {

--- a/lsposed/gradle.properties
+++ b/lsposed/gradle.properties
@@ -2,3 +2,14 @@ org.gradle.jvmargs=-Xmx2048m -Dfile.encoding=UTF-8
 android.useAndroidX=true
 kotlin.code.style=official
 android.nonTransitiveRClass=true
+
+# Reuse task outputs across builds when inputs match. Combined with
+# gradle/actions/setup-gradle in CI, repeat builds of the same code go
+# UP-TO-DATE on most tasks instead of executing again.
+org.gradle.caching=true
+
+# Skip the configuration phase entirely when nothing in the build files
+# has changed. Verified compatible with Gobley 0.3.7 + AGP 8.9.3 +
+# Kotlin 2.1.20 (`./gradlew :app:assembleDebug --configuration-cache`
+# reports "Configuration cache entry stored" without warnings).
+org.gradle.configuration-cache=true


### PR DESCRIPTION
## Why

Warm-cache profiling from #105 showed three remaining hot spots in the Gradle phase of \`lint\` and \`lsposed\`:

| task | warm time | what it is |
|---|---|---|
| \`:app:installUniffiBindgen\` | 52s | \`cargo install uniffi-bindgen\` re-built every CI run |
| \`:app:cargoBuildAndroidArm64Debug\` | 30s | Rust crate compile (left for later) |
| \`:app:lintAnalyze*\` (×3 variants) | 43s | AGP Lint analysing main + unitTest + androidTest |

This PR targets the first one fully and the third partially. The Rust crate compile is left as-is — it would require teaching Gobley to share the cargo target dir, higher risk for a smaller win.

## Summary

- **\`Dockerfile\`** — pre-install \`uniffi-bindgen\` 0.29.x in the CI image. Version range matches \`uniffi = "0.29"\` in \`lsposed/native/Cargo.toml\`. Once the image is rebuilt, \`:app:installUniffiBindgen\` should go UP-TO-DATE.
- **\`lsposed/gradle.properties\`** — enable build cache + configuration cache. Verified compatible with Gobley 0.3.7 + AGP 8.9.3 + Kotlin 2.1.20 locally (\`Configuration cache entry stored\` cleanly).
- **\`lsposed/app/build.gradle.kts\`** — \`lint { checkTestSources = false }\`. Skips \`lintAnalyze*Test\` (our \`src/test/\` is pure JVM unit-test logic; \`src/androidTest/\` is empty). \`checkReleaseBuilds\` stays at its default (true) so \`./gradlew :app:lint\` still catches R8/ProGuard issues locally.
- **\`.github/workflows/ci.yml\`** — \`:app:lint\` → \`:app:lintDebug\`. Lints debug variant only on PRs.
- **\`docs/development.md\`** — refresh local-lint snippet.

## Expected effect — NOT measured yet

Per-task warm-cache budget I'm targeting (hypothesis, not data):

| task | now | target |
|---|---|---|
| \`installUniffiBindgen\` | 52s | ~0s (UP-TO-DATE after image rebuild) |
| \`lintAnalyze*Test\` | ~18s | 0s (skipped) |
| \`lintAnalyzeRelease\` | (only when \`:app:lint\` ran) | not invoked |

If those targets land, lint+lsposed should each drop ~70–90s on warm cache. **Real numbers to be filled in after merge** (image must rebuild before the gains are observable).

## CI sequencing — important

The Dockerfile change triggers \`ci-image.yml\` (paths-filter on \`.github/docker/ci/Dockerfile\`), but only on push to main. So:

1. CI on this PR uses the **old** image — \`installUniffiBindgen\` is still ~52s here.
2. After merge, push-to-main triggers \`ci-image.yml\` → new image published as \`:latest\`.
3. The next CI run on main (or any PR after that) picks up the new image.
4. To measure: \`gh workflow run ci.yml --ref main\` after step 2 finishes, then compare \`lint\`/\`lsposed\` durations against the warm baseline from PR #105 (286s / 227s).

This PR's own CI run is **not** the measurement run — it's a cold-write to the branch-scoped Gradle cache, plus a write penalty on the configuration-cache entry, so it may even appear marginally slower than the #105 baseline. Don't conclude from this PR's CI — wait for the post-merge main run.

No changelog (CI/dev-tooling).