### PR TITLE
ci: revert broken uniffi-bindgen pre-install (Dockerfile)

### DIFF
--- a/.github/docker/ci/Dockerfile
+++ b/.github/docker/ci/Dockerfile
@@ -53,11 +53,6 @@ RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | \
     rustup target add aarch64-linux-android && \
     rustup component add rustfmt clippy && \
     cargo install cargo-ndk --locked && \
-    # Pre-built uniffi-bindgen so Gobley's :app:installUniffiBindgen task
-    # finds it ready (instead of running `cargo install uniffi-bindgen` on
-    # every CI build — that took ~50 s of the lsposed/lint job each run).
-    # Version range matches lsposed/native/Cargo.toml's `uniffi = "0.29"`.
-    cargo install uniffi-bindgen --version "^0.29" --locked && \
     chmod -R a+w /usr/local/rustup /usr/local/cargo
 
 # ── Android NDK (for zygisk) ─────────────────────────────────────────


### PR DESCRIPTION
## Why

#106 added \`cargo install uniffi-bindgen --version "^0.29" --locked\` to the CI image. That broke ci-image rebuilds:

\`\`\`
error: could not find \`uniffi-bindgen\` in registry \`crates-io\` with version \`^0.29\`
\`\`\`

Two things were wrong with that idea:

1. **Wrong crate name.** Gobley doesn't install upstream \`uniffi-bindgen\` — it installs its own fork \`gobley-uniffi-bindgen\` (latest on crates.io is \`0.3.7\`).
2. **Wrong location.** Gobley puts the binary under \`app/build/gobley-tools-install/uniffi-bindgen/\` (a task-local output dir), not \`~/.cargo/bin\`. A globally pre-installed binary wouldn't satisfy the UP-TO-DATE check anyway.

## Summary

Drop only the offending \`cargo install\` line from \`.github/docker/ci/Dockerfile\`. The rest of #106 stays intact (build cache, configuration cache, \`lint { checkTestSources = false }\`, \`:app:lintDebug\`).

## Why we don't need the pre-install

\`org.gradle.caching=true\` (added in #106) already makes \`installUniffiBindgen\` go UP-TO-DATE on warm runs through Gradle's build cache. Verified locally with \`./gradlew :app:lintDebug :app:testDebugUnitTest --configuration-cache\`: \`BUILD SUCCESSFUL in 1m 9s\`, 17/40 tasks UP-TO-DATE on the second run. The optimisation #106 was reaching for is in effect — just via build cache rather than via the image.

No changelog (CI-only).