### PR TITLE
fix(rust): tighten netlink/recvmsg edge cases + install rollback

### DIFF
--- a/lsposed/native/src/lib.rs
+++ b/lsposed/native/src/lib.rs
@@ -396,16 +396,23 @@ unsafe fn for_each_rtattr(
     buf: &[u8],
     start: usize,
     end: usize,
-    mut on_attr: impl FnMut(&Rtattr, usize),
+    mut on_attr: impl FnMut(&Rtattr, &[u8]),
 ) {
+    // Walk rtattrs in `buf[start..end]`. For each, hand the callback
+    // the header AND a slice covering its payload — already bounds-
+    // checked against `end`, so callbacks can never read past the
+    // message. A truncated tail (rta_len < 4, or rta_len reaching
+    // past `end`) ends the walk; netlink dumps end on padding, so
+    // this is the normal exit too.
     let mut off = start;
     while off + 4 <= end {
         let rta = unsafe { &*(buf.as_ptr().add(off) as *const Rtattr) };
-        if rta.rta_len < 4 {
+        let rta_len = rta.rta_len as usize;
+        if rta_len < 4 || off + rta_len > end {
             break;
         }
-        on_attr(rta, off);
-        off += (rta.rta_len as usize + 3) & !3;
+        on_attr(rta, &buf[off + 4..off + rta_len]);
+        off += (rta_len + 3) & !3;
     }
 }
 
@@ -458,10 +465,11 @@ fn check_netlink_getlink() -> CheckOutput {
                 |b, offset, msg_len| {
                     let data_start = offset + hdr_plus_ifinfo;
                     let msg_end = offset + msg_len;
-                    for_each_rtattr(b, data_start, msg_end, |rta, rta_off| {
-                        if rta.rta_type == IFLA_IFNAME {
-                            let name =
-                                cstr_to_str(b.as_ptr().add(rta_off + 4) as *const libc::c_char);
+                    for_each_rtattr(b, data_start, msg_end, |rta, payload| {
+                        if rta.rta_type == IFLA_IFNAME && !payload.is_empty() {
+                            // IFLA_IFNAME is a NUL-terminated string;
+                            // payload was bounds-checked by for_each_rtattr.
+                            let name = cstr_to_str(payload.as_ptr() as *const libc::c_char);
                             if is_vpn_iface(&name) {
                                 vpn.push(name.clone());
                             }
@@ -533,9 +541,9 @@ fn check_netlink_getroute() -> CheckOutput {
                     total += 1;
                     let data_start = offset + hdr_plus_rtmsg;
                     let msg_end = offset + msg_len;
-                    for_each_rtattr(b, data_start, msg_end, |rta, rta_off| {
-                        if rta.rta_type == RTA_OIF {
-                            let ifindex = *(b.as_ptr().add(rta_off + 4) as *const i32);
+                    for_each_rtattr(b, data_start, msg_end, |rta, payload| {
+                        if rta.rta_type == RTA_OIF && payload.len() >= 4 {
+                            let ifindex = i32::from_ne_bytes(payload[..4].try_into().unwrap());
                             let mut ifname_buf = [0u8; libc::IF_NAMESIZE];
                             let ptr = libc::if_indextoname(
                                 ifindex as u32,

--- a/zygisk/src/hooks.rs
+++ b/zygisk/src/hooks.rs
@@ -424,6 +424,18 @@ fn match_rel_proc_net(dirfd: c_int, basename: &[u8]) -> Option<ProcNetFile> {
     }
 }
 
+/// Resolves what `dirfd` currently points at by reading
+/// `/proc/self/fd/<dirfd>`. There is a TOCTOU window: the caller can
+/// race `dup2`/`fchdir` between this readlink and the subsequent open
+/// (`open_filtered_proc_net`), so the open could land on a different
+/// directory than the one we just classified.
+///
+/// Treated as accepted exposure: closing it would mean opening through
+/// an unhooked syscall and validating inode/path manually, which is a
+/// large amount of code for what amounts to caller-controlled self-DoS
+/// (the caller has to fight its own fd table to lose the race). Real
+/// detectors don't need this — they just don't `openat` through dirfd
+/// in the first place.
 fn is_dirfd_proc_net(dirfd: c_int) -> bool {
     let mut link_buf = [0u8; 128];
     let mut fd_path = [0u8; 32];
@@ -748,8 +760,16 @@ pub fn set_real_recvmsg_ptr(p: *const ()) {
 /// so, collects VPN interface indices and removes matching entries from
 /// the buffer before returning to the caller.
 ///
-/// Only handles the common single-iov case. Multi-iov netlink responses
-/// pass through unfiltered (extremely rare in practice).
+/// recvmsg distributes `ret` bytes across the iov array in order:
+/// iov[0] fills first, then iov[1], and so on. We filter the portion
+/// that landed in iov[0] — netlink dumps fit there in any sane caller
+/// (bionic always uses iov[0] only). A deliberately split call where
+/// the netlink message crosses an iov boundary is a corner case we
+/// don't try to stitch back together: filtering iov[0] still hides
+/// VPN entries that landed in it; entries fully inside iov[1+] pass
+/// through unfiltered. Strictly better than the previous behaviour,
+/// which bailed out entirely as soon as `iovlen != 1` and let a caller
+/// bypass the filter with a single extra zero-length iov.
 pub unsafe extern "C" fn hooked_recvmsg(fd: c_int, msg: *mut libc::msghdr, flags: c_int) -> isize {
     let Some(real) = real_recvmsg() else {
         set_errno(libc::EFAULT);
@@ -763,7 +783,7 @@ pub unsafe extern "C" fn hooked_recvmsg(fd: c_int, msg: *mut libc::msghdr, flags
     }
 
     let hdr = unsafe { &*msg };
-    if hdr.msg_iovlen != 1 || hdr.msg_iov.is_null() {
+    if hdr.msg_iovlen == 0 || hdr.msg_iov.is_null() {
         return ret;
     }
 
@@ -772,7 +792,12 @@ pub unsafe extern "C" fn hooked_recvmsg(fd: c_int, msg: *mut libc::msghdr, flags
         return ret;
     }
 
-    unsafe { maybe_filter_netlink_buf(fd, iov.iov_base as *mut u8, ret) }
+    let in_first = ret.min(iov.iov_len as isize);
+    let filtered_first = unsafe { maybe_filter_netlink_buf(fd, iov.iov_base as *mut u8, in_first) };
+
+    // Propagate any shrink of iov[0] to the total return value; bytes
+    // that landed in iov[1+] are unchanged.
+    ret - (in_first - filtered_first)
 }
 
 /// Post-process a netlink read: if `fd` is a netlink socket and the

--- a/zygisk/src/lib.rs
+++ b/zygisk/src/lib.rs
@@ -361,30 +361,61 @@ fn mark_cleanup(api: &mut ZygiskApi<'_, V2>) {
 fn install_hooks() -> Result<(), String> {
     shadowhook::init_once().map_err(|rc| format!("shadowhook_init: rc={rc}"))?;
 
-    hook_libc_sym(c"ioctl", hooked_ioctl as *mut _, set_real_ioctl_ptr)?;
-    hook_libc_sym(
-        c"getifaddrs",
-        hooked_getifaddrs as *mut _,
-        set_real_getifaddrs_ptr,
-    )?;
-    hook_libc_sym(c"openat", hooked_openat as *mut _, set_real_openat_ptr)?;
-    hook_libc_sym(c"recvmsg", hooked_recvmsg as *mut _, set_real_recvmsg_ptr)?;
-    // Hook recv directly. We cannot hook recvfrom because bionic's recv()
-    // does a bare `b recvfrom` — patching recvfrom's prologue breaks recv.
-    // recv itself is 12 bytes (3 instructions), safe for island-mode hooking.
-    hook_libc_sym(c"recv", hooked_recv as *mut _, set_real_recv_ptr)?;
+    // (sym, replacement, stash-original-via). Install order is the
+    // order we'll roll back in on failure (LIFO).
+    //
+    // recv is hooked directly because bionic's `recv()` tail-calls
+    // recvfrom via a bare `b` branch — patching recvfrom's prologue
+    // would break recv. recv itself is 12 bytes (3 instructions),
+    // safe for island-mode hooking.
+    type StoreFn = fn(*const ());
+    let plan: [(&core::ffi::CStr, *mut core::ffi::c_void, StoreFn); 5] = [
+        (c"ioctl", hooked_ioctl as *mut _, set_real_ioctl_ptr),
+        (
+            c"getifaddrs",
+            hooked_getifaddrs as *mut _,
+            set_real_getifaddrs_ptr,
+        ),
+        (c"openat", hooked_openat as *mut _, set_real_openat_ptr),
+        (c"recvmsg", hooked_recvmsg as *mut _, set_real_recvmsg_ptr),
+        (c"recv", hooked_recv as *mut _, set_real_recv_ptr),
+    ];
+
+    let mut installed: Vec<*mut core::ffi::c_void> = Vec::with_capacity(plan.len());
+    for (sym, new_fn, store_orig) in plan {
+        match hook_libc_sym(sym, new_fn, store_orig) {
+            Ok(stub) => installed.push(stub),
+            Err(err) => {
+                // Roll back any hooks already installed before this
+                // one failed — better to be fully off than to leave
+                // the process with a torn hook plan that filters
+                // some libc paths but not others.
+                for stub in installed.into_iter().rev() {
+                    let rc = unsafe { shadowhook::unhook(stub) };
+                    if rc != 0 {
+                        // Nothing useful to do — we're already on
+                        // the error path. Surface it via log so a
+                        // bad install at least leaves a trail.
+                        error!("install_hooks rollback: shadowhook_unhook rc={rc}");
+                    }
+                }
+                return Err(err);
+            }
+        }
+    }
 
     Ok(())
 }
 
-/// Install a single inline hook on a libc symbol and stash the original
-/// trampoline via `store_orig`. Used for every entry point from
-/// `install_hooks`.
+/// Install a single inline hook on a libc symbol and stash the
+/// original trampoline via `store_orig`. Returns the shadowhook stub
+/// pointer on success — caller keeps it for the partial-install
+/// rollback in `install_hooks`.
 fn hook_libc_sym(
     sym: &core::ffi::CStr,
     new_fn: *mut core::ffi::c_void,
     store_orig: fn(*const ()),
-) -> Result<(), String> {
+) -> Result<*mut core::ffi::c_void, String> {
     let mut orig: *mut core::ffi::c_void = core::ptr::null_mut();
     // SAFETY: `new_fn` has an ABI-compatible signature with the target
     // libc symbol; `&mut orig` is a valid writable pointer.
@@ -402,7 +433,7 @@ fn hook_libc_sym(
         ));
     }
     store_orig(orig as *const ());
-    Ok(())
+    Ok(stub)
 }
 
 // ============================================================================

--- a/zygisk/src/shadowhook.rs
+++ b/zygisk/src/shadowhook.rs
@@ -37,7 +37,6 @@ unsafe extern "C" {
         orig_addr: *mut *mut c_void,
     ) -> *mut c_void;
 
-    #[allow(dead_code)]
     fn shadowhook_unhook(stub: *mut c_void) -> c_int;
 }
 
@@ -74,4 +73,18 @@ pub unsafe fn hook_sym(
     out_orig: *mut *mut c_void,
 ) -> *mut c_void {
     unsafe { shadowhook_hook_sym_name(lib.as_ptr(), sym.as_ptr(), new_fn, out_orig) }
+}
+
+/// Remove a hook previously installed by `hook_sym`. `stub` is the
+/// non-null pointer that `hook_sym` returned. Returns 0 on success,
+/// non-zero on failure (best-effort — there's nothing useful to do
+/// with a failure here, since we only call this during partial-install
+/// rollback).
+///
+/// # Safety
+///
+/// `stub` must be a non-null pointer previously returned by
+/// `hook_sym`, and not already unhooked.
+pub unsafe fn unhook(stub: *mut c_void) -> c_int {
+    unsafe { shadowhook_unhook(stub) }
 }


### PR DESCRIPTION
Four small Rust touches in \`zygisk\` and \`lsposed/native\`. All on adversarial- or kernel-edge-case paths; happy paths and the per-app filter behaviour are unchanged.

## Changes

**\`zygisk/src/hooks.rs::hooked_recvmsg\` — multi-iov no longer bypasses the filter**

Old code bailed out as soon as \`msg_iovlen != 1\`, so a caller could pass an iov array with one extra zero-length iov to skip filtering entirely. Now we filter the portion of \`ret\` that landed in iov[0] (recvmsg fills iovs in order) and propagate any shrink back into the returned byte count. Bytes in iov[1..] pass through — bionic only ever uses iov[0], so legitimate callers are unaffected, and an attacker who deliberately splits across iovs at least loses everything in iov[0].

**\`zygisk/src/lib.rs::install_hooks\` — partial install rollback**

Previously \`?\`-propagated the first failure but left already-installed hooks in place. If hook 1-4 succeeded and hook 5 failed, the app would see filtered ioctl/getifaddrs/openat/recvmsg but unfiltered recv — a torn plan, worse than no install. Now we collect each \`shadowhook\` stub and, on first failure, walk back through them in LIFO order calling \`shadowhook_unhook\`. Added a thin \`shadowhook::unhook\` wrapper to keep the FFI out of lib.rs.

**\`zygisk/src/hooks.rs::is_dirfd_proc_net\` — document the TOCTOU window**

\`match_rel_proc_net\` resolves dirfd via readlink before the open. A caller racing dup2/fchdir between them can pass the classifier and have the open land elsewhere. Accepted exposure (caller-controlled self-DoS; real detectors don't go through dirfd) — added a comment so the next reader doesn't think it's an oversight. Comment-only change.

**\`lsposed/native/src/lib.rs::for_each_rtattr\` — bounds-checked payload slice**

Old callbacks computed \`b.as_ptr().add(rta_off + 4)\` and read payload from there. If the kernel returned \`rta_len == 4\` (header only, zero payload), the read passed the rtattr loop check and then touched bytes belonging to the next attr or past the message end. Now \`for_each_rtattr\` verifies \`off + rta_len <= end\` and yields a \`&[u8]\` payload slice; callbacks validate \`payload.len()\` before reading. The unsafe \`*const i32\` deref for \`RTA_OIF\` becomes a safe \`i32::from_ne_bytes\`.

## Verification

Pixel 8 Pro (husky, android14-6.1, Android 16):

| mode | result | start |
|---|---|---|
| Enforcing | 26/26 PASS | ~1.9 s |
| Permissive | 22/26 PASS — same four by-design FAILs as before (\`proc_dev\`, \`sys_class_net\`, \`proc_ipv6_route\`, \`proc_if_inet6\`) | ~1.5 s |

No regression in \`netlink_getlink\`, \`netlink_getroute\`, \`getifaddrs\`, \`ioctl_*\`, \`proc_route\`, \`proc_fib_trie\`. zygisk and APK-native md5 match local build artifacts.

## Local

- \`cargo fmt --check\` clean (zygisk + lsposed/native)
- \`cargo ndk -t arm64-v8a clippy --tests -- -D warnings\` clean (both)