### PR TITLE
fix(portshide): re-apply iptables 30s after boot in case netd flushes

### DIFF
--- a/portshide/module/service.sh
+++ b/portshide/module/service.sh
@@ -14,3 +14,14 @@ for i in $(seq 1 60); do
 done
 
 sh "$APPLY" && log -t vpnhide_ports "applied iptables rules at boot"
+
+# Re-apply once more 30 s later. On slow boots netd has been observed to
+# flush/rebuild its own chains AFTER bw_OUTPUT first appears, which
+# would wipe ours. The apply script is idempotent — chains are created
+# with `-N ... 2>/dev/null || true` and rebuilt atomically via
+# `iptables-restore --noflush` — so a second pass is harmless when
+# nothing was wiped and self-healing when it was.
+(
+    sleep 30
+    sh "$APPLY" && log -t vpnhide_ports "re-applied iptables rules (T+30s safety pass)"
+) &


### PR DESCRIPTION
## Why

\`portshide/module/service.sh\` waits for netd's \`bw_OUTPUT\` chain to appear and then applies our rules once. On slow boots netd has been observed to flush/rebuild its own chains **after** \`bw_OUTPUT\` first appears — wiping the rules we just installed. They stay missing until the user opens the app and Save runs apply again.

## Summary

- \`service.sh\`: backgrounded second pass 30 s after the first apply.

\`vpnhide_ports_apply.sh\` is already idempotent — chains are created with \`-N … 2>/dev/null || true\` and rebuilt atomically via \`iptables-restore --noflush\`. The extra pass is harmless when nothing was wiped and self-healing when it was. Cost is one shell process + one iptables-restore per boot.

shellcheck clean (no new lint, same exclusions as the lint job).

No changelog (boot-time robustness, no user-visible behaviour change for happy paths).