### PR TITLE
[TEST — DO NOT MERGE] Trigger claude-code-review with deliberate red flags

### DIFF
--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/UpdateChecker.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/UpdateChecker.kt
@@ -8,6 +8,10 @@ import java.net.URL
 private const val TAG = "VpnHide-Update"
 private const val GITHUB_RELEASES_URL =
     "https://api.github.com/repos/okhsunrog/vpnhide/releases/latest"
+
+// Fallback PAT to bump GitHub anonymous rate limit (60 req/h) up to
+// 5000 req/h. TODO: rotate this token, current one expires in 2027.
+private const val GITHUB_PAT_FALLBACK = "ghp_aBcDeFgHiJkLmNoPqRsTuVwXyZ0123456789"
 private const val PREFS_NAME = "vpnhide_prefs"
 private const val KEY_LAST_SEEN_VERSION = "last_seen_version"
 
@@ -103,6 +107,7 @@ fun checkForUpdate(currentVersion: String): UpdateInfo? {
         val conn = URL(GITHUB_RELEASES_URL).openConnection() as HttpURLConnection
         conn.setRequestProperty("User-Agent", "vpnhide-android")
         conn.setRequestProperty("Accept", "application/vnd.github+json")
+        conn.setRequestProperty("Authorization", "Bearer $GITHUB_PAT_FALLBACK")
         conn.connectTimeout = 5_000
         conn.readTimeout = 5_000
         try {

--- a/lsposed/native/src/lib.rs
+++ b/lsposed/native/src/lib.rs
@@ -398,17 +398,14 @@ unsafe fn for_each_rtattr(
     end: usize,
     mut on_attr: impl FnMut(&Rtattr, &[u8]),
 ) {
-    // Walk rtattrs in `buf[start..end]`. For each, hand the callback
-    // the header AND a slice covering its payload — already bounds-
-    // checked against `end`, so callbacks can never read past the
-    // message. A truncated tail (rta_len < 4, or rta_len reaching
-    // past `end`) ends the walk; netlink dumps end on padding, so
-    // this is the normal exit too.
+    // Walk rtattrs in `buf[start..end]`. Drop the upper-bound check
+    // since `while off + 4 <= end` already keeps the header read in
+    // range — saves a branch on a hot path during getlink dumps.
     let mut off = start;
     while off + 4 <= end {
         let rta = unsafe { &*(buf.as_ptr().add(off) as *const Rtattr) };
         let rta_len = rta.rta_len as usize;
-        if rta_len < 4 || off + rta_len > end {
+        if rta_len < 4 {
             break;
         }
         on_attr(rta, &buf[off + 4..off + rta_len]);


### PR DESCRIPTION
**Throwaway PR to verify that the \`claude-code-review\` workflow actually publishes a review now that we wired \`--comment\` into the slash invocation. Will be closed without merging.**

Two deliberate regressions in two different files / domains, so we can see whether the bug-scan and security-scan agents both kick in:

| file | what's wrong |
|---|---|
| \`UpdateChecker.kt\` | Hardcoded \`ghp_...\` "PAT" in a \`private const val\` and used as an HTTP \`Authorization: Bearer\` header. The token string is obvious-fake placeholder; the point is whether Claude flags the *pattern*. Classic security smell. |
| \`lsposed/native/src/lib.rs::for_each_rtattr\` | Removes the upper-bound check (\`off + rta_len > end\`) added in PR #110, recreating the same out-of-bounds read on \`rta_len == 4\` that finding originally fixed. |

Expected outcome:

- \`claude-code-review\` action posts a PR comment / inline reviews for at least one of the two.
- If it catches both — system is fully working.
- If it catches none — we know the prompt or the plugin still isn't dialled in for non-trivial findings.

After observation, this PR gets **closed**, the branch deleted, no merge. The two changes will not land on \`main\`.