### PR TITLE
chore: publish CLAUDE.md / AGENTS.md repo conventions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,1 @@
+CLAUDE.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,51 @@
+# vpnhide — repo conventions for AI agents and contributors
+
+Quick orientation file for anyone (or anything) working on this repo.
+Read in full before opening a PR; it's short on purpose.
+
+This file is also exposed as `AGENTS.md` (symlink) so vendor-neutral
+tooling that follows the AGENTS-convention picks it up automatically.
+
+## Project layout
+
+Monorepo for hiding VPN interfaces from selected Android apps. Three runtime components plus tooling:
+
+- `kmod/` — kernel module, kretprobes-based, per-GKI-generation builds
+- `zygisk/` — Rust Zygisk module, inline `libc` hooks via shadowhook
+- `lsposed/` — LSPosed module + Compose target-picker app
+- `portshide/` — localhost port blocker (shell + iptables)
+
+## Read before touching code
+
+These short files cover everything specific to this repo. Skipping them leads to broken commits and unnecessary review iterations.
+
+- [CONTRIBUTING.md](CONTRIBUTING.md) — PR process, commit conventions, changelog requirement
+- [docs/development.md](docs/development.md) — prereqs, per-module build quickstart, keystore setup, device install, CI lints
+- [docs/changelog.md](docs/changelog.md) — changelog storage (`changelog.d/` fragments + history JSON), `./scripts/changelog.py` usage
+- [docs/releasing.md](docs/releasing.md) — `./scripts/release.py` usage, version-bump flow
+- [kmod/BUILDING.md](kmod/BUILDING.md) — kernel-module build (one-command DDK via `./kmod/build.py`, GKI matrix, troubleshooting)
+
+## Workflow rules
+
+- **Add a changelog entry BEFORE committing user-visible changes:**
+  ```sh
+  ./scripts/changelog.py <type> "<EN text>" "<RU text>"
+  # types: added | changed | fixed | removed | deprecated | security
+  ```
+  This writes a Markdown fragment to `changelog.d/<type>-<slug>-<hex4>.md` — nothing else. `CHANGELOG.md` is regenerated only at release time (that's what keeps PRs from conflicting on it). Commit just the new fragment alongside the code change. To preview pending entries: `./scripts/preview-changelog.py`. Skip the entry for internal refactors / docs-only / CI-only / test-only changes.
+- **Do not bump `VERSION` or run `./scripts/release.py` unless the maintainer explicitly asks for a release.** Fragments under `changelog.d/` don't need a version number. `release.py` rotates every fragment into `history[0]` of `changelog.json`, deletes the fragment files, and is maintainer-only.
+- **Don't put `#NN` in commit messages or PR titles to refer to local review notes.** GitHub auto-links `#NN` to PR/issue numbers in this repo, and the cross-reference will almost certainly point at the wrong PR. Real GitHub references (`fixes #38` where #38 is an actual issue) are fine — verify the number first.
+
+## Build entry points
+
+Single-command builds for both CI and local — the same scripts run in both places.
+
+- **kmod**: `./kmod/build.py --kmi <kmi>` (or `--all`). Auto-spawns the DDK podman/docker container if you're not already inside it; CI passes `--inside-container` to skip the spawn. The DDK image tag is `DDK_IMAGE_TAG` in `kmod/build.py` — `.github/workflows/ci.yml` mirrors it, bump both together.
+- **zygisk**: `cd zygisk && ./build.py` — host-side cargo-ndk build, same script in CI image.
+- **lsposed APK**: `cd lsposed && ./gradlew :app:assembleRelease`.
+
+Both Rust cdylibs (`zygisk/build.rs`, `lsposed/native/build.rs`) pass `-Wl,-z,max-page-size=16384` so the resulting `.so` files load cleanly on 16 KiB-page Android devices (Pixel 8 Pro on Android 16, future hardware). Don't strip that flag.
+
+## Design notes
+
+- **KPatch-Next KPM:** `kmod/` currently uses kretprobes and requires per-GKI-generation builds (kernel headers + `Module.symvers`). Porting to a [KPatch-Next](https://github.com/KernelSU-Next/KPatch-Next) KPM would produce a single binary for kernels 3.18–6.12, eliminating the multi-GKI build problem. Tradeoff: adds KPatch-Next as a hard dependency (already bundled in KernelSU-Next).


### PR DESCRIPTION
## Why

Two reasons to bring this file into the repo:

1. **Auto-review utility**. The \`claude-code-review\` workflow runs four parallel agents per PR; **two of them are CLAUDE.md compliance checks**. Without a checked-in CLAUDE.md they just report "no CLAUDE.md to check" — half the review goes idle. With this file, those agents start verifying things like "changelog fragment present?", "no \`#NN\` cross-refs in the commit?", "VERSION untouched?".
2. **Quick orientation for contributors**. Plain markdown summary of what to read (CONTRIBUTING / docs / kmod/BUILDING), the workflow rules, build entry points, and the KPatch-Next design note. Useful regardless of any AI tool — it's basically a CONTRIBUTING-quickref.

## Summary

- \`CLAUDE.md\` (new, 100644) — canonical source.
- \`AGENTS.md\` (new, 120000 symlink → CLAUDE.md) — exposes the same file under the vendor-neutral \`AGENTS.md\` convention used by Codex / Cursor / etc. Stored as a real git symlink (mode 120000), not a duplicate, so there's only one place to update.
- Wording is neutral — no Claude-specific addressing — so the file reads naturally to humans and to other AI tooling.

## Notes

- **Windows without Developer Mode**: \`AGENTS.md\` may materialise as a one-line text file containing \`CLAUDE.md\` instead of a real symlink. Not a blocker — contributor sees the target name and opens \`CLAUDE.md\`. Most of this project's contributors are on Linux/macOS anyway.
- This file does **not** replace \`CONTRIBUTING.md\`. CONTRIBUTING stays the long-form contributor doc; CLAUDE.md is the 50-line quickref.
- No personal preferences leak in here — the maintainer's local AI memory (private feedback, custom shortcuts) stays out-of-tree.