### PR TITLE
feat(lsposed): smoke-check private AOSP fields used by writeToParcel hooks

### DIFF
--- a/changelog.d/added-lsposed-install-time-smoke-check-on-ba36.md
+++ b/changelog.d/added-lsposed-install-time-smoke-check-on-ba36.md
@@ -1,0 +1,9 @@
+_2026-04-27_
+
+## English
+
+lsposed: install-time smoke-check on private AOSP fields used by writeToParcel hooks. If AOSP renames or retypes mIfaceName / mTransportTypes / mNetworkType / similar, the affected hook is skipped at install (no per-call NoSuchFieldError spam) and the dashboard shows a red error listing the broken fields and Android SDK so users can file a bug.
+
+## Русский
+
+lsposed: smoke-check приватных AOSP-полей при установке writeToParcel-хуков. Если в новой AOSP поле переименовано или сменило тип, соответствующий хук пропускается при установке (без спама NoSuchFieldError на каждом вызове), а дашборд показывает красную ошибку со списком сломанных полей и версией Android — чтобы пользователь мог завести issue.

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DashboardData.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DashboardData.kt
@@ -913,6 +913,20 @@ internal fun loadDashboardState(
             }
         }
     }
+
+    // AOSP-drift detector: HookEntry's install-time smoke-check on the
+    // private NetworkCapabilities/NetworkInfo/LinkProperties fields it
+    // touches by reflection. Non-empty means the running AOSP renamed
+    // or retyped a field — the corresponding writeToParcel hook was
+    // skipped at install time, Java-layer protection is degraded for
+    // that class. Independent of lsposed Active/Inactive state: hooks
+    // can still be "active" in heartbeat sense but with partial coverage.
+    val brokenFields = hookProps["broken_fields"]?.takeIf { it.isNotBlank() }
+    if (brokenFields != null) {
+        val sdkLabel = hookProps["aosp_sdk"]?.takeIf { it.isNotBlank() } ?: "?"
+        err(res.getString(R.string.dashboard_issue_lsposed_field_rename, brokenFields, sdkLabel))
+    }
+
     val appVersion = BuildConfig.VERSION_NAME
     // Version mismatches are warnings — modules keep working, user just needs to
     // update the lagging side. Full coverage is not affected by a patch-level gap.

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/HookEntry.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/HookEntry.kt
@@ -5,6 +5,7 @@ import android.net.NetworkCapabilities
 import android.net.NetworkInfo
 import android.net.RouteInfo
 import android.os.Binder
+import android.os.Build
 import de.robv.android.xposed.IXposedHookLoadPackage
 import de.robv.android.xposed.XC_MethodHook
 import de.robv.android.xposed.XposedHelpers
@@ -51,9 +52,9 @@ class HookEntry : IXposedHookLoadPackage {
         if (hookInstalled.compareAndSet(false, true)) {
             HookLog.install()
             HookLog.i("VpnHide: system_server detected, installing Binder hooks")
-            installSystemServerHooks()
+            val brokenFields = installSystemServerHooks()
             tryHook("PackageVisibility") { PackageVisibilityHooks.install(lpparam.classLoader) }
-            writeHookStatusFile()
+            writeHookStatusFile(brokenFields)
         }
     }
 
@@ -199,30 +200,139 @@ class HookEntry : IXposedHookLoadPackage {
         systemServerTargetUids = null
     }
 
-    private fun installSystemServerHooks() {
-        tryHook("NC.writeToParcel") { hookNCWriteToParcel() }
-        tryHook("NI.writeToParcel") { hookNIWriteToParcel() }
-        tryHook("LP.writeToParcel") { hookLPWriteToParcel() }
+    // Smoke-check at install time: every private AOSP field/ctor we touch
+    // by reflection in the writeToParcel hooks. Returns the keys that
+    // failed (missing or wrong-typed). Empty list = all good.
+    //
+    // Per-hook gates below skip installing a hook entirely when its
+    // critical reflection broke — silent fail-open is preferable to
+    // throwing NoSuchFieldError on every writeToParcel call (system_server
+    // gets that on every NetworkCapabilities IPC, target or not). The
+    // dashboard surfaces the broken_fields list as a red error so the
+    // user can see and report the AOSP drift.
+    private fun installSystemServerHooks(): List<String> {
+        val brokenFields = runReflectionSmokeCheck()
+        if (brokenFields.isNotEmpty()) {
+            HookLog.e("VpnHide: reflection smoke-check found broken keys: $brokenFields")
+        }
+
+        // Match a probe key against either an exact entry in `broken` or
+        // an entry with a `:type=...` suffix (wrong-typed field).
+        fun anyBroken(critical: Set<String>): Boolean = brokenFields.any { it.substringBefore(':') in critical }
+
+        // LP: mIfaceName + copy ctor are critical. mRoutes / mStackedLinks
+        // are non-critical — the existing inner try/catch in
+        // sanitizeLinkProperties already lets the rest of the sanitizer
+        // proceed when those are absent.
+        if (anyBroken(LP_CRITICAL_KEYS)) {
+            HookLog.e("VpnHide: LP.writeToParcel hook SKIPPED — critical reflection broken")
+        } else {
+            tryHook("LP.writeToParcel") { hookLPWriteToParcel() }
+        }
+
+        // NC: the two long bitmasks are critical. mTransportInfo is
+        // non-critical because it doesn't exist on API 28 (Android 9)
+        // and the existing inner try/catch in hookNCWriteToParcel already
+        // tolerates its absence on API 29+ if AOSP renames it later.
+        if (anyBroken(NC_CRITICAL_KEYS)) {
+            HookLog.e("VpnHide: NC.writeToParcel hook SKIPPED — critical reflection broken")
+        } else {
+            tryHook("NC.writeToParcel") { hookNCWriteToParcel() }
+        }
+
+        // NI: every field + ctor is critical — the hook body has no
+        // inner try/catch around the per-field setIntField/setBooleanField
+        // calls, so any rename would fail-open per call with logcat spam.
+        if (anyBroken(NI_CRITICAL_KEYS)) {
+            HookLog.e("VpnHide: NI.writeToParcel hook SKIPPED — critical reflection broken")
+        } else {
+            tryHook("NI.writeToParcel") { hookNIWriteToParcel() }
+        }
+
         tryHook("FileObserver") { watchTargetUidsFile() }
+        return brokenFields
+    }
+
+    private data class FieldProbe(
+        val key: String,
+        val clazz: Class<*>,
+        val name: String,
+        // If the device's SDK is below this, the probe is skipped entirely
+        // (not "found", not "broken" — not applicable). Used for fields
+        // introduced after our minSdk floor (e.g. mTransportInfo at API 29).
+        // Listed before `typeCheck` so the latter stays the last parameter
+        // — that lets call sites use trailing-lambda syntax for the probe
+        // without having to name `typeCheck =` every time.
+        val minSdk: Int = 0,
+        // Field-type compatibility predicate. For collections we use
+        // isAssignableFrom() so AOSP swapping ArrayList → LinkedList stays OK.
+        val typeCheck: (Class<*>) -> Boolean,
+    )
+
+    private data class CtorProbe(
+        val key: String,
+        val clazz: Class<*>,
+        val params: Array<Class<*>>,
+    )
+
+    private fun runReflectionSmokeCheck(): List<String> {
+        val broken = mutableListOf<String>()
+        for (probe in FIELD_PROBES) {
+            if (Build.VERSION.SDK_INT < probe.minSdk) continue
+            val field =
+                try {
+                    XposedHelpers.findField(probe.clazz, probe.name)
+                } catch (_: NoSuchFieldError) {
+                    broken += probe.key
+                    continue
+                }
+            if (!probe.typeCheck(field.type)) {
+                // Suffix carries the actual type to help debug AOSP-drift
+                // bug reports without rebuilding/instrumenting the device.
+                broken += "${probe.key}:type=${field.type.name}"
+            }
+        }
+        for (probe in CTOR_PROBES) {
+            try {
+                probe.clazz.getDeclaredConstructor(*probe.params)
+            } catch (_: NoSuchMethodException) {
+                broken += probe.key
+            }
+        }
+        return broken
     }
 
     /**
      * Write a status file so the VPN Hide app can verify hooks are active.
-     * Includes boot_id to distinguish stale files from previous boots.
+     * Includes boot_id to distinguish stale files from previous boots,
+     * aosp_sdk for diagnostic context in bug reports, and (only when
+     * non-empty) broken_fields listing the reflection probes that the
+     * smoke-check rejected this boot.
      */
-    private fun writeHookStatusFile() {
+    private fun writeHookStatusFile(brokenFields: List<String>) {
         try {
             val bootId = File("/proc/sys/kernel/random/boot_id").readText().trim()
             val timestamp = System.currentTimeMillis() / 1000
             val version = BuildConfig.VERSION_NAME
-            val content = "version=$version\nboot_id=$bootId\ntimestamp=$timestamp\n"
+            val sdk = Build.VERSION.SDK_INT
+            val sb = StringBuilder()
+            sb.append("version=").append(version).append('\n')
+            sb.append("boot_id=").append(bootId).append('\n')
+            sb.append("timestamp=").append(timestamp).append('\n')
+            sb.append("aosp_sdk=").append(sdk).append('\n')
+            if (brokenFields.isNotEmpty()) {
+                sb.append("broken_fields=").append(brokenFields.joinToString(",")).append('\n')
+            }
             val statusFile = File(HOOK_STATUS_FILE)
-            statusFile.writeText(content)
+            statusFile.writeText(sb.toString())
             // Don't expose this file to untrusted apps — anti-tamper SDKs
             // scan /data/system/ for known marker filenames. The VPN Hide
             // app reads it via root (`suExec("cat ...")`), see
             // DashboardData.kt — same pattern as vpnhide_uids.txt.
-            HookLog.i("VpnHide: wrote hook status file (version=$version, boot_id=$bootId)")
+            HookLog.i(
+                "VpnHide: wrote hook status file (version=$version, boot_id=$bootId, " +
+                    "sdk=$sdk, broken=${brokenFields.size})",
+            )
         } catch (t: Throwable) {
             HookLog.e("VpnHide: failed to write hook status: ${t.message}")
         }
@@ -441,5 +551,103 @@ class HookEntry : IXposedHookLoadPackage {
         private const val TYPE_VPN = 17
         private const val TYPE_WIFI = 1
         const val HOOK_STATUS_FILE = "/data/system/vpnhide_hook_active"
+
+        private val FIELD_PROBES =
+            listOf(
+                FieldProbe(
+                    "LinkProperties.mIfaceName",
+                    LinkProperties::class.java,
+                    "mIfaceName",
+                ) { it == String::class.java },
+                FieldProbe(
+                    "LinkProperties.mRoutes",
+                    LinkProperties::class.java,
+                    "mRoutes",
+                ) { MutableList::class.java.isAssignableFrom(it) },
+                FieldProbe(
+                    "LinkProperties.mStackedLinks",
+                    LinkProperties::class.java,
+                    "mStackedLinks",
+                ) { MutableMap::class.java.isAssignableFrom(it) },
+                FieldProbe(
+                    "NetworkCapabilities.mTransportTypes",
+                    NetworkCapabilities::class.java,
+                    "mTransportTypes",
+                ) { it == java.lang.Long.TYPE },
+                FieldProbe(
+                    "NetworkCapabilities.mNetworkCapabilities",
+                    NetworkCapabilities::class.java,
+                    "mNetworkCapabilities",
+                ) { it == java.lang.Long.TYPE },
+                FieldProbe(
+                    "NetworkCapabilities.mTransportInfo",
+                    NetworkCapabilities::class.java,
+                    "mTransportInfo",
+                    minSdk = Build.VERSION_CODES.Q,
+                ) { fieldType ->
+                    // android.net.TransportInfo arrived in API 29; on
+                    // API 28 the probe is skipped via minSdk above.
+                    runCatching { Class.forName("android.net.TransportInfo") }
+                        .map { it.isAssignableFrom(fieldType) }
+                        .getOrDefault(false)
+                },
+                FieldProbe(
+                    "NetworkInfo.mNetworkType",
+                    NetworkInfo::class.java,
+                    "mNetworkType",
+                ) { it == Integer.TYPE },
+                FieldProbe(
+                    "NetworkInfo.mState",
+                    NetworkInfo::class.java,
+                    "mState",
+                ) { it == NetworkInfo.State::class.java },
+                FieldProbe(
+                    "NetworkInfo.mDetailedState",
+                    NetworkInfo::class.java,
+                    "mDetailedState",
+                ) { it == NetworkInfo.DetailedState::class.java },
+                FieldProbe(
+                    "NetworkInfo.mIsAvailable",
+                    NetworkInfo::class.java,
+                    "mIsAvailable",
+                ) { it == java.lang.Boolean.TYPE },
+            )
+
+        private val CTOR_PROBES =
+            listOf(
+                CtorProbe(
+                    "LinkProperties.<init>(LinkProperties)",
+                    LinkProperties::class.java,
+                    arrayOf(LinkProperties::class.java),
+                ),
+                CtorProbe(
+                    "NetworkInfo.<init>(int,int,String,String)",
+                    NetworkInfo::class.java,
+                    arrayOf(Integer.TYPE, Integer.TYPE, String::class.java, String::class.java),
+                ),
+            )
+
+        // Per-hook critical-probe sets. A hook is skipped if any key in
+        // its set is in the broken list. mRoutes / mStackedLinks /
+        // mTransportInfo are intentionally NOT critical — graceful
+        // degradation lives in the existing inner try/catch blocks.
+        private val LP_CRITICAL_KEYS =
+            setOf(
+                "LinkProperties.mIfaceName",
+                "LinkProperties.<init>(LinkProperties)",
+            )
+        private val NC_CRITICAL_KEYS =
+            setOf(
+                "NetworkCapabilities.mTransportTypes",
+                "NetworkCapabilities.mNetworkCapabilities",
+            )
+        private val NI_CRITICAL_KEYS =
+            setOf(
+                "NetworkInfo.mNetworkType",
+                "NetworkInfo.mState",
+                "NetworkInfo.mDetailedState",
+                "NetworkInfo.mIsAvailable",
+                "NetworkInfo.<init>(int,int,String,String)",
+            )
     }
 }

--- a/lsposed/app/src/main/res/values-ru/strings.xml
+++ b/lsposed/app/src/main/res/values-ru/strings.xml
@@ -102,6 +102,7 @@
     <string name="dashboard_issue_lsposed_not_enabled">VPN Hide найден в LSPosed/Vector, но модуль выключен. Включите VPN Hide в LSPosed/Vector и оставьте в scope System Framework.</string>
     <string name="dashboard_issue_lsposed_no_system_scope">VPN Hide включён в LSPosed/Vector, но в его scope отсутствует System Framework. Добавьте System Framework в scope модуля VPN Hide в LSPosed/Vector.</string>
     <string name="dashboard_issue_lsposed_extra_scope">VPN Hide в LSPosed/Vector должен быть включён только для System Framework. Уберите из scope модуля VPN Hide эти приложения: %1$s. Для фильтрации используйте Защита → Туннели в VPN Hide.</string>
+    <string name="dashboard_issue_lsposed_field_rename">Обнаружено переименование AOSP-поля на Android SDK %2$s: %1$s. Java-защита отключена для затронутых хуков (они пропущены при установке, чтобы не спамить logcat NoSuchFieldError на каждом вызове). Пожалуйста, заведите issue на github.com/okhsunrog/vpnhide/issues с этим списком — это нужно, чтобы обновить хуки под вашу версию Android.</string>
     <string name="dashboard_issue_no_targets">Целевые приложения не настроены. Перейдите в Защита → Туннели.</string>
     <string name="dashboard_issue_ports_no_observers">Модуль скрытия портов установлен, но наблюдатели не настроены. Перейдите в Защита → Порты.</string>
     <string name="dashboard_issue_version_mismatch">Несоответствие версий LSPosed модуля: запущена %1$s, установлена %2$s. Перезагрузите устройство для обновления.</string>

--- a/lsposed/app/src/main/res/values/strings.xml
+++ b/lsposed/app/src/main/res/values/strings.xml
@@ -133,6 +133,7 @@
     <string name="dashboard_issue_lsposed_not_enabled">VPN Hide is present in LSPosed/Vector, but the module is disabled. Enable VPN Hide in LSPosed/Vector and keep System Framework in its scope.</string>
     <string name="dashboard_issue_lsposed_no_system_scope">VPN Hide is enabled in LSPosed/Vector, but System Framework is missing from its scope. Add System Framework to the VPN Hide scope in LSPosed/Vector.</string>
     <string name="dashboard_issue_lsposed_extra_scope">VPN Hide should stay scoped only to System Framework in LSPosed/Vector. Remove these apps from the VPN Hide scope: %1$s. Use Protection → Tun in VPN Hide for filtering instead.</string>
+    <string name="dashboard_issue_lsposed_field_rename">AOSP field rename detected on Android SDK %2$s: %1$s. Java-layer protection is degraded for the affected hooks (they were skipped at install time to avoid logcat-spam from per-call NoSuchFieldError). Please file an issue at github.com/okhsunrog/vpnhide/issues with this list so the hooks can be updated for your Android version.</string>
     <string name="dashboard_issue_no_targets">No target apps configured. Go to Protection → Tun to select apps.</string>
     <string name="dashboard_issue_ports_no_observers">Ports hiding module is installed but no observers are configured. Go to Protection → Ports to pick apps.</string>
     <string name="dashboard_issue_version_mismatch">LSPosed module version mismatch: running %1$s, installed %2$s. Reboot the device to apply the update.</string>


### PR DESCRIPTION
## Why

The three `writeToParcel` hooks (`NetworkCapabilities`, `NetworkInfo`,
`LinkProperties`) reach into private AOSP fields by reflection. If a
future AOSP rev renames or retypes any of those, the current code
fails open silently per call — `NoSuchFieldError` gets caught by an
inner `try/catch`, `param.result` stays unset, the original
`writeToParcel` runs and the VPN flag leaks to the target app. Worse,
the NC hook does its critical reflection read BEFORE the `isTarget`
check, so any rename spams an exception on every `system_server`
`NetworkCapabilities` IPC.

Detect the drift at install time and surface it on the dashboard
instead of letting it silently degrade protection.

## Summary

- `HookEntry.installSystemServerHooks` now runs `runReflectionSmokeCheck()`
  over a declarative probe table covering 10 fields + 2 private ctors,
  with per-field type predicates and a per-probe `minSdk` gate so
  `mTransportInfo` is correctly treated as not-applicable on API 28
  (forward-compatible with the open Android 9 PR).
- Per-hook critical-key sets in `HookEntry.companion`. Hook is skipped
  at install when any of its critical keys is broken — `tryHook` is not
  called, so there's no per-call exception spam. Non-critical keys
  (`mRoutes`, `mStackedLinks`, `mTransportInfo`) keep their existing
  graceful-degradation `try/catch`.
- `writeHookStatusFile` now always emits `aosp_sdk=<int>` (diagnostic)
  and, only when non-empty, `broken_fields=<key,key,...>` where each
  key may carry a `:type=<actualType>` suffix for type mismatches.
- `DashboardData.loadDashboardState` reads both, emits a red ERROR
  issue independent of `LsposedState` (hooks can be heartbeat-Active
  but partially degraded).
- New `dashboard_issue_lsposed_field_rename` string in `values/` and
  `values-ru/`.
- Changelog fragment under `changelog.d/`.

Empirically verified on Pixel 8 Pro / Android 16 (SDK 36): post-reboot
`/data/system/vpnhide_hook_active` carries `aosp_sdk=36` and no
`broken_fields` line; logcat shows all three hooks firing per call
without exceptions.