### PR TITLE
[DRAFT] fix(portshide): fix push-notifications

### DIFF
--- a/changelog.d/fixed-fixed-push-notifications-for-apps-with-2212.md
+++ b/changelog.d/fixed-fixed-push-notifications-for-apps-with-2212.md
@@ -1,0 +1,9 @@
+_2026-05-04_
+
+## English
+
+Fixed push-notifications for apps with flag P
+
+## Русский
+
+Исправлено отображение push-уведомлений для приложений с флагом P

--- a/portshide/module/vpnhide_ports_apply.sh
+++ b/portshide/module/vpnhide_ports_apply.sh
@@ -83,14 +83,23 @@ fi
 build_ruleset() {
     chain="$1"
     loopback="$2"
-    udp_reject="$3"
     echo "*filter"
     echo ":${chain} - [0:0]"
     if [ -n "$UIDS" ]; then
         echo "$UIDS" | while IFS= read -r uid; do
             [ -z "$uid" ] && continue
-            echo "-A ${chain} -m owner --uid-owner ${uid} -d ${loopback} -p tcp -j REJECT --reject-with tcp-reset"
-            echo "-A ${chain} -m owner --uid-owner ${uid} -d ${loopback} -p udp -j REJECT --reject-with ${udp_reject}"
+
+            # 1. ловим попытки НОВЫХ соединений к localhost
+            # 2. но только если это "подозрительное поведение"
+            echo "-A ${chain} -m owner --uid-owner ${uid} -d ${loopback} -p tcp \
+                  -m conntrack --ctstate NEW \
+                  -m limit --limit 3/second --limit-burst 5 \
+                  -j RETURN"
+
+            # всё что НЕ прошло whitelist — это scan / probing
+            echo "-A ${chain} -m owner --uid-owner ${uid} -d ${loopback} -p tcp \
+                  -m conntrack --ctstate NEW \
+                  -j DROP"
         done
     fi
     echo "-A ${chain} -j RETURN"


### PR DESCRIPTION
### DO NOT MERGE. NEEDS TESTING AND REVIEW.

### WHY:
Current app breaks push-notifications with flag "P" is enabled.
Android using localhost to receive notifications. As a result apps can't sync data in background.

### SUMMARY:
Changed behaviour from "block all localhost connections" to "block rapid/burst localhost connections (bruteforce ports)"

Closes #121 