### PR TITLE
feat(lsposed): new logic for sorting apps

### DIFF
--- a/changelog.d/added-changed-sorting-logic-to-show-selected-4ba7.md
+++ b/changelog.d/added-changed-sorting-logic-to-show-selected-4ba7.md
@@ -2,8 +2,8 @@ _2026-05-05_
 
 ## English
 
-Changed sorting logic to show selected apps first, then non-selected apps
+Changed sorting logic to show hidden apps first, then observers and non-selected at the end
 
 ## Русский
 
-Изменена сортировка приложений. Теперь отмеченные чекбоксом отображаются в начале списка
+Изменена сортировка приложений. Теперь сначала отображаются hidden, затем observers и в конце не отмеченные

--- a/changelog.d/added-changed-sorting-logic-to-show-selected-4ba7.md
+++ b/changelog.d/added-changed-sorting-logic-to-show-selected-4ba7.md
@@ -1,0 +1,9 @@
+_2026-05-05_
+
+## English
+
+Changed sorting logic to show selected apps first, then non-selected apps
+
+## Русский
+
+Изменена сортировка приложений. Теперь отмеченные чекбоксом отображаются в начале списка

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/AppHidingScreen.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/AppHidingScreen.kt
@@ -151,8 +151,10 @@ fun AppHidingScreen(
                         hidden = finalHidden,
                         observer = finalObserver,
                     )
-                }
-        dirty = autoFixedConflict
+                }.sortedWith(
+                    compareByDescending<HidingEntry> { it.anySelected }
+                        .thenBy(String.CASE_INSENSITIVE_ORDER) { it.label },
+                )
     }
 
     val loading = cachedApps == null || targets == null

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/AppHidingScreen.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/AppHidingScreen.kt
@@ -152,8 +152,13 @@ fun AppHidingScreen(
                         observer = finalObserver,
                     )
                 }.sortedWith(
-                    compareByDescending<HidingEntry> { it.anySelected }
-                        .thenBy(String.CASE_INSENSITIVE_ORDER) { it.label },
+                    compareBy<HidingEntry> {
+                        when {
+                            it.hidden -> 0
+                            it.observer -> 1
+                            else -> 2
+                        }
+                    }.thenBy(String.CASE_INSENSITIVE_ORDER) { it.label },
                 )
     }
 

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/AppPickerScreen.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/AppPickerScreen.kt
@@ -123,8 +123,10 @@ fun AppPickerScreen(
                         zygisk = app.packageName in t.zygiskTargets,
                         lsposed = app.packageName in t.lsposedTargets,
                     )
-                }
-        dirty = false
+                }.sortedWith(
+                    compareByDescending<AppEntry> { it.anySelected }
+                        .thenBy(String.CASE_INSENSITIVE_ORDER) { it.label },
+                )
     }
 
     val loading = cachedApps == null || targets == null

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/PortsHidingScreen.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/PortsHidingScreen.kt
@@ -127,8 +127,10 @@ fun PortsHidingScreen(
                         userIds = app.userIds,
                         observer = app.packageName in t.portsObservers,
                     )
-                }
-        dirty = false
+                }.sortedWith(
+                    compareByDescending<PortsEntry> { it.observer }
+                        .thenBy(String.CASE_INSENSITIVE_ORDER) { it.label },
+                )
     }
 
     val loading = cachedApps == null || targets == null


### PR DESCRIPTION
### WHY:
Apps were shown only in alphabetical order, no matter selected or not.

### SUMMARY:
Changed sorting logic to show selected apps first, then non-selected apps.

<img width="575" height="1280" alt="2026-05-05 10 10 16" src="https://github.com/user-attachments/assets/282a48a2-1fc5-4591-899a-46bf55c2a038" />
