### PR TITLE
Force routing

### DIFF
--- a/kmod/module/service.sh
+++ b/kmod/module/service.sh
@@ -4,13 +4,15 @@
 # lsposed targets → /data/system/vpnhide_uids.txt
 
 KMOD_TARGETS="/data/adb/vpnhide_kmod/targets.txt"
+KMOD_DIRECT_TARGETS="/data/adb/vpnhide_kmod/direct_targets.txt"
 LSPOSED_TARGETS="/data/adb/vpnhide_lsposed/targets.txt"
 PROC_TARGETS="/proc/vpnhide_targets"
+PROC_DIRECT_TARGETS="/proc/vpnhide_direct_targets"
 SS_UIDS_FILE="/data/system/vpnhide_uids.txt"
 
-# Wait for the proc entry (kernel module must be loaded)
+# Wait for the proc entries (kernel module must be loaded)
 for i in 1 2 3 4 5 6 7 8 9 10; do
-    [ -f "$PROC_TARGETS" ] && break
+    [ -f "$PROC_TARGETS" ] && [ -f "$PROC_DIRECT_TARGETS" ] && break
     sleep 1
 done
 
@@ -80,6 +82,18 @@ if [ -f "$PROC_TARGETS" ] && [ -f "$KMOD_TARGETS" ]; then
         log -t vpnhide "kmod: loaded $count target UIDs"
     else
         log -t vpnhide "kmod: no UIDs resolved"
+    fi
+fi
+
+# Resolve kmod direct bypass targets → /proc/vpnhide_direct_targets
+if [ -f "$PROC_DIRECT_TARGETS" ] && [ -f "$KMOD_DIRECT_TARGETS" ]; then
+    DIRECT_UIDS="$(resolve_uids "$KMOD_DIRECT_TARGETS")"
+    if [ -n "$DIRECT_UIDS" ]; then
+        echo "$DIRECT_UIDS" > "$PROC_DIRECT_TARGETS"
+        count="$(echo "$DIRECT_UIDS" | wc -l)"
+        log -t vpnhide "kmod-direct: loaded $count target UIDs"
+    else
+        log -t vpnhide "kmod-direct: no UIDs resolved"
     fi
 fi
 

--- a/kmod/vpnhide_kmod.c
+++ b/kmod/vpnhide_kmod.c
@@ -92,28 +92,33 @@ static bool debug_enabled;
 
 #define is_vpn_ifname(name) vpnhide_iface_is_vpn(name)
 
-/* ------------------------------------------------------------------ */
-/*  Target UID list                                                   */
-/* ------------------------------------------------------------------ */
+struct vpnhide_targets {
+	uid_t uids[MAX_TARGET_UIDS];
+	int count;
+	struct rcu_head rcu;
+};
 
-static uid_t target_uids[MAX_TARGET_UIDS];
-static int nr_target_uids;
-static DEFINE_SPINLOCK(uids_lock);
+static struct vpnhide_targets __rcu *global_targets;
+static DEFINE_SPINLOCK(targets_update_lock);
 
 static bool is_target_uid(void)
 {
 	uid_t uid = from_kuid(&init_user_ns, current_uid());
+	struct vpnhide_targets *t;
 	bool found = false;
 	int i;
 
-	spin_lock(&uids_lock);
-	for (i = 0; i < nr_target_uids; i++) {
-		if (target_uids[i] == uid) {
-			found = true;
-			break;
+	rcu_read_lock();
+	t = rcu_dereference(global_targets);
+	if (t) {
+		for (i = 0; i < t->count; i++) {
+			if (t->uids[i] == uid) {
+				found = true;
+				break;
+			}
 		}
 	}
-	spin_unlock(&uids_lock);
+	rcu_read_unlock();
 	return found;
 }
 
@@ -121,12 +126,18 @@ static bool is_target_uid(void)
 /*  /proc/vpnhide_targets                                             */
 /* ------------------------------------------------------------------ */
 
+static void free_targets_rcu(struct rcu_head *rcu)
+{
+	struct vpnhide_targets *t = container_of(rcu, struct vpnhide_targets, rcu);
+	kfree(t);
+}
+
 static ssize_t targets_write(struct file *file, const char __user *ubuf,
 			     size_t count, loff_t *ppos)
 {
 	char *buf, *line, *next;
+	struct vpnhide_targets *new_t, *old_t;
 	int new_count = 0;
-	uid_t new_uids[MAX_TARGET_UIDS];
 
 	if (count > PAGE_SIZE)
 		return -EINVAL;
@@ -140,6 +151,12 @@ static ssize_t targets_write(struct file *file, const char __user *ubuf,
 		return -EFAULT;
 	}
 	buf[count] = '\0';
+
+	new_t = kzalloc(sizeof(*new_t), GFP_KERNEL);
+	if (!new_t) {
+		kfree(buf);
+		return -ENOMEM;
+	}
 
 	for (line = buf; line && *line && new_count < MAX_TARGET_UIDS;
 	     line = next) {
@@ -155,13 +172,18 @@ static ssize_t targets_write(struct file *file, const char __user *ubuf,
 			continue;
 
 		if (kstrtoul(line, 10, &uid) == 0)
-			new_uids[new_count++] = (uid_t)uid;
+			new_t->uids[new_count++] = (uid_t)uid;
 	}
+	new_t->count = new_count;
 
-	spin_lock(&uids_lock);
-	memcpy(target_uids, new_uids, new_count * sizeof(uid_t));
-	nr_target_uids = new_count;
-	spin_unlock(&uids_lock);
+	spin_lock(&targets_update_lock);
+	old_t = rcu_dereference_protected(global_targets,
+					  lockdep_is_held(&targets_update_lock));
+	rcu_assign_pointer(global_targets, new_t);
+	spin_unlock(&targets_update_lock);
+
+	if (old_t)
+		call_rcu(&old_t->rcu, free_targets_rcu);
 
 	kfree(buf);
 	pr_info(MODNAME ": loaded %d target UIDs\n", new_count);
@@ -170,12 +192,16 @@ static ssize_t targets_write(struct file *file, const char __user *ubuf,
 
 static int targets_show(struct seq_file *m, void *v)
 {
+	struct vpnhide_targets *t;
 	int i;
 
-	spin_lock(&uids_lock);
-	for (i = 0; i < nr_target_uids; i++)
-		seq_printf(m, "%u\n", target_uids[i]);
-	spin_unlock(&uids_lock);
+	rcu_read_lock();
+	t = rcu_dereference(global_targets);
+	if (t) {
+		for (i = 0; i < t->count; i++)
+			seq_printf(m, "%u\n", t->uids[i]);
+	}
+	rcu_read_unlock();
 	return 0;
 }
 
@@ -1018,6 +1044,185 @@ static struct kretprobe rt_fill_krp = {
 };
 
 /* ================================================================== */
+/*  Direct Interface Discovery                                        */
+/* ================================================================== */
+
+static bool is_any_vpn_active(struct net *net)
+{
+	struct net_device *dev;
+	bool active = false;
+
+	rcu_read_lock();
+	for_each_netdev_rcu(net, dev) {
+		if ((dev->flags & IFF_UP) && is_vpn_ifname(dev->name)) {
+			active = true;
+			break;
+		}
+	}
+	rcu_read_unlock();
+	return active;
+}
+
+static int get_direct_ifindex(struct net *net)
+{
+	struct net_device *dev;
+	int best_idx = 0;
+	int current_prio = -1;
+
+	rcu_read_lock();
+	for_each_netdev_rcu(net, dev) {
+		bool up = !!(dev->flags & IFF_UP);
+		bool loopback = !!(dev->flags & IFF_LOOPBACK);
+		bool ptp = !!(dev->flags & IFF_POINTOPOINT);
+		bool vpn = is_vpn_ifname(dev->name);
+
+		if (up && !loopback && !ptp && !vpn) {
+			int prio = 0; /* Default low priority */
+
+			if (vpnhide_iface_starts_with_ci(dev->name, "wlan"))
+				prio = 10;
+			else if (vpnhide_iface_starts_with_ci(dev->name, "rmnet") ||
+				 vpnhide_iface_starts_with_ci(dev->name, "ccmni") ||
+				 vpnhide_iface_starts_with_ci(dev->name, "pdp"))
+				prio = 5;
+
+			if (prio > current_prio) {
+				best_idx = dev->ifindex;
+				current_prio = prio;
+				/* If we found Wi-Fi, we can stop searching. */
+				if (prio == 10)
+					break;
+			}
+		}
+	}
+	rcu_read_unlock();
+
+	return best_idx;
+}
+
+/* ================================================================== */
+/*  Hook 10: ip_route_output_flow — IPv4 routing bypass               */
+/*                                                                    */
+/*  ip_route_output_flow(net, flp4, sk)                               */
+/*  arm64: x1=flp4 (struct flowi4*)                                  */
+/*                                                                    */
+/*  For target UIDs, we set the 'protectedFromVpn' bit in the mark.   */
+/*  On Android, this bit (typically 1 << 17) tells the routing        */
+/*  rules to skip VPN tables and use physical ones.                   */
+/* ================================================================== */
+
+#define ANDROID_PROTECTED_FROM_VPN_BIT (1 << 17)
+#define ANDROID_EXPLICITLY_SELECTED_BIT (1 << 16)
+
+static int ip_route_output_flow_entry(struct kretprobe_instance *ri,
+				      struct pt_regs *regs)
+{
+	struct net *net = (struct net *)regs->regs[0];
+	struct flowi4 *flp4 = (struct flowi4 *)regs->regs[1];
+
+	if (flp4 && is_target_uid() && is_any_vpn_active(net)) {
+		int phys_idx = get_direct_ifindex(net);
+
+		/* 1. Force marks to bypass VPN. */
+		flp4->flowi4_mark &= ~0xFFFF;
+		flp4->flowi4_mark |= (ANDROID_PROTECTED_FROM_VPN_BIT |
+				      ANDROID_EXPLICITLY_SELECTED_BIT);
+
+		/* 2. Clear source IP. */
+		flp4->saddr = 0;
+
+		/* 3. Force output to physical interface if found. */
+		if (phys_idx > 0) {
+			flp4->flowi4_oif = phys_idx;
+		} else if (flp4->flowi4_oif > 0) {
+			/* Fallback: just clear VPN ifindex if no physical found. */
+			struct net_device *dev;
+			rcu_read_lock();
+			dev = dev_get_by_index_rcu(net, flp4->flowi4_oif);
+			if (dev && is_vpn_ifname(dev->name))
+				flp4->flowi4_oif = 0;
+			rcu_read_unlock();
+		}
+
+		vpnhide_dbg("ip_route_output_flow: forced bypass (mark=0x%x, oif=%d) for uid=%u\n",
+			    flp4->flowi4_mark, flp4->flowi4_oif,
+			    from_kuid(&init_user_ns, current_uid()));
+	}
+	return 0;
+}
+
+static struct kretprobe ip_route_output_flow_krp = {
+	.entry_handler = ip_route_output_flow_entry,
+	.maxactive = VPNHIDE_KRETPROBE_MAXACTIVE,
+	.kp.symbol_name = "ip_route_output_flow",
+};
+
+/* __ip_route_output_key is the inner routing function. */
+static int ip_route_output_key_entry(struct kretprobe_instance *ri,
+				     struct pt_regs *regs)
+{
+	struct net *net = (struct net *)regs->regs[0];
+	struct flowi4 *flp4 = (struct flowi4 *)regs->regs[1];
+
+	if (flp4 && is_target_uid() && is_any_vpn_active(net)) {
+		int phys_idx = get_direct_ifindex(net);
+		flp4->flowi4_mark &= ~0xFFFF;
+		flp4->flowi4_mark |= (ANDROID_PROTECTED_FROM_VPN_BIT |
+				      ANDROID_EXPLICITLY_SELECTED_BIT);
+		flp4->saddr = 0;
+		if (phys_idx > 0)
+			flp4->flowi4_oif = phys_idx;
+		
+		vpnhide_dbg("__ip_route_output_key: forced bypass (oif=%d) for uid=%u\n",
+			    flp4->flowi4_oif, from_kuid(&init_user_ns, current_uid()));
+	}
+	return 0;
+}
+
+static struct kretprobe ip_route_output_key_krp = {
+	.entry_handler = ip_route_output_key_entry,
+	.maxactive = VPNHIDE_KRETPROBE_MAXACTIVE,
+	.kp.symbol_name = "__ip_route_output_key",
+};
+
+/* ================================================================== */
+/*  Hook 11: ip6_route_output — IPv6 routing bypass                   */
+/*                                                                    */
+/*  ip6_route_output(net, sk, fl6)                                    */
+/*  arm64: x2=fl6 (struct flowi6*)                                   */
+/* ================================================================== */
+
+static int ip6_route_output_entry(struct kretprobe_instance *ri,
+				  struct pt_regs *regs)
+{
+	struct net *net = (struct net *)regs->regs[0];
+	struct flowi6 *fl6 = (struct flowi6 *)regs->regs[2];
+
+	if (fl6) {
+		bool target = is_target_uid();
+		if (target && is_any_vpn_active(net)) {
+			int phys_idx = get_direct_ifindex(net);
+			fl6->flowi6_mark &= ~0xFFFF;
+			fl6->flowi6_mark |= (ANDROID_PROTECTED_FROM_VPN_BIT |
+					     ANDROID_EXPLICITLY_SELECTED_BIT);
+			fl6->saddr = in6addr_any;
+			if (phys_idx > 0)
+				fl6->flowi6_oif = phys_idx;
+			
+			vpnhide_dbg("ip6_route_output: forced bypass (oif=%d) for uid=%u\n",
+				    fl6->flowi6_oif, from_kuid(&init_user_ns, current_uid()));
+		}
+	}
+	return 0;
+}
+
+static struct kretprobe ip6_route_output_krp = {
+	.entry_handler = ip6_route_output_entry,
+	.maxactive = VPNHIDE_KRETPROBE_MAXACTIVE,
+	.kp.symbol_name = "ip6_route_output",
+};
+
+/* ================================================================== */
 /*  Module init / exit                                                */
 /* ================================================================== */
 
@@ -1040,11 +1245,17 @@ static struct kretprobe_reg probes[] = {
 	{ &fib_dump_krp, "fib_dump_info", false },
 	{ &rt6_fill_krp, "rt6_fill_node", false },
 	{ &rt_fill_krp, "rt_fill_info", false },
+	{ &ip_route_output_flow_krp, "ip_route_output_flow", false },
+	{ &ip_route_output_key_krp, "__ip_route_output_key", false },
+	{ &ip6_route_output_krp, "ip6_route_output", false },
 };
 
 static int __init vpnhide_init(void)
 {
 	int i, ret, ok = 0;
+
+	/* Initialize RCU targets pointer */
+	rcu_assign_pointer(global_targets, NULL);
 
 	for (i = 0; i < ARRAY_SIZE(probes); i++) {
 		ret = register_kretprobe(probes[i].krp);
@@ -1094,6 +1305,7 @@ static int __init vpnhide_init(void)
 
 static void __exit vpnhide_exit(void)
 {
+	struct vpnhide_targets *t;
 	int i;
 
 	if (debug_entry)
@@ -1108,6 +1320,19 @@ static void __exit vpnhide_exit(void)
 					"(missed %d)\n",
 				probes[i].name, probes[i].krp->nmissed);
 		}
+	}
+
+	/* Cleanup RCU targets */
+	spin_lock(&targets_update_lock);
+	t = rcu_dereference_protected(global_targets,
+				      lockdep_is_held(&targets_update_lock));
+	rcu_assign_pointer(global_targets, NULL);
+	spin_unlock(&targets_update_lock);
+
+	if (t) {
+		/* Wait for any pending is_target_uid calls to finish */
+		synchronize_rcu();
+		kfree(t);
 	}
 
 	pr_info(MODNAME ": unloaded\n");

--- a/kmod/vpnhide_kmod.c
+++ b/kmod/vpnhide_kmod.c
@@ -1044,41 +1044,38 @@ static struct kretprobe rt_fill_krp = {
 };
 
 /* ================================================================== */
-/*  Direct Interface Discovery                                        */
+/*  Optimized Routing State Cache                                     */
 /* ================================================================== */
 
-static bool is_any_vpn_active(struct net *net)
-{
-	struct net_device *dev;
-	bool active = false;
+struct vpnhide_cache {
+	bool vpn_active;
+	int direct_idx;
+	unsigned long last_update;
+};
 
-	rcu_read_lock();
-	for_each_netdev_rcu(net, dev) {
-		if ((dev->flags & IFF_UP) && is_vpn_ifname(dev->name)) {
-			active = true;
-			break;
-		}
-	}
-	rcu_read_unlock();
-	return active;
-}
+static struct vpnhide_cache routing_cache;
+static DEFINE_SPINLOCK(cache_lock);
 
-static int get_direct_ifindex(struct net *net)
+#define CACHE_TTL (HZ) /* 1 second */
+
+static void update_routing_cache(struct net *net, struct vpnhide_cache *c)
 {
 	struct net_device *dev;
 	int best_idx = 0;
 	int current_prio = -1;
+	bool vpn_found = false;
 
 	rcu_read_lock();
 	for_each_netdev_rcu(net, dev) {
 		bool up = !!(dev->flags & IFF_UP);
-		bool loopback = !!(dev->flags & IFF_LOOPBACK);
-		bool ptp = !!(dev->flags & IFF_POINTOPOINT);
 		bool vpn = is_vpn_ifname(dev->name);
 
-		if (up && !loopback && !ptp && !vpn) {
-			int prio = 0; /* Default low priority */
+		if (up && vpn)
+			vpn_found = true;
 
+		if (up && !vpn && !(dev->flags & IFF_LOOPBACK) &&
+		    !(dev->flags & IFF_POINTOPOINT)) {
+			int prio = 0;
 			if (vpnhide_iface_starts_with_ci(dev->name, "wlan"))
 				prio = 10;
 			else if (vpnhide_iface_starts_with_ci(dev->name, "rmnet") ||
@@ -1089,15 +1086,31 @@ static int get_direct_ifindex(struct net *net)
 			if (prio > current_prio) {
 				best_idx = dev->ifindex;
 				current_prio = prio;
-				/* If we found Wi-Fi, we can stop searching. */
-				if (prio == 10)
-					break;
 			}
 		}
 	}
 	rcu_read_unlock();
 
-	return best_idx;
+	c->vpn_active = vpn_found;
+	c->direct_idx = best_idx;
+	c->last_update = jiffies;
+}
+
+static void get_routing_info(struct net *net, bool *vpn_active, int *direct_idx)
+{
+	unsigned long now = jiffies;
+
+	/* We use a simple spinlock for the cache update. Since it only happens
+	 * once per second, there is no meaningful contention. */
+	if (time_after(now, READ_ONCE(routing_cache.last_update) + CACHE_TTL)) {
+		if (spin_trylock(&cache_lock)) {
+			update_routing_cache(net, &routing_cache);
+			spin_unlock(&cache_lock);
+		}
+	}
+
+	*vpn_active = READ_ONCE(routing_cache.vpn_active);
+	*direct_idx = READ_ONCE(routing_cache.direct_idx);
 }
 
 /* ================================================================== */
@@ -1120,33 +1133,24 @@ static int ip_route_output_flow_entry(struct kretprobe_instance *ri,
 	struct net *net = (struct net *)regs->regs[0];
 	struct flowi4 *flp4 = (struct flowi4 *)regs->regs[1];
 
-	if (flp4 && is_target_uid() && is_any_vpn_active(net)) {
-		int phys_idx = get_direct_ifindex(net);
+	if (flp4 && is_target_uid()) {
+		bool vpn_active;
+		int phys_idx;
 
-		/* 1. Force marks to bypass VPN. */
+		get_routing_info(net, &vpn_active, &phys_idx);
+		if (!vpn_active)
+			return 0;
+
+		/* Force marks to bypass VPN. */
 		flp4->flowi4_mark &= ~0xFFFF;
 		flp4->flowi4_mark |= (ANDROID_PROTECTED_FROM_VPN_BIT |
 				      ANDROID_EXPLICITLY_SELECTED_BIT);
-
-		/* 2. Clear source IP. */
 		flp4->saddr = 0;
-
-		/* 3. Force output to physical interface if found. */
-		if (phys_idx > 0) {
+		if (phys_idx > 0)
 			flp4->flowi4_oif = phys_idx;
-		} else if (flp4->flowi4_oif > 0) {
-			/* Fallback: just clear VPN ifindex if no physical found. */
-			struct net_device *dev;
-			rcu_read_lock();
-			dev = dev_get_by_index_rcu(net, flp4->flowi4_oif);
-			if (dev && is_vpn_ifname(dev->name))
-				flp4->flowi4_oif = 0;
-			rcu_read_unlock();
-		}
 
-		vpnhide_dbg("ip_route_output_flow: forced bypass (mark=0x%x, oif=%d) for uid=%u\n",
-			    flp4->flowi4_mark, flp4->flowi4_oif,
-			    from_kuid(&init_user_ns, current_uid()));
+		vpnhide_dbg("ip_route_output_flow: forced bypass (oif=%d) for uid=%u\n",
+			    flp4->flowi4_oif, from_kuid(&init_user_ns, current_uid()));
 	}
 	return 0;
 }
@@ -1164,8 +1168,14 @@ static int ip_route_output_key_entry(struct kretprobe_instance *ri,
 	struct net *net = (struct net *)regs->regs[0];
 	struct flowi4 *flp4 = (struct flowi4 *)regs->regs[1];
 
-	if (flp4 && is_target_uid() && is_any_vpn_active(net)) {
-		int phys_idx = get_direct_ifindex(net);
+	if (flp4 && is_target_uid()) {
+		bool vpn_active;
+		int phys_idx;
+
+		get_routing_info(net, &vpn_active, &phys_idx);
+		if (!vpn_active)
+			return 0;
+
 		flp4->flowi4_mark &= ~0xFFFF;
 		flp4->flowi4_mark |= (ANDROID_PROTECTED_FROM_VPN_BIT |
 				      ANDROID_EXPLICITLY_SELECTED_BIT);
@@ -1198,20 +1208,23 @@ static int ip6_route_output_entry(struct kretprobe_instance *ri,
 	struct net *net = (struct net *)regs->regs[0];
 	struct flowi6 *fl6 = (struct flowi6 *)regs->regs[2];
 
-	if (fl6) {
-		bool target = is_target_uid();
-		if (target && is_any_vpn_active(net)) {
-			int phys_idx = get_direct_ifindex(net);
-			fl6->flowi6_mark &= ~0xFFFF;
-			fl6->flowi6_mark |= (ANDROID_PROTECTED_FROM_VPN_BIT |
-					     ANDROID_EXPLICITLY_SELECTED_BIT);
-			fl6->saddr = in6addr_any;
-			if (phys_idx > 0)
-				fl6->flowi6_oif = phys_idx;
-			
-			vpnhide_dbg("ip6_route_output: forced bypass (oif=%d) for uid=%u\n",
-				    fl6->flowi6_oif, from_kuid(&init_user_ns, current_uid()));
-		}
+	if (fl6 && is_target_uid()) {
+		bool vpn_active;
+		int phys_idx;
+
+		get_routing_info(net, &vpn_active, &phys_idx);
+		if (!vpn_active)
+			return 0;
+
+		fl6->flowi6_mark &= ~0xFFFF;
+		fl6->flowi6_mark |= (ANDROID_PROTECTED_FROM_VPN_BIT |
+				     ANDROID_EXPLICITLY_SELECTED_BIT);
+		fl6->saddr = in6addr_any;
+		if (phys_idx > 0)
+			fl6->flowi6_oif = phys_idx;
+		
+		vpnhide_dbg("ip6_route_output: forced bypass (oif=%d) for uid=%u\n",
+			    fl6->flowi6_oif, from_kuid(&init_user_ns, current_uid()));
 	}
 	return 0;
 }

--- a/kmod/vpnhide_kmod.c
+++ b/kmod/vpnhide_kmod.c
@@ -40,6 +40,10 @@
 #include <linux/skbuff.h>
 #include <linux/inetdevice.h>
 #include <net/if_inet6.h>
+#include <net/ip_fib.h>
+#include <net/ip6_fib.h>
+#include <net/ip6_route.h>
+#include <net/route.h>
 
 #include "generated/iface_lists.h"
 
@@ -805,6 +809,215 @@ static struct kretprobe fib_route_krp = {
 };
 
 /* ================================================================== */
+/*  Hook 7: fib_dump_info — IPv4 routes dump                          */
+/*                                                                    */
+/*  fib_dump_info(skb, portid, seq, event, fri, flags)                */
+/*  arm64: x0=skb, x4=fri (struct fib_rt_info*)                       */
+/* ================================================================== */
+
+struct fib_dump_data {
+	struct sk_buff *skb;
+	unsigned int saved_len;
+	bool should_filter;
+};
+
+static int fib_dump_entry(struct kretprobe_instance *ri, struct pt_regs *regs)
+{
+	struct fib_dump_data *data = (void *)ri->data;
+	struct fib_info *fi = NULL;
+
+	data->should_filter = false;
+
+	if (!is_target_uid())
+		return 0;
+
+	/* x0=skb, x4=fi (or fri in 6.1+) */
+	data->skb = (struct sk_buff *)regs->regs[0];
+
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 1, 0)
+	{
+		struct fib_rt_info *fri = (struct fib_rt_info *)regs->regs[4];
+		if (fri)
+			fi = fri->fi;
+	}
+#else
+	fi = (struct fib_info *)regs->regs[4];
+#endif
+
+	rcu_read_lock();
+	if (fi && fi->fib_nhs > 0) {
+		/* Access first nexthop interface */
+		struct net_device *dev = fi->fib_nh[0].nh_common.nhc_dev;
+		if (dev && is_vpn_ifname(dev->name)) {
+			data->saved_len = data->skb ? data->skb->len : 0;
+			data->should_filter = true;
+			vpnhide_dbg("fib_dump_entry: hiding route via %s\n",
+				    dev->name);
+		}
+	}
+	rcu_read_unlock();
+
+	return 0;
+}
+
+static int fib_dump_ret(struct kretprobe_instance *ri, struct pt_regs *regs)
+{
+	struct fib_dump_data *data = (void *)ri->data;
+
+	if (!data->should_filter || !data->skb)
+		return 0;
+
+	if (regs_return_value(regs) >= 0) {
+		skb_trim(data->skb, data->saved_len);
+		regs_set_return_value(regs, 0);
+	}
+	return 0;
+}
+
+static struct kretprobe fib_dump_krp = {
+	.handler = fib_dump_ret,
+	.entry_handler = fib_dump_entry,
+	.data_size = sizeof(struct fib_dump_data),
+	.maxactive = VPNHIDE_KRETPROBE_MAXACTIVE,
+	.kp.symbol_name = "fib_dump_info",
+};
+
+/* ================================================================== */
+/*  Hook 8: rt6_fill_node — IPv6 routes                                */
+/*                                                                    */
+/*  rt6_fill_node(net, skb, rt, dst, ...)                             */
+/*  arm64: x1=skb, x3=dst (struct dst_entry*)                         */
+/* ================================================================== */
+
+struct rt6_fill_data {
+	struct sk_buff *skb;
+	unsigned int saved_len;
+	bool should_filter;
+};
+
+static int rt6_fill_entry(struct kretprobe_instance *ri, struct pt_regs *regs)
+{
+	struct rt6_fill_data *data = (void *)ri->data;
+	struct dst_entry *dst;
+
+	data->should_filter = false;
+
+	if (!is_target_uid())
+		return 0;
+
+	/* x1=skb, x3=dst */
+	data->skb = (struct sk_buff *)regs->regs[1];
+	dst = (struct dst_entry *)regs->regs[3];
+
+	rcu_read_lock();
+	if (dst && dst->dev && is_vpn_ifname(dst->dev->name)) {
+		data->saved_len = data->skb ? data->skb->len : 0;
+		data->should_filter = true;
+		vpnhide_dbg("rt6_fill_entry: hiding IPv6 route via %s\n",
+			    dst->dev->name);
+	}
+	rcu_read_unlock();
+
+	return 0;
+}
+
+static int rt6_fill_ret(struct kretprobe_instance *ri, struct pt_regs *regs)
+{
+	struct rt6_fill_data *data = (void *)ri->data;
+
+	if (!data->should_filter || !data->skb)
+		return 0;
+
+	if (regs_return_value(regs) >= 0) {
+		skb_trim(data->skb, data->saved_len);
+		regs_set_return_value(regs, 0);
+	}
+	return 0;
+}
+
+static struct kretprobe rt6_fill_krp = {
+	.handler = rt6_fill_ret,
+	.entry_handler = rt6_fill_entry,
+	.data_size = sizeof(struct rt6_fill_data),
+	.maxactive = VPNHIDE_KRETPROBE_MAXACTIVE,
+	.kp.symbol_name = "rt6_fill_node",
+};
+
+/* ================================================================== */
+/*  Hook 9: rt_fill_info — IPv4 single route lookup                   */
+/*                                                                    */
+/*  rt_fill_info(skb, dst, src, rt, ...)                              */
+/*  arm64: x0=skb, x3=rt (struct rtable*)                             */
+/* ================================================================== */
+
+struct rt_fill_data {
+	struct sk_buff *skb;
+	unsigned int saved_len;
+	bool should_filter;
+};
+
+static int rt_fill_entry(struct kretprobe_instance *ri, struct pt_regs *regs)
+{
+	struct rt_fill_data *data = (void *)ri->data;
+	struct net_device *dev = NULL;
+
+	data->should_filter = false;
+
+	if (!is_target_uid())
+		return 0;
+
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 1, 0)
+	/* GKI 6.1+ mapping: x0=skb, x3=rt */
+	data->skb = (struct sk_buff *)regs->regs[0];
+	{
+		struct rtable *rt = (struct rtable *)regs->regs[3];
+		if (rt)
+			dev = rt->dst.dev;
+	}
+#else
+	/* GKI 5.10 / 5.15 mapping: x6=skb, x7=rt/fri */
+	data->skb = (struct sk_buff *)regs->regs[6];
+	{
+		struct rtable *rt = (struct rtable *)regs->regs[7];
+		if (rt)
+			dev = rt->dst.dev;
+	}
+#endif
+
+	rcu_read_lock();
+	if (dev && is_vpn_ifname(dev->name)) {
+		data->saved_len = data->skb ? data->skb->len : 0;
+		data->should_filter = true;
+		vpnhide_dbg("rt_fill_entry: hiding route via %s\n", dev->name);
+	}
+	rcu_read_unlock();
+
+	return 0;
+}
+
+static int rt_fill_ret(struct kretprobe_instance *ri, struct pt_regs *regs)
+{
+	struct rt_fill_data *data = (void *)ri->data;
+
+	if (!data->should_filter || !data->skb)
+		return 0;
+
+	if (regs_return_value(regs) >= 0) {
+		skb_trim(data->skb, data->saved_len);
+		regs_set_return_value(regs, 0);
+	}
+	return 0;
+}
+
+static struct kretprobe rt_fill_krp = {
+	.handler = rt_fill_ret,
+	.entry_handler = rt_fill_entry,
+	.data_size = sizeof(struct rt_fill_data),
+	.maxactive = VPNHIDE_KRETPROBE_MAXACTIVE,
+	.kp.symbol_name = "rt_fill_info",
+};
+
+/* ================================================================== */
 /*  Module init / exit                                                */
 /* ================================================================== */
 
@@ -824,6 +1037,9 @@ static struct kretprobe_reg probes[] = {
 	{ &inet6_fill_krp, "inet6_fill_ifaddr", false },
 	{ &inet_fill_krp, "inet_fill_ifaddr", false },
 	{ &fib_route_krp, "fib_route_seq_show", false },
+	{ &fib_dump_krp, "fib_dump_info", false },
+	{ &rt6_fill_krp, "rt6_fill_node", false },
+	{ &rt_fill_krp, "rt_fill_info", false },
 };
 
 static int __init vpnhide_init(void)

--- a/kmod/vpnhide_kmod.c
+++ b/kmod/vpnhide_kmod.c
@@ -967,15 +967,15 @@ static int rt_fill_entry(struct kretprobe_instance *ri, struct pt_regs *regs)
 		return 0;
 
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 1, 0)
-	/* GKI 6.1+ mapping: x0=skb, x3=rt */
+	/* GKI 6.1+ mapping: x0=skb, x3=fri */
 	data->skb = (struct sk_buff *)regs->regs[0];
 	{
-		struct rtable *rt = (struct rtable *)regs->regs[3];
-		if (rt)
-			dev = rt->dst.dev;
+		struct fib_rt_info *fri = (struct fib_rt_info *)regs->regs[3];
+		if (fri && fri->fi && fri->fi->fib_nhs > 0)
+			dev = fri->fi->fib_nh[0].nh_common.nhc_dev;
 	}
 #else
-	/* GKI 5.10 / 5.15 mapping: x6=skb, x7=rt/fri */
+	/* GKI 5.10 / 5.15 mapping: x6=skb, x7=rt */
 	data->skb = (struct sk_buff *)regs->regs[6];
 	{
 		struct rtable *rt = (struct rtable *)regs->regs[7];

--- a/kmod/vpnhide_kmod.c
+++ b/kmod/vpnhide_kmod.c
@@ -101,6 +101,9 @@ struct vpnhide_targets {
 static struct vpnhide_targets __rcu *global_targets;
 static DEFINE_SPINLOCK(targets_update_lock);
 
+static struct vpnhide_targets __rcu *global_direct_targets;
+static DEFINE_SPINLOCK(direct_targets_update_lock);
+
 static bool is_target_uid(void)
 {
 	uid_t uid = from_kuid(&init_user_ns, current_uid());
@@ -110,6 +113,27 @@ static bool is_target_uid(void)
 
 	rcu_read_lock();
 	t = rcu_dereference(global_targets);
+	if (t) {
+		for (i = 0; i < t->count; i++) {
+			if (t->uids[i] == uid) {
+				found = true;
+				break;
+			}
+		}
+	}
+	rcu_read_unlock();
+	return found;
+}
+
+static bool is_direct_target_uid(void)
+{
+	uid_t uid = from_kuid(&init_user_ns, current_uid());
+	struct vpnhide_targets *t;
+	bool found = false;
+	int i;
+
+	rcu_read_lock();
+	t = rcu_dereference(global_direct_targets);
 	if (t) {
 		for (i = 0; i < t->count; i++) {
 			if (t->uids[i] == uid) {
@@ -214,6 +238,90 @@ static const struct proc_ops targets_proc_ops = {
 	.proc_open = targets_open,
 	.proc_read = seq_read,
 	.proc_write = targets_write,
+	.proc_lseek = seq_lseek,
+	.proc_release = single_release,
+};
+
+/* ------------------------------------------------------------------ */
+/*  /proc/vpnhide_direct_targets                                      */
+/* ------------------------------------------------------------------ */
+
+static ssize_t direct_targets_write(struct file *file, const char __user *ubuf,
+				    size_t count, loff_t *ppos)
+{
+	char *buf, *line, *next;
+	struct vpnhide_targets *new_t, *old_t;
+	int new_count = 0;
+
+	if (count > PAGE_SIZE)
+		return -EINVAL;
+
+	buf = kmalloc(count + 1, GFP_KERNEL);
+	if (!buf)
+		return -ENOMEM;
+
+	if (copy_from_user(buf, ubuf, count)) {
+		kfree(buf);
+		return -EFAULT;
+	}
+	buf[count] = '\0';
+
+	new_t = kzalloc(sizeof(*new_t), GFP_KERNEL);
+	if (!new_t) {
+		kfree(buf);
+		return -ENOMEM;
+	}
+
+	for (line = buf; line && *line && new_count < MAX_TARGET_UIDS;
+	     line = next) {
+		unsigned long uid;
+		next = strchr(line, '\n');
+		if (next) *next++ = '\0';
+		while (*line == ' ' || *line == '\t') line++;
+		if (!*line || *line == '#') continue;
+		if (kstrtoul(line, 10, &uid) == 0)
+			new_t->uids[new_count++] = (uid_t)uid;
+	}
+	new_t->count = new_count;
+
+	spin_lock(&direct_targets_update_lock);
+	old_t = rcu_dereference_protected(global_direct_targets,
+					  lockdep_is_held(&direct_targets_update_lock));
+	rcu_assign_pointer(global_direct_targets, new_t);
+	spin_unlock(&direct_targets_update_lock);
+
+	if (old_t)
+		call_rcu(&old_t->rcu, free_targets_rcu);
+
+	kfree(buf);
+	pr_info(MODNAME ": loaded %d direct target UIDs\n", new_count);
+	return count;
+}
+
+static int direct_targets_show(struct seq_file *m, void *v)
+{
+	struct vpnhide_targets *t;
+	int i;
+
+	rcu_read_lock();
+	t = rcu_dereference(global_direct_targets);
+	if (t) {
+		for (i = 0; i < t->count; i++)
+			seq_printf(m, "%u\n", t->uids[i]);
+	}
+	rcu_read_unlock();
+	return 0;
+}
+
+static int direct_targets_open(struct inode *inode, struct file *file)
+{
+	return single_open(file, direct_targets_show, NULL);
+}
+
+static const struct proc_ops direct_targets_proc_ops = {
+	.proc_open = direct_targets_open,
+	.proc_read = seq_read,
+	.proc_write = direct_targets_write,
 	.proc_lseek = seq_lseek,
 	.proc_release = single_release,
 };
@@ -1133,7 +1241,7 @@ static int ip_route_output_flow_entry(struct kretprobe_instance *ri,
 	struct net *net = (struct net *)regs->regs[0];
 	struct flowi4 *flp4 = (struct flowi4 *)regs->regs[1];
 
-	if (flp4 && is_target_uid()) {
+	if (flp4 && is_direct_target_uid()) {
 		bool vpn_active;
 		int phys_idx;
 
@@ -1168,7 +1276,7 @@ static int ip_route_output_key_entry(struct kretprobe_instance *ri,
 	struct net *net = (struct net *)regs->regs[0];
 	struct flowi4 *flp4 = (struct flowi4 *)regs->regs[1];
 
-	if (flp4 && is_target_uid()) {
+	if (flp4 && is_direct_target_uid()) {
 		bool vpn_active;
 		int phys_idx;
 
@@ -1208,7 +1316,7 @@ static int ip6_route_output_entry(struct kretprobe_instance *ri,
 	struct net *net = (struct net *)regs->regs[0];
 	struct flowi6 *fl6 = (struct flowi6 *)regs->regs[2];
 
-	if (fl6 && is_target_uid()) {
+	if (fl6 && is_direct_target_uid()) {
 		bool vpn_active;
 		int phys_idx;
 
@@ -1240,6 +1348,7 @@ static struct kretprobe ip6_route_output_krp = {
 /* ================================================================== */
 
 static struct proc_dir_entry *targets_entry;
+static struct proc_dir_entry *direct_targets_entry;
 static struct proc_dir_entry *debug_entry;
 
 struct kretprobe_reg {
@@ -1267,8 +1376,9 @@ static int __init vpnhide_init(void)
 {
 	int i, ret, ok = 0;
 
-	/* Initialize RCU targets pointer */
+	/* Initialize RCU targets pointers */
 	rcu_assign_pointer(global_targets, NULL);
+	rcu_assign_pointer(global_direct_targets, NULL);
 
 	for (i = 0; i < ARRAY_SIZE(probes); i++) {
 		ret = register_kretprobe(probes[i].krp);
@@ -1297,9 +1407,6 @@ static int __init vpnhide_init(void)
 	targets_entry =
 		proc_create("vpnhide_targets", 0600, NULL, &targets_proc_ops);
 	if (!targets_entry) {
-		/* Without /proc/vpnhide_targets userspace cannot configure
-		 * the target UID list, so the module would silently filter
-		 * nothing — fail loudly instead of pretending to work. */
 		pr_err(MODNAME
 		       ": proc_create(vpnhide_targets) failed; aborting\n");
 		for (i = 0; i < ARRAY_SIZE(probes); i++)
@@ -1307,12 +1414,19 @@ static int __init vpnhide_init(void)
 				unregister_kretprobe(probes[i].krp);
 		return -ENOMEM;
 	}
+
+	direct_targets_entry =
+		proc_create("vpnhide_direct_targets", 0600, NULL, &direct_targets_proc_ops);
+	if (!direct_targets_entry)
+		pr_warn(MODNAME
+			": proc_create(vpnhide_direct_targets) failed; direct routing configuration unavailable\n");
+
 	debug_entry = proc_create("vpnhide_debug", 0600, NULL, &debug_proc_ops);
 	if (!debug_entry)
 		pr_warn(MODNAME
 			": proc_create(vpnhide_debug) failed; debug toggle unavailable\n");
 
-	pr_info(MODNAME ": loaded — write UIDs to /proc/vpnhide_targets\n");
+	pr_info(MODNAME ": loaded — write UIDs to /proc/vpnhide_targets and /proc/vpnhide_direct_targets\n");
 	return 0;
 }
 
@@ -1325,6 +1439,8 @@ static void __exit vpnhide_exit(void)
 		proc_remove(debug_entry);
 	if (targets_entry)
 		proc_remove(targets_entry);
+	if (direct_targets_entry)
+		proc_remove(direct_targets_entry);
 
 	for (i = 0; i < ARRAY_SIZE(probes); i++) {
 		if (probes[i].registered) {
@@ -1343,7 +1459,18 @@ static void __exit vpnhide_exit(void)
 	spin_unlock(&targets_update_lock);
 
 	if (t) {
-		/* Wait for any pending is_target_uid calls to finish */
+		synchronize_rcu();
+		kfree(t);
+	}
+
+	/* Cleanup RCU direct targets */
+	spin_lock(&direct_targets_update_lock);
+	t = rcu_dereference_protected(global_direct_targets,
+				      lockdep_is_held(&direct_targets_update_lock));
+	rcu_assign_pointer(global_direct_targets, NULL);
+	spin_unlock(&direct_targets_update_lock);
+
+	if (t) {
 		synchronize_rcu();
 		kfree(t);
 	}

--- a/lsposed/app/build.gradle.kts
+++ b/lsposed/app/build.gradle.kts
@@ -94,7 +94,6 @@ android {
             )
         }
         debug {
-            signingConfig = signingConfigs.getByName("release")
         }
     }
 

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/AppHidingScreen.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/AppHidingScreen.kt
@@ -404,7 +404,7 @@ private fun buildHidingSaveCommand(
 
     // Observer list: resolved UIDs. Same 0640 root:system rationale.
     if (observerPkgs.isNotEmpty()) {
-        parts += buildHidingUidResolver(observerPkgs, SS_OBSERVER_UIDS_FILE)
+        parts += buildUidResolver(observerPkgs, SS_OBSERVER_UIDS_FILE)
         parts += "chmod 640 $SS_OBSERVER_UIDS_FILE 2>/dev/null"
         parts += "chown root:system $SS_OBSERVER_UIDS_FILE 2>/dev/null"
         parts += "chcon u:object_r:system_data_file:s0 $SS_OBSERVER_UIDS_FILE 2>/dev/null; true"
@@ -418,32 +418,6 @@ private fun buildHidingSaveCommand(
 
     return parts.joinToString(" ; ")
 }
-
-private fun buildHidingUidResolver(
-    packages: List<String>,
-    outputFile: String,
-): String =
-    buildString {
-        // `--user all` emits comma-separated UIDs for multi-profile
-        // packages (e.g. work profile). `tr ',' '\n'` splits them so
-        // each profile's observer gets matched by the system_server
-        // hook, not just the primary-user one. Literal field match via
-        // awk — grep would treat dots in `pkg` as regex wildcards.
-        append("ALL_PKGS=\"\$(pm list packages -U --user all 2>/dev/null)\"")
-        append("; UIDS=\"\"")
-        for (pkg in packages) {
-            append(
-                "; U=\$(echo \"\$ALL_PKGS\" | awk -v p=\"package:$pkg\" " +
-                    "'\$1 == p { sub(/uid:/, \"\", \$2); print \$2; exit }' | tr ',' '\\n')",
-            )
-            append("; if [ -n \"\$U\" ]; then if [ -z \"\$UIDS\" ]; then UIDS=\"\$U\"; else UIDS=\"\$UIDS")
-            append("\n")
-            append("\$U\"; fi; fi")
-        }
-        append("; if [ -n \"\$UIDS\" ]; then echo \"\$UIDS\" > $outputFile 2>/dev/null")
-        append("; else echo > $outputFile 2>/dev/null; fi")
-    }
-
 @Composable
 private fun HidingAppRow(
     app: HidingEntry,

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/AppPickerScreen.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/AppPickerScreen.kt
@@ -412,34 +412,6 @@ private fun buildSaveCommand(
     return parts.joinToString(" ; ")
 }
 
-private fun buildUidResolver(
-    packages: List<String>,
-    outputFile: String,
-): String =
-    buildString {
-        // `--user all` produces comma-separated UIDs for packages that
-        // exist in multiple profiles (e.g. work profile), like:
-        //   package:com.android.chrome uid:10187,1010187
-        // `tr ',' '\n'` expands each to its own line so every profile's
-        // copy of the target is individually filtered by the hooks.
-        // Literal field match via awk — grep would treat dots in `pkg`
-        // as regex wildcards, occasionally cross-matching distinct
-        // packages.
-        append("ALL_PKGS=\"\$(pm list packages -U --user all 2>/dev/null)\"")
-        append("; UIDS=\"\"")
-        for (pkg in packages) {
-            append(
-                "; U=\$(echo \"\$ALL_PKGS\" | awk -v p=\"package:$pkg\" " +
-                    "'\$1 == p { sub(/uid:/, \"\", \$2); print \$2; exit }' | tr ',' '\\n')",
-            )
-            append("; if [ -n \"\$U\" ]; then if [ -z \"\$UIDS\" ]; then UIDS=\"\$U\"; else UIDS=\"\$UIDS")
-            append("\n")
-            append("\$U\"; fi; fi")
-        }
-        append("; if [ -n \"\$UIDS\" ]; then echo \"\$UIDS\" > $outputFile 2>/dev/null")
-        append("; else echo > $outputFile 2>/dev/null; fi")
-    }
-
 @Composable
 private fun AppRow(
     app: AppEntry,

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/ProtectionScreen.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/ProtectionScreen.kt
@@ -17,7 +17,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 
-internal enum class ProtectionMode { VpnTargets, AppHiding, PortHiding }
+internal enum class ProtectionMode { VpnTargets, TunBypass, AppHiding, PortHiding }
 
 @Composable
 fun ProtectionScreen(
@@ -36,6 +36,15 @@ fun ProtectionScreen(
         when (mode) {
             ProtectionMode.VpnTargets -> {
                 AppPickerScreen(
+                    searchQuery = searchQuery,
+                    showSystem = showSystem,
+                    showRussianOnly = showRussianOnly,
+                    modifier = Modifier.fillMaxSize(),
+                )
+            }
+            
+            ProtectionMode.TunBypass -> {
+                TunBypassScreen(
                     searchQuery = searchQuery,
                     showSystem = showSystem,
                     showRussianOnly = showRussianOnly,
@@ -72,6 +81,7 @@ private fun ProtectionModeSwitcher(
     val options =
         listOf(
             ProtectionMode.VpnTargets to R.string.mode_vpn_targets,
+            ProtectionMode.TunBypass to R.string.mode_tun_bypass,
             ProtectionMode.AppHiding to R.string.mode_app_hiding,
             ProtectionMode.PortHiding to R.string.mode_port_hiding,
         )

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/ShellUtils.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/ShellUtils.kt
@@ -12,10 +12,12 @@ import java.util.concurrent.atomic.AtomicReference
 private const val TAG = "VpnHide"
 
 internal const val KMOD_TARGETS = "/data/adb/vpnhide_kmod/targets.txt"
+internal const val KMOD_DIRECT_TARGETS = "/data/adb/vpnhide_kmod/direct_targets.txt"
 internal const val ZYGISK_TARGETS = "/data/adb/vpnhide_zygisk/targets.txt"
 internal const val ZYGISK_MODULE_TARGETS = "/data/adb/modules/vpnhide_zygisk/targets.txt"
 internal const val LSPOSED_TARGETS = "/data/adb/vpnhide_lsposed/targets.txt"
 internal const val PROC_TARGETS = "/proc/vpnhide_targets"
+internal const val PROC_DIRECT_TARGETS = "/proc/vpnhide_direct_targets"
 internal const val KMOD_DEBUG_PROC = "/proc/vpnhide_debug"
 internal const val SS_UIDS_FILE = "/data/system/vpnhide_uids.txt"
 internal const val SS_HIDDEN_PKGS_FILE = "/data/system/vpnhide_hidden_pkgs.txt"
@@ -253,3 +255,31 @@ internal fun ensureSelfInTargets(selfPkg: String): Boolean {
     VpnHideLog.d(TAG, "ensureSelfInTargets: done, added=$added")
     return added
 }
+
+internal fun buildUidResolver(
+    packages: List<String>,
+    outputFile: String,
+): String =
+    buildString {
+        // `--user all` produces comma-separated UIDs for packages that
+        // exist in multiple profiles (e.g. work profile), like:
+        //   package:com.android.chrome uid:10187,1010187
+        // `tr ',' '\n'` expands each to its own line so every profile's
+        // copy of the target is individually filtered by the hooks.
+        // Literal field match via awk — grep would treat dots in `pkg`
+        // as regex wildcards, occasionally cross-matching distinct
+        // packages.
+        append("ALL_PKGS=\"\$(pm list packages -U --user all 2>/dev/null)\"")
+        append("; UIDS=\"\"")
+        for (pkg in packages) {
+            append(
+                "; U=\$(echo \"\$ALL_PKGS\" | awk -v p=\"package:$pkg\" " +
+                    "'\$1 == p { sub(/uid:/, \"\", \$2); print \$2; exit }' | tr ',' '\\n')",
+            )
+            append("; if [ -n \"\$U\" ]; then if [ -z \"\$UIDS\" ]; then UIDS=\"\$U\"; else UIDS=\"\$UIDS")
+            append("\n")
+            append("\$U\"; fi; fi")
+        }
+        append("; if [ -n \"\$UIDS\" ]; then echo \"\$UIDS\" > $outputFile 2>/dev/null")
+        append("; else echo > $outputFile 2>/dev/null; fi")
+    }

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/TargetsCache.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/TargetsCache.kt
@@ -32,6 +32,7 @@ internal data class TargetsSnapshot(
     val zygiskModuleInstalled: Boolean,
     val portsModuleInstalled: Boolean,
     val kmodTargets: Set<String>,
+    val kmodDirectTargets: Set<String>,
     val zygiskTargets: Set<String>,
     val lsposedTargets: Set<String>,
     val hiddenPkgs: Set<String>,
@@ -96,6 +97,8 @@ internal object TargetsCache {
         cat $PORTS_MODULE_DIR/module.prop 2>/dev/null || true
         echo "$SENTINEL KMOD_TARGETS"
         cat $KMOD_TARGETS 2>/dev/null || true
+        echo "$SENTINEL KMOD_DIRECT_TARGETS"
+        cat $KMOD_DIRECT_TARGETS 2>/dev/null || true
         echo "$SENTINEL ZYGISK_TARGETS"
         cat $ZYGISK_TARGETS 2>/dev/null || true
         echo "$SENTINEL LSPOSED_TARGETS"
@@ -176,6 +179,7 @@ internal object TargetsCache {
             zygiskModuleInstalled = sections["ZYGISK_MODULE_DIR"]?.trim() == "1",
             portsModuleInstalled = portsInstalled,
             kmodTargets = nonEmptyLines(sections["KMOD_TARGETS"]),
+            kmodDirectTargets = nonEmptyLines(sections["KMOD_DIRECT_TARGETS"]),
             zygiskTargets = nonEmptyLines(sections["ZYGISK_TARGETS"]),
             lsposedTargets = nonEmptyLines(sections["LSPOSED_TARGETS"]),
             hiddenPkgs = nonEmptyLines(sections["HIDDEN_PKGS"]),

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/TunBypassScreen.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/TunBypassScreen.kt
@@ -1,0 +1,274 @@
+package dev.okhsunrog.vpnhide
+
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.interaction.collectIsDraggedAsState
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.drawBehind
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.asImageBitmap
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.core.graphics.drawable.toBitmap
+import io.github.oikvpqya.compose.fastscroller.VerticalScrollbar
+import io.github.oikvpqya.compose.fastscroller.indicator.IndicatorConstants
+import io.github.oikvpqya.compose.fastscroller.material3.defaultMaterialScrollbarStyle
+import io.github.oikvpqya.compose.fastscroller.rememberScrollbarAdapter
+import kotlinx.coroutines.launch
+
+internal data class BypassEntry(
+    val packageName: String,
+    val label: String,
+    val icon: android.graphics.drawable.Drawable?,
+    val isSystem: Boolean,
+    val userIds: List<Int> = emptyList(),
+    val kmod: Boolean = false,
+)
+
+@Composable
+fun TunBypassScreen(
+    searchQuery: String,
+    showSystem: Boolean,
+    showRussianOnly: Boolean,
+    modifier: Modifier = Modifier,
+) {
+    val context = LocalContext.current
+    val scope = rememberCoroutineScope()
+
+    val cachedApps by AppListCache.apps.collectAsState()
+    val userNames by AppListCache.userNames.collectAsState()
+    val targets by TargetsCache.snapshot.collectAsState()
+
+    var allApps by remember { mutableStateOf<List<BypassEntry>>(emptyList()) }
+    var saving by remember { mutableStateOf(false) }
+    var dirty by remember { mutableStateOf(false) }
+    var snackMessage by remember { mutableStateOf<String?>(null) }
+    val snackbarHostState = remember { SnackbarHostState() }
+
+    LaunchedEffect(snackMessage) {
+        snackMessage?.let {
+            snackbarHostState.showSnackbar(message = it, duration = SnackbarDuration.Long)
+            snackMessage = null
+        }
+    }
+
+    LaunchedEffect(Unit) {
+        TargetsCache.ensureLoaded(scope, context)
+    }
+
+    LaunchedEffect(cachedApps, targets) {
+        if (dirty) return@LaunchedEffect
+        val apps = cachedApps ?: return@LaunchedEffect
+        val t = targets ?: return@LaunchedEffect
+        val selfPkg = context.packageName
+        allApps = apps.filter { it.packageName != selfPkg }.map { app ->
+            BypassEntry(
+                packageName = app.packageName,
+                label = app.label,
+                icon = app.icon,
+                isSystem = app.isSystem,
+                userIds = app.userIds,
+                kmod = app.packageName in t.kmodDirectTargets,
+            )
+        }
+        dirty = false
+    }
+
+    val loading = cachedApps == null || targets == null
+    val filteredApps = remember(allApps, searchQuery, showSystem, showRussianOnly) {
+        val q = searchQuery.trim().lowercase()
+        allApps.filter { app ->
+            (showSystem || !app.isSystem || app.kmod) &&
+            (!showRussianOnly || isRussianApp(app.packageName, app.label)) &&
+            (q.isEmpty() || app.label.lowercase().contains(q) || app.packageName.lowercase().contains(q))
+        }
+    }
+
+    val selectedCount = remember(allApps) { allApps.count { it.kmod } }
+
+    Column(modifier = modifier.fillMaxSize()) {
+        if (loading) {
+            Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                CircularProgressIndicator()
+            }
+        } else {
+            val listState = rememberLazyListState()
+            Box(modifier = Modifier.weight(1f)) {
+                LazyColumn(state = listState, modifier = Modifier.fillMaxSize()) {
+                    item {
+                        Box(modifier = Modifier.padding(horizontal = 12.dp, vertical = 8.dp)) {
+                            HelpAccordion(
+                                prefKey = "apps_bypass",
+                                title = stringResource(R.string.bypass_help_title),
+                            ) {
+                                Text(
+                                    text = stringResource(R.string.bypass_hint_logic),
+                                    style = MaterialTheme.typography.bodyMedium,
+                                )
+                                Text(
+                                    text = stringResource(R.string.bypass_hint_kmod),
+                                    style = MaterialTheme.typography.bodyMedium,
+                                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                )
+                            }
+                        }
+                    }
+                    items(filteredApps, key = { it.packageName }) { app ->
+                        BypassAppRow(
+                            app = app,
+                            userNames = userNames,
+                            onToggle = {
+                                allApps = allApps.map {
+                                    if (it.packageName != app.packageName) it else it.copy(kmod = !it.kmod)
+                                }
+                                dirty = true
+                            }
+                        )
+                    }
+                }
+                
+                val interactionSource = remember { MutableInteractionSource() }
+                val isDragging by interactionSource.collectIsDraggedAsState()
+                val indicatorAlpha by animateFloatAsState(if (isDragging) 1f else 0f, label = "alpha")
+                VerticalScrollbar(
+                    adapter = rememberScrollbarAdapter(scrollState = listState),
+                    interactionSource = interactionSource,
+                    style = defaultMaterialScrollbarStyle(),
+                    modifier = Modifier.align(Alignment.TopEnd).fillMaxHeight(),
+                    indicator = { position, isVisible ->
+                        val firstChar = filteredApps.getOrNull(listState.firstVisibleItemIndex)?.label?.firstOrNull()?.uppercase() ?: ""
+                        Box(
+                            modifier = Modifier.align(Alignment.TopEnd).padding(end = 8.dp).graphicsLayer {
+                                translationY = position; alpha = indicatorAlpha
+                            }
+                        ) {
+                            Surface(
+                                shape = RoundedCornerShape(4.dp),
+                                color = if (isVisible) MaterialTheme.colorScheme.primary else Color.Transparent,
+                                modifier = Modifier.size(48.dp)
+                            ) {
+                                Box(contentAlignment = Alignment.Center) {
+                                    Text(firstChar, color = MaterialTheme.colorScheme.onPrimary, style = MaterialTheme.typography.titleMedium)
+                                }
+                            }
+                        }
+                    }
+                )
+            }
+
+            Surface(tonalElevation = 3.dp) {
+                Row(
+                    modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp, vertical = 12.dp),
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    Text(
+                        text = stringResource(R.string.selected_count, selectedCount),
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        modifier = Modifier.weight(1f),
+                    )
+                    Button(
+                        onClick = {
+                            saving = true
+                            dirty = false
+                        },
+                        enabled = dirty && !saving,
+                    ) {
+                        Text(stringResource(R.string.btn_save))
+                    }
+                }
+            }
+        }
+    }
+
+    if (saving) {
+        LaunchedEffect(Unit) {
+            val selfPkg = context.packageName
+            val kmodPkgs = (allApps.filter { it.kmod }.map { it.packageName } + selfPkg).distinct().sorted()
+            val header = context.getString(R.string.save_header_comment)
+
+            try {
+                val (exitCode, _) = suExecAsync(buildBypassSaveCommand(header, kmodPkgs))
+                if (exitCode == 0) {
+                    snackMessage = context.getString(R.string.save_success, selectedCount)
+                    DashboardCache.invalidate()
+                    TargetsCache.refresh(scope, context)
+                } else {
+                    snackMessage = context.getString(R.string.save_failed_exit, exitCode)
+                    dirty = true
+                }
+            } catch (e: Exception) {
+                snackMessage = e.message
+                dirty = true
+            }
+            saving = false
+        }
+    }
+}
+
+private fun buildBypassSaveCommand(header: String, kmodPkgs: List<String>): String {
+    val body = "$header\n" + kmodPkgs.joinToString("\n") + if (kmodPkgs.isNotEmpty()) "\n" else ""
+    val b64 = android.util.Base64.encodeToString(body.toByteArray(), android.util.Base64.NO_WRAP)
+    
+    val parts = mutableListOf<String>()
+    parts += "if [ -d /data/adb/vpnhide_kmod ]; then echo '$b64' | base64 -d > $KMOD_DIRECT_TARGETS && chmod 644 $KMOD_DIRECT_TARGETS; fi"
+    
+    if (kmodPkgs.isNotEmpty()) {
+        parts += buildUidResolver(kmodPkgs, PROC_DIRECT_TARGETS)
+    } else {
+        parts += "echo > $PROC_DIRECT_TARGETS 2>/dev/null; true"
+    }
+    
+    return parts.joinToString(" ; ")
+}
+
+@Composable
+private fun BypassAppRow(
+    app: BypassEntry,
+    userNames: Map<Int, String>,
+    onToggle: () -> Unit,
+) {
+    Row(
+        modifier = Modifier.fillMaxWidth().clickable(onClick = onToggle).padding(horizontal = 16.dp, vertical = 10.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        app.icon?.let { drawable ->
+            Image(bitmap = drawable.toBitmap(48, 48).asImageBitmap(), contentDescription = null, modifier = Modifier.size(40.dp))
+            Spacer(Modifier.width(12.dp))
+        }
+        Column(modifier = Modifier.weight(1f)) {
+            Text(text = labelWithUsers(app.label, app.userIds, userNames), style = MaterialTheme.typography.bodyLarge, fontWeight = FontWeight.Medium)
+            Text(text = app.packageName, style = MaterialTheme.typography.bodySmall, fontFamily = FontFamily.Monospace, fontSize = 12.sp, color = MaterialTheme.colorScheme.onSurfaceVariant)
+            Spacer(Modifier.height(4.dp))
+            Surface(
+                shape = RoundedCornerShape(4.dp),
+                color = if (app.kmod) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.surfaceVariant,
+                modifier = Modifier.clickable(onClick = onToggle)
+            ) {
+                Text(
+                    text = "K",
+                    style = MaterialTheme.typography.labelSmall,
+                    fontWeight = FontWeight.Bold,
+                    color = if (app.kmod) MaterialTheme.colorScheme.onPrimary else MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
+                )
+            }
+        }
+    }
+}

--- a/lsposed/app/src/main/res/values-ru/strings.xml
+++ b/lsposed/app/src/main/res/values-ru/strings.xml
@@ -9,6 +9,7 @@
 
     <!-- Protection modes (segmented button) -->
     <string name="mode_vpn_targets">Туннели</string>
+    <string name="mode_tun_bypass">Байпас</string>
     <string name="mode_app_hiding">Приложения</string>
     <string name="mode_port_hiding">Порты</string>
     <string name="port_hiding_coming_soon">Скоро</string>
@@ -34,6 +35,11 @@
     <string name="apps_hint_toggles">Нажимайте L, K, Z для переключения отдельных уровней защиты (LSPosed, модуль ядра, Zygisk). Нажмите на строку, чтобы переключить все уровни сразу.</string>
     <string name="apps_hint_restart_target">После Save: L (LSPosed) и K (модуль ядра) применяются к целевому приложению мгновенно — рестарт не нужен. Z (Zygisk) внедряется при форке процесса, поэтому для любого только что переключённого целевого приложения с Z (включением или выключением) нужен force-stop + повторный запуск, чтобы изменение для него вступило в силу.</string>
     <string name="apps_hint_zygisk">Банковские и платёжные приложения обнаруживают Zygisk-хуки и при включённом Z крашатся или отказываются работать. Держите Z выключенным для таких приложений и полагайтесь на модуль ядра + LSPosed.</string>
+
+    <!-- TUN bypass -->
+    <string name="bypass_help_title">Как работает байпас TUN</string>
+    <string name="bypass_hint_logic">Нажмите K, чтобы заставить приложение обходить VPN-туннель. Трафик отмеченных приложений пойдет напрямую через Wi-Fi или мобильную сеть, даже если VPN включен.</string>
+    <string name="bypass_hint_kmod">Требуется установленный и активный модуль ядра (kmod). Эта функция работает только на уровне ядра для обеспечения надежного перенаправления маршрутизации.</string>
 
     <!-- App hiding -->
     <string name="hiding_help_title">Как работает скрытие приложений</string>

--- a/lsposed/app/src/main/res/values/strings.xml
+++ b/lsposed/app/src/main/res/values/strings.xml
@@ -9,6 +9,7 @@
 
     <!-- Protection modes (segmented button) -->
     <string name="mode_vpn_targets">Tun</string>
+    <string name="mode_tun_bypass">Bypass</string>
     <string name="mode_app_hiding">Apps</string>
     <string name="mode_port_hiding">Ports</string>
     <string name="port_hiding_coming_soon">Coming soon</string>
@@ -36,6 +37,11 @@
     <string name="apps_hint_toggles">Tap L, K, Z to toggle individual layers (LSPosed, Kernel module, Zygisk). Tap the row to toggle all layers at once.</string>
     <string name="apps_hint_restart_target">After Save: L (LSPosed) and K (Kernel module) apply to the target app immediately — no restart needed. Z (Zygisk) hooks are injected at process fork, so any newly-toggled target with Z on (or off) needs a force-stop + reopen for the change to take effect for it.</string>
     <string name="apps_hint_zygisk">Banking and payment apps detect Zygisk hooks and crash or refuse to work when Z is enabled for them. Keep Z off for such apps and rely on the Kernel module + LSPosed layers instead.</string>
+
+    <!-- TUN bypass -->
+    <string name="bypass_help_title">How TUN bypass works</string>
+    <string name="bypass_hint_logic">Tap K to force an app to bypass the VPN tunnel. Traffic from marked apps will go directly through Wi-Fi or Mobile Data, even when a VPN is active.</string>
+    <string name="bypass_hint_kmod">Requires the Kernel module (kmod) to be installed and active. This feature only works at the kernel level to ensure reliable routing redirection.</string>
 
     <!-- App hiding -->
     <string name="hiding_chip_hidden" translatable="false">H</string>


### PR DESCRIPTION
Как известно, существует множество способов попытаться обойти Split Tunnel в Android. Даже сокрытие TUN не гарантирует полной изоляции, т.к. приложение может попытаться принудительно привязать себя к другому интерфейсу, и, таким образом, вычислить выходной IP (хорошо показано в том же RKN Hardering).

Проще всего для победы, казалось бы - гибкие правила. Четко разделяем по именам пакетов через гибкие правила маршрутизации (например, ядра singbox), что и как идет, и без разницы, через tun трафик или нет.

Но не тут то было. Даже singbox не способен соотнести каждый пакет с приложением и происходят утечки, которые правила неспособны обработать.

Предлагаемое мною решение/фича. Раз уж мы залезли в ядро, то почему бы нам и не контроллировать этот процесс там же? 

Я добавил еще одно окно "/proc/vpnhide_direct_targets", чтобы разграничить логику сокрытия от логики принудительного перенаправления.
Добавил еще одну вкладку в приложение под названием "Bypass".
Имлпементировал в модуле ядра функционал для принудительного сброса маршрута и перенаправления на первый приоритетный интерфейс (сначала wlan, потом мобилки rmnet и ccmni) с кэшированием для скорости.

Таким образом, выбранные на этой вкладке приложения НЕЗАВИСИМО от любых иных настроек будут идти мимо TUN на уровне маршрутизации пакетов в ядре.

Пример результата RKN Hardering (запущен singbox демоном через root, split routing не включен, правила маршрутизации отключены для теста - все в прокси):

<img width="1152" height="2560" alt="изображение" src="https://github.com/user-attachments/assets/2f81078c-ab19-49d1-95b4-4d4363883df9" />


На скрине также видно результат моего предыдущего пул реквеста по скрытию TUN маршрутов от целевых приложений.

Визуал:
<img width="1152" height="2560" alt="изображение" src="https://github.com/user-attachments/assets/03d54fb0-7e97-481d-a887-411d676a3714" />


На этом все. Если есть вопросы - готов ответить либо здесь, либо в тг @soranerai
