### PR TITLE
Improve startup metrics and root snapshot caching

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,9 @@ permissions:
   contents: read
   packages: read
 
+env:
+  RUFF_VERSION: "0.15.18"
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
@@ -47,10 +50,12 @@ jobs:
       - name: ruff format
         uses: astral-sh/ruff-action@v4.0.0
         with:
+          version: ${{ env.RUFF_VERSION }}
           args: format --check
       - name: ruff check
         uses: astral-sh/ruff-action@v4.0.0
         with:
+          version: ${{ env.RUFF_VERSION }}
           args: check
 
       # Cache cargo deps + target dirs for clippy/test. Same key shape as

--- a/changelog.d/changed-dashboard-startup-now-reports-a-real-1c86.md
+++ b/changelog.d/changed-dashboard-startup-now-reports-a-real-1c86.md
@@ -1,0 +1,9 @@
+_2026-06-22_
+
+## English
+
+Dashboard startup now reports a real fully-drawn metric and opens faster by batching root probes during cold launch.
+
+## Русский
+
+Запуск Dashboard теперь измеряется по реальной готовности экрана и проходит быстрее за счёт пакетного выполнения root-проверок при холодном старте.

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/AppHidingScreen.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/AppHidingScreen.kt
@@ -90,6 +90,7 @@ fun AppHidingScreen(
     val cachedApps by AppListCache.apps.collectAsState()
     val userNames by AppListCache.userNames.collectAsState()
     val targets by TargetsCache.snapshot.collectAsState()
+    val targetsError by TargetsCache.error.collectAsState()
 
     var allApps by remember { mutableStateOf<List<HidingEntry>>(emptyList()) }
     var saving by remember { mutableStateOf(false) }
@@ -109,6 +110,14 @@ fun AppHidingScreen(
 
     LaunchedEffect(Unit) {
         TargetsCache.ensureLoaded(scope, context)
+    }
+
+    if (targetsError != null && targets == null) {
+        TargetsLoadErrorCard(
+            onRetry = { TargetsCache.refresh(scope, context) },
+            modifier = modifier,
+        )
+        return
     }
 
     // Packages with both roles crash on startup: the app queries its own

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/AppListCache.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/AppListCache.kt
@@ -105,6 +105,7 @@ internal object AppListCache {
     private suspend fun reload(appContext: Context) {
         _loading.value = true
         try {
+            StartupTrace.mark("app_list_cache_start")
             val loaded =
                 withContext(Dispatchers.IO) {
                     val pm = appContext.packageManager
@@ -159,6 +160,7 @@ internal object AppListCache {
 
             _apps.value = loaded
             _refreshCounter.value = _refreshCounter.value + 1
+            StartupTrace.mark("app_list_cache_done")
         } finally {
             _loading.value = false
         }

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/AppPickerScreen.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/AppPickerScreen.kt
@@ -70,6 +70,7 @@ fun AppPickerScreen(
     val cachedApps by AppListCache.apps.collectAsState()
     val userNames by AppListCache.userNames.collectAsState()
     val targets by TargetsCache.snapshot.collectAsState()
+    val targetsError by TargetsCache.error.collectAsState()
 
     var allApps by remember { mutableStateOf<List<AppEntry>>(emptyList()) }
     var saving by remember { mutableStateOf(false) }
@@ -89,6 +90,14 @@ fun AppPickerScreen(
 
     LaunchedEffect(Unit) {
         TargetsCache.ensureLoaded(scope, context)
+    }
+
+    if (targetsError != null && targets == null) {
+        TargetsLoadErrorCard(
+            onRetry = { TargetsCache.refresh(scope, context) },
+            modifier = modifier,
+        )
+        return
     }
 
     val installed =

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DashboardCache.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DashboardCache.kt
@@ -2,6 +2,7 @@ package dev.okhsunrog.vpnhide
 
 import android.content.Context
 import android.net.ConnectivityManager
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
@@ -30,6 +31,9 @@ internal object DashboardCache {
     private val _loading = MutableStateFlow(false)
     val loading: StateFlow<Boolean> = _loading.asStateFlow()
 
+    private val _error = MutableStateFlow<String?>(null)
+    val error: StateFlow<String?> = _error.asStateFlow()
+
     private var inflight: Job? = null
 
     fun ensureLoaded(
@@ -37,7 +41,7 @@ internal object DashboardCache {
         context: Context,
         selfNeedsRestart: Boolean,
     ) {
-        if (_state.value != null || inflight?.isActive == true) return
+        if (_state.value != null || _error.value != null || inflight?.isActive == true) return
         inflight = scope.launch { reload(context, selfNeedsRestart) }
     }
 
@@ -47,7 +51,9 @@ internal object DashboardCache {
         selfNeedsRestart: Boolean,
     ) {
         inflight?.cancel()
-        inflight = scope.launch { reload(context, selfNeedsRestart) }
+        RootSnapshotCache.invalidate()
+        _error.value = null
+        inflight = scope.launch { reload(context, selfNeedsRestart, forceRootRefresh = true) }
     }
 
     /** Invalidate so the next `ensureLoaded` call reloads. Used after
@@ -57,21 +63,36 @@ internal object DashboardCache {
      */
     fun invalidate() {
         _state.value = null
+        _error.value = null
     }
 
     private suspend fun reload(
         context: Context,
         selfNeedsRestart: Boolean,
+        forceRootRefresh: Boolean = false,
     ) {
         _loading.value = true
         try {
             val cm = context.getSystemService(ConnectivityManager::class.java)
+            val rootSnapshot =
+                if (forceRootRefresh) {
+                    RootSnapshotCache.refresh()
+                } else {
+                    RootSnapshotCache.getOrLoad()
+                }
             val next =
                 withContext(Dispatchers.IO) {
-                    loadDashboardState(cm, context.applicationContext, selfNeedsRestart)
+                    loadDashboardState(cm, context.applicationContext, selfNeedsRestart, rootSnapshot)
                 }
             StartupTrace.mark("dashboard_state_loaded")
             _state.value = next
+            _error.value = null
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            StartupTrace.mark("dashboard_state_failed")
+            _error.value = e.message ?: e.javaClass.simpleName
+            VpnHideLog.w("VpnHide-Dashboard", "dashboard reload failed: ${e.message}", e)
         } finally {
             _loading.value = false
         }

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DashboardCache.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DashboardCache.kt
@@ -70,6 +70,7 @@ internal object DashboardCache {
                 withContext(Dispatchers.IO) {
                     loadDashboardState(cm, context.applicationContext, selfNeedsRestart)
                 }
+            StartupTrace.mark("dashboard_state_loaded")
             _state.value = next
         } finally {
             _loading.value = false

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DashboardData.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DashboardData.kt
@@ -619,7 +619,18 @@ internal fun loadDashboardState(
     fun detectLsposedFramework(): LsposedFramework {
         val out = shellSnapshot["lsposed_framework"].orEmpty()
         val props = parseProps(out)
-        val installed = props["installed"] == "1"
+        val probeOk = props["probe_ok"] == "1"
+        val installedValue = props["installed"]
+        val disabledValue = props["disabled"]
+        val malformed =
+            !probeOk ||
+                installedValue == null ||
+                (installedValue == "1" && disabledValue == null)
+        if (malformed) {
+            VpnHideLog.w(TAG, "lsposed framework probe returned malformed output: $out")
+            return LsposedFramework.NotInstalled
+        }
+        val installed = installedValue == "1"
         val disabled = props["disabled"] == "1"
         val framework =
             if (installed) {
@@ -629,19 +640,6 @@ internal fun loadDashboardState(
             }
         VpnHideLog.i(TAG, "lsposed framework: $framework (raw=$out)")
         return framework
-    }
-
-    fun isVpnActiveFromSnapshot(raw: String): Boolean {
-        val vpnIfaces = parseVpnIfaceStates(raw)
-        if (vpnIfaces.isEmpty()) {
-            VpnHideLog.d(TAG, "isVpnActive: no VPN interfaces found")
-            return false
-        }
-        return vpnIfaces.any { (iface, state) ->
-            val up = state == "unknown" || state == "up"
-            VpnHideLog.d(TAG, "isVpnActive: $iface operstate=$state up=$up")
-            up
-        }
     }
 
     // kmod

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DashboardData.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DashboardData.kt
@@ -5,6 +5,7 @@ import android.database.sqlite.SQLiteDatabase
 import android.net.ConnectivityManager
 import android.net.NetworkCapabilities
 import android.os.Build
+import android.util.Base64
 import android.util.Log
 import dev.okhsunrog.vpnhide.checks.CheckOutput
 import dev.okhsunrog.vpnhide.checks.CheckStatus
@@ -215,6 +216,76 @@ internal data class KmodLoadStatus(
 
 private const val TAG = "VpnHide-Dashboard"
 
+private const val DASHBOARD_SNAPSHOT_PREFIX = "__VPNHIDE_DASHBOARD_SECTION__:"
+
+private fun loadDashboardShellSnapshot(): Map<String, String> {
+    val script =
+        """
+        emit() {
+          NAME="${'$'}1"
+          shift
+          echo "$DASHBOARD_SNAPSHOT_PREFIX${'$'}NAME"
+          "$@" 2>/dev/null | base64 | tr -d '\n'
+          echo
+        }
+        emit_sh() {
+          NAME="${'$'}1"
+          shift
+          echo "$DASHBOARD_SNAPSHOT_PREFIX${'$'}NAME"
+          sh -c "${'$'}*" 2>/dev/null | base64 | tr -d '\n'
+          echo
+        }
+        emit kmod_prop cat $KMOD_MODULE_DIR/module.prop
+        emit zygisk_prop cat $ZYGISK_MODULE_DIR/module.prop
+        emit ports_prop cat $PORTS_MODULE_DIR/module.prop
+        emit kmod_targets cat $KMOD_TARGETS
+        emit zygisk_targets cat $ZYGISK_TARGETS
+        emit ports_observers cat $PORTS_OBSERVERS_FILE
+        emit lsposed_targets cat $LSPOSED_TARGETS
+        emit current_boot_id cat /proc/sys/kernel/random/boot_id
+        emit kmod_load_status cat $KMOD_LOAD_STATUS_FILE
+        emit kmod_load_dmesg cat $KMOD_LOAD_DMESG_FILE
+        emit kernel_release uname -r
+        emit hook_status cat ${HookEntry.HOOK_STATUS_FILE}
+        emit debug_logging cat /data/system/vpnhide_debug_logging
+        emit getenforce getenforce
+        emit pm_packages pm list packages -U --user all
+        emit_sh proc_exists '[ -f $PROC_TARGETS ] && echo 1 || echo 0'
+        emit_sh ports_chain 'iptables -L vpnhide_out -n >/dev/null 2>/dev/null && echo 1 || echo 0'
+        emit_sh lsposed_framework 'for id in zygisk_vector zygisk_lsposed lsposed; do for base in /data/adb/modules /data/adb/modules_update; do dir="${'$'}base/${'$'}id"; if [ -f "${'$'}dir/module.prop" ]; then echo installed=1; if [ -f "${'$'}dir/disable" ]; then echo disabled=1; else echo disabled=0; fi; exit 0; fi; done; done; echo installed=0'
+        emit_sh vpn_ifaces 'for iface in ${'$'}(ls /sys/class/net/ 2>/dev/null); do state="${'$'}(cat /sys/class/net/${'$'}iface/operstate 2>/dev/null)"; printf "%s=%s\n" "${'$'}iface" "${'$'}state"; done'
+        """.trimIndent()
+
+    val (exitCode, raw) = suExec(script)
+    if (exitCode != 0) {
+        VpnHideLog.w(TAG, "dashboard shell snapshot failed: exit=$exitCode out=${raw.trim()}")
+    }
+
+    val sections = linkedMapOf<String, String>()
+    var currentName: String? = null
+    raw.lineSequence().forEach { line ->
+        if (line.startsWith(DASHBOARD_SNAPSHOT_PREFIX)) {
+            currentName = line.removePrefix(DASHBOARD_SNAPSHOT_PREFIX)
+            return@forEach
+        }
+        val name = currentName ?: return@forEach
+        val decoded =
+            if (line.isBlank()) {
+                ""
+            } else {
+                runCatching {
+                    String(Base64.decode(line, Base64.DEFAULT))
+                }.getOrElse {
+                    VpnHideLog.w(TAG, "failed to decode dashboard snapshot section $name: ${it.message}")
+                    ""
+                }
+            }
+        sections[name] = decoded
+        currentName = null
+    }
+    return sections
+}
+
 internal fun parseKernelSeries(raw: String): String? = Regex("""\b(\d+\.\d+)""").find(raw)?.groupValues?.get(1)
 
 internal fun parseKernelAndroidBranch(raw: String): String? =
@@ -357,6 +428,7 @@ internal fun loadDashboardState(
     }
 
     VpnHideLog.i(TAG, "=== Loading dashboard state ===")
+    val shellSnapshot = loadDashboardShellSnapshot()
 
     // ── Module detection ──
     // Strip the `v` prefix from module.prop versions at parse time so
@@ -378,13 +450,12 @@ internal fun loadDashboardState(
     // without requiring a reinstall.
     val updateJsonKmiRegex = Regex("""update-kmod-([^/]+)\.json""")
 
-    fun parseModuleProp(dir: String): ModulePropInfo {
-        val (exitCode, out) = suExec("cat $dir/module.prop 2>/dev/null")
-        if (exitCode != 0 || out.isBlank()) return ModulePropInfo(false, null, null)
+    fun parseModuleProp(raw: String): ModulePropInfo {
+        if (raw.isBlank()) return ModulePropInfo(false, null, null)
         var version: String? = null
         var gkiVariant: String? = null
         var updateJsonKmi: String? = null
-        for (line in out.lines()) {
+        for (line in raw.lines()) {
             when {
                 line.startsWith("version=") -> {
                     version = normalizeVersion(line.removePrefix("version="))
@@ -406,13 +477,11 @@ internal fun loadDashboardState(
         return ModulePropInfo(true, version, gkiVariant ?: updateJsonKmi)
     }
 
-    fun countTargets(path: String): Int {
-        val (_, out) = suExec("cat $path 2>/dev/null || true")
-        return out.lines().count { line ->
+    fun countTargets(raw: String): Int =
+        raw.lines().count { line ->
             val trimmed = line.trim()
             trimmed.isNotEmpty() && !trimmed.startsWith("#") && trimmed != selfPkg
         }
-    }
 
     fun parseProps(raw: String): Map<String, String> =
         raw
@@ -479,13 +548,13 @@ internal fun loadDashboardState(
         return "Android $release"
     }
 
-    fun readKmodLoadStatus(currentBootId: String): KmodLoadStatus? {
-        val (exit, raw) = suExec("cat $KMOD_LOAD_STATUS_FILE 2>/dev/null")
-        if (exit != 0 || raw.isBlank()) return null
+    fun readKmodLoadStatus(
+        currentBootId: String,
+        raw: String,
+        dmesgRaw: String,
+    ): KmodLoadStatus? {
+        if (raw.isBlank()) return null
         val props = parseProps(raw)
-        // load_dmesg is a separate file because its content spans many
-        // lines and the key=value format can't carry them.
-        val (_, dmesgRaw) = suExec("cat $KMOD_LOAD_DMESG_FILE 2>/dev/null")
         val bootId = props["boot_id"]?.trim()
         return KmodLoadStatus(
             timestamp = props["timestamp"]?.trim()?.toLongOrNull(),
@@ -612,21 +681,9 @@ internal fun loadDashboardState(
     }
 
     fun detectLsposedFramework(): LsposedFramework {
-        // Known module directory names for LSPosed / LSPosed-Next / Vector
-        val knownIds = listOf("zygisk_vector", "zygisk_lsposed", "lsposed")
-        val checkScript =
-            knownIds
-                .flatMap { id ->
-                    listOf("/data/adb/modules/$id", "/data/adb/modules_update/$id")
-                }.joinToString("; ") { dir ->
-                    "if [ -f $dir/module.prop ]; then " +
-                        "echo installed=1; " +
-                        "echo disabled=\$([ -f $dir/disable ] && echo 1 || echo 0); " +
-                        "exit 0; fi"
-                } + "; echo installed=0"
-        val (exitCode, out) = suExec(checkScript)
+        val out = shellSnapshot["lsposed_framework"].orEmpty()
         val props = parseProps(out)
-        val installed = exitCode == 0 && props["installed"] == "1"
+        val installed = props["installed"] == "1"
         val disabled = props["disabled"] == "1"
         val framework =
             if (installed) {
@@ -638,11 +695,31 @@ internal fun loadDashboardState(
         return framework
     }
 
+    fun isVpnActiveFromSnapshot(raw: String): Boolean {
+        val vpnIfaces =
+            raw
+                .lineSequence()
+                .mapNotNull { line ->
+                    val parts = line.split("=", limit = 2)
+                    if (parts.size == 2) parts[0].trim() to parts[1].trim() else null
+                }.filter { (name, _) -> IfaceLists.isVpnIface(name) }
+                .toList()
+        if (vpnIfaces.isEmpty()) {
+            VpnHideLog.d(TAG, "isVpnActive: no VPN interfaces found")
+            return false
+        }
+        return vpnIfaces.any { (iface, state) ->
+            val up = state == "unknown" || state == "up"
+            VpnHideLog.d(TAG, "isVpnActive: $iface operstate=$state up=$up")
+            up
+        }
+    }
+
     // kmod
-    val kmodProp = parseModuleProp(KMOD_MODULE_DIR)
-    val (_, procExists) = suExec("[ -f $PROC_TARGETS ] && echo 1 || echo 0")
+    val kmodProp = parseModuleProp(shellSnapshot["kmod_prop"].orEmpty())
+    val procExists = shellSnapshot["proc_exists"].orEmpty()
     val kmodActive = kmodProp.installed && procExists.trim() == "1"
-    val kmodTargetCount = if (kmodProp.installed) countTargets(KMOD_TARGETS) else 0
+    val kmodTargetCount = if (kmodProp.installed) countTargets(shellSnapshot["kmod_targets"].orEmpty()) else 0
     // Built without brokenReason — populated below after kernelRecommendation
     // and kmodLoadStatus are ready.
     val kmodRaw: ModuleState =
@@ -659,7 +736,7 @@ internal fun loadDashboardState(
     VpnHideLog.i(TAG, "kmodRaw: $kmodRaw")
 
     // zygisk
-    val zygiskProp = parseModuleProp(ZYGISK_MODULE_DIR)
+    val zygiskProp = parseModuleProp(shellSnapshot["zygisk_prop"].orEmpty())
     val zygiskInstalled = zygiskProp.installed
     val zygiskVersion = zygiskProp.version
     val zygiskStatusFile = File(context.filesDir, ZYGISK_STATUS_FILE_NAME)
@@ -671,10 +748,10 @@ internal fun loadDashboardState(
             ""
         }
     val zygiskProps = parseProps(zygiskStatusRaw)
-    val (_, currentBootId) = suExec("cat /proc/sys/kernel/random/boot_id 2>/dev/null")
+    val currentBootId = shellSnapshot["current_boot_id"].orEmpty()
     val zygiskBootId = zygiskProps["boot_id"]
     val zygiskActive = zygiskInstalled && zygiskBootId != null && zygiskBootId == currentBootId.trim()
-    val zygiskTargetCount = if (zygiskInstalled) countTargets(ZYGISK_TARGETS) else 0
+    val zygiskTargetCount = if (zygiskInstalled) countTargets(shellSnapshot["zygisk_targets"].orEmpty()) else 0
     val zygisk: ModuleState =
         if (zygiskInstalled) {
             ModuleState.Installed(zygiskVersion, zygiskActive, zygiskTargetCount)
@@ -684,10 +761,10 @@ internal fun loadDashboardState(
     VpnHideLog.i(TAG, "zygisk: $zygisk (heartbeatBootId=$zygiskBootId currentBootId=${currentBootId.trim()})")
 
     // ports (iptables-based loopback blocker)
-    val portsProp = parseModuleProp(PORTS_MODULE_DIR)
+    val portsProp = parseModuleProp(shellSnapshot["ports_prop"].orEmpty())
     val portsObserverCount =
-        if (portsProp.installed) countTargets(PORTS_OBSERVERS_FILE) else 0
-    val (_, portsChainExists) = suExec("iptables -L vpnhide_out -n 2>/dev/null >/dev/null && echo 1 || echo 0")
+        if (portsProp.installed) countTargets(shellSnapshot["ports_observers"].orEmpty()) else 0
+    val portsChainExists = shellSnapshot["ports_chain"].orEmpty()
     val portsActive = portsProp.installed && portsChainExists.trim() == "1"
     val ports: ModuleState =
         if (portsProp.installed) {
@@ -700,9 +777,14 @@ internal fun loadDashboardState(
     // Recommendation based purely on the kernel — used by the install card,
     // the "kmod-capable kernel, only zygisk installed" warning (W1), and the
     // wrong-variant detection below.
-    val (_, kernelRaw) = suExec("uname -r 2>/dev/null")
+    val kernelRaw = shellSnapshot["kernel_release"].orEmpty()
     val kernelRecommendation = buildNativeInstallRecommendation(kernelRaw, androidMajorVersionLabel())
-    val kmodLoadStatus = readKmodLoadStatus(currentBootId.trim())
+    val kmodLoadStatus =
+        readKmodLoadStatus(
+            currentBootId.trim(),
+            shellSnapshot["kmod_load_status"].orEmpty(),
+            shellSnapshot["kmod_load_dmesg"].orEmpty(),
+        )
     VpnHideLog.i(TAG, "kmodLoadStatus=$kmodLoadStatus")
 
     // Decide whether to surface the install-recommendation card.
@@ -802,12 +884,12 @@ internal fun loadDashboardState(
     )
 
     // lsposed hook status
-    val (_, hookStatusRaw) = suExec("cat ${HookEntry.HOOK_STATUS_FILE} 2>/dev/null || true")
+    val hookStatusRaw = shellSnapshot["hook_status"].orEmpty()
     val hookProps = parseProps(hookStatusRaw)
     val hookVersion = hookProps["version"]
     val hookBootId = hookProps["boot_id"]
     val hooksActiveThisBoot = hookBootId != null && hookBootId == currentBootId.trim()
-    val lsposedTargetCount = countTargets(LSPOSED_TARGETS)
+    val lsposedTargetCount = countTargets(shellSnapshot["lsposed_targets"].orEmpty())
     val lsposedFramework = detectLsposedFramework()
     val lsposedConfig =
         when (lsposedFramework) {
@@ -988,15 +1070,15 @@ internal fun loadDashboardState(
     // to logcat that a forensic reader with root can see. The flag file is
     // written by the Diagnostics → Debug logging toggle; absent file ⇒
     // default off ⇒ no warning.
-    val (debugEnabledExit, debugEnabledRaw) = suExec("cat /data/system/vpnhide_debug_logging 2>/dev/null")
-    if (debugEnabledExit == 0 && debugEnabledRaw.trim() == "1") {
+    val debugEnabledRaw = shellSnapshot["debug_logging"].orEmpty()
+    if (debugEnabledRaw.trim() == "1") {
         warn(res.getString(R.string.dashboard_issue_debug_logging_on))
     }
 
     // W4: SELinux Permissive exposes six detection vectors we rely on SELinux
     // to block (RTM_GETROUTE, /proc/net/{tcp,tcp6,udp,udp6,dev,fib_trie},
     // /sys/class/net). See the coverage table in the top-level README.
-    val (_, getenforce) = suExec("getenforce 2>/dev/null")
+    val getenforce = shellSnapshot["getenforce"].orEmpty()
     if (getenforce.trim().equals("Permissive", ignoreCase = true)) {
         warn(res.getString(R.string.dashboard_issue_selinux_permissive))
     }
@@ -1009,11 +1091,7 @@ internal fun loadDashboardState(
     // drop them. Recommend uninstalling everywhere except the main profile.
     // Literal field match via awk — grep would treat dots in `selfPkg`
     // as regex wildcards.
-    val (_, selfPmRaw) =
-        suExec(
-            "pm list packages -U --user all 2>/dev/null | " +
-                "awk -v p=\"package:$selfPkg\" '\$1 == p'",
-        )
+    val selfPmRaw = shellSnapshot["pm_packages"].orEmpty()
     val selfUidCount =
         selfPmRaw
             .lines()
@@ -1103,7 +1181,7 @@ internal fun loadDashboardState(
     }
 
     // ── Protection checks ──
-    val vpnActive = isVpnActiveBlocking()
+    val vpnActive = isVpnActiveFromSnapshot(shellSnapshot["vpn_ifaces"].orEmpty())
     VpnHideLog.i(TAG, "vpnActive=$vpnActive selfNeedsRestart=$selfNeedsRestart")
 
     val protection: ProtectionCheck =

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DashboardData.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DashboardData.kt
@@ -5,7 +5,7 @@ import android.database.sqlite.SQLiteDatabase
 import android.net.ConnectivityManager
 import android.net.NetworkCapabilities
 import android.os.Build
-import android.util.Base64
+import android.os.SystemClock
 import android.util.Log
 import dev.okhsunrog.vpnhide.checks.CheckOutput
 import dev.okhsunrog.vpnhide.checks.CheckStatus
@@ -216,76 +216,6 @@ internal data class KmodLoadStatus(
 
 private const val TAG = "VpnHide-Dashboard"
 
-private const val DASHBOARD_SNAPSHOT_PREFIX = "__VPNHIDE_DASHBOARD_SECTION__:"
-
-private fun loadDashboardShellSnapshot(): Map<String, String> {
-    val script =
-        """
-        emit() {
-          NAME="${'$'}1"
-          shift
-          echo "$DASHBOARD_SNAPSHOT_PREFIX${'$'}NAME"
-          "$@" 2>/dev/null | base64 | tr -d '\n'
-          echo
-        }
-        emit_sh() {
-          NAME="${'$'}1"
-          shift
-          echo "$DASHBOARD_SNAPSHOT_PREFIX${'$'}NAME"
-          sh -c "${'$'}*" 2>/dev/null | base64 | tr -d '\n'
-          echo
-        }
-        emit kmod_prop cat $KMOD_MODULE_DIR/module.prop
-        emit zygisk_prop cat $ZYGISK_MODULE_DIR/module.prop
-        emit ports_prop cat $PORTS_MODULE_DIR/module.prop
-        emit kmod_targets cat $KMOD_TARGETS
-        emit zygisk_targets cat $ZYGISK_TARGETS
-        emit ports_observers cat $PORTS_OBSERVERS_FILE
-        emit lsposed_targets cat $LSPOSED_TARGETS
-        emit current_boot_id cat /proc/sys/kernel/random/boot_id
-        emit kmod_load_status cat $KMOD_LOAD_STATUS_FILE
-        emit kmod_load_dmesg cat $KMOD_LOAD_DMESG_FILE
-        emit kernel_release uname -r
-        emit hook_status cat ${HookEntry.HOOK_STATUS_FILE}
-        emit debug_logging cat /data/system/vpnhide_debug_logging
-        emit getenforce getenforce
-        emit pm_packages pm list packages -U --user all
-        emit_sh proc_exists '[ -f $PROC_TARGETS ] && echo 1 || echo 0'
-        emit_sh ports_chain 'iptables -L vpnhide_out -n >/dev/null 2>/dev/null && echo 1 || echo 0'
-        emit_sh lsposed_framework 'for id in zygisk_vector zygisk_lsposed lsposed; do for base in /data/adb/modules /data/adb/modules_update; do dir="${'$'}base/${'$'}id"; if [ -f "${'$'}dir/module.prop" ]; then echo installed=1; if [ -f "${'$'}dir/disable" ]; then echo disabled=1; else echo disabled=0; fi; exit 0; fi; done; done; echo installed=0'
-        emit_sh vpn_ifaces 'for iface in ${'$'}(ls /sys/class/net/ 2>/dev/null); do state="${'$'}(cat /sys/class/net/${'$'}iface/operstate 2>/dev/null)"; printf "%s=%s\n" "${'$'}iface" "${'$'}state"; done'
-        """.trimIndent()
-
-    val (exitCode, raw) = suExec(script)
-    if (exitCode != 0) {
-        VpnHideLog.w(TAG, "dashboard shell snapshot failed: exit=$exitCode out=${raw.trim()}")
-    }
-
-    val sections = linkedMapOf<String, String>()
-    var currentName: String? = null
-    raw.lineSequence().forEach { line ->
-        if (line.startsWith(DASHBOARD_SNAPSHOT_PREFIX)) {
-            currentName = line.removePrefix(DASHBOARD_SNAPSHOT_PREFIX)
-            return@forEach
-        }
-        val name = currentName ?: return@forEach
-        val decoded =
-            if (line.isBlank()) {
-                ""
-            } else {
-                runCatching {
-                    String(Base64.decode(line, Base64.DEFAULT))
-                }.getOrElse {
-                    VpnHideLog.w(TAG, "failed to decode dashboard snapshot section $name: ${it.message}")
-                    ""
-                }
-            }
-        sections[name] = decoded
-        currentName = null
-    }
-    return sections
-}
-
 internal fun parseKernelSeries(raw: String): String? = Regex("""\b(\d+\.\d+)""").find(raw)?.groupValues?.get(1)
 
 internal fun parseKernelAndroidBranch(raw: String): String? =
@@ -414,6 +344,7 @@ internal fun loadDashboardState(
     cm: ConnectivityManager,
     context: android.content.Context,
     selfNeedsRestart: Boolean,
+    rootSnapshot: RootSnapshot,
 ): DashboardState {
     val issues = mutableListOf<Issue>()
     val res = context.resources
@@ -428,7 +359,8 @@ internal fun loadDashboardState(
     }
 
     VpnHideLog.i(TAG, "=== Loading dashboard state ===")
-    val shellSnapshot = loadDashboardShellSnapshot()
+    StartupTrace.mark("dashboard_derive_start")
+    val shellSnapshot = rootSnapshot.sections
 
     // ── Module detection ──
     // Strip the `v` prefix from module.prop versions at parse time so
@@ -607,6 +539,7 @@ internal fun loadDashboardState(
         val walPath = dbWalCopy.absolutePath
         val shmPath = dbShmCopy.absolutePath
         val sourceBase = "/data/adb/lspd/config/modules_config.db"
+        val copyStart = SystemClock.elapsedRealtime()
         val (copyExit, copyOut) =
             suExec(
                 "cat $sourceBase > $dbPath && " +
@@ -615,12 +548,14 @@ internal fun loadDashboardState(
                     "(cat $sourceBase-shm > $shmPath 2>/dev/null && chmod 644 $shmPath || true) && " +
                     "ls -l $dbPath $walPath $shmPath 2>/dev/null || true",
             )
+        StartupTrace.metric("dashboard_lsposed_db_copy", SystemClock.elapsedRealtime() - copyStart)
         if (copyExit != 0 || !dbCopy.isFile) {
             VpnHideLog.w(TAG, "failed to copy LSPosed config db for inspection: exit=$copyExit out=$copyOut")
             return null
         }
         VpnHideLog.i(TAG, "lsposed db copy: ${copyOut.trim()}")
 
+        val queryStart = SystemClock.elapsedRealtime()
         return try {
             SQLiteDatabase.openDatabase(dbPath, null, SQLiteDatabase.OPEN_READONLY).use { db ->
                 db
@@ -674,6 +609,7 @@ internal fun loadDashboardState(
             VpnHideLog.w(TAG, "failed to inspect LSPosed config db: ${e.message}")
             null
         } finally {
+            StartupTrace.metric("dashboard_lsposed_db_query", SystemClock.elapsedRealtime() - queryStart)
             dbCopy.delete()
             dbWalCopy.delete()
             dbShmCopy.delete()
@@ -696,14 +632,7 @@ internal fun loadDashboardState(
     }
 
     fun isVpnActiveFromSnapshot(raw: String): Boolean {
-        val vpnIfaces =
-            raw
-                .lineSequence()
-                .mapNotNull { line ->
-                    val parts = line.split("=", limit = 2)
-                    if (parts.size == 2) parts[0].trim() to parts[1].trim() else null
-                }.filter { (name, _) -> IfaceLists.isVpnIface(name) }
-                .toList()
+        val vpnIfaces = parseVpnIfaceStates(raw)
         if (vpnIfaces.isEmpty()) {
             VpnHideLog.d(TAG, "isVpnActive: no VPN interfaces found")
             return false
@@ -773,6 +702,7 @@ internal fun loadDashboardState(
             ModuleState.NotInstalled
         }
     VpnHideLog.i(TAG, "ports: $ports")
+    StartupTrace.mark("dashboard_modules_done")
 
     // Recommendation based purely on the kernel — used by the install card,
     // the "kmod-capable kernel, only zygisk installed" warning (W1), and the
@@ -882,6 +812,7 @@ internal fun loadDashboardState(
             "(raw=$kernelRecommendation variantMismatch=$kmodVariantMismatch " +
             "unknownVariantBroken=$kmodUnknownVariantBroken)",
     )
+    StartupTrace.mark("dashboard_kernel_done")
 
     // lsposed hook status
     val hookStatusRaw = shellSnapshot["hook_status"].orEmpty()
@@ -892,19 +823,27 @@ internal fun loadDashboardState(
     val lsposedTargetCount = countTargets(shellSnapshot["lsposed_targets"].orEmpty())
     val lsposedFramework = detectLsposedFramework()
     val lsposedConfig =
-        when (lsposedFramework) {
-            LsposedFramework.NotInstalled -> {
-                LsposedConfig.ModuleNotConfigured
-            }
+        if (hooksActiveThisBoot) {
+            // A current-boot hook heartbeat is stronger evidence than the
+            // on-disk LSPosed DB: the module is active, and config warnings
+            // are intentionally suppressed for active hooks below.
+            null
+        } else {
+            when (lsposedFramework) {
+                LsposedFramework.NotInstalled -> {
+                    LsposedConfig.ModuleNotConfigured
+                }
 
-            is LsposedFramework.Installed -> {
-                if (lsposedFramework.disabled) {
-                    LsposedConfig.Disabled
-                } else {
-                    readLsposedConfig()
+                is LsposedFramework.Installed -> {
+                    if (lsposedFramework.disabled) {
+                        LsposedConfig.Disabled
+                    } else {
+                        readLsposedConfig()
+                    }
                 }
             }
         }
+    StartupTrace.mark("dashboard_lsposed_config_done")
     val lsposedRuntime: LsposedRuntime =
         if (hooksActiveThisBoot) {
             LsposedRuntime.Active(hookVersion)
@@ -949,6 +888,7 @@ internal fun loadDashboardState(
         TAG,
         "lsposed: $lsposed (hookBootId=$hookBootId currentBootId=${currentBootId.trim()} framework=$lsposedFramework runtime=$lsposedRuntime config=$lsposedConfig)",
     )
+    StartupTrace.mark("dashboard_lsposed_done")
 
     // ── Issues ──
     val hasNative = kmod is ModuleState.Installed || zygisk is ModuleState.Installed
@@ -1103,6 +1043,7 @@ internal fun loadDashboardState(
     if (selfUidCount > 1) {
         warn(res.getString(R.string.dashboard_issue_self_multi_profile, selfUidCount))
     }
+    StartupTrace.mark("dashboard_issues_done")
 
     // ── Errors: kmod variant / load problems ──
     // Priority ordered: kprobes-missing first (no variant will ever work),
@@ -1181,6 +1122,7 @@ internal fun loadDashboardState(
     }
 
     // ── Protection checks ──
+    StartupTrace.mark("dashboard_protection_start")
     val vpnActive = isVpnActiveFromSnapshot(shellSnapshot["vpn_ifaces"].orEmpty())
     VpnHideLog.i(TAG, "vpnActive=$vpnActive selfNeedsRestart=$selfNeedsRestart")
 
@@ -1216,6 +1158,7 @@ internal fun loadDashboardState(
         }
 
     VpnHideLog.i(TAG, "protection=$protection issues=$issues")
+    StartupTrace.mark("dashboard_protection_done")
     VpnHideLog.i(TAG, "=== Dashboard state loaded ===")
 
     return DashboardState(

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DashboardScreen.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DashboardScreen.kt
@@ -33,6 +33,7 @@ fun DashboardScreen(
     val scope = rememberCoroutineScope()
 
     val state by DashboardCache.state.collectAsState()
+    val loadError by DashboardCache.error.collectAsState()
     val updateInfo by UpdateCheckCache.info.collectAsState()
     var showChangelog by remember { mutableStateOf(false) }
     var changelogData by remember { mutableStateOf<ChangelogData?>(null) }
@@ -71,14 +72,6 @@ fun DashboardScreen(
     ) {
         Spacer(Modifier.height(12.dp))
 
-        val s = state
-        if (s == null) {
-            Box(Modifier.fillMaxWidth(), contentAlignment = Alignment.Center) {
-                CircularProgressIndicator()
-            }
-            return@Column
-        }
-
         // Pinned status palette — shared by the Protection status banners
         // (NeedsRestart) and the Errors / Warnings issue banners below.
         // Theme.colorScheme.{errorContainer,tertiaryContainer} get remixed
@@ -92,6 +85,35 @@ fun DashboardScreen(
         val warningBg = if (darkTheme) Color(0xFFE65100).copy(alpha = 0.2f) else Color(0xFFFFF3E0)
         val warningHeader = if (darkTheme) Color(0xFFFFB74D) else Color(0xFFE65100)
         val onBannerColor = MaterialTheme.colorScheme.onSurface
+
+        val s = state
+        val error = loadError
+        if (error != null) {
+            DashboardLoadErrorCard(
+                title = stringResource(R.string.dashboard_load_failed_title),
+                message =
+                    stringResource(
+                        if (s == null) {
+                            R.string.dashboard_load_failed_message
+                        } else {
+                            R.string.dashboard_refresh_failed_message
+                        },
+                    ),
+                containerColor = errorBg,
+                titleColor = errorHeader,
+                contentColor = onBannerColor,
+                onRetry = { DashboardCache.refresh(scope, context, selfNeedsRestart) },
+            )
+            Spacer(Modifier.height(12.dp))
+            if (s == null) return@Column
+        }
+
+        if (s == null) {
+            Box(Modifier.fillMaxWidth(), contentAlignment = Alignment.Center) {
+                CircularProgressIndicator()
+            }
+            return@Column
+        }
 
         // Module status cards
         Text(
@@ -600,6 +622,41 @@ private fun StatusBanner(
             color = contentColor,
             modifier = Modifier.padding(12.dp),
         )
+    }
+}
+
+@Composable
+private fun DashboardLoadErrorCard(
+    title: String,
+    message: String,
+    containerColor: Color,
+    titleColor: Color,
+    contentColor: Color,
+    onRetry: () -> Unit,
+) {
+    Card(
+        shape = RoundedCornerShape(8.dp),
+        colors = CardDefaults.cardColors(containerColor = containerColor),
+        modifier = Modifier.fillMaxWidth(),
+    ) {
+        Column(modifier = Modifier.padding(16.dp)) {
+            Text(
+                text = title,
+                style = MaterialTheme.typography.titleSmall,
+                fontWeight = FontWeight.Bold,
+                color = titleColor,
+            )
+            Spacer(Modifier.height(6.dp))
+            Text(
+                text = message,
+                style = MaterialTheme.typography.bodyMedium,
+                color = contentColor,
+            )
+            Spacer(Modifier.height(12.dp))
+            Button(onClick = onRetry) {
+                Text(stringResource(R.string.vpn_off_retry))
+            }
+        }
     }
 }
 

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DebugLoggingPrefs.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DebugLoggingPrefs.kt
@@ -54,6 +54,8 @@ internal fun setDebugLoggingEnabled(
         .putBoolean(KEY_DEBUG_LOGGING, enabled)
         .apply()
     applyDebugLoggingRuntime(enabled)
+    RootSnapshotCache.invalidate()
+    DashboardCache.invalidate()
 }
 
 /**

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DiagnosticsCache.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DiagnosticsCache.kt
@@ -102,9 +102,11 @@ internal object DiagnosticsCache {
     private suspend fun doRun(appContext: Context) {
         _state.value = State.Running
         try {
+            StartupTrace.mark("diagnostics_cache_start")
             val vpnActive = withContext(Dispatchers.IO) { isVpnActive() }
             if (!vpnActive) {
                 _state.value = State.VpnOff
+                StartupTrace.mark("diagnostics_cache_vpn_off")
                 return
             }
             val results =
@@ -113,12 +115,14 @@ internal object DiagnosticsCache {
                     runAllChecks(cm, appContext)
                 }
             _state.value = State.Ready(results)
+            StartupTrace.mark("diagnostics_cache_done")
         } catch (e: Exception) {
             // Failures leave us in VpnOff so the user sees the retry UI
             // rather than a frozen spinner. Real-world causes here are
             // transient (root dropped, shell exec failure) and a retry
             // usually works.
             _state.value = State.VpnOff
+            StartupTrace.mark("diagnostics_cache_failed")
             VpnHideLog.w("VpnHide-Diag", "runAllChecks failed: ${e.message}")
         }
     }

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DiagnosticsScreen.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DiagnosticsScreen.kt
@@ -77,7 +77,10 @@ internal data class CheckResults(
     val all get() = native + java
 }
 
-internal suspend fun isVpnActive(): Boolean = withContext(Dispatchers.IO) { isVpnActiveBlocking() }
+internal suspend fun isVpnActive(): Boolean {
+    val snapshot = RootSnapshotCache.getOrLoad()
+    return isVpnActiveFromSnapshot(snapshot.sections["vpn_ifaces"].orEmpty())
+}
 
 @Composable
 fun DiagnosticsScreen(

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/MainActivity.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/MainActivity.kt
@@ -2,6 +2,7 @@ package dev.okhsunrog.vpnhide
 
 import android.os.Bundle
 import androidx.activity.ComponentActivity
+import androidx.activity.compose.ReportDrawnWhen
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
 import androidx.compose.foundation.isSystemInDarkTheme
@@ -38,28 +39,32 @@ class MainActivity : ComponentActivity() {
     private val splashReady = AtomicBoolean(false)
 
     override fun onCreate(savedInstanceState: Bundle?) {
+        StartupTrace.mark("activity_on_create")
         installSplashScreen().setKeepOnScreenCondition { !splashReady.get() }
         enableEdgeToEdge()
         super.onCreate(savedInstanceState)
         // Load the user's debug-logging preference before anything else
         // runs so the first suExec + Dashboard reload honor it.
         VpnHideLog.init(applicationContext)
-        // Re-propagate the persisted flag to the on-disk sinks as a
-        // safety-net. Most reinstall scenarios are now covered by:
-        //   - the canonical /data/adb/vpnhide_zygisk/debug_logging file
-        //     surviving module reinstall (lives outside /data/adb/modules/),
-        //   - kmod's service.sh re-seeding /proc/vpnhide_debug at boot,
-        //   - zygisk's service.sh copying the canonical debug_logging
-        //     into the module dir at boot.
-        // The remaining gap is "user reinstalled a native module mid-
-        // session and didn't reboot before opening the app" — service.sh
-        // hasn't re-seeded the module-dir copy yet, so the next fork of
-        // a target app would default to OFF without this re-write.
-        // Cheap — one `su` roundtrip on a background dispatcher.
-        lifecycleScope.launch(Dispatchers.IO) {
-            applyDebugLoggingRuntime(VpnHideLog.enabled)
+        setContent {
+            VpnHideApp(
+                onDashboardReady = {
+                    if (splashReady.compareAndSet(false, true)) {
+                        StartupTrace.dashboardReady()
+                        // Re-propagate the persisted flag to the on-disk sinks as a
+                        // safety-net, but keep it off the cold-start critical path.
+                        lifecycleScope.launch(Dispatchers.IO) {
+                            applyDebugLoggingRuntime(VpnHideLog.enabled)
+                        }
+                    }
+                },
+                onRootDeniedReady = {
+                    if (splashReady.compareAndSet(false, true)) {
+                        StartupTrace.rootDeniedReady()
+                    }
+                },
+            )
         }
-        setContent { VpnHideApp(onReady = { splashReady.set(true) }) }
     }
 }
 
@@ -76,11 +81,14 @@ private fun checkRootAccess(): Boolean {
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun VpnHideApp(onReady: () -> Unit = {}) {
+fun VpnHideApp(
+    onDashboardReady: () -> Unit = {},
+    onRootDeniedReady: () -> Unit = {},
+) {
     val darkTheme = isSystemInDarkTheme()
+    val context = LocalContext.current
     val colorScheme =
         if (android.os.Build.VERSION.SDK_INT >= 31) {
-            val context = LocalContext.current
             if (darkTheme) dynamicDarkColorScheme(context) else dynamicLightColorScheme(context)
         } else {
             if (darkTheme) darkColorScheme() else lightColorScheme()
@@ -94,22 +102,22 @@ fun VpnHideApp(onReady: () -> Unit = {}) {
                 withContext(Dispatchers.IO) {
                     if (checkRootAccess()) RootState.Granted else RootState.Denied
                 }
+            StartupTrace.mark("root_check_done")
         }
 
         when (rootState) {
             // splash holds until root check completes
             null -> {
-                Unit
             }
 
             RootState.Denied -> {
                 // Drop splash — RootDeniedScreen has no async prerequisites.
-                LaunchedEffect(Unit) { onReady() }
+                LaunchedEffect(Unit) { onRootDeniedReady() }
                 RootDeniedScreen()
             }
 
             RootState.Granted -> {
-                MainScreen(onReady = onReady)
+                MainScreen(onReady = onDashboardReady)
             }
         }
     }
@@ -143,9 +151,11 @@ private fun MainScreen(onReady: () -> Unit = {}) {
     LaunchedEffect(Unit) {
         selfNeedsRestart =
             withContext(Dispatchers.IO) {
-                cleanupStaleZygiskStatus(context)
-                ensureSelfInTargets(context.packageName)
+                val preparation = ensureSelfInTargets(context.packageName)
+                cleanupStaleZygiskStatus(context, preparation.currentBootId)
+                preparation.selfNeedsRestart
             }
+        StartupTrace.mark("self_targets_done")
     }
 
     // Kick off both Protection caches as early as possible so tab
@@ -172,8 +182,14 @@ private fun MainScreen(onReady: () -> Unit = {}) {
     // selfNeedsRestart-null spinner → brief Dashboard state-null spinner
     // → content, with each spinner swap being visible flicker.
     val uiReady = selfNeedsRestart != null && dashboardState != null
+    var fullyDrawnReady by remember { mutableStateOf(false) }
+    ReportDrawnWhen { fullyDrawnReady }
     LaunchedEffect(uiReady) {
-        if (uiReady) onReady()
+        if (uiReady) {
+            withFrameNanos { }
+            fullyDrawnReady = true
+            onReady()
+        }
     }
 
     // Kick the update check once (silently) on first launch, and again

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/MainActivity.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/MainActivity.kt
@@ -137,6 +137,8 @@ private fun MainScreen(onReady: () -> Unit = {}) {
     val scope = rememberCoroutineScope()
     var currentTab by remember { mutableStateOf(Tab.Dashboard) }
     var selfNeedsRestart by remember { mutableStateOf<Boolean?>(null) }
+    var selfTargetError by remember { mutableStateOf<String?>(null) }
+    var selfTargetAttempt by remember { mutableIntStateOf(0) }
     var searchQuery by remember { mutableStateOf("") }
     var searchActive by remember { mutableStateOf(false) }
     var showSystem by remember { mutableStateOf(false) }
@@ -150,15 +152,26 @@ private fun MainScreen(onReady: () -> Unit = {}) {
     val rootSnapshot by RootSnapshotCache.snapshot.collectAsState()
     val refreshRestart = selfNeedsRestart ?: false
 
-    LaunchedEffect(Unit) {
+    LaunchedEffect(selfTargetAttempt) {
+        selfNeedsRestart = null
+        selfTargetError = null
         StartupTrace.mark("self_targets_start")
-        selfNeedsRestart =
+        val preparation =
             withContext(Dispatchers.IO) {
                 val preparation = ensureSelfInTargets(context.packageName)
-                cleanupStaleZygiskStatus(context, preparation.currentBootId)
-                preparation.selfNeedsRestart
+                if (preparation.rootAvailable) {
+                    RootSnapshotCache.seedPmPackages(preparation.pmPackages)
+                    cleanupStaleZygiskStatus(context, preparation.currentBootId)
+                }
+                preparation
             }
         StartupTrace.mark("self_targets_done")
+        if (preparation.rootAvailable) {
+            selfNeedsRestart = preparation.selfNeedsRestart
+        } else {
+            StartupTrace.mark("self_targets_failed")
+            selfTargetError = preparation.error ?: "root preparation failed"
+        }
     }
 
     // Start the app-scoped caches as soon as the self-target preparation
@@ -168,6 +181,7 @@ private fun MainScreen(onReady: () -> Unit = {}) {
     // prewarms during splash, but without racing the self-target root shell.
     LaunchedEffect(selfNeedsRestart) {
         val r = selfNeedsRestart ?: return@LaunchedEffect
+        if (selfTargetError != null) return@LaunchedEffect
         AppListCache.ensureLoaded(scope, context)
         DashboardCache.ensureLoaded(scope, context, r)
         if (!r) DiagnosticsCache.run(scope, context)
@@ -188,7 +202,9 @@ private fun MainScreen(onReady: () -> Unit = {}) {
     // with real content. Without this, the user sees splash → brief
     // selfNeedsRestart-null spinner → brief Dashboard state-null spinner
     // → content, with each spinner swap being visible flicker.
-    val uiReady = selfNeedsRestart != null && (dashboardState != null || dashboardError != null)
+    val uiReady =
+        selfTargetError != null ||
+            (selfNeedsRestart != null && (dashboardState != null || dashboardError != null))
     var fullyDrawnReady by remember { mutableStateOf(false) }
     ReportDrawnWhen { fullyDrawnReady }
     LaunchedEffect(uiReady) {
@@ -395,7 +411,13 @@ private fun MainScreen(onReady: () -> Unit = {}) {
         },
     ) { innerPadding ->
         val restart = selfNeedsRestart
-        if (restart == null) {
+        val preparationError = selfTargetError
+        if (preparationError != null) {
+            RootPreparationErrorScreen(
+                modifier = Modifier.padding(innerPadding),
+                onRetry = { selfTargetAttempt += 1 },
+            )
+        } else if (restart == null) {
             Box(
                 modifier = Modifier.fillMaxSize().padding(innerPadding),
                 contentAlignment = Alignment.Center,
@@ -425,6 +447,50 @@ private fun MainScreen(onReady: () -> Unit = {}) {
                         selfNeedsRestart = restart,
                         modifier = Modifier.padding(innerPadding),
                     )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun RootPreparationErrorScreen(
+    onRetry: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Box(
+        modifier =
+            modifier
+                .fillMaxSize()
+                .padding(24.dp),
+        contentAlignment = Alignment.Center,
+    ) {
+        Card(
+            colors =
+                CardDefaults.cardColors(
+                    containerColor = MaterialTheme.colorScheme.errorContainer,
+                    contentColor = MaterialTheme.colorScheme.onErrorContainer,
+                ),
+        ) {
+            Column(
+                modifier = Modifier.padding(24.dp),
+                horizontalAlignment = Alignment.CenterHorizontally,
+            ) {
+                Text(
+                    text = stringResource(R.string.self_targets_error_title),
+                    style = MaterialTheme.typography.titleMedium,
+                    fontWeight = FontWeight.Bold,
+                    textAlign = TextAlign.Center,
+                )
+                Spacer(Modifier.height(12.dp))
+                Text(
+                    text = stringResource(R.string.self_targets_error_message),
+                    style = MaterialTheme.typography.bodyMedium,
+                    textAlign = TextAlign.Center,
+                )
+                Spacer(Modifier.height(16.dp))
+                Button(onClick = onRetry) {
+                    Text(stringResource(R.string.vpn_off_retry))
                 }
             }
         }

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/MainActivity.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/MainActivity.kt
@@ -146,9 +146,12 @@ private fun MainScreen(onReady: () -> Unit = {}) {
     val targetsLoading by TargetsCache.loading.collectAsState()
     val dashboardLoading by DashboardCache.loading.collectAsState()
     val dashboardState by DashboardCache.state.collectAsState()
+    val dashboardError by DashboardCache.error.collectAsState()
+    val rootSnapshot by RootSnapshotCache.snapshot.collectAsState()
     val refreshRestart = selfNeedsRestart ?: false
 
     LaunchedEffect(Unit) {
+        StartupTrace.mark("self_targets_start")
         selfNeedsRestart =
             withContext(Dispatchers.IO) {
                 val preparation = ensureSelfInTargets(context.packageName)
@@ -158,30 +161,34 @@ private fun MainScreen(onReady: () -> Unit = {}) {
         StartupTrace.mark("self_targets_done")
     }
 
-    // Kick off both Protection caches as early as possible so tab
-    // switches into Protection render instantly instead of paying the
-    // per-screen pm + icon + root-shell cost each time.
-    LaunchedEffect(Unit) {
-        AppListCache.ensureLoaded(scope, context)
-        TargetsCache.ensureLoaded(scope, context)
-    }
-
-    // Pre-warm Dashboard (needed for first frame) and Diagnostics (needed
-    // when user switches to Diagnostics tab) as soon as selfNeedsRestart
-    // is resolved. Dashboard prewarm here — not in DashboardScreen's own
-    // LaunchedEffect — so it runs while the splash is still held, not
-    // only after MainScreen has rendered.
+    // Start the app-scoped caches as soon as the self-target preparation
+    // is resolved. Keep that preparation first: it mutates the target files
+    // and determines whether this app process needs a restart, so Dashboard
+    // must not derive protection state from a stale answer. Protection still
+    // prewarms during splash, but without racing the self-target root shell.
     LaunchedEffect(selfNeedsRestart) {
         val r = selfNeedsRestart ?: return@LaunchedEffect
+        AppListCache.ensureLoaded(scope, context)
         DashboardCache.ensureLoaded(scope, context, r)
         if (!r) DiagnosticsCache.run(scope, context)
+    }
+
+    // Protection depends on the same root snapshot as Dashboard. Let
+    // Dashboard own the initial root snapshot so a transient shell timeout
+    // cannot make startup immediately do a second expensive retry. As soon
+    // as that shared snapshot exists, TargetsCache parses it from memory and
+    // Protection is still prewarmed before a normal tab switch.
+    LaunchedEffect(selfNeedsRestart, rootSnapshot) {
+        if (selfNeedsRestart != null && rootSnapshot != null) {
+            TargetsCache.ensureLoaded(scope, context)
+        }
     }
 
     // Hold the splash screen until the first Dashboard frame can render
     // with real content. Without this, the user sees splash → brief
     // selfNeedsRestart-null spinner → brief Dashboard state-null spinner
     // → content, with each spinner swap being visible flicker.
-    val uiReady = selfNeedsRestart != null && dashboardState != null
+    val uiReady = selfNeedsRestart != null && (dashboardState != null || dashboardError != null)
     var fullyDrawnReady by remember { mutableStateOf(false) }
     ReportDrawnWhen { fullyDrawnReady }
     LaunchedEffect(uiReady) {

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/PortsHidingScreen.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/PortsHidingScreen.kt
@@ -87,6 +87,7 @@ fun PortsHidingScreen(
     val cachedApps by AppListCache.apps.collectAsState()
     val userNames by AppListCache.userNames.collectAsState()
     val targets by TargetsCache.snapshot.collectAsState()
+    val targetsError by TargetsCache.error.collectAsState()
 
     var allApps by remember { mutableStateOf<List<PortsEntry>>(emptyList()) }
     var saving by remember { mutableStateOf(false) }
@@ -106,6 +107,14 @@ fun PortsHidingScreen(
 
     LaunchedEffect(Unit) {
         TargetsCache.ensureLoaded(scope, context)
+    }
+
+    if (targetsError != null && targets == null) {
+        TargetsLoadErrorCard(
+            onRetry = { TargetsCache.refresh(scope, context) },
+            modifier = modifier,
+        )
+        return
     }
 
     // While `dirty` is true the user has unsaved checkbox edits — don't

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/RootSnapshotCache.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/RootSnapshotCache.kt
@@ -1,0 +1,293 @@
+package dev.okhsunrog.vpnhide
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.withContext
+
+internal data class RootSnapshot(
+    val generation: Long,
+    val sections: Map<String, String>,
+)
+
+internal class RootSnapshotException(
+    message: String,
+) : RuntimeException(message)
+
+private const val ROOT_SNAPSHOT_BEGIN_PREFIX = "__VPNHIDE_ROOT_SECTION_BEGIN__:"
+private const val ROOT_SNAPSHOT_END_PREFIX = "__VPNHIDE_ROOT_SECTION_END__:"
+private const val ROOT_TIMING_PREFIX = "__VPNHIDE_ROOT_TIMING__:"
+private const val ROOT_SNAPSHOT_TIMEOUT_SEC: Long = 5
+
+internal val REQUIRED_ROOT_SNAPSHOT_SECTIONS =
+    setOf(
+        "kmod_prop",
+        "zygisk_prop",
+        "ports_prop",
+        "kmod_module_dir",
+        "zygisk_module_dir",
+        "kmod_targets",
+        "zygisk_targets",
+        "lsposed_targets",
+        "hidden_pkgs",
+        "observer_uids",
+        "ports_observers",
+        "current_boot_id",
+        "kmod_load_status",
+        "kmod_load_dmesg",
+        "kernel_release",
+        "hook_status",
+        "debug_logging",
+        "getenforce",
+        "pm_packages",
+        "proc_exists",
+        "ports_chain",
+        "lsposed_framework",
+        "vpn_ifaces",
+    )
+
+/**
+ * Single in-process source for root-owned/system state. Dashboard and
+ * Protection derive different UI models from the same generation so their
+ * counts/statuses cannot drift because two independent shell snapshots raced.
+ */
+internal object RootSnapshotCache {
+    private val _snapshot = MutableStateFlow<RootSnapshot?>(null)
+    val snapshot: StateFlow<RootSnapshot?> = _snapshot.asStateFlow()
+
+    private val _loading = MutableStateFlow(false)
+    val loading: StateFlow<Boolean> = _loading.asStateFlow()
+
+    private val mutex = Mutex()
+    private var nextGeneration = 1L
+
+    suspend fun getOrLoad(): RootSnapshot =
+        withContext(Dispatchers.IO) {
+            _snapshot.value?.let { return@withContext it }
+            mutex.withLock {
+                _snapshot.value ?: loadLocked()
+            }
+        }
+
+    suspend fun refresh(): RootSnapshot =
+        withContext(Dispatchers.IO) {
+            mutex.withLock {
+                _snapshot.value = null
+                loadLocked()
+            }
+        }
+
+    fun invalidate() {
+        _snapshot.value = null
+    }
+
+    private fun loadLocked(): RootSnapshot {
+        _loading.value = true
+        return try {
+            StartupTrace.mark("root_snapshot_start")
+            val sections = loadRootShellSnapshot()
+            val snapshot = RootSnapshot(nextGeneration++, sections)
+            _snapshot.value = snapshot
+            StartupTrace.mark("root_snapshot_done")
+            snapshot
+        } catch (e: Exception) {
+            StartupTrace.mark("root_snapshot_failed")
+            throw e
+        } finally {
+            _loading.value = false
+        }
+    }
+}
+
+private fun loadRootShellSnapshot(): Map<String, String> {
+    val (exitCode, raw) = suExec(buildRootShellSnapshotCommand(), timeoutSec = ROOT_SNAPSHOT_TIMEOUT_SEC)
+    if (exitCode != 0) {
+        throw RootSnapshotException("root snapshot command failed with exit=$exitCode")
+    }
+    val sections = parseRootShellSnapshot(raw)
+    validateRootSnapshotSections(sections)
+    return sections
+}
+
+internal fun validateRootSnapshotSections(sections: Map<String, String>) {
+    val missing = REQUIRED_ROOT_SNAPSHOT_SECTIONS.filterNot(sections::containsKey)
+    if (missing.isNotEmpty()) {
+        throw RootSnapshotException("root snapshot incomplete, missing sections: ${missing.joinToString()}")
+    }
+}
+
+internal fun buildRootShellSnapshotCommand(): String =
+    """
+    emit_cmd() {
+      NAME="${'$'}1"
+      shift
+      echo "$ROOT_SNAPSHOT_BEGIN_PREFIX${'$'}NAME"
+      "$@" 2>/dev/null || true
+      echo "$ROOT_SNAPSHOT_END_PREFIX${'$'}NAME"
+    }
+    emit_file() {
+      NAME="${'$'}1"
+      PATH_TO_READ="${'$'}2"
+      echo "$ROOT_SNAPSHOT_BEGIN_PREFIX${'$'}NAME"
+      if [ -f "${'$'}PATH_TO_READ" ]; then
+        cat "${'$'}PATH_TO_READ" 2>/dev/null || true
+      fi
+      echo "$ROOT_SNAPSHOT_END_PREFIX${'$'}NAME"
+    }
+    emit_eval() {
+      NAME="${'$'}1"
+      shift
+      echo "$ROOT_SNAPSHOT_BEGIN_PREFIX${'$'}NAME"
+      eval "${'$'}*" 2>/dev/null || true
+      echo "$ROOT_SNAPSHOT_END_PREFIX${'$'}NAME"
+    }
+    now_ms() {
+      if [ -n "${'$'}{EPOCHREALTIME:-}" ]; then
+        SEC="${'$'}{EPOCHREALTIME%.*}"
+        FRAC="${'$'}{EPOCHREALTIME#*.}"
+      else
+        IFS=' .' read -r SEC FRAC _ < /proc/uptime
+      fi
+      FRAC="${'$'}{FRAC}000"
+      FRAC="${'$'}{FRAC%${'$'}{FRAC#???}}"
+      while [ -n "${'$'}FRAC" ] && [ "${'$'}{FRAC#0}" != "${'$'}FRAC" ]; do
+        FRAC="${'$'}{FRAC#0}"
+      done
+      [ -n "${'$'}FRAC" ] || FRAC=0
+      case "${'$'}SEC${'$'}FRAC" in
+        ''|*[!0-9]*) echo 0 ;;
+        *) echo ${'$'}((SEC * 1000 + FRAC)) ;;
+      esac
+    }
+    phase_start() {
+      PHASE_NAME="${'$'}1"
+      PHASE_START="${'$'}(now_ms)"
+    }
+    phase_end() {
+      END="${'$'}(now_ms)"
+      echo "$ROOT_TIMING_PREFIX${'$'}PHASE_NAME=${'$'}((END - PHASE_START))"
+    }
+    phase_module_props() {
+      phase_start module_props
+      emit_file kmod_prop $KMOD_MODULE_DIR/module.prop
+      emit_file zygisk_prop $ZYGISK_MODULE_DIR/module.prop
+      emit_file ports_prop $PORTS_MODULE_DIR/module.prop
+      emit_eval kmod_module_dir '[ -d $KMOD_MODULE_DIR ] && echo 1 || echo 0'
+      emit_eval zygisk_module_dir '[ -d $ZYGISK_MODULE_DIR ] && echo 1 || echo 0'
+      phase_end
+    }
+    phase_target_files() {
+      phase_start target_files
+      emit_file kmod_targets $KMOD_TARGETS
+      emit_file zygisk_targets $ZYGISK_TARGETS
+      emit_file lsposed_targets $LSPOSED_TARGETS
+      emit_file hidden_pkgs $SS_HIDDEN_PKGS_FILE
+      emit_file observer_uids $SS_OBSERVER_UIDS_FILE
+      emit_file ports_observers $PORTS_OBSERVERS_FILE
+      phase_end
+    }
+    phase_kmod_status_files() {
+      phase_start kmod_status_files
+      emit_file current_boot_id /proc/sys/kernel/random/boot_id
+      emit_file kmod_load_status $KMOD_LOAD_STATUS_FILE
+      emit_file kmod_load_dmesg $KMOD_LOAD_DMESG_FILE
+      phase_end
+    }
+    phase_runtime_status_files() {
+      phase_start runtime_status_files
+      emit_cmd kernel_release uname -r
+      emit_file hook_status ${HookEntry.HOOK_STATUS_FILE}
+      emit_file debug_logging /data/system/vpnhide_debug_logging
+      emit_cmd getenforce getenforce
+      phase_end
+    }
+    phase_pm_packages() {
+      phase_start pm_packages
+      emit_cmd pm_packages pm list packages -U --user all
+      phase_end
+    }
+    phase_proc_exists() {
+      phase_start shell_probe_proc_exists
+      emit_eval proc_exists '[ -f $PROC_TARGETS ] && echo 1 || echo 0'
+      phase_end
+    }
+    phase_ports_chain() {
+      phase_start shell_probe_ports_chain
+      emit_eval ports_chain 'iptables -L vpnhide_out -n >/dev/null 2>/dev/null && echo 1 || echo 0'
+      phase_end
+    }
+    phase_lsposed_framework() {
+      phase_start shell_probe_lsposed_framework
+      emit_eval lsposed_framework 'FOUND=0; for id in zygisk_vector zygisk_lsposed lsposed; do for base in /data/adb/modules /data/adb/modules_update; do dir="${'$'}base/${'$'}id"; if [ -f "${'$'}dir/module.prop" ]; then echo installed=1; if [ -f "${'$'}dir/disable" ]; then echo disabled=1; else echo disabled=0; fi; FOUND=1; break 2; fi; done; done; [ "${'$'}FOUND" = 1 ] || echo installed=0'
+      phase_end
+    }
+    phase_vpn_ifaces() {
+      phase_start shell_probe_vpn_ifaces
+      emit_cmd vpn_ifaces grep -H . /sys/class/net/*/operstate
+      phase_end
+    }
+    run_all_phases_sequential() {
+      phase_module_props
+      phase_target_files
+      phase_kmod_status_files
+      phase_runtime_status_files
+      phase_pm_packages
+      phase_proc_exists
+      phase_ports_chain
+      phase_lsposed_framework
+      phase_vpn_ifaces
+    }
+    run_all_phases_sequential
+    """.trimIndent()
+
+internal fun parseRootShellSnapshot(
+    raw: String,
+    recordMetric: (String, Long) -> Unit = StartupTrace::metric,
+): Map<String, String> {
+    val sections = linkedMapOf<String, String>()
+    var currentName: String? = null
+    val currentBody = StringBuilder()
+
+    fun finishSection(name: String) {
+        sections[name] = currentBody.toString()
+        currentBody.clear()
+        currentName = null
+    }
+
+    raw.lineSequence().forEach { line ->
+        if (line.startsWith(ROOT_TIMING_PREFIX)) {
+            val body = line.removePrefix(ROOT_TIMING_PREFIX)
+            val parts = body.split("=", limit = 2)
+            val name = parts.getOrNull(0)?.trim().orEmpty()
+            val durationMs = parts.getOrNull(1)?.trim()?.toLongOrNull()
+            if (name.isNotEmpty() && durationMs != null) {
+                recordMetric("root_shell_$name", durationMs)
+            }
+            return@forEach
+        }
+        if (line.startsWith(ROOT_SNAPSHOT_BEGIN_PREFIX)) {
+            currentName = line.removePrefix(ROOT_SNAPSHOT_BEGIN_PREFIX)
+            currentBody.clear()
+            return@forEach
+        }
+        if (line.startsWith(ROOT_SNAPSHOT_END_PREFIX)) {
+            val endName = line.removePrefix(ROOT_SNAPSHOT_END_PREFIX)
+            val name =
+                currentName?.takeIf { it == endName } ?: run {
+                    currentBody.clear()
+                    currentName = null
+                    return@forEach
+                }
+            finishSection(name)
+            return@forEach
+        }
+        if (currentName != null) {
+            if (currentBody.isNotEmpty()) currentBody.append('\n')
+            currentBody.append(line)
+        }
+    }
+    return sections
+}

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/RootSnapshotCache.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/RootSnapshotCache.kt
@@ -9,7 +9,6 @@ import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
 
 internal data class RootSnapshot(
-    val generation: Long,
     val sections: Map<String, String>,
 )
 
@@ -51,8 +50,9 @@ internal val REQUIRED_ROOT_SNAPSHOT_SECTIONS =
 
 /**
  * Single in-process source for root-owned/system state. Dashboard and
- * Protection derive different UI models from the same generation so their
- * counts/statuses cannot drift because two independent shell snapshots raced.
+ * Protection derive different UI models from the same cached snapshot, so
+ * their counts/statuses cannot drift because two independent shell snapshots
+ * raced.
  */
 internal object RootSnapshotCache {
     private val _snapshot = MutableStateFlow<RootSnapshot?>(null)
@@ -62,7 +62,7 @@ internal object RootSnapshotCache {
     val loading: StateFlow<Boolean> = _loading.asStateFlow()
 
     private val mutex = Mutex()
-    private var nextGeneration = 1L
+    private var preloadedPmPackages: String? = null
 
     suspend fun getOrLoad(): RootSnapshot =
         withContext(Dispatchers.IO) {
@@ -75,21 +75,28 @@ internal object RootSnapshotCache {
     suspend fun refresh(): RootSnapshot =
         withContext(Dispatchers.IO) {
             mutex.withLock {
-                _snapshot.value = null
+                preloadedPmPackages = null
                 loadLocked()
             }
         }
 
     fun invalidate() {
         _snapshot.value = null
+        preloadedPmPackages = null
+    }
+
+    fun seedPmPackages(pmPackages: String?) {
+        preloadedPmPackages = pmPackages?.trimEnd()?.takeIf { it.isNotBlank() }
     }
 
     private fun loadLocked(): RootSnapshot {
         _loading.value = true
         return try {
             StartupTrace.mark("root_snapshot_start")
-            val sections = loadRootShellSnapshot()
-            val snapshot = RootSnapshot(nextGeneration++, sections)
+            val pmPackages = preloadedPmPackages
+            preloadedPmPackages = null
+            val sections = loadRootShellSnapshot(pmPackagesOverride = pmPackages)
+            val snapshot = RootSnapshot(sections)
             _snapshot.value = snapshot
             StartupTrace.mark("root_snapshot_done")
             snapshot
@@ -102,12 +109,19 @@ internal object RootSnapshotCache {
     }
 }
 
-private fun loadRootShellSnapshot(): Map<String, String> {
-    val (exitCode, raw) = suExec(buildRootShellSnapshotCommand(), timeoutSec = ROOT_SNAPSHOT_TIMEOUT_SEC)
+private fun loadRootShellSnapshot(pmPackagesOverride: String?): Map<String, String> {
+    val (exitCode, raw) =
+        suExec(
+            buildRootShellSnapshotCommand(includePmPackages = pmPackagesOverride == null),
+            timeoutSec = ROOT_SNAPSHOT_TIMEOUT_SEC,
+        )
     if (exitCode != 0) {
         throw RootSnapshotException("root snapshot command failed with exit=$exitCode")
     }
-    val sections = parseRootShellSnapshot(raw)
+    val sections = parseRootShellSnapshot(raw).toMutableMap()
+    if (pmPackagesOverride != null) {
+        sections["pm_packages"] = pmPackagesOverride
+    }
     validateRootSnapshotSections(sections)
     return sections
 }
@@ -119,7 +133,7 @@ internal fun validateRootSnapshotSections(sections: Map<String, String>) {
     }
 }
 
-internal fun buildRootShellSnapshotCommand(): String =
+internal fun buildRootShellSnapshotCommand(includePmPackages: Boolean = true): String =
     """
     emit_cmd() {
       NAME="${'$'}1"
@@ -204,11 +218,7 @@ internal fun buildRootShellSnapshotCommand(): String =
       emit_cmd getenforce getenforce
       phase_end
     }
-    phase_pm_packages() {
-      phase_start pm_packages
-      emit_cmd pm_packages pm list packages -U --user all
-      phase_end
-    }
+    __VPNHIDE_PM_PACKAGES_FUNCTION__
     phase_proc_exists() {
       phase_start shell_probe_proc_exists
       emit_eval proc_exists '[ -f $PROC_TARGETS ] && echo 1 || echo 0'
@@ -221,7 +231,7 @@ internal fun buildRootShellSnapshotCommand(): String =
     }
     phase_lsposed_framework() {
       phase_start shell_probe_lsposed_framework
-      emit_eval lsposed_framework 'FOUND=0; for id in zygisk_vector zygisk_lsposed lsposed; do for base in /data/adb/modules /data/adb/modules_update; do dir="${'$'}base/${'$'}id"; if [ -f "${'$'}dir/module.prop" ]; then echo installed=1; if [ -f "${'$'}dir/disable" ]; then echo disabled=1; else echo disabled=0; fi; FOUND=1; break 2; fi; done; done; [ "${'$'}FOUND" = 1 ] || echo installed=0'
+      emit_eval lsposed_framework 'FOUND=0; for id in zygisk_vector zygisk_lsposed lsposed; do for base in /data/adb/modules /data/adb/modules_update; do dir="${'$'}base/${'$'}id"; if [ -f "${'$'}dir/module.prop" ]; then echo installed=1; if [ -f "${'$'}dir/disable" ]; then echo disabled=1; else echo disabled=0; fi; FOUND=1; break 2; fi; done; done; [ "${'$'}FOUND" = 1 ] || echo installed=0; echo probe_ok=1'
       phase_end
     }
     phase_vpn_ifaces() {
@@ -234,7 +244,7 @@ internal fun buildRootShellSnapshotCommand(): String =
       phase_target_files
       phase_kmod_status_files
       phase_runtime_status_files
-      phase_pm_packages
+      __VPNHIDE_PM_PACKAGES_PHASE__
       phase_proc_exists
       phase_ports_chain
       phase_lsposed_framework
@@ -242,6 +252,23 @@ internal fun buildRootShellSnapshotCommand(): String =
     }
     run_all_phases_sequential
     """.trimIndent()
+        .replace(
+            "__VPNHIDE_PM_PACKAGES_FUNCTION__",
+            if (includePmPackages) {
+                """
+                phase_pm_packages() {
+                  phase_start pm_packages
+                  emit_cmd pm_packages pm list packages -U --user all
+                  phase_end
+                }
+                """.trimIndent()
+            } else {
+                ""
+            },
+        ).replace(
+            "__VPNHIDE_PM_PACKAGES_PHASE__",
+            if (includePmPackages) "phase_pm_packages" else ":",
+        )
 
 internal fun parseRootShellSnapshot(
     raw: String,

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/ShellCommandBuilders.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/ShellCommandBuilders.kt
@@ -1,5 +1,8 @@
 package dev.okhsunrog.vpnhide
 
+internal const val SELF_PM_PACKAGES_BEGIN = "__VPNHIDE_SELF_PM_PACKAGES_BEGIN__"
+internal const val SELF_PM_PACKAGES_END = "__VPNHIDE_SELF_PM_PACKAGES_END__"
+
 internal fun buildPackageUidsExpression(
     packageName: String,
     outputVariable: String,
@@ -68,6 +71,9 @@ internal fun buildEnsureSelfInTargetsCommand(selfPkg: String): String =
         append("; ensure_line $LSPOSED_TARGETS '' 644 0 1")
         append("; ensure_line $SS_HIDDEN_PKGS_FILE '' 640 1 0")
         append("; ALL_PKGS=\"\$(pm list packages -U --user all 2>/dev/null)\"")
+        append("; echo $SELF_PM_PACKAGES_BEGIN")
+        append("; printf '%s\\n' \"\$ALL_PKGS\"")
+        append("; echo $SELF_PM_PACKAGES_END")
         append("; ")
         append(buildPackageUidsExpression(selfPkg, "SELF_UIDS"))
         append("; if [ -n \"\$SELF_UIDS\" ]; then")

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/ShellCommandBuilders.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/ShellCommandBuilders.kt
@@ -25,3 +25,65 @@ internal fun buildUidResolverCommand(
         append("; if [ -n \"\$UIDS\" ]; then echo \"\$UIDS\" > $outputFile 2>/dev/null")
         append("; else echo > $outputFile 2>/dev/null; fi")
     }
+
+internal fun buildEnsureSelfInTargetsCommand(selfPkg: String): String =
+    buildString {
+        append("SELF_PKG=\"")
+        append(selfPkg)
+        append("\"")
+        append("; ADDED=0")
+        append(
+            """
+            ; ensure_line() {
+              PATH_TO_UPDATE="${'$'}1"
+              REQUIRED_DIR="${'$'}2"
+              MODE="${'$'}3"
+              SYSTEM_FILE="${'$'}4"
+              COUNTS_RESTART="${'$'}5"
+              if [ -n "${'$'}REQUIRED_DIR" ] && [ ! -d "${'$'}REQUIRED_DIR" ]; then
+                return
+              fi
+              EXISTING="${'$'}(cat "${'$'}PATH_TO_UPDATE" 2>/dev/null | sed 's/\r${'$'}//' | awk 'NF && ${'$'}1 !~ /^#/ { print }')"
+              if printf '%s\n' "${'$'}EXISTING" | awk -v p="${'$'}SELF_PKG" '${'$'}0 == p { found=1 } END { exit found ? 0 : 1 }'; then
+                return
+              fi
+              BODY="${'$'}(printf '%s\n%s\n' "${'$'}EXISTING" "${'$'}SELF_PKG" | awk 'NF { print }' | sort -u)"
+              { printf '# Managed by VPN Hide app\n'; printf '%s\n' "${'$'}BODY"; } > "${'$'}PATH_TO_UPDATE"
+              chmod "${'$'}MODE" "${'$'}PATH_TO_UPDATE"
+              if [ "${'$'}SYSTEM_FILE" = 1 ]; then
+                chown root:system "${'$'}PATH_TO_UPDATE"
+                chcon u:object_r:system_data_file:s0 "${'$'}PATH_TO_UPDATE" 2>/dev/null || true
+              fi
+              if [ "${'$'}COUNTS_RESTART" = 1 ]; then
+                ADDED=1
+              fi
+              echo "added:${'$'}PATH_TO_UPDATE"
+            }
+            """.trimIndent().replace("\n", " "),
+        )
+        append("; ensure_line $KMOD_TARGETS /data/adb/vpnhide_kmod 644 0 1")
+        append("; ensure_line $ZYGISK_TARGETS /data/adb/vpnhide_zygisk 644 0 1")
+        append("; if [ -d $ZYGISK_MODULE_DIR ]; then cp $ZYGISK_TARGETS $ZYGISK_MODULE_TARGETS 2>&1 || echo zygisk_cp_failed; fi")
+        append("; mkdir -p /data/adb/vpnhide_lsposed")
+        append("; ensure_line $LSPOSED_TARGETS '' 644 0 1")
+        append("; ensure_line $SS_HIDDEN_PKGS_FILE '' 640 1 0")
+        append("; ALL_PKGS=\"\$(pm list packages -U --user all 2>/dev/null)\"")
+        append("; ")
+        append(buildPackageUidsExpression(selfPkg, "SELF_UIDS"))
+        append("; if [ -n \"\$SELF_UIDS\" ]; then")
+        append(" for U in \$SELF_UIDS; do")
+        append("   case \"\$U\" in ''|*[!0-9]*) continue;; esac")
+        append(" ; if [ -f $PROC_TARGETS ]; then")
+        append("     grep -qx \"\$U\" $PROC_TARGETS 2>/dev/null || echo \"\$U\" >> $PROC_TARGETS")
+        append("   ; fi")
+        append(" ; grep -qx \"\$U\" $SS_UIDS_FILE 2>/dev/null || {")
+        append("     echo \"\$U\" >> $SS_UIDS_FILE")
+        append("   ; chmod 640 $SS_UIDS_FILE")
+        append("   ; chown root:system $SS_UIDS_FILE")
+        append("   ; chcon u:object_r:system_data_file:s0 $SS_UIDS_FILE 2>/dev/null || true")
+        append("   ; }")
+        append(" ; done")
+        append("; fi")
+        append("; echo BOOT_ID=\$(cat /proc/sys/kernel/random/boot_id 2>/dev/null)")
+        append("; echo ADDED=\$ADDED")
+    }

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/ShellUtils.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/ShellUtils.kt
@@ -1,6 +1,5 @@
 package dev.okhsunrog.vpnhide
 
-import android.util.Base64
 import android.util.Log
 import dev.okhsunrog.vpnhide.generated.IfaceLists
 import kotlinx.coroutines.Dispatchers
@@ -111,7 +110,16 @@ internal fun isVpnActiveBlocking(): Boolean {
     }
 }
 
-internal fun cleanupStaleZygiskStatus(context: android.content.Context) {
+internal data class SelfTargetPreparation(
+    val rootAvailable: Boolean,
+    val selfNeedsRestart: Boolean,
+    val currentBootId: String?,
+)
+
+internal fun cleanupStaleZygiskStatus(
+    context: android.content.Context,
+    knownCurrentBootId: String? = null,
+) {
     val statusFile = File(context.filesDir, ZYGISK_STATUS_FILE_NAME)
     if (!statusFile.isFile) return
 
@@ -129,8 +137,11 @@ internal fun cleanupStaleZygiskStatus(context: android.content.Context) {
         }
 
     val heartbeatBootId = props["boot_id"]
-    val (_, currentBootIdRaw) = suExec("cat /proc/sys/kernel/random/boot_id 2>/dev/null")
-    val currentBootId = currentBootIdRaw.trim()
+    val currentBootId =
+        knownCurrentBootId
+            ?.trim()
+            ?.takeIf { it.isNotEmpty() }
+            ?: suExec("cat /proc/sys/kernel/random/boot_id 2>/dev/null").second.trim()
     val stale =
         heartbeatBootId.isNullOrBlank() ||
             heartbeatBootId != currentBootId
@@ -154,100 +165,24 @@ internal fun cleanupStaleZygiskStatus(context: android.content.Context) {
  * applied to the current process, restart needed for zygisk).
  * Called once at app startup; result is shared with all screens.
  */
-internal fun ensureSelfInTargets(selfPkg: String): Boolean {
-    var added = false
-
-    fun addIfMissing(
-        path: String,
-        dirCheck: String?,
-    ) {
-        if (dirCheck != null) {
-            val (_, exists) = suExec("[ -d $dirCheck ] && echo 1 || echo 0")
-            if (exists.trim() != "1") {
-                VpnHideLog.d(TAG, "ensureSelfInTargets: $dirCheck not found, skipping $path")
-                return
+internal fun ensureSelfInTargets(selfPkg: String): SelfTargetPreparation {
+    val (exitCode, out) = suExec(buildEnsureSelfInTargetsCommand(selfPkg))
+    if (exitCode != 0) {
+        VpnHideLog.w(TAG, "ensureSelfInTargets: batch failed (exit=$exitCode): ${out.trim()}")
+        return SelfTargetPreparation(rootAvailable = false, selfNeedsRestart = false, currentBootId = null)
+    }
+    val added = out.lineSequence().any { it.trim() == "ADDED=1" }
+    val currentBootId =
+        out
+            .lineSequence()
+            .firstNotNullOfOrNull { line ->
+                line.trim().removePrefix("BOOT_ID=").takeIf { it != line.trim() && it.isNotBlank() }
             }
-        }
-        val (_, raw) = suExec("cat $path 2>/dev/null || true")
-        val existing = raw.lines().map { it.trim() }.filter { it.isNotEmpty() && !it.startsWith("#") }
-        if (selfPkg in existing) {
-            VpnHideLog.d(TAG, "ensureSelfInTargets: $selfPkg already in $path")
-            return
-        }
-        val newBody =
-            "# Managed by VPN Hide app\n" +
-                (existing + selfPkg).sorted().joinToString("\n") + "\n"
-        val b64 = Base64.encodeToString(newBody.toByteArray(), Base64.NO_WRAP)
-        suExec("echo '$b64' | base64 -d > $path && chmod 644 $path")
-        VpnHideLog.i(TAG, "ensureSelfInTargets: added $selfPkg to $path")
-        added = true
-    }
-
-    addIfMissing(KMOD_TARGETS, "/data/adb/vpnhide_kmod")
-    addIfMissing(ZYGISK_TARGETS, "/data/adb/vpnhide_zygisk")
-    // Zygisk reads targets from module dir (via get_module_dir() fd), not
-    // from persistent dir. Must sync after adding self, otherwise zygisk
-    // won't hook us on next launch. Surface real `cp` failures (read-only
-    // mount, SELinux denial) — silent failure here used to manifest as
-    // "I edited targets in the app but zygisk didn't pick it up".
-    val (cpExit, cpOut) =
-        suExec("if [ -d $ZYGISK_MODULE_DIR ]; then cp $ZYGISK_TARGETS $ZYGISK_MODULE_TARGETS 2>&1; fi")
-    if (cpExit != 0 && cpOut.isNotBlank()) {
-        VpnHideLog.w(TAG, "ensureSelfInTargets: zygisk module dir copy failed (exit=$cpExit): ${cpOut.trim()}")
-    }
-    suExec("mkdir -p /data/adb/vpnhide_lsposed")
-    addIfMissing(LSPOSED_TARGETS, null)
-
-    // Always hide self via package visibility hooks — prevents observer apps from seeing us.
-    // File lives in /data/system/ (system_data_file), readable by system_server.
-    val (_, hiddenRaw) = suExec("cat $SS_HIDDEN_PKGS_FILE 2>/dev/null || true")
-    val hiddenExisting = hiddenRaw.lines().map { it.trim() }.filter { it.isNotEmpty() && !it.startsWith("#") }
-    if (selfPkg !in hiddenExisting) {
-        val body =
-            "# Managed by VPN Hide app\n" +
-                (hiddenExisting + selfPkg).sorted().joinToString("\n") + "\n"
-        val b64 = Base64.encodeToString(body.toByteArray(), Base64.NO_WRAP)
-        suExec(
-            // Mode 0640 + group=system: system_server reads via the group
-            // bit; untrusted apps fall to "other" and get EACCES.
-            // /data/system/ itself is mode 0775 traversable by untrusted —
-            // a plain 0644 here used to be enumerable + readable.
-            "echo '$b64' | base64 -d > $SS_HIDDEN_PKGS_FILE" +
-                " && chmod 640 $SS_HIDDEN_PKGS_FILE" +
-                " && chown root:system $SS_HIDDEN_PKGS_FILE" +
-                " && chcon u:object_r:system_data_file:s0 $SS_HIDDEN_PKGS_FILE 2>/dev/null; true",
-        )
-        VpnHideLog.i(TAG, "ensureSelfInTargets: added $selfPkg to $SS_HIDDEN_PKGS_FILE")
-        // Don't flip `added`: PM hooks live in system_server and pick up the file change
-        // immediately via inotify — no app restart is needed, unlike native (zygisk) hooks.
-    }
-
-    // Resolve UIDs so hooks pick us up immediately (kmod + lsposed support live reload).
-    // `--user all` catches the case where vpnhide is installed in a work profile too —
-    // each UID gets added to targets so both instances are covered. `tr ',' '\n'`
-    // expands comma-separated UIDs, then we iterate one per line and dedup against
-    // the existing file content.
-    val uidCmd =
-        buildString {
-            // Literal field match via awk — grep would treat dots in
-            // `selfPkg` as regex wildcards.
-            append("ALL_PKGS=\"\$(pm list packages -U --user all 2>/dev/null)\"")
-            append("; ")
-            append(buildPackageUidsExpression(selfPkg, "SELF_UIDS"))
-            append("; if [ -n \"\$SELF_UIDS\" ]; then")
-            append("   for U in \$SELF_UIDS; do")
-            append("     if [ -f $PROC_TARGETS ]; then")
-            append("       EXISTING=\$(cat $PROC_TARGETS 2>/dev/null)")
-            append(";      echo \"\$EXISTING\" | grep -q \"^\$U\$\" || echo \"\$U\" >> $PROC_TARGETS")
-            append("     ; fi")
-            append("   ; EXISTING2=\$(cat $SS_UIDS_FILE 2>/dev/null)")
-            append(
-                "   ; echo \"\$EXISTING2\" | grep -q \"^\$U\$\" || { echo \"\$U\" >> $SS_UIDS_FILE; chmod 640 $SS_UIDS_FILE; chown root:system $SS_UIDS_FILE; chcon u:object_r:system_data_file:s0 $SS_UIDS_FILE 2>/dev/null; }",
-            )
-            append("   ; done")
-            append("; fi")
-        }
-    suExec(uidCmd)
+    out
+        .lineSequence()
+        .map { it.trim() }
+        .filter { it.startsWith("added:") || it == "zygisk_cp_failed" }
+        .forEach { VpnHideLog.i(TAG, "ensureSelfInTargets: $it") }
     VpnHideLog.d(TAG, "ensureSelfInTargets: done, added=$added")
-    return added
+    return SelfTargetPreparation(rootAvailable = true, selfNeedsRestart = added, currentBootId = currentBootId)
 }

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/ShellUtils.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/ShellUtils.kt
@@ -32,6 +32,7 @@ internal const val ZYGISK_STATUS_FILE_NAME = "vpnhide_zygisk_active"
  *  in milliseconds; this only fires if the su binary is genuinely stuck
  *  (e.g. waiting on a GUI prompt that the user dismissed). */
 internal const val SU_DEFAULT_TIMEOUT_SEC: Long = 10
+private const val SELF_TARGETS_TIMEOUT_SEC: Long = 4
 
 /**
  * Returns exit code and stdout. Exit code -1 means the su binary
@@ -62,7 +63,7 @@ internal fun suExec(
 
             val finished = proc.waitFor(timeoutSec, TimeUnit.SECONDS)
             if (!finished) {
-                Log.w(TAG, "su exec timed out after ${timeoutSec}s: $cmd")
+                Log.w(TAG, "su exec timed out after ${timeoutSec}s: ${commandPreview(cmd)}")
                 proc.destroyForcibly()
             }
             // After destroyForcibly the pipes close and the drains exit;
@@ -80,10 +81,43 @@ internal fun suExec(
         -1 to ""
     }
 
+private fun commandPreview(cmd: String): String {
+    val preview =
+        cmd
+            .lineSequence()
+            .map { it.trimEnd() }
+            .filter { it.isNotBlank() }
+            .take(12)
+            .joinToString("\n")
+    return if (preview.length <= 800) preview else preview.take(800) + "..."
+}
+
 internal suspend fun suExecAsync(
     cmd: String,
     timeoutSec: Long = SU_DEFAULT_TIMEOUT_SEC,
 ): Pair<Int, String> = withContext(Dispatchers.IO) { suExec(cmd, timeoutSec) }
+
+internal fun parseVpnIfaceStates(raw: String): List<Pair<String, String>> =
+    raw
+        .lineSequence()
+        .mapNotNull { line ->
+            val trimmed = line.trim()
+            if (trimmed.isEmpty()) return@mapNotNull null
+
+            val legacyParts = trimmed.split("=", limit = 2)
+            if (legacyParts.size == 2) {
+                return@mapNotNull legacyParts[0].trim() to legacyParts[1].trim()
+            }
+
+            val marker = "/operstate:"
+            val markerIndex = trimmed.indexOf(marker)
+            if (markerIndex <= 0) return@mapNotNull null
+            val path = trimmed.substring(0, markerIndex)
+            val iface = path.substringAfterLast('/').trim()
+            val state = trimmed.substring(markerIndex + marker.length).trim()
+            if (iface.isEmpty()) null else iface to state
+        }.filter { (name, _) -> IfaceLists.isVpnIface(name) }
+        .toList()
 
 /**
  * Single source of truth for "is a VPN currently up?". Both the dashboard
@@ -94,18 +128,19 @@ internal suspend fun suExecAsync(
  * from issue #86, `MyVPN`, `wg-client`).
  */
 internal fun isVpnActiveBlocking(): Boolean {
-    val (exitCode, output) = suExec("ls /sys/class/net/ 2>/dev/null")
+    val (exitCode, output) =
+        suExec(
+            "grep -H . /sys/class/net/*/operstate 2>/dev/null",
+        )
     if (exitCode != 0) return false
-    val vpnIfaces =
-        output.lines().map { it.trim() }.filter { name -> IfaceLists.isVpnIface(name) }
+    val vpnIfaces = parseVpnIfaceStates(output)
     if (vpnIfaces.isEmpty()) {
         VpnHideLog.d(TAG, "isVpnActive: no VPN interfaces found")
         return false
     }
-    return vpnIfaces.any { iface ->
-        val (_, state) = suExec("cat /sys/class/net/$iface/operstate 2>/dev/null")
-        val up = state.trim() == "unknown" || state.trim() == "up"
-        VpnHideLog.d(TAG, "isVpnActive: $iface operstate=${state.trim()} up=$up")
+    return vpnIfaces.any { (iface, state) ->
+        val up = state == "unknown" || state == "up"
+        VpnHideLog.d(TAG, "isVpnActive: $iface operstate=$state up=$up")
         up
     }
 }
@@ -165,8 +200,11 @@ internal fun cleanupStaleZygiskStatus(
  * applied to the current process, restart needed for zygisk).
  * Called once at app startup; result is shared with all screens.
  */
-internal fun ensureSelfInTargets(selfPkg: String): SelfTargetPreparation {
-    val (exitCode, out) = suExec(buildEnsureSelfInTargetsCommand(selfPkg))
+internal fun ensureSelfInTargets(
+    selfPkg: String,
+    timeoutSec: Long = SELF_TARGETS_TIMEOUT_SEC,
+): SelfTargetPreparation {
+    val (exitCode, out) = suExec(buildEnsureSelfInTargetsCommand(selfPkg), timeoutSec = timeoutSec)
     if (exitCode != 0) {
         VpnHideLog.w(TAG, "ensureSelfInTargets: batch failed (exit=$exitCode): ${out.trim()}")
         return SelfTargetPreparation(rootAvailable = false, selfNeedsRestart = false, currentBootId = null)

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/ShellUtils.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/ShellUtils.kt
@@ -32,7 +32,7 @@ internal const val ZYGISK_STATUS_FILE_NAME = "vpnhide_zygisk_active"
  *  in milliseconds; this only fires if the su binary is genuinely stuck
  *  (e.g. waiting on a GUI prompt that the user dismissed). */
 internal const val SU_DEFAULT_TIMEOUT_SEC: Long = 10
-private const val SELF_TARGETS_TIMEOUT_SEC: Long = 4
+private const val SELF_TARGETS_TIMEOUT_SEC: Long = SU_DEFAULT_TIMEOUT_SEC
 
 /**
  * Returns exit code and stdout. Exit code -1 means the su binary
@@ -119,21 +119,7 @@ internal fun parseVpnIfaceStates(raw: String): List<Pair<String, String>> =
         }.filter { (name, _) -> IfaceLists.isVpnIface(name) }
         .toList()
 
-/**
- * Single source of truth for "is a VPN currently up?". Both the dashboard
- * (sync, off the main thread already) and the diagnostics screen (suspend,
- * via `withContext(Dispatchers.IO)`) call this so the answer doesn't drift
- * — a previous version of the dashboard hard-coded a prefix list and missed
- * names the codegen-driven `IfaceLists.isVpnIface` catches (e.g. `if<N>`
- * from issue #86, `MyVPN`, `wg-client`).
- */
-internal fun isVpnActiveBlocking(): Boolean {
-    val (exitCode, output) =
-        suExec(
-            "grep -H . /sys/class/net/*/operstate 2>/dev/null",
-        )
-    if (exitCode != 0) return false
-    val vpnIfaces = parseVpnIfaceStates(output)
+internal fun isVpnActiveFromStates(vpnIfaces: List<Pair<String, String>>): Boolean {
     if (vpnIfaces.isEmpty()) {
         VpnHideLog.d(TAG, "isVpnActive: no VPN interfaces found")
         return false
@@ -145,10 +131,28 @@ internal fun isVpnActiveBlocking(): Boolean {
     }
 }
 
+internal fun isVpnActiveFromSnapshot(raw: String): Boolean = isVpnActiveFromStates(parseVpnIfaceStates(raw))
+
+/**
+ * Single source of truth for the live shell probe. Startup paths should prefer
+ * [isVpnActiveFromSnapshot] over this function when a root snapshot already
+ * exists, so Dashboard and Diagnostics don't drift during one launch.
+ */
+internal fun isVpnActiveBlocking(): Boolean {
+    val (exitCode, output) =
+        suExec(
+            "grep -H . /sys/class/net/*/operstate 2>/dev/null",
+        )
+    if (exitCode != 0) return false
+    return isVpnActiveFromSnapshot(output)
+}
+
 internal data class SelfTargetPreparation(
     val rootAvailable: Boolean,
     val selfNeedsRestart: Boolean,
     val currentBootId: String?,
+    val pmPackages: String? = null,
+    val error: String? = null,
 )
 
 internal fun cleanupStaleZygiskStatus(
@@ -207,9 +211,15 @@ internal fun ensureSelfInTargets(
     val (exitCode, out) = suExec(buildEnsureSelfInTargetsCommand(selfPkg), timeoutSec = timeoutSec)
     if (exitCode != 0) {
         VpnHideLog.w(TAG, "ensureSelfInTargets: batch failed (exit=$exitCode): ${out.trim()}")
-        return SelfTargetPreparation(rootAvailable = false, selfNeedsRestart = false, currentBootId = null)
+        return SelfTargetPreparation(
+            rootAvailable = false,
+            selfNeedsRestart = false,
+            currentBootId = null,
+            error = "exit=$exitCode",
+        )
     }
     val added = out.lineSequence().any { it.trim() == "ADDED=1" }
+    val pmPackages = extractSelfTargetPmPackages(out)
     val currentBootId =
         out
             .lineSequence()
@@ -222,5 +232,23 @@ internal fun ensureSelfInTargets(
         .filter { it.startsWith("added:") || it == "zygisk_cp_failed" }
         .forEach { VpnHideLog.i(TAG, "ensureSelfInTargets: $it") }
     VpnHideLog.d(TAG, "ensureSelfInTargets: done, added=$added")
-    return SelfTargetPreparation(rootAvailable = true, selfNeedsRestart = added, currentBootId = currentBootId)
+    return SelfTargetPreparation(
+        rootAvailable = true,
+        selfNeedsRestart = added,
+        currentBootId = currentBootId,
+        pmPackages = pmPackages,
+    )
+}
+
+internal fun extractSelfTargetPmPackages(output: String): String? {
+    val lines = mutableListOf<String>()
+    var inSection = false
+    output.lineSequence().forEach { line ->
+        when (line.trim()) {
+            SELF_PM_PACKAGES_BEGIN -> inSection = true
+            SELF_PM_PACKAGES_END -> inSection = false
+            else -> if (inSection) lines += line
+        }
+    }
+    return lines.joinToString("\n").trimEnd().takeIf { it.isNotBlank() }
 }

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/StartupTrace.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/StartupTrace.kt
@@ -14,6 +14,13 @@ internal object StartupTrace {
         Log.i(STARTUP_TAG, "event=$event elapsedMs=${elapsedMs()}")
     }
 
+    fun metric(
+        name: String,
+        valueMs: Long,
+    ) {
+        Log.i(STARTUP_TAG, "metric=$name valueMs=$valueMs elapsedMs=${elapsedMs()}")
+    }
+
     fun dashboardReady() {
         if (readyLogged.compareAndSet(false, true)) {
             Log.i(STARTUP_TAG, "event=dashboard_ready elapsedMs=${elapsedMs()}")

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/StartupTrace.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/StartupTrace.kt
@@ -1,0 +1,30 @@
+package dev.okhsunrog.vpnhide
+
+import android.os.SystemClock
+import android.util.Log
+import java.util.concurrent.atomic.AtomicBoolean
+
+private const val STARTUP_TAG = "VpnHide-Startup"
+
+internal object StartupTrace {
+    private val originMs = SystemClock.elapsedRealtime()
+    private val readyLogged = AtomicBoolean(false)
+
+    fun mark(event: String) {
+        Log.i(STARTUP_TAG, "event=$event elapsedMs=${elapsedMs()}")
+    }
+
+    fun dashboardReady() {
+        if (readyLogged.compareAndSet(false, true)) {
+            Log.i(STARTUP_TAG, "event=dashboard_ready elapsedMs=${elapsedMs()}")
+        }
+    }
+
+    fun rootDeniedReady() {
+        if (readyLogged.compareAndSet(false, true)) {
+            Log.i(STARTUP_TAG, "event=root_denied_ready elapsedMs=${elapsedMs()}")
+        }
+    }
+
+    private fun elapsedMs(): Long = SystemClock.elapsedRealtime() - originMs
+}

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/TargetsCache.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/TargetsCache.kt
@@ -53,13 +53,16 @@ internal object TargetsCache {
     private val _loading = MutableStateFlow(false)
     val loading: StateFlow<Boolean> = _loading.asStateFlow()
 
+    private val _error = MutableStateFlow<String?>(null)
+    val error: StateFlow<String?> = _error.asStateFlow()
+
     private var inflight: Job? = null
 
     fun ensureLoaded(
         scope: CoroutineScope,
         context: Context,
     ) {
-        if (_snapshot.value != null || inflight?.isActive == true) return
+        if (_snapshot.value != null || _error.value != null || inflight?.isActive == true) return
         inflight = scope.launch { reload(context.applicationContext) }
     }
 
@@ -69,6 +72,7 @@ internal object TargetsCache {
     ) {
         inflight?.cancel()
         RootSnapshotCache.invalidate()
+        _error.value = null
         inflight = scope.launch { reload(context.applicationContext, forceRootRefresh = true) }
     }
 
@@ -78,6 +82,7 @@ internal object TargetsCache {
      */
     fun invalidate() {
         _snapshot.value = null
+        _error.value = null
         RootSnapshotCache.invalidate()
     }
 
@@ -95,11 +100,13 @@ internal object TargetsCache {
                     RootSnapshotCache.getOrLoad()
                 }
             _snapshot.value = parseTargetsSnapshot(rootSnapshot)
+            _error.value = null
             StartupTrace.mark("targets_cache_done")
         } catch (e: CancellationException) {
             throw e
         } catch (e: Exception) {
             StartupTrace.mark("targets_cache_failed")
+            _error.value = e.message ?: e.javaClass.simpleName
             VpnHideLog.w("VpnHide-Targets", "targets cache reload failed: ${e.message}", e)
         } finally {
             _loading.value = false

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/TargetsCache.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/TargetsCache.kt
@@ -1,14 +1,13 @@
 package dev.okhsunrog.vpnhide
 
 import android.content.Context
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
 
 /**
  * Per-screen protection state from root-owned files and package
@@ -69,7 +68,8 @@ internal object TargetsCache {
         context: Context,
     ) {
         inflight?.cancel()
-        inflight = scope.launch { reload(context.applicationContext) }
+        RootSnapshotCache.invalidate()
+        inflight = scope.launch { reload(context.applicationContext, forceRootRefresh = true) }
     }
 
     /** Drop the cached snapshot so the next subscriber triggers a
@@ -78,110 +78,72 @@ internal object TargetsCache {
      */
     fun invalidate() {
         _snapshot.value = null
+        RootSnapshotCache.invalidate()
     }
-
-    // Bundle every read into a single `suExec` call separated by
-    // distinctive banner lines. One root roundtrip beats 8 serial
-    // ones — PM + 7 cats typically take <100ms this way.
-    private const val SENTINEL = "===VPNHIDE-TARGETS-BOUNDARY==="
-    private const val END = "===VPNHIDE-TARGETS-END==="
-
-    private val BATCH_SCRIPT =
-        """
-        echo "$SENTINEL KMOD_MODULE_DIR"
-        [ -d $KMOD_MODULE_DIR ] && echo 1 || echo 0
-        echo "$SENTINEL ZYGISK_MODULE_DIR"
-        [ -d $ZYGISK_MODULE_DIR ] && echo 1 || echo 0
-        echo "$SENTINEL PORTS_MODULE_PROP"
-        cat $PORTS_MODULE_DIR/module.prop 2>/dev/null || true
-        echo "$SENTINEL KMOD_TARGETS"
-        cat $KMOD_TARGETS 2>/dev/null || true
-        echo "$SENTINEL ZYGISK_TARGETS"
-        cat $ZYGISK_TARGETS 2>/dev/null || true
-        echo "$SENTINEL LSPOSED_TARGETS"
-        cat $LSPOSED_TARGETS 2>/dev/null || true
-        echo "$SENTINEL HIDDEN_PKGS"
-        cat $SS_HIDDEN_PKGS_FILE 2>/dev/null || true
-        echo "$SENTINEL OBSERVER_UIDS"
-        cat $SS_OBSERVER_UIDS_FILE 2>/dev/null || true
-        echo "$SENTINEL PORTS_OBSERVERS"
-        cat $PORTS_OBSERVERS_FILE 2>/dev/null || true
-        echo "$SENTINEL PM_LIST"
-        pm list packages -U --user all 2>/dev/null || true
-        echo "$END"
-        """.trimIndent()
 
     private suspend fun reload(
         @Suppress("UNUSED_PARAMETER") appContext: Context,
+        forceRootRefresh: Boolean = false,
     ) {
         _loading.value = true
         try {
-            val (_, out) =
-                withContext(Dispatchers.IO) { suExec(BATCH_SCRIPT) }
-            _snapshot.value = parse(out)
+            StartupTrace.mark("targets_cache_start")
+            val rootSnapshot =
+                if (forceRootRefresh) {
+                    RootSnapshotCache.refresh()
+                } else {
+                    RootSnapshotCache.getOrLoad()
+                }
+            _snapshot.value = parseTargetsSnapshot(rootSnapshot)
+            StartupTrace.mark("targets_cache_done")
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            StartupTrace.mark("targets_cache_failed")
+            VpnHideLog.w("VpnHide-Targets", "targets cache reload failed: ${e.message}", e)
         } finally {
             _loading.value = false
         }
     }
+}
 
-    private fun parse(out: String): TargetsSnapshot {
-        val sections = mutableMapOf<String, String>()
-        var currentKey: String? = null
-        val buf = StringBuilder()
-        for (line in out.lines()) {
-            when {
-                line.startsWith(SENTINEL) -> {
-                    currentKey?.let { sections[it] = buf.toString() }
-                    buf.clear()
-                    currentKey = line.removePrefix("$SENTINEL ").trim()
-                }
+internal fun parseTargetsSnapshot(rootSnapshot: RootSnapshot): TargetsSnapshot {
+    val sections = rootSnapshot.sections
 
-                line.startsWith(END) -> {
-                    currentKey?.let { sections[it] = buf.toString() }
-                    currentKey = null
-                }
+    fun nonEmptyLines(raw: String?): Set<String> =
+        raw
+            ?.lines()
+            ?.map { it.trim() }
+            ?.filter { it.isNotEmpty() && !it.startsWith("#") }
+            ?.toSet() ?: emptySet()
 
-                currentKey != null -> {
-                    buf.appendLine(line)
-                }
-            }
+    val portsInstalled = sections["ports_prop"]?.isNotBlank() == true
+    val observerUids = nonEmptyLines(sections["observer_uids"]).mapNotNull { it.toIntOrNull() }.toSet()
+
+    // With `--user all`, multi-profile packages report comma-separated
+    // UIDs: `package:com.android.chrome uid:10187,1010187`. Each UID
+    // becomes its own entry in the reverse map so observer lookups
+    // from any profile resolve back to the same package name.
+    val pmLine = Regex("^package:(\\S+) uid:(\\S+)")
+    val uidToPkg = mutableMapOf<Int, String>()
+    sections["pm_packages"]?.lines()?.forEach { line ->
+        val m = pmLine.find(line) ?: return@forEach
+        val pkg = m.groupValues[1]
+        for (id in m.groupValues[2].split(',')) {
+            id.toIntOrNull()?.let { uidToPkg[it] = pkg }
         }
-
-        fun nonEmptyLines(raw: String?): Set<String> =
-            raw
-                ?.lines()
-                ?.map { it.trim() }
-                ?.filter { it.isNotEmpty() && !it.startsWith("#") }
-                ?.toSet() ?: emptySet()
-
-        val portsInstalled = sections["PORTS_MODULE_PROP"]?.isNotBlank() == true
-        val observerUids = nonEmptyLines(sections["OBSERVER_UIDS"]).mapNotNull { it.toIntOrNull() }.toSet()
-
-        // With `--user all`, multi-profile packages report comma-separated
-        // UIDs: `package:com.android.chrome uid:10187,1010187`. Each UID
-        // becomes its own entry in the reverse map so observer lookups
-        // from any profile resolve back to the same package name.
-        val pmLine = Regex("^package:(\\S+) uid:(\\S+)")
-        val uidToPkg = mutableMapOf<Int, String>()
-        sections["PM_LIST"]?.lines()?.forEach { line ->
-            val m = pmLine.find(line) ?: return@forEach
-            val pkg = m.groupValues[1]
-            for (id in m.groupValues[2].split(',')) {
-                id.toIntOrNull()?.let { uidToPkg[it] = pkg }
-            }
-        }
-
-        return TargetsSnapshot(
-            kmodModuleInstalled = sections["KMOD_MODULE_DIR"]?.trim() == "1",
-            zygiskModuleInstalled = sections["ZYGISK_MODULE_DIR"]?.trim() == "1",
-            portsModuleInstalled = portsInstalled,
-            kmodTargets = nonEmptyLines(sections["KMOD_TARGETS"]),
-            zygiskTargets = nonEmptyLines(sections["ZYGISK_TARGETS"]),
-            lsposedTargets = nonEmptyLines(sections["LSPOSED_TARGETS"]),
-            hiddenPkgs = nonEmptyLines(sections["HIDDEN_PKGS"]),
-            observerUids = observerUids,
-            portsObservers = nonEmptyLines(sections["PORTS_OBSERVERS"]),
-            uidToPkg = uidToPkg,
-        )
     }
+
+    return TargetsSnapshot(
+        kmodModuleInstalled = sections["kmod_module_dir"]?.trim() == "1",
+        zygiskModuleInstalled = sections["zygisk_module_dir"]?.trim() == "1",
+        portsModuleInstalled = portsInstalled,
+        kmodTargets = nonEmptyLines(sections["kmod_targets"]),
+        zygiskTargets = nonEmptyLines(sections["zygisk_targets"]),
+        lsposedTargets = nonEmptyLines(sections["lsposed_targets"]),
+        hiddenPkgs = nonEmptyLines(sections["hidden_pkgs"]),
+        observerUids = observerUids,
+        portsObservers = nonEmptyLines(sections["ports_observers"]),
+        uidToPkg = uidToPkg,
+    )
 }

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/TargetsLoadErrorCard.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/TargetsLoadErrorCard.kt
@@ -1,0 +1,70 @@
+package dev.okhsunrog.vpnhide
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Button
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+
+@Composable
+internal fun TargetsLoadErrorCard(
+    onRetry: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Box(
+        modifier =
+            modifier
+                .fillMaxSize()
+                .padding(24.dp),
+        contentAlignment = Alignment.Center,
+    ) {
+        Card(
+            shape = RoundedCornerShape(8.dp),
+            colors =
+                CardDefaults.cardColors(
+                    containerColor = MaterialTheme.colorScheme.errorContainer,
+                    contentColor = MaterialTheme.colorScheme.onErrorContainer,
+                ),
+        ) {
+            Column(
+                modifier = Modifier.padding(16.dp),
+                horizontalAlignment = Alignment.CenterHorizontally,
+            ) {
+                Text(
+                    text = stringResource(R.string.targets_load_failed_title),
+                    style = MaterialTheme.typography.titleSmall,
+                    fontWeight = FontWeight.Bold,
+                    textAlign = TextAlign.Center,
+                )
+                Spacer(Modifier.height(8.dp))
+                Text(
+                    text = stringResource(R.string.targets_load_failed_message),
+                    style = MaterialTheme.typography.bodyMedium,
+                    textAlign = TextAlign.Center,
+                )
+                Spacer(Modifier.height(12.dp))
+                Button(
+                    onClick = onRetry,
+                    modifier = Modifier.fillMaxWidth(),
+                ) {
+                    Text(stringResource(R.string.vpn_off_retry))
+                }
+            }
+        }
+    }
+}

--- a/lsposed/app/src/main/res/values-ru/strings.xml
+++ b/lsposed/app/src/main/res/values-ru/strings.xml
@@ -54,6 +54,9 @@
 
     <!-- Dashboard -->
     <string name="dashboard_modules">Модули</string>
+    <string name="dashboard_load_failed_title">Данные обзора недоступны</string>
+    <string name="dashboard_load_failed_message">VPN Hide не смог собрать root-состояние для этого экрана. Проверьте менеджер root, если разрешение было прервано, затем нажмите «Повторить».</string>
+    <string name="dashboard_refresh_failed_message">Обновление не удалось. Показываются предыдущие данные обзора.</string>
     <string name="dashboard_kmod">Модуль ядра</string>
     <string name="dashboard_zygisk">VPN Hide Zygisk модуль</string>
     <string name="dashboard_lsposed_module">VPN Hide LSPosed-хук</string>

--- a/lsposed/app/src/main/res/values-ru/strings.xml
+++ b/lsposed/app/src/main/res/values-ru/strings.xml
@@ -57,6 +57,10 @@
     <string name="dashboard_load_failed_title">Данные обзора недоступны</string>
     <string name="dashboard_load_failed_message">VPN Hide не смог собрать root-состояние для этого экрана. Проверьте менеджер root, если разрешение было прервано, затем нажмите «Повторить».</string>
     <string name="dashboard_refresh_failed_message">Обновление не удалось. Показываются предыдущие данные обзора.</string>
+    <string name="self_targets_error_title">Подготовка запуска не удалась</string>
+    <string name="self_targets_error_message">VPN Hide не смог обновить root-файлы целей. Проверьте менеджер root, если разрешение было прервано, затем нажмите «Повторить».</string>
+    <string name="targets_load_failed_title">Данные защиты недоступны</string>
+    <string name="targets_load_failed_message">VPN Hide не смог собрать root-состояние для этой вкладки. Проверьте менеджер root, если разрешение было прервано, затем нажмите «Повторить».</string>
     <string name="dashboard_kmod">Модуль ядра</string>
     <string name="dashboard_zygisk">VPN Hide Zygisk модуль</string>
     <string name="dashboard_lsposed_module">VPN Hide LSPosed-хук</string>

--- a/lsposed/app/src/main/res/values/strings.xml
+++ b/lsposed/app/src/main/res/values/strings.xml
@@ -88,6 +88,10 @@
     <string name="dashboard_load_failed_title">Dashboard data unavailable</string>
     <string name="dashboard_load_failed_message">VPN Hide could not collect the root state needed for this screen. Check your root manager if permission was interrupted, then tap Retry.</string>
     <string name="dashboard_refresh_failed_message">Refresh failed. Showing the previous dashboard data.</string>
+    <string name="self_targets_error_title">Startup preparation failed</string>
+    <string name="self_targets_error_message">VPN Hide could not update its root target files. Check your root manager if permission was interrupted, then tap Retry.</string>
+    <string name="targets_load_failed_title">Protection data unavailable</string>
+    <string name="targets_load_failed_message">VPN Hide could not collect the root state needed for this tab. Check your root manager if permission was interrupted, then tap Retry.</string>
     <string name="dashboard_kmod">Kernel module</string>
     <string name="dashboard_zygisk">VPN Hide Zygisk module</string>
     <string name="dashboard_lsposed_module">VPN Hide LSPosed hook</string>

--- a/lsposed/app/src/main/res/values/strings.xml
+++ b/lsposed/app/src/main/res/values/strings.xml
@@ -85,6 +85,9 @@
 
     <!-- Dashboard -->
     <string name="dashboard_modules">Modules</string>
+    <string name="dashboard_load_failed_title">Dashboard data unavailable</string>
+    <string name="dashboard_load_failed_message">VPN Hide could not collect the root state needed for this screen. Check your root manager if permission was interrupted, then tap Retry.</string>
+    <string name="dashboard_refresh_failed_message">Refresh failed. Showing the previous dashboard data.</string>
     <string name="dashboard_kmod">Kernel module</string>
     <string name="dashboard_zygisk">VPN Hide Zygisk module</string>
     <string name="dashboard_lsposed_module">VPN Hide LSPosed hook</string>

--- a/lsposed/app/src/test/kotlin/dev/okhsunrog/vpnhide/RootSnapshotCacheTest.kt
+++ b/lsposed/app/src/test/kotlin/dev/okhsunrog/vpnhide/RootSnapshotCacheTest.kt
@@ -1,0 +1,82 @@
+package dev.okhsunrog.vpnhide
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class RootSnapshotCacheTest {
+    @Test
+    fun `parser keeps multiline sections and records timing metrics`() {
+        val raw =
+            """
+            __VPNHIDE_ROOT_SECTION_BEGIN__:kmod_targets
+            # Managed by VPN Hide app
+            dev.okhsunrog.vpnhide
+            com.example.target
+            __VPNHIDE_ROOT_SECTION_END__:kmod_targets
+            __VPNHIDE_ROOT_TIMING__:target_files=42
+            __VPNHIDE_ROOT_SECTION_BEGIN__:empty_file
+            __VPNHIDE_ROOT_SECTION_END__:empty_file
+            """.trimIndent()
+
+        val metrics = mutableMapOf<String, Long>()
+        val sections =
+            parseRootShellSnapshot(raw) { name, durationMs ->
+                metrics[name] = durationMs
+            }
+
+        assertEquals("# Managed by VPN Hide app\ndev.okhsunrog.vpnhide\ncom.example.target", sections["kmod_targets"])
+        assertEquals("", sections["empty_file"])
+        assertEquals(42L, metrics["root_shell_target_files"])
+    }
+
+    @Test
+    fun `parser ignores unclosed partial section`() {
+        val raw =
+            """
+            __VPNHIDE_ROOT_SECTION_BEGIN__:complete
+            ok
+            __VPNHIDE_ROOT_SECTION_END__:complete
+            __VPNHIDE_ROOT_SECTION_BEGIN__:partial
+            incomplete
+            """.trimIndent()
+
+        val sections = parseRootShellSnapshot(raw, recordMetric = { _, _ -> })
+
+        assertEquals("ok", sections["complete"])
+        assertFalse(sections.containsKey("partial"))
+    }
+
+    @Test
+    fun `snapshot validation rejects missing sections`() {
+        val sections = REQUIRED_ROOT_SNAPSHOT_SECTIONS.associateWith { "" } - "vpn_ifaces"
+        var thrown: RootSnapshotException? = null
+
+        try {
+            validateRootSnapshotSections(sections)
+        } catch (e: RootSnapshotException) {
+            thrown = e
+        }
+
+        assertTrue(thrown?.message?.contains("vpn_ifaces") == true)
+    }
+
+    @Test
+    fun `snapshot command avoids per-section base64 and external date timing`() {
+        val command = buildRootShellSnapshotCommand()
+
+        assertTrue(command.contains("__VPNHIDE_ROOT_SECTION_BEGIN__:"))
+        assertTrue(command.contains("__VPNHIDE_ROOT_SECTION_END__:"))
+        assertTrue(command.contains("EPOCHREALTIME"))
+        assertTrue(command.contains("/proc/uptime"))
+        assertTrue(command.contains("cat \"${'$'}PATH_TO_READ\""))
+        assertTrue(command.contains("grep -H . /sys/class/net/*/operstate"))
+        assertFalse(command.contains("while IFS= read"))
+        assertFalse(command.contains("base64"))
+        assertFalse(command.contains("date +%s%3N"))
+        assertFalse(command.contains("exit 0"))
+        assertFalse(command.contains("run_phase"))
+        assertFalse(command.contains("TMP_DIR"))
+    }
+}

--- a/lsposed/app/src/test/kotlin/dev/okhsunrog/vpnhide/RootSnapshotCacheTest.kt
+++ b/lsposed/app/src/test/kotlin/dev/okhsunrog/vpnhide/RootSnapshotCacheTest.kt
@@ -71,12 +71,23 @@ class RootSnapshotCacheTest {
         assertTrue(command.contains("EPOCHREALTIME"))
         assertTrue(command.contains("/proc/uptime"))
         assertTrue(command.contains("cat \"${'$'}PATH_TO_READ\""))
+        assertTrue(command.contains("pm list packages -U --user all"))
         assertTrue(command.contains("grep -H . /sys/class/net/*/operstate"))
+        assertTrue(command.contains("probe_ok=1"))
         assertFalse(command.contains("while IFS= read"))
         assertFalse(command.contains("base64"))
         assertFalse(command.contains("date +%s%3N"))
         assertFalse(command.contains("exit 0"))
         assertFalse(command.contains("run_phase"))
         assertFalse(command.contains("TMP_DIR"))
+    }
+
+    @Test
+    fun `snapshot command can skip package enumeration when startup seeded it`() {
+        val command = buildRootShellSnapshotCommand(includePmPackages = false)
+
+        assertFalse(command.contains("pm list packages -U --user all"))
+        assertTrue(command.contains("phase_target_files"))
+        assertTrue(command.contains("phase_vpn_ifaces"))
     }
 }

--- a/lsposed/app/src/test/kotlin/dev/okhsunrog/vpnhide/ShellCommandBuildersTest.kt
+++ b/lsposed/app/src/test/kotlin/dev/okhsunrog/vpnhide/ShellCommandBuildersTest.kt
@@ -69,7 +69,28 @@ class ShellCommandBuildersTest {
         assertTrue(cmd.contains("ensure_line $LSPOSED_TARGETS"))
         assertTrue(cmd.contains("ensure_line $SS_HIDDEN_PKGS_FILE"))
         assertTrue(cmd.contains("pm list packages -U --user all"))
+        assertTrue(cmd.contains(SELF_PM_PACKAGES_BEGIN))
+        assertTrue(cmd.contains(SELF_PM_PACKAGES_END))
         assertTrue(cmd.contains("echo ADDED=\$ADDED"))
+    }
+
+    @Test
+    fun `self target output extracts seeded package list`() {
+        val output =
+            """
+            added:/data/adb/vpnhide_kmod/targets.txt
+            $SELF_PM_PACKAGES_BEGIN
+            package:dev.okhsunrog.vpnhide uid:10123,1010123
+            package:com.example.app uid:10234
+            $SELF_PM_PACKAGES_END
+            BOOT_ID=boot
+            ADDED=1
+            """.trimIndent()
+
+        assertEquals(
+            "package:dev.okhsunrog.vpnhide uid:10123,1010123\npackage:com.example.app uid:10234",
+            extractSelfTargetPmPackages(output),
+        )
     }
 
     private fun runPackageUidExpression(

--- a/lsposed/app/src/test/kotlin/dev/okhsunrog/vpnhide/ShellCommandBuildersTest.kt
+++ b/lsposed/app/src/test/kotlin/dev/okhsunrog/vpnhide/ShellCommandBuildersTest.kt
@@ -60,6 +60,18 @@ class ShellCommandBuildersTest {
         assertEquals("", runPackageUidExpression(allPkgs, "com.example.app"))
     }
 
+    @Test
+    fun `startup self target command batches root work and reports restart flag`() {
+        val cmd = buildEnsureSelfInTargetsCommand("dev.okhsunrog.vpnhide")
+
+        assertTrue(cmd.contains("ensure_line $KMOD_TARGETS"))
+        assertTrue(cmd.contains("ensure_line $ZYGISK_TARGETS"))
+        assertTrue(cmd.contains("ensure_line $LSPOSED_TARGETS"))
+        assertTrue(cmd.contains("ensure_line $SS_HIDDEN_PKGS_FILE"))
+        assertTrue(cmd.contains("pm list packages -U --user all"))
+        assertTrue(cmd.contains("echo ADDED=\$ADDED"))
+    }
+
     private fun runPackageUidExpression(
         allPkgs: String,
         packageName: String,

--- a/lsposed/app/src/test/kotlin/dev/okhsunrog/vpnhide/TargetsCacheTest.kt
+++ b/lsposed/app/src/test/kotlin/dev/okhsunrog/vpnhide/TargetsCacheTest.kt
@@ -1,0 +1,44 @@
+package dev.okhsunrog.vpnhide
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class TargetsCacheTest {
+    @Test
+    fun `targets snapshot parses module flags target files and observer names`() {
+        val rootSnapshot =
+            RootSnapshot(
+                generation = 1,
+                sections =
+                    mapOf(
+                        "kmod_module_dir" to "1",
+                        "zygisk_module_dir" to "0",
+                        "ports_prop" to "version=1.2.3",
+                        "kmod_targets" to "# comment\ndev.okhsunrog.vpnhide\ncom.bank.app\n",
+                        "zygisk_targets" to "com.chat.app\n\n",
+                        "lsposed_targets" to "system\n# ignored\n",
+                        "hidden_pkgs" to "com.hidden.one\ncom.hidden.two\n",
+                        "observer_uids" to "10123\n1010123\nnot-a-uid\n",
+                        "ports_observers" to "com.browser\n",
+                        "pm_packages" to
+                            "package:com.observer uid:10123,1010123\n" +
+                            "package:com.other uid:20222\n",
+                    ),
+            )
+
+        val targets = parseTargetsSnapshot(rootSnapshot)
+
+        assertTrue(targets.kmodModuleInstalled)
+        assertFalse(targets.zygiskModuleInstalled)
+        assertTrue(targets.portsModuleInstalled)
+        assertEquals(setOf("dev.okhsunrog.vpnhide", "com.bank.app"), targets.kmodTargets)
+        assertEquals(setOf("com.chat.app"), targets.zygiskTargets)
+        assertEquals(setOf("system"), targets.lsposedTargets)
+        assertEquals(setOf("com.hidden.one", "com.hidden.two"), targets.hiddenPkgs)
+        assertEquals(setOf(10123, 1010123), targets.observerUids)
+        assertEquals(setOf("com.observer"), targets.observerNames)
+        assertEquals(setOf("com.browser"), targets.portsObservers)
+    }
+}

--- a/lsposed/app/src/test/kotlin/dev/okhsunrog/vpnhide/TargetsCacheTest.kt
+++ b/lsposed/app/src/test/kotlin/dev/okhsunrog/vpnhide/TargetsCacheTest.kt
@@ -10,7 +10,6 @@ class TargetsCacheTest {
     fun `targets snapshot parses module flags target files and observer names`() {
         val rootSnapshot =
             RootSnapshot(
-                generation = 1,
                 sections =
                     mapOf(
                         "kmod_module_dir" to "1",

--- a/lsposed/app/src/test/kotlin/dev/okhsunrog/vpnhide/VpnIfaceStateParserTest.kt
+++ b/lsposed/app/src/test/kotlin/dev/okhsunrog/vpnhide/VpnIfaceStateParserTest.kt
@@ -1,0 +1,30 @@
+package dev.okhsunrog.vpnhide
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class VpnIfaceStateParserTest {
+    @Test
+    fun `parser accepts grep operstate output`() {
+        val raw =
+            """
+            /sys/class/net/wlan0/operstate:up
+            /sys/class/net/tun0/operstate:unknown
+            /sys/class/net/rmnet_data0/operstate:down
+            """.trimIndent()
+
+        assertEquals(listOf("tun0" to "unknown"), parseVpnIfaceStates(raw))
+    }
+
+    @Test
+    fun `parser keeps compatibility with legacy iface equals state output`() {
+        val raw =
+            """
+            wlan0=up
+            wg-client=up
+            rmnet_data0=down
+            """.trimIndent()
+
+        assertEquals(listOf("wg-client" to "up"), parseVpnIfaceStates(raw))
+    }
+}

--- a/lsposed/app/src/test/kotlin/dev/okhsunrog/vpnhide/VpnIfaceStateParserTest.kt
+++ b/lsposed/app/src/test/kotlin/dev/okhsunrog/vpnhide/VpnIfaceStateParserTest.kt
@@ -1,6 +1,8 @@
 package dev.okhsunrog.vpnhide
 
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
 class VpnIfaceStateParserTest {
@@ -26,5 +28,13 @@ class VpnIfaceStateParserTest {
             """.trimIndent()
 
         assertEquals(listOf("wg-client" to "up"), parseVpnIfaceStates(raw))
+    }
+
+    @Test
+    fun `vpn active evaluator treats unknown and up as active`() {
+        assertTrue(isVpnActiveFromStates(listOf("tun0" to "unknown")))
+        assertTrue(isVpnActiveFromStates(listOf("wg-client" to "up")))
+        assertFalse(isVpnActiveFromStates(listOf("tun0" to "down")))
+        assertFalse(isVpnActiveFromStates(emptyList()))
     }
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,6 +3,7 @@
 # header), so ruff is a dev/CI tool here, never a runtime dependency.
 
 [tool.ruff]
+required-version = "==0.15.18"
 target-version = "py312"  # CI image (Ubuntu 24.04) ships Python 3.12
 line-length = 100
 extend-exclude = [

--- a/scripts/measure-startup.py
+++ b/scripts/measure-startup.py
@@ -4,7 +4,8 @@
 The script reports both Android's `am start -W` timing and the app-defined
 `VpnHide-Startup event=dashboard_ready` marker. The latter is the primary
 metric: it fires after the startup splash can be released and the Dashboard
-content has reached a Compose frame.
+content has reached a Compose frame. All other `VpnHide-Startup` events are
+captured as stage timings for profiling startup work.
 """
 
 from __future__ import annotations
@@ -27,7 +28,23 @@ STARTUP_TAG = "VpnHide-Startup"
 class Sample:
     total_time_ms: int | None
     wait_time_ms: int | None
-    dashboard_ready_ms: int
+    events: dict[str, int]
+    metrics: dict[str, int]
+
+    @property
+    def dashboard_ready_ms(self) -> int:
+        return self.events["dashboard_ready"]
+
+    @property
+    def failed(self) -> bool:
+        return any(
+            event in self.events
+            for event in (
+                "root_snapshot_failed",
+                "targets_cache_failed",
+                "dashboard_state_failed",
+            )
+        )
 
 
 def adb(serial: str | None, *args: str, check: bool = True, timeout: float | None = None) -> subprocess.CompletedProcess[str]:
@@ -43,10 +60,15 @@ def parse_am_time(output: str, key: str) -> int | None:
     return int(match.group(1)) if match else None
 
 
-def read_dashboard_ready(serial: str | None) -> int | None:
+def read_startup_trace(serial: str | None) -> tuple[dict[str, int], dict[str, int]]:
     out = adb(serial, "logcat", "-d", "-v", "brief", "-s", f"{STARTUP_TAG}:I", "*:S").stdout
-    matches = re.findall(r"event=dashboard_ready elapsedMs=(\d+)", out)
-    return int(matches[-1]) if matches else None
+    events: dict[str, int] = {}
+    for event, elapsed_ms in re.findall(r"event=([a-zA-Z0-9_]+) elapsedMs=(\d+)", out):
+        events[event] = int(elapsed_ms)
+    metrics: dict[str, int] = {}
+    for metric, value_ms in re.findall(r"metric=([a-zA-Z0-9_]+) valueMs=(\d+)", out):
+        metrics[metric] = int(value_ms)
+    return events, metrics
 
 
 def percentile(values: list[int], pct: float) -> int:
@@ -64,20 +86,22 @@ def measure_one(serial: str | None, timeout_sec: float, cold_delay_sec: float) -
 
     am = adb(serial, "shell", "am", "start", "-W", "-n", ACTIVITY, timeout=timeout_sec)
     deadline = time.monotonic() + timeout_sec
-    dashboard_ready_ms: int | None = None
+    events: dict[str, int] = {}
+    metrics: dict[str, int] = {}
     while time.monotonic() < deadline:
-        dashboard_ready_ms = read_dashboard_ready(serial)
-        if dashboard_ready_ms is not None:
+        events, metrics = read_startup_trace(serial)
+        if "dashboard_ready" in events:
             break
         time.sleep(0.1)
 
-    if dashboard_ready_ms is None:
+    if "dashboard_ready" not in events:
         raise TimeoutError(f"did not see {STARTUP_TAG} dashboard_ready marker within {timeout_sec:.1f}s")
 
     return Sample(
         total_time_ms=parse_am_time(am.stdout, "TotalTime"),
         wait_time_ms=parse_am_time(am.stdout, "WaitTime"),
-        dashboard_ready_ms=dashboard_ready_ms,
+        events=events,
+        metrics=metrics,
     )
 
 
@@ -86,6 +110,16 @@ def print_summary(name: str, values: list[int]) -> None:
         f"{name}: median={round(statistics.median(values))}ms "
         f"p90={percentile(values, 0.90)}ms min={min(values)}ms max={max(values)}ms"
     )
+
+
+def format_event(sample: Sample, event: str) -> str:
+    value = sample.events.get(event)
+    return f"{event}={value}ms" if value is not None else f"{event}=?"
+
+
+def format_metric(sample: Sample, metric: str) -> str:
+    value = sample.metrics.get(metric)
+    return f"{metric}={value}ms" if value is not None else f"{metric}=?"
 
 
 def main() -> int:
@@ -101,18 +135,56 @@ def main() -> int:
 
     adb(args.serial, "start-server")
     samples: list[Sample] = []
+    run_events = [
+        "activity_on_create",
+        "self_targets_start",
+        "self_targets_done",
+        "root_snapshot_start",
+        "root_snapshot_done",
+        "root_snapshot_failed",
+        "targets_cache_failed",
+        "dashboard_derive_start",
+        "dashboard_modules_done",
+        "dashboard_kernel_done",
+        "dashboard_lsposed_config_done",
+        "dashboard_lsposed_done",
+        "dashboard_issues_done",
+        "dashboard_protection_done",
+        "dashboard_state_failed",
+        "dashboard_ready",
+    ]
+    run_metrics = [
+        "dashboard_lsposed_db_copy",
+        "dashboard_lsposed_db_query",
+        "root_shell_module_props",
+        "root_shell_target_files",
+        "root_shell_kmod_status_files",
+        "root_shell_runtime_status_files",
+        "root_shell_pm_packages",
+        "root_shell_shell_probe_proc_exists",
+        "root_shell_shell_probe_ports_chain",
+        "root_shell_shell_probe_lsposed_framework",
+        "root_shell_shell_probe_vpn_ifaces",
+    ]
     for idx in range(1, args.runs + 1):
         sample = measure_one(args.serial, args.timeout, args.cold_delay)
         samples.append(sample)
         print(
             f"run {idx}: dashboardReady={sample.dashboard_ready_ms}ms "
+            f"status={'error' if sample.failed else 'ok'} "
             f"amTotal={sample.total_time_ms if sample.total_time_ms is not None else '?'}ms "
             f"amWait={sample.wait_time_ms if sample.wait_time_ms is not None else '?'}ms"
         )
+        print("  " + " ".join(format_event(sample, event) for event in run_events if event in sample.events))
+        if sample.metrics:
+            print("  " + " ".join(format_metric(sample, metric) for metric in run_metrics if metric in sample.metrics))
         sys.stdout.flush()
 
     dashboard = [sample.dashboard_ready_ms for sample in samples]
     print_summary("dashboardReady", dashboard)
+    failures = sum(1 for sample in samples if sample.failed)
+    if failures:
+        print(f"startupFailures: {failures}/{len(samples)}")
 
     total = [sample.total_time_ms for sample in samples if sample.total_time_ms is not None]
     if total:
@@ -121,6 +193,44 @@ def main() -> int:
     wait = [sample.wait_time_ms for sample in samples if sample.wait_time_ms is not None]
     if wait:
         print_summary("amWait", wait)
+
+    all_events = sorted({event for sample in samples for event in sample.events})
+    if all_events:
+        print()
+        print("Startup events:")
+        for event in all_events:
+            values = [sample.events[event] for sample in samples if event in sample.events]
+            print_summary(event, values)
+
+    all_metrics = sorted({metric for sample in samples for metric in sample.metrics})
+    if all_metrics:
+        print()
+        print("Startup metrics:")
+        for metric in all_metrics:
+            values = [sample.metrics[metric] for sample in samples if metric in sample.metrics]
+            print_summary(metric, values)
+
+    stage_pairs = [
+        ("self_targets", "self_targets_start", "self_targets_done"),
+        ("root_snapshot", "root_snapshot_start", "root_snapshot_done"),
+        ("derive_modules", "dashboard_derive_start", "dashboard_modules_done"),
+        ("kernel", "dashboard_modules_done", "dashboard_kernel_done"),
+        ("lsposed_config", "dashboard_kernel_done", "dashboard_lsposed_config_done"),
+        ("lsposed_state", "dashboard_lsposed_config_done", "dashboard_lsposed_done"),
+        ("issues", "dashboard_lsposed_done", "dashboard_issues_done"),
+        ("protection", "dashboard_protection_start", "dashboard_protection_done"),
+        ("compose_frame", "dashboard_protection_done", "dashboard_ready"),
+    ]
+    print()
+    print("Startup stage deltas:")
+    for name, start, end in stage_pairs:
+        values = [
+            sample.events[end] - sample.events[start]
+            for sample in samples
+            if start in sample.events and end in sample.events
+        ]
+        if values:
+            print_summary(name, values)
 
     return 0
 

--- a/scripts/measure-startup.py
+++ b/scripts/measure-startup.py
@@ -18,7 +18,6 @@ import sys
 import time
 from dataclasses import dataclass
 
-
 PACKAGE = "dev.okhsunrog.vpnhide"
 ACTIVITY = f"{PACKAGE}/.MainActivity"
 STARTUP_TAG = "VpnHide-Startup"

--- a/scripts/measure-startup.py
+++ b/scripts/measure-startup.py
@@ -39,6 +39,7 @@ class Sample:
         return any(
             event in self.events
             for event in (
+                "self_targets_failed",
                 "root_snapshot_failed",
                 "targets_cache_failed",
                 "dashboard_state_failed",
@@ -146,6 +147,7 @@ def main() -> int:
         "activity_on_create",
         "self_targets_start",
         "self_targets_done",
+        "self_targets_failed",
         "root_snapshot_start",
         "root_snapshot_done",
         "root_snapshot_failed",

--- a/scripts/measure-startup.py
+++ b/scripts/measure-startup.py
@@ -47,7 +47,9 @@ class Sample:
         )
 
 
-def adb(serial: str | None, *args: str, check: bool = True, timeout: float | None = None) -> subprocess.CompletedProcess[str]:
+def adb(
+    serial: str | None, *args: str, check: bool = True, timeout: float | None = None
+) -> subprocess.CompletedProcess[str]:
     cmd = ["adb"]
     if serial:
         cmd += ["-s", serial]
@@ -95,7 +97,9 @@ def measure_one(serial: str | None, timeout_sec: float, cold_delay_sec: float) -
         time.sleep(0.1)
 
     if "dashboard_ready" not in events:
-        raise TimeoutError(f"did not see {STARTUP_TAG} dashboard_ready marker within {timeout_sec:.1f}s")
+        raise TimeoutError(
+            f"did not see {STARTUP_TAG} dashboard_ready marker within {timeout_sec:.1f}s"
+        )
 
     return Sample(
         total_time_ms=parse_am_time(am.stdout, "TotalTime"),
@@ -126,8 +130,12 @@ def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("-s", "--serial", help="adb device serial")
     parser.add_argument("-n", "--runs", type=int, default=10, help="number of cold starts")
-    parser.add_argument("--timeout", type=float, default=20.0, help="seconds to wait for each launch")
-    parser.add_argument("--cold-delay", type=float, default=1.0, help="seconds after force-stop before launching")
+    parser.add_argument(
+        "--timeout", type=float, default=20.0, help="seconds to wait for each launch"
+    )
+    parser.add_argument(
+        "--cold-delay", type=float, default=1.0, help="seconds after force-stop before launching"
+    )
     args = parser.parse_args()
 
     if args.runs <= 0:
@@ -175,9 +183,21 @@ def main() -> int:
             f"amTotal={sample.total_time_ms if sample.total_time_ms is not None else '?'}ms "
             f"amWait={sample.wait_time_ms if sample.wait_time_ms is not None else '?'}ms"
         )
-        print("  " + " ".join(format_event(sample, event) for event in run_events if event in sample.events))
+        print(
+            "  "
+            + " ".join(
+                format_event(sample, event) for event in run_events if event in sample.events
+            )
+        )
         if sample.metrics:
-            print("  " + " ".join(format_metric(sample, metric) for metric in run_metrics if metric in sample.metrics))
+            print(
+                "  "
+                + " ".join(
+                    format_metric(sample, metric)
+                    for metric in run_metrics
+                    if metric in sample.metrics
+                )
+            )
         sys.stdout.flush()
 
     dashboard = [sample.dashboard_ready_ms for sample in samples]

--- a/scripts/measure-startup.py
+++ b/scripts/measure-startup.py
@@ -1,0 +1,129 @@
+#!/usr/bin/env python3
+"""Measure VPN Hide cold startup until the Dashboard is ready.
+
+The script reports both Android's `am start -W` timing and the app-defined
+`VpnHide-Startup event=dashboard_ready` marker. The latter is the primary
+metric: it fires after the startup splash can be released and the Dashboard
+content has reached a Compose frame.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import statistics
+import subprocess
+import sys
+import time
+from dataclasses import dataclass
+
+
+PACKAGE = "dev.okhsunrog.vpnhide"
+ACTIVITY = f"{PACKAGE}/.MainActivity"
+STARTUP_TAG = "VpnHide-Startup"
+
+
+@dataclass(frozen=True)
+class Sample:
+    total_time_ms: int | None
+    wait_time_ms: int | None
+    dashboard_ready_ms: int
+
+
+def adb(serial: str | None, *args: str, check: bool = True, timeout: float | None = None) -> subprocess.CompletedProcess[str]:
+    cmd = ["adb"]
+    if serial:
+        cmd += ["-s", serial]
+    cmd += list(args)
+    return subprocess.run(cmd, check=check, capture_output=True, text=True, timeout=timeout)
+
+
+def parse_am_time(output: str, key: str) -> int | None:
+    match = re.search(rf"^{re.escape(key)}:\s*(\d+)$", output, re.MULTILINE)
+    return int(match.group(1)) if match else None
+
+
+def read_dashboard_ready(serial: str | None) -> int | None:
+    out = adb(serial, "logcat", "-d", "-v", "brief", "-s", f"{STARTUP_TAG}:I", "*:S").stdout
+    matches = re.findall(r"event=dashboard_ready elapsedMs=(\d+)", out)
+    return int(matches[-1]) if matches else None
+
+
+def percentile(values: list[int], pct: float) -> int:
+    if not values:
+        raise ValueError("empty values")
+    ordered = sorted(values)
+    index = min(len(ordered) - 1, round((len(ordered) - 1) * pct))
+    return ordered[index]
+
+
+def measure_one(serial: str | None, timeout_sec: float, cold_delay_sec: float) -> Sample:
+    adb(serial, "logcat", "-c")
+    adb(serial, "shell", "am", "force-stop", PACKAGE)
+    time.sleep(cold_delay_sec)
+
+    am = adb(serial, "shell", "am", "start", "-W", "-n", ACTIVITY, timeout=timeout_sec)
+    deadline = time.monotonic() + timeout_sec
+    dashboard_ready_ms: int | None = None
+    while time.monotonic() < deadline:
+        dashboard_ready_ms = read_dashboard_ready(serial)
+        if dashboard_ready_ms is not None:
+            break
+        time.sleep(0.1)
+
+    if dashboard_ready_ms is None:
+        raise TimeoutError(f"did not see {STARTUP_TAG} dashboard_ready marker within {timeout_sec:.1f}s")
+
+    return Sample(
+        total_time_ms=parse_am_time(am.stdout, "TotalTime"),
+        wait_time_ms=parse_am_time(am.stdout, "WaitTime"),
+        dashboard_ready_ms=dashboard_ready_ms,
+    )
+
+
+def print_summary(name: str, values: list[int]) -> None:
+    print(
+        f"{name}: median={round(statistics.median(values))}ms "
+        f"p90={percentile(values, 0.90)}ms min={min(values)}ms max={max(values)}ms"
+    )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("-s", "--serial", help="adb device serial")
+    parser.add_argument("-n", "--runs", type=int, default=10, help="number of cold starts")
+    parser.add_argument("--timeout", type=float, default=20.0, help="seconds to wait for each launch")
+    parser.add_argument("--cold-delay", type=float, default=1.0, help="seconds after force-stop before launching")
+    args = parser.parse_args()
+
+    if args.runs <= 0:
+        parser.error("--runs must be positive")
+
+    adb(args.serial, "start-server")
+    samples: list[Sample] = []
+    for idx in range(1, args.runs + 1):
+        sample = measure_one(args.serial, args.timeout, args.cold_delay)
+        samples.append(sample)
+        print(
+            f"run {idx}: dashboardReady={sample.dashboard_ready_ms}ms "
+            f"amTotal={sample.total_time_ms if sample.total_time_ms is not None else '?'}ms "
+            f"amWait={sample.wait_time_ms if sample.wait_time_ms is not None else '?'}ms"
+        )
+        sys.stdout.flush()
+
+    dashboard = [sample.dashboard_ready_ms for sample in samples]
+    print_summary("dashboardReady", dashboard)
+
+    total = [sample.total_time_ms for sample in samples if sample.total_time_ms is not None]
+    if total:
+        print_summary("amTotal", total)
+
+    wait = [sample.wait_time_ms for sample in samples if sample.wait_time_ms is not None]
+    if wait:
+        print_summary("amWait", wait)
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

- Add startup measurement tooling and `StartupTrace` markers for launch milestones, failures, and root-snapshot stages.
- Add a shared, validated root snapshot cache used by Dashboard and Protection state derivation.
- Rework startup prewarming so Dashboard owns the first root snapshot and Protection parses the same snapshot from memory instead of racing duplicate root work.
- Treat failed or incomplete root snapshots as explicit Dashboard load errors with Retry instead of rendering empty data.
- Optimize root-owned file reads in the snapshot command by replacing per-line shell loops with bulk `cat` reads.
- Add regression coverage for root snapshot parsing/caching, target cache behavior, shell command generation, and VPN interface parsing.

## Why

Startup work was doing too much root-state collection on the critical path, and some of that work could be duplicated between Dashboard and Protection. During repeated cold-start testing on Pixel 4a, a long splash could occasionally be followed by a Dashboard without complete data because a failed or partial root snapshot was still treated as usable.

Later profiling on Pixel 8 Pro / Android 16 / KernelSU showed another concrete bottleneck: the shell `while read` loop used for root-owned files made small target/status file reads cost hundreds of milliseconds. Bulk `cat` reads remove most of that overhead while preserving the same snapshot format.

## Device Coverage

Pixel 4a was the primary device for the iterative startup work:

- established the baseline install/run path from `main`;
- added and checked startup metrics across repeated cold starts;
- reproduced the intermittent long splash / incomplete Dashboard case;
- verified the shared-cache and Dashboard error-state changes with VPN enabled;
- representative post-cache run: `dashboardReady` median 1280 ms, p90 1360 ms.

Pixel 8 Pro was used for the later comparison after the second phone was connected:

- before bulk reads: `dashboardReady` median ~1607 ms, `root_snapshot` ~1205 ms, `root_shell_target_files` ~710-717 ms;
- after bulk reads: `dashboardReady` median 603 ms, p90 609 ms, max 613 ms; `root_snapshot` median 203 ms; `root_shell_target_files` median 42 ms;
- final release APK check with VPN enabled: 20 cold starts, 20/20 `status=ok`, no root snapshot or Dashboard failure markers.

## Validation

- `python3 -m py_compile scripts/measure-startup.py`
- `git diff --check`
- `./gradlew :app:testDebugUnitTest :app:lintDebug :app:assembleRelease`
- Native/Rust/zygisk files were not changed.


## Review Follow-ups

- Restore the self-target preparation timeout to the normal root-shell timeout and surface preparation failures with Retry instead of silently continuing.
- Reuse the startup `pm list packages -U --user all` output for the first root snapshot so cold start avoids a second PackageManager enumeration.
- Make Diagnostics use the shared root snapshot VPN state, add Protection-tab root-state error UI, preserve the previous snapshot on failed refresh, and tighten LSPosed framework probe validation.
