### PR TITLE
refactor(lsposed): dedupe UI/cache layer, extract startup coordinator, fix startup

### DIFF
--- a/changelog.d/fixed-fixed-app-failing-to-start-with-52a7.md
+++ b/changelog.d/fixed-fixed-app-failing-to-start-with-52a7.md
@@ -1,0 +1,9 @@
+_2026-06-23_
+
+## English
+
+Fixed app failing to start with "Startup preparation failed" — the root setup command was flattened to one line, breaking its shell syntax.
+
+## Русский
+
+Исправлен запуск приложения с ошибкой «Startup preparation failed» — команда настройки root схлопывалась в одну строку и ломала синтаксис shell.

--- a/changelog.d/fixed-protection-screens-now-show-a-retry-ea4f.md
+++ b/changelog.d/fixed-protection-screens-now-show-a-retry-ea4f.md
@@ -1,0 +1,9 @@
+_2026-06-22_
+
+## English
+
+Protection screens now show a retry card instead of spinning forever if the installed-app list fails to load.
+
+## Русский
+
+Экраны защиты теперь показывают карточку повтора вместо бесконечной загрузки, если список приложений не удалось загрузить.

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/AppHidingScreen.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/AppHidingScreen.kt
@@ -373,8 +373,7 @@ fun AppHidingScreen(
                 if (exitCode == 0) {
                     snackMessage =
                         resources.getString(R.string.hiding_save_success, hiddenCount, observerCount)
-                    DashboardCache.invalidate()
-                    TargetsCache.refresh(scope, context)
+                    TargetsCache.refreshAfterSave(scope, context)
                 } else if (exitCode == -1) {
                     snackMessage = resources.getString(R.string.save_failed_root)
                     dirty = true

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/AppHidingScreen.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/AppHidingScreen.kt
@@ -1,77 +1,22 @@
 package dev.okhsunrog.vpnhide
 
 import android.graphics.drawable.Drawable
-import androidx.compose.animation.core.animateFloatAsState
-import androidx.compose.foundation.Image
-import androidx.compose.foundation.clickable
-import androidx.compose.foundation.interaction.MutableInteractionSource
-import androidx.compose.foundation.interaction.collectIsDraggedAsState
-import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.defaultMinSize
-import androidx.compose.foundation.layout.fillMaxHeight
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.layout.wrapContentHeight
-import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.items
-import androidx.compose.foundation.lazy.rememberLazyListState
-import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material3.Button
-import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.SnackbarDuration
-import androidx.compose.material3.SnackbarHost
-import androidx.compose.material3.SnackbarHostState
-import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.collectAsState
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.rememberCoroutineScope
-import androidx.compose.runtime.setValue
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.drawBehind
-import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.asImageBitmap
-import androidx.compose.ui.graphics.graphicsLayer
-import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.platform.LocalResources
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.text.font.FontFamily
-import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.text.style.TextAlign
-import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
-import androidx.core.graphics.drawable.toBitmap
-import io.github.oikvpqya.compose.fastscroller.VerticalScrollbar
-import io.github.oikvpqya.compose.fastscroller.indicator.IndicatorConstants
-import io.github.oikvpqya.compose.fastscroller.material3.defaultMaterialScrollbarStyle
-import io.github.oikvpqya.compose.fastscroller.rememberScrollbarAdapter
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.withContext
 
 internal data class HidingEntry(
-    val packageName: String,
-    val label: String,
-    val icon: Drawable?,
-    val isSystem: Boolean,
-    val userIds: List<Int> = emptyList(),
+    override val packageName: String,
+    override val label: String,
+    override val icon: Drawable?,
+    override val isSystem: Boolean,
+    override val userIds: List<Int> = emptyList(),
     val hidden: Boolean = false,
     val observer: Boolean = false,
-) {
-    val anySelected get() = hidden || observer
+) : TargetEntry {
+    override val anySelected get() = hidden || observer
 }
 
 internal enum class HidingRole { HIDDEN, OBSERVER }
@@ -83,310 +28,103 @@ fun AppHidingScreen(
     showRussianOnly: Boolean,
     modifier: Modifier = Modifier,
 ) {
-    val context = LocalContext.current
-    val resources = LocalResources.current
-    val scope = rememberCoroutineScope()
-
-    val cachedApps by AppListCache.apps.collectAsState()
-    val userNames by AppListCache.userNames.collectAsState()
-    val targets by TargetsCache.snapshot.collectAsState()
-    val targetsError by TargetsCache.error.collectAsState()
-
-    var allApps by remember { mutableStateOf<List<HidingEntry>>(emptyList()) }
-    var saving by remember { mutableStateOf(false) }
-    var dirty by remember { mutableStateOf(false) }
-    var snackMessage by remember { mutableStateOf<String?>(null) }
-    val snackbarHostState = remember { SnackbarHostState() }
-
-    LaunchedEffect(snackMessage) {
-        snackMessage?.let {
-            snackbarHostState.showSnackbar(
-                message = it,
-                duration = SnackbarDuration.Long,
+    TargetPickerScreen(
+        searchQuery = searchQuery,
+        showSystem = showSystem,
+        showRussianOnly = showRussianOnly,
+        modifier = modifier,
+        helpPrefKey = "apps_hiding",
+        helpTitle = stringResource(R.string.hiding_help_title),
+        help = {
+            Text(
+                text = stringResource(R.string.hiding_hint_roles),
+                style = MaterialTheme.typography.bodyMedium,
             )
-            snackMessage = null
-        }
-    }
-
-    LaunchedEffect(Unit) {
-        TargetsCache.ensureLoaded(scope, context)
-    }
-
-    if (targetsError != null && targets == null) {
-        TargetsLoadErrorCard(
-            onRetry = { TargetsCache.refresh(scope, context) },
-            modifier = modifier,
-        )
-        return
-    }
-
-    // Packages with both roles crash on startup: the app queries its own
-    // PackageInfo/ResolveInfo during init, we detect the observer caller
-    // (itself) and strip its own package from the result, so frameworks
-    // see a self-lookup NameNotFoundException and bail. Collapse to
-    // observer-only on load so the next Save persists the fix.
-    //
-    // While `dirty` is true the user has unsaved checkbox edits — don't
-    // overwrite them with a fresh snapshot from the cache. Caches can
-    // refresh under us (ON_RESUME, another screen calling
-    // `TargetsCache.refresh()`) and silently dropping the edits is the
-    // worst outcome here. Treat saving as the only legitimate point
-    // where the snapshot becomes authoritative again.
-    LaunchedEffect(cachedApps, targets) {
-        if (dirty) return@LaunchedEffect
-        val apps = cachedApps ?: return@LaunchedEffect
-        val t = targets ?: return@LaunchedEffect
-        val hidden = t.hiddenPkgs
-        val observers = t.observerNames
-        val selfPkg = context.packageName
-        var autoFixedConflict = false
-        allApps =
-            apps
-                .filter { it.packageName != selfPkg }
-                .map { app ->
-                    val rawHidden = app.packageName in hidden
-                    val rawObserver = app.packageName in observers
-                    val (finalHidden, finalObserver) =
-                        if (rawHidden && rawObserver) {
-                            autoFixedConflict = true
-                            false to true
-                        } else {
-                            rawHidden to rawObserver
-                        }
-                    HidingEntry(
-                        packageName = app.packageName,
-                        label = app.label,
-                        icon = app.icon,
-                        isSystem = app.isSystem,
-                        userIds = app.userIds,
-                        hidden = finalHidden,
-                        observer = finalObserver,
-                    )
-                }
-        dirty = autoFixedConflict
-    }
-
-    val loading = cachedApps == null || targets == null
-
-    val filteredApps =
-        remember(allApps, searchQuery, showSystem, showRussianOnly) {
-            val q = searchQuery.trim().lowercase()
-            allApps.filter { app ->
-                (showSystem || !app.isSystem || app.anySelected) &&
-                    (!showRussianOnly || isRussianApp(app.packageName, app.label)) &&
-                    (q.isEmpty() || app.label.lowercase().contains(q) || app.packageName.lowercase().contains(q))
-            }
-        }
-
-    val hiddenCount = remember(allApps) { allApps.count { it.hidden } }
-    val observerCount = remember(allApps) { allApps.count { it.observer } }
-
-    Column(modifier = modifier.fillMaxSize()) {
-        if (loading) {
-            Box(
-                modifier = Modifier.fillMaxSize(),
-                contentAlignment = Alignment.Center,
-            ) {
-                CircularProgressIndicator()
-            }
-        } else {
-            val listState = rememberLazyListState()
-            Box(modifier = Modifier.weight(1f)) {
-                LazyColumn(
-                    state = listState,
-                    modifier = Modifier.fillMaxSize(),
-                ) {
-                    item {
-                        Box(modifier = Modifier.padding(horizontal = 12.dp, vertical = 8.dp)) {
-                            HelpAccordion(
-                                prefKey = "apps_hiding",
-                                title = stringResource(R.string.hiding_help_title),
-                            ) {
-                                Text(
-                                    text = stringResource(R.string.hiding_hint_roles),
-                                    style = MaterialTheme.typography.bodyMedium,
-                                )
-                                Text(
-                                    text = stringResource(R.string.hiding_hint_system),
-                                    style = MaterialTheme.typography.bodyMedium,
-                                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                                )
-                                Text(
-                                    text = stringResource(R.string.hiding_hint_reboot),
-                                    style = MaterialTheme.typography.bodyMedium,
-                                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                                )
+            Text(
+                text = stringResource(R.string.hiding_hint_system),
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            Text(
+                text = stringResource(R.string.hiding_hint_reboot),
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        },
+        merge = { apps, t, selfPkg ->
+            // Packages with both roles crash on startup: the app queries its own
+            // PackageInfo/ResolveInfo during init, we detect the observer caller
+            // (itself) and strip its own package from the result, so frameworks
+            // see a self-lookup NameNotFoundException and bail. Collapse to
+            // observer-only on load so the next Save persists the fix.
+            val hidden = t.hiddenPkgs
+            val observers = t.observerNames
+            var autoFixedConflict = false
+            val entries =
+                apps
+                    .filter { it.packageName != selfPkg }
+                    .map { app ->
+                        val rawHidden = app.packageName in hidden
+                        val rawObserver = app.packageName in observers
+                        val (finalHidden, finalObserver) =
+                            if (rawHidden && rawObserver) {
+                                autoFixedConflict = true
+                                false to true
+                            } else {
+                                rawHidden to rawObserver
                             }
-                        }
-                    }
-                    items(filteredApps, key = { it.packageName }) { app ->
-                        HidingAppRow(
-                            app = app,
-                            userNames = userNames,
-                            onToggle = { role ->
-                                allApps =
-                                    allApps.map {
-                                        if (it.packageName != app.packageName) {
-                                            it
-                                        } else {
-                                            // Roles are mutually exclusive: turning one on
-                                            // forces the other off. Avoids the H+O self-hide
-                                            // crash (app can't resolve its own package info).
-                                            when (role) {
-                                                HidingRole.HIDDEN -> {
-                                                    val newHidden = !it.hidden
-                                                    it.copy(
-                                                        hidden = newHidden,
-                                                        observer = if (newHidden) false else it.observer,
-                                                    )
-                                                }
-
-                                                HidingRole.OBSERVER -> {
-                                                    val newObserver = !it.observer
-                                                    it.copy(
-                                                        observer = newObserver,
-                                                        hidden = if (newObserver) false else it.hidden,
-                                                    )
-                                                }
-                                            }
-                                        }
-                                    }
-                                dirty = true
-                            },
+                        HidingEntry(
+                            packageName = app.packageName,
+                            label = app.label,
+                            icon = app.icon,
+                            isSystem = app.isSystem,
+                            userIds = app.userIds,
+                            hidden = finalHidden,
+                            observer = finalObserver,
                         )
                     }
-                }
-                val interactionSource = remember { MutableInteractionSource() }
-                val isDragging by interactionSource.collectIsDraggedAsState()
-                val indicatorAlpha by animateFloatAsState(
-                    if (isDragging) 1f else 0f,
-                    label = "indicatorAlpha",
-                )
-                VerticalScrollbar(
-                    adapter = rememberScrollbarAdapter(scrollState = listState),
-                    interactionSource = interactionSource,
-                    style = defaultMaterialScrollbarStyle(),
-                    enablePressToScroll = false,
-                    modifier =
-                        Modifier
-                            .align(Alignment.TopEnd)
-                            .fillMaxHeight(),
-                    indicator = { position, isVisible ->
-                        val firstChar =
-                            filteredApps
-                                .getOrNull(listState.firstVisibleItemIndex)
-                                ?.label
-                                ?.firstOrNull()
-                                ?.uppercase() ?: ""
-                        Box(
-                            modifier =
-                                Modifier
-                                    .align(Alignment.TopEnd)
-                                    .padding(end = IndicatorConstants.Default.PADDING)
-                                    .graphicsLayer {
-                                        val y = -(IndicatorConstants.Default.MIN_HEIGHT / 2).toPx()
-                                        translationY = (y + position).coerceAtLeast(0f)
-                                        alpha = indicatorAlpha
-                                    },
-                        ) {
-                            val indicatorColor =
-                                if (isVisible) MaterialTheme.colorScheme.primary else Color.Transparent
-                            val textColor =
-                                if (isVisible) MaterialTheme.colorScheme.onPrimary else Color.Transparent
-                            Box(
-                                modifier =
-                                    Modifier
-                                        .defaultMinSize(
-                                            minHeight = IndicatorConstants.Default.MIN_HEIGHT,
-                                            minWidth = IndicatorConstants.Default.MIN_WIDTH,
-                                        ).graphicsLayer {
-                                            clip = true
-                                            shape = IndicatorConstants.Default.SHAPE
-                                        }.drawBehind { drawRect(indicatorColor) },
-                            )
-                            Text(
-                                text = firstChar,
-                                color = textColor,
-                                textAlign = TextAlign.Center,
-                                style = MaterialTheme.typography.titleMedium,
-                                modifier =
-                                    Modifier
-                                        .align(Alignment.CenterEnd)
-                                        .wrapContentHeight()
-                                        .padding(end = IndicatorConstants.Default.PADDING)
-                                        .width(IndicatorConstants.Default.MIN_HEIGHT),
-                            )
+            MergeResult(entries, resaveNeeded = autoFixedConflict)
+        },
+        countText = { entries, _ ->
+            "H: ${entries.count { it.hidden }} · O: ${entries.count { it.observer }}"
+        },
+        buildSaveCommand = { entries, selfPkg, header ->
+            // Always include self in the hidden list — self is managed invisibly, never shown in UI.
+            val hiddenPkgs =
+                (entries.filter { it.hidden }.map { it.packageName } + selfPkg).distinct().sorted()
+            val observerPkgs = entries.filter { it.observer }.map { it.packageName }.sorted()
+            buildHidingSaveCommand(header, hiddenPkgs, observerPkgs)
+        },
+        successMessage = { entries, res ->
+            res.getString(
+                R.string.hiding_save_success,
+                entries.count { it.hidden },
+                entries.count { it.observer },
+            )
+        },
+    ) { app, userNames, _, onChange ->
+        HidingAppRow(
+            app = app,
+            userNames = userNames,
+            onToggle = { role ->
+                // Roles are mutually exclusive: turning one on forces the other
+                // off. Avoids the H+O self-hide crash (app can't resolve its own
+                // package info).
+                onChange(
+                    when (role) {
+                        HidingRole.HIDDEN -> {
+                            val newHidden = !app.hidden
+                            app.copy(hidden = newHidden, observer = if (newHidden) false else app.observer)
+                        }
+
+                        HidingRole.OBSERVER -> {
+                            val newObserver = !app.observer
+                            app.copy(observer = newObserver, hidden = if (newObserver) false else app.hidden)
                         }
                     },
                 )
-            }
-            Surface(tonalElevation = 3.dp) {
-                Box {
-                    Row(
-                        modifier =
-                            Modifier
-                                .fillMaxWidth()
-                                .padding(horizontal = 16.dp, vertical = 12.dp),
-                        verticalAlignment = Alignment.CenterVertically,
-                    ) {
-                        Text(
-                            text = "H: $hiddenCount · O: $observerCount",
-                            style = MaterialTheme.typography.bodyMedium,
-                            color = MaterialTheme.colorScheme.onSurfaceVariant,
-                            modifier = Modifier.weight(1f),
-                        )
-                        Button(
-                            onClick = {
-                                saving = true
-                                dirty = false
-                            },
-                            enabled = dirty && !saving,
-                        ) {
-                            Text(stringResource(R.string.btn_save))
-                        }
-                    }
-
-                    SnackbarHost(
-                        hostState = snackbarHostState,
-                        modifier =
-                            Modifier
-                                .fillMaxWidth()
-                                .align(Alignment.TopCenter),
-                    )
-                }
-            }
-        }
-    }
-
-    if (saving) {
-        LaunchedEffect(Unit) {
-            // Always include self in the hidden list — self is managed invisibly, never shown in UI.
-            val selfPkg = context.packageName
-            val hiddenPkgs =
-                (allApps.filter { it.hidden }.map { it.packageName } + selfPkg).distinct().sorted()
-            val observerPkgs = allApps.filter { it.observer }.map { it.packageName }.sorted()
-            val header = resources.getString(R.string.save_header_comment)
-
-            try {
-                val (exitCode, _) =
-                    suExecAsync(buildHidingSaveCommand(header, hiddenPkgs, observerPkgs))
-                if (exitCode == 0) {
-                    snackMessage =
-                        resources.getString(R.string.hiding_save_success, hiddenCount, observerCount)
-                    TargetsCache.refreshAfterSave(scope, context)
-                } else if (exitCode == -1) {
-                    snackMessage = resources.getString(R.string.save_failed_root)
-                    dirty = true
-                } else {
-                    snackMessage = resources.getString(R.string.save_failed_exit, exitCode)
-                    dirty = true
-                }
-            } catch (e: Exception) {
-                snackMessage = resources.getString(R.string.save_failed_error, e.message ?: "")
-                dirty = true
-            }
-            saving = false
-        }
+            },
+        )
     }
 }
 
@@ -406,25 +144,16 @@ private fun buildHidingSaveCommand(
     // enumerating the hidden-package list to fingerprint vpnhide.
     val hiddenBody = "$header\n" + hiddenPkgs.joinToString("\n") + if (hiddenPkgs.isNotEmpty()) "\n" else ""
     val hiddenB64 = encode(hiddenBody)
-    parts +=
-        "echo '$hiddenB64' | base64 -d > $SS_HIDDEN_PKGS_FILE" +
-        " && chmod 640 $SS_HIDDEN_PKGS_FILE" +
-        " && chown root:system $SS_HIDDEN_PKGS_FILE" +
-        " && chcon u:object_r:system_data_file:s0 $SS_HIDDEN_PKGS_FILE 2>/dev/null; true"
+    parts += "echo '$hiddenB64' | base64 -d > $SS_HIDDEN_PKGS_FILE"
+    parts += systemDataFilePermsParts(SS_HIDDEN_PKGS_FILE, "640")
 
     // Observer list: resolved UIDs. Same 0640 root:system rationale.
     if (observerPkgs.isNotEmpty()) {
         parts += buildUidResolverCommand(observerPkgs, SS_OBSERVER_UIDS_FILE)
-        parts += "chmod 640 $SS_OBSERVER_UIDS_FILE 2>/dev/null"
-        parts += "chown root:system $SS_OBSERVER_UIDS_FILE 2>/dev/null"
-        parts += "chcon u:object_r:system_data_file:s0 $SS_OBSERVER_UIDS_FILE 2>/dev/null; true"
     } else {
-        parts +=
-            "echo > $SS_OBSERVER_UIDS_FILE 2>/dev/null;" +
-            " chmod 640 $SS_OBSERVER_UIDS_FILE 2>/dev/null;" +
-            " chown root:system $SS_OBSERVER_UIDS_FILE 2>/dev/null;" +
-            " chcon u:object_r:system_data_file:s0 $SS_OBSERVER_UIDS_FILE 2>/dev/null; true"
+        parts += "echo > $SS_OBSERVER_UIDS_FILE 2>/dev/null"
     }
+    parts += systemDataFilePermsParts(SS_OBSERVER_UIDS_FILE, "640")
 
     return parts.joinToString(" ; ")
 }
@@ -435,70 +164,22 @@ private fun HidingAppRow(
     userNames: Map<Int, String>,
     onToggle: (HidingRole) -> Unit,
 ) {
-    Row(
-        modifier =
-            Modifier
-                .fillMaxWidth()
-                .padding(horizontal = 16.dp, vertical = 10.dp),
-        verticalAlignment = Alignment.CenterVertically,
+    TargetRowShell(
+        label = app.label,
+        packageName = app.packageName,
+        icon = app.icon,
+        userIds = app.userIds,
+        userNames = userNames,
     ) {
-        app.icon?.let { drawable ->
-            Image(
-                bitmap = drawable.toBitmap(48, 48).asImageBitmap(),
-                contentDescription = null,
-                modifier = Modifier.size(40.dp),
-            )
-            Spacer(Modifier.width(12.dp))
-        }
-        Column(modifier = Modifier.weight(1f)) {
-            Text(
-                text = labelWithUsers(app.label, app.userIds, userNames),
-                style = MaterialTheme.typography.bodyLarge,
-                fontWeight = FontWeight.Medium,
-            )
-            Text(
-                text = app.packageName,
-                style = MaterialTheme.typography.bodySmall,
-                fontFamily = FontFamily.Monospace,
-                fontSize = 12.sp,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
-            )
-            Spacer(Modifier.height(4.dp))
-            Row(horizontalArrangement = Arrangement.spacedBy(6.dp)) {
-                RoleChip(
-                    label = stringResource(R.string.hiding_chip_hidden),
-                    enabled = app.hidden,
-                    onClick = { onToggle(HidingRole.HIDDEN) },
-                )
-                RoleChip(
-                    label = stringResource(R.string.hiding_chip_observer),
-                    enabled = app.observer,
-                    onClick = { onToggle(HidingRole.OBSERVER) },
-                )
-            }
-        }
-    }
-}
-
-@Composable
-private fun RoleChip(
-    label: String,
-    enabled: Boolean,
-    onClick: () -> Unit,
-) {
-    val containerColor = if (enabled) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.surfaceVariant
-    val contentColor = if (enabled) MaterialTheme.colorScheme.onPrimary else MaterialTheme.colorScheme.onSurfaceVariant
-    Surface(
-        shape = RoundedCornerShape(4.dp),
-        color = containerColor,
-        modifier = Modifier.clickable(onClick = onClick),
-    ) {
-        Text(
-            text = label,
-            style = MaterialTheme.typography.labelSmall,
-            fontWeight = FontWeight.Bold,
-            color = contentColor,
-            modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
+        TargetChip(
+            label = stringResource(R.string.hiding_chip_hidden),
+            enabled = app.hidden,
+            onClick = { onToggle(HidingRole.HIDDEN) },
+        )
+        TargetChip(
+            label = stringResource(R.string.hiding_chip_observer),
+            enabled = app.observer,
+            onClick = { onToggle(HidingRole.OBSERVER) },
         )
     }
 }

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/AppListCache.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/AppListCache.kt
@@ -7,11 +7,9 @@ import android.graphics.drawable.Drawable
 import android.os.Process
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
-import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 
 /**
@@ -55,16 +53,16 @@ internal fun labelWithUsers(
 /**
  * App-scoped cache for the installed-app list. Loaded asynchronously
  * at startup; Protection screens subscribe to `apps` and render
- * instantly on tab switch.
- *
- * [refreshCounter] increments on every refresh — screens that maintain
- * their own per-screen state (targets.txt / observer files etc.) key
- * their reload `LaunchedEffect` on it, so the TopBar refresh button
- * rehydrates *everything*, not just the package+icon cache.
+ * instantly on tab switch. The top-bar refresh button calls [refresh]
+ * which reloads the package + icon list; Protection screens re-merge
+ * their per-screen target flags reactively off `apps` + the targets
+ * snapshot, so nothing keys off a manual refresh counter anymore.
  */
-internal object AppListCache {
-    private val _apps = MutableStateFlow<List<AppSummary>?>(null)
-    val apps: StateFlow<List<AppSummary>?> = _apps.asStateFlow()
+internal object AppListCache : StateCache<List<AppSummary>>(
+    traceName = "app_list_cache",
+    logTag = "VpnHide-AppList",
+) {
+    val apps: StateFlow<List<AppSummary>?> get() = value
 
     /** user_id → friendly profile name (e.g. 10 → "Work"). Populated
      * from `pm list users` alongside the package scan. Empty map if
@@ -74,95 +72,77 @@ internal object AppListCache {
     private val _userNames = MutableStateFlow<Map<Int, String>>(emptyMap())
     val userNames: StateFlow<Map<Int, String>> = _userNames.asStateFlow()
 
-    private val _refreshCounter = MutableStateFlow(0)
-    val refreshCounter: StateFlow<Int> = _refreshCounter.asStateFlow()
-
-    private val _loading = MutableStateFlow(false)
-    val loading: StateFlow<Boolean> = _loading.asStateFlow()
-
-    private var inflight: Job? = null
+    @Volatile private var appContext: Context? = null
 
     /** Kick off an initial load if not already loaded or loading. */
     fun ensureLoaded(
         scope: CoroutineScope,
         context: Context,
     ) {
-        if (_apps.value != null || inflight?.isActive == true) return
-        inflight = scope.launch { reload(context.applicationContext) }
+        appContext = context.applicationContext
+        ensure(scope)
     }
 
-    /** Force a reload and bump the refresh counter so screens re-read
-     * their per-screen state (targets.txt / observer files etc.) too.
-     */
+    /** Force a reload of the package + icon list. */
     fun refresh(
         scope: CoroutineScope,
         context: Context,
     ) {
-        inflight?.cancel()
-        inflight = scope.launch { reload(context.applicationContext) }
+        appContext = context.applicationContext
+        forceRefresh(scope)
     }
 
-    private suspend fun reload(appContext: Context) {
-        _loading.value = true
-        try {
-            StartupTrace.mark("app_list_cache_start")
-            val loaded =
-                withContext(Dispatchers.IO) {
-                    val pm = appContext.packageManager
-                    val (packages, users) = loadPackagesAndUsersViaRoot()
-                    _userNames.value = users
-                    if (packages.isNotEmpty()) {
-                        packages.entries
-                            .map { (pkg, meta) ->
-                                val info = runCatching { pm.getApplicationInfo(pkg, 0) }.getOrNull()
-                                val archiveInfo =
-                                    if (info == null) loadArchiveApplicationInfo(pm, meta.apkPath) else null
-                                val effectiveInfo = info ?: archiveInfo
+    override suspend fun load(force: Boolean): List<AppSummary> {
+        val appContext = requireNotNull(appContext) { "AppListCache.load before ensureLoaded/refresh" }
+        return withContext(Dispatchers.IO) {
+            val pm = appContext.packageManager
+            val (packages, users) = loadPackagesAndUsersViaRoot()
+            _userNames.value = users
+            if (packages.isNotEmpty()) {
+                packages.entries
+                    .map { (pkg, meta) ->
+                        val info = runCatching { pm.getApplicationInfo(pkg, 0) }.getOrNull()
+                        val archiveInfo =
+                            if (info == null) loadArchiveApplicationInfo(pm, meta.apkPath) else null
+                        val effectiveInfo = info ?: archiveInfo
 
-                                // Archive-parsed ApplicationInfo doesn't carry
-                                // FLAG_SYSTEM (that bit is attached by PM at
-                                // install time, not stored in the manifest), so
-                                // for secondary-only packages we'd misclassify
-                                // every system app as user-installed. Fall back
-                                // to the APK path: /data/app/... is user-
-                                // installed, everything else is baked into the
-                                // system image.
-                                val isSystem =
-                                    if (info != null) {
-                                        (info.flags and ApplicationInfo.FLAG_SYSTEM) != 0
-                                    } else {
-                                        !meta.apkPath.startsWith("/data/app/")
-                                    }
+                        // Archive-parsed ApplicationInfo doesn't carry
+                        // FLAG_SYSTEM (that bit is attached by PM at
+                        // install time, not stored in the manifest), so
+                        // for secondary-only packages we'd misclassify
+                        // every system app as user-installed. Fall back
+                        // to the APK path: /data/app/... is user-
+                        // installed, everything else is baked into the
+                        // system image.
+                        val isSystem =
+                            if (info != null) {
+                                (info.flags and ApplicationInfo.FLAG_SYSTEM) != 0
+                            } else {
+                                !meta.apkPath.startsWith("/data/app/")
+                            }
 
-                                AppSummary(
-                                    packageName = pkg,
-                                    label = effectiveInfo?.loadLabel(pm)?.toString() ?: pkg,
-                                    icon = effectiveInfo?.let { runCatching { pm.getApplicationIcon(it) }.getOrNull() },
-                                    isSystem = isSystem,
-                                    userIds = meta.userIds,
-                                )
-                            }.sortedBy { it.label.lowercase() }
-                    } else {
-                        // Fallback: current-profile only (legacy behavior)
-                        pm
-                            .getInstalledApplications(0)
-                            .map { info ->
-                                AppSummary(
-                                    packageName = info.packageName,
-                                    label = info.loadLabel(pm).toString(),
-                                    icon = runCatching { pm.getApplicationIcon(info) }.getOrNull(),
-                                    isSystem = (info.flags and ApplicationInfo.FLAG_SYSTEM) != 0,
-                                    userIds = listOf(Process.myUid() / 100000),
-                                )
-                            }.sortedBy { it.label.lowercase() }
-                    }
-                }
-
-            _apps.value = loaded
-            _refreshCounter.value = _refreshCounter.value + 1
-            StartupTrace.mark("app_list_cache_done")
-        } finally {
-            _loading.value = false
+                        AppSummary(
+                            packageName = pkg,
+                            label = effectiveInfo?.loadLabel(pm)?.toString() ?: pkg,
+                            icon = effectiveInfo?.let { runCatching { pm.getApplicationIcon(it) }.getOrNull() },
+                            isSystem = isSystem,
+                            userIds = meta.userIds,
+                        )
+                    }.sortedBy { it.label.lowercase() }
+            } else {
+                // Fallback: current-profile only (legacy behavior)
+                pm
+                    .getInstalledApplications(0)
+                    .map { info ->
+                        AppSummary(
+                            packageName = info.packageName,
+                            label = info.loadLabel(pm).toString(),
+                            icon = runCatching { pm.getApplicationIcon(info) }.getOrNull(),
+                            isSystem = (info.flags and ApplicationInfo.FLAG_SYSTEM) != 0,
+                            userIds = listOf(Process.myUid() / 100000),
+                        )
+                    }.sortedBy { it.label.lowercase() }
+            }
         }
     }
 

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/AppPickerScreen.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/AppPickerScreen.kt
@@ -348,11 +348,7 @@ fun AppPickerScreen(
                 val totalSelected = allApps.count { it.anySelected }
                 if (exitCode == 0) {
                     snackMessage = resources.getString(R.string.save_success, totalSelected)
-                    // Target counts shown on the Dashboard just changed;
-                    // invalidate so next open reflects them without a
-                    // manual refresh tap.
-                    DashboardCache.invalidate()
-                    TargetsCache.refresh(scope, context)
+                    TargetsCache.refreshAfterSave(scope, context)
                 } else if (exitCode == -1) {
                     snackMessage = resources.getString(R.string.save_failed_root)
                     dirty = true

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/AppPickerScreen.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/AppPickerScreen.kt
@@ -1,51 +1,24 @@
 package dev.okhsunrog.vpnhide
 
 import android.graphics.drawable.Drawable
-import androidx.compose.animation.core.animateFloatAsState
-import androidx.compose.foundation.Image
 import androidx.compose.foundation.clickable
-import androidx.compose.foundation.interaction.MutableInteractionSource
-import androidx.compose.foundation.interaction.collectIsDraggedAsState
-import androidx.compose.foundation.layout.*
-import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.items
-import androidx.compose.foundation.lazy.rememberLazyListState
-import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material3.*
-import androidx.compose.runtime.*
-import androidx.compose.ui.Alignment
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.drawBehind
-import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.asImageBitmap
-import androidx.compose.ui.graphics.graphicsLayer
-import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.platform.LocalResources
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.text.font.FontFamily
-import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.text.style.TextAlign
-import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
-import androidx.core.graphics.drawable.toBitmap
-import io.github.oikvpqya.compose.fastscroller.VerticalScrollbar
-import io.github.oikvpqya.compose.fastscroller.indicator.IndicatorConstants
-import io.github.oikvpqya.compose.fastscroller.material3.defaultMaterialScrollbarStyle
-import io.github.oikvpqya.compose.fastscroller.rememberScrollbarAdapter
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.withContext
 
 data class AppEntry(
-    val packageName: String,
-    val label: String,
-    val icon: Drawable?,
-    val isSystem: Boolean,
-    val userIds: List<Int> = emptyList(),
+    override val packageName: String,
+    override val label: String,
+    override val icon: Drawable?,
+    override val isSystem: Boolean,
+    override val userIds: List<Int> = emptyList(),
     val kmod: Boolean = false,
     val zygisk: Boolean = false,
     val lsposed: Boolean = false,
-) {
-    val anySelected get() = kmod || zygisk || lsposed
+) : TargetEntry {
+    override val anySelected get() = kmod || zygisk || lsposed
 }
 
 /** Which installed modules are present (detected once at load). */
@@ -63,305 +36,88 @@ fun AppPickerScreen(
     showRussianOnly: Boolean,
     modifier: Modifier = Modifier,
 ) {
-    val context = LocalContext.current
-    val resources = LocalResources.current
-    val scope = rememberCoroutineScope()
-
-    val cachedApps by AppListCache.apps.collectAsState()
-    val userNames by AppListCache.userNames.collectAsState()
-    val targets by TargetsCache.snapshot.collectAsState()
-    val targetsError by TargetsCache.error.collectAsState()
-
-    var allApps by remember { mutableStateOf<List<AppEntry>>(emptyList()) }
-    var saving by remember { mutableStateOf(false) }
-    var dirty by remember { mutableStateOf(false) }
-    var snackMessage by remember { mutableStateOf<String?>(null) }
-    val snackbarHostState = remember { SnackbarHostState() }
-
-    LaunchedEffect(snackMessage) {
-        snackMessage?.let {
-            snackbarHostState.showSnackbar(
-                message = it,
-                duration = SnackbarDuration.Long,
+    TargetPickerScreen(
+        searchQuery = searchQuery,
+        showSystem = showSystem,
+        showRussianOnly = showRussianOnly,
+        modifier = modifier,
+        helpPrefKey = "apps_tun",
+        helpTitle = stringResource(R.string.apps_help_title),
+        help = {
+            Text(
+                text = stringResource(R.string.apps_hint_toggles),
+                style = MaterialTheme.typography.bodyMedium,
             )
-            snackMessage = null
-        }
-    }
-
-    LaunchedEffect(Unit) {
-        TargetsCache.ensureLoaded(scope, context)
-    }
-
-    if (targetsError != null && targets == null) {
-        TargetsLoadErrorCard(
-            onRetry = { TargetsCache.refresh(scope, context) },
-            modifier = modifier,
-        )
-        return
-    }
-
-    val installed =
-        remember(targets) {
-            InstalledModules(
-                kmod = targets?.kmodModuleInstalled == true,
-                zygisk = targets?.zygiskModuleInstalled == true,
+            Text(
+                text = stringResource(R.string.apps_hint_restart_target),
+                style = MaterialTheme.typography.bodyMedium,
             )
-        }
-
-    // Merge cached app metadata with per-screen target flags. Cheap —
-    // runs whenever either side of the cache changes.
-    //
-    // While `dirty` is true the user has unsaved checkbox edits — don't
-    // overwrite them with a fresh snapshot. Caches can refresh under us
-    // (ON_RESUME, another screen calling `TargetsCache.refresh()`) and
-    // silently dropping the edits is the worst outcome.
-    LaunchedEffect(cachedApps, targets) {
-        if (dirty) return@LaunchedEffect
-        val apps = cachedApps ?: return@LaunchedEffect
-        val t = targets ?: return@LaunchedEffect
-        val selfPkg = context.packageName
-        allApps =
-            apps
-                .filter { it.packageName != selfPkg }
-                .map { app ->
-                    AppEntry(
-                        packageName = app.packageName,
-                        label = app.label,
-                        icon = app.icon,
-                        isSystem = app.isSystem,
-                        userIds = app.userIds,
-                        kmod = app.packageName in t.kmodTargets,
-                        zygisk = app.packageName in t.zygiskTargets,
-                        lsposed = app.packageName in t.lsposedTargets,
-                    )
-                }
-        dirty = false
-    }
-
-    val loading = cachedApps == null || targets == null
-
-    val filteredApps =
-        remember(allApps, searchQuery, showSystem, showRussianOnly) {
-            val q = searchQuery.trim().lowercase()
-            allApps.filter { app ->
-                (showSystem || !app.isSystem || app.anySelected) &&
-                    (!showRussianOnly || isRussianApp(app.packageName, app.label)) &&
-                    (q.isEmpty() || app.label.lowercase().contains(q) || app.packageName.lowercase().contains(q))
-            }
-        }
-
-    val selectedCount = remember(allApps) { allApps.count { it.anySelected } }
-
-    Column(modifier = modifier.fillMaxSize()) {
-        if (loading) {
-            Box(
-                modifier = Modifier.fillMaxSize(),
-                contentAlignment = Alignment.Center,
-            ) {
-                CircularProgressIndicator()
-            }
-        } else {
-            val listState = rememberLazyListState()
-            Box(modifier = Modifier.weight(1f)) {
-                LazyColumn(
-                    state = listState,
-                    modifier = Modifier.fillMaxSize(),
-                ) {
-                    item {
-                        Box(modifier = Modifier.padding(horizontal = 12.dp, vertical = 8.dp)) {
-                            HelpAccordion(
-                                prefKey = "apps_tun",
-                                title = stringResource(R.string.apps_help_title),
-                            ) {
-                                Text(
-                                    text = stringResource(R.string.apps_hint_toggles),
-                                    style = MaterialTheme.typography.bodyMedium,
-                                )
-                                Text(
-                                    text = stringResource(R.string.apps_hint_restart_target),
-                                    style = MaterialTheme.typography.bodyMedium,
-                                )
-                                Text(
-                                    text = stringResource(R.string.apps_hint_zygisk),
-                                    style = MaterialTheme.typography.bodyMedium,
-                                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                                )
-                            }
-                        }
-                    }
-                    items(filteredApps, key = { it.packageName }) { app ->
-                        AppRow(
-                            app = app,
-                            userNames = userNames,
-                            installed = installed,
-                            onToggle = { layer ->
-                                allApps =
-                                    allApps.map {
-                                        if (it.packageName != app.packageName) {
-                                            it
-                                        } else {
-                                            when (layer) {
-                                                Layer.KMOD -> it.copy(kmod = !it.kmod)
-                                                Layer.ZYGISK -> it.copy(zygisk = !it.zygisk)
-                                                Layer.LSPOSED -> it.copy(lsposed = !it.lsposed)
-                                            }
-                                        }
-                                    }
-                                dirty = true
-                            },
-                            onToggleAll = {
-                                allApps =
-                                    allApps.map {
-                                        if (it.packageName != app.packageName) {
-                                            it
-                                        } else {
-                                            val newState = !it.anySelected
-                                            it.copy(
-                                                kmod = if (installed.kmod) newState else false,
-                                                zygisk = if (installed.zygisk) newState else false,
-                                                lsposed = newState,
-                                            )
-                                        }
-                                    }
-                                dirty = true
-                            },
+            Text(
+                text = stringResource(R.string.apps_hint_zygisk),
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        },
+        merge = { apps, t, selfPkg ->
+            MergeResult(
+                apps
+                    .filter { it.packageName != selfPkg }
+                    .map { app ->
+                        AppEntry(
+                            packageName = app.packageName,
+                            label = app.label,
+                            icon = app.icon,
+                            isSystem = app.isSystem,
+                            userIds = app.userIds,
+                            kmod = app.packageName in t.kmodTargets,
+                            zygisk = app.packageName in t.zygiskTargets,
+                            lsposed = app.packageName in t.lsposedTargets,
                         )
-                    }
-                }
-                val interactionSource = remember { MutableInteractionSource() }
-                val isDragging by interactionSource.collectIsDraggedAsState()
-                val indicatorAlpha by animateFloatAsState(
-                    if (isDragging) 1f else 0f,
-                    label = "indicatorAlpha",
-                )
-                VerticalScrollbar(
-                    adapter = rememberScrollbarAdapter(scrollState = listState),
-                    interactionSource = interactionSource,
-                    style = defaultMaterialScrollbarStyle(),
-                    enablePressToScroll = false,
-                    modifier =
-                        Modifier
-                            .align(Alignment.TopEnd)
-                            .fillMaxHeight(),
-                    indicator = { position, isVisible ->
-                        val firstChar =
-                            filteredApps
-                                .getOrNull(listState.firstVisibleItemIndex)
-                                ?.label
-                                ?.firstOrNull()
-                                ?.uppercase() ?: ""
-                        Box(
-                            modifier =
-                                Modifier
-                                    .align(Alignment.TopEnd)
-                                    .padding(end = IndicatorConstants.Default.PADDING)
-                                    .graphicsLayer {
-                                        val y = -(IndicatorConstants.Default.MIN_HEIGHT / 2).toPx()
-                                        translationY = (y + position).coerceAtLeast(0f)
-                                        alpha = indicatorAlpha
-                                    },
-                        ) {
-                            val indicatorColor =
-                                if (isVisible) MaterialTheme.colorScheme.primary else Color.Transparent
-                            val textColor =
-                                if (isVisible) MaterialTheme.colorScheme.onPrimary else Color.Transparent
-                            Box(
-                                modifier =
-                                    Modifier
-                                        .defaultMinSize(
-                                            minHeight = IndicatorConstants.Default.MIN_HEIGHT,
-                                            minWidth = IndicatorConstants.Default.MIN_WIDTH,
-                                        ).graphicsLayer {
-                                            clip = true
-                                            shape = IndicatorConstants.Default.SHAPE
-                                        }.drawBehind { drawRect(indicatorColor) },
-                            )
-                            Text(
-                                text = firstChar,
-                                color = textColor,
-                                textAlign = TextAlign.Center,
-                                style = MaterialTheme.typography.titleMedium,
-                                modifier =
-                                    Modifier
-                                        .align(Alignment.CenterEnd)
-                                        .wrapContentHeight()
-                                        .padding(end = IndicatorConstants.Default.PADDING)
-                                        .width(IndicatorConstants.Default.MIN_HEIGHT),
-                            )
-                        }
+                    },
+            )
+        },
+        countText = { entries, res ->
+            res.getString(R.string.selected_count, entries.count { it.anySelected })
+        },
+        buildSaveCommand = { entries, selfPkg, header ->
+            val kmodPkgs = (entries.filter { it.kmod }.map { it.packageName } + selfPkg).distinct().sorted()
+            val zygiskPkgs = (entries.filter { it.zygisk }.map { it.packageName } + selfPkg).distinct().sorted()
+            val lsposedPkgs = (entries.filter { it.lsposed }.map { it.packageName } + selfPkg).distinct().sorted()
+            buildSaveCommand(header, kmodPkgs, zygiskPkgs, lsposedPkgs)
+        },
+        successMessage = { entries, res ->
+            res.getString(R.string.save_success, entries.count { it.anySelected })
+        },
+    ) { app, userNames, targets, onChange ->
+        val installed =
+            InstalledModules(
+                kmod = targets.kmodModuleInstalled,
+                zygisk = targets.zygiskModuleInstalled,
+            )
+        AppRow(
+            app = app,
+            userNames = userNames,
+            installed = installed,
+            onToggle = { layer ->
+                onChange(
+                    when (layer) {
+                        Layer.KMOD -> app.copy(kmod = !app.kmod)
+                        Layer.ZYGISK -> app.copy(zygisk = !app.zygisk)
+                        Layer.LSPOSED -> app.copy(lsposed = !app.lsposed)
                     },
                 )
-            }
-            Surface(tonalElevation = 3.dp) {
-                Box {
-                    Row(
-                        modifier =
-                            Modifier
-                                .fillMaxWidth()
-                                .padding(horizontal = 16.dp, vertical = 12.dp),
-                        verticalAlignment = Alignment.CenterVertically,
-                    ) {
-                        Text(
-                            text = stringResource(R.string.selected_count, selectedCount),
-                            style = MaterialTheme.typography.bodyMedium,
-                            color = MaterialTheme.colorScheme.onSurfaceVariant,
-                            modifier = Modifier.weight(1f),
-                        )
-                        Button(
-                            onClick = {
-                                saving = true
-                                dirty = false
-                            },
-                            enabled = dirty && !saving,
-                        ) {
-                            Text(stringResource(R.string.btn_save))
-                        }
-                    }
-
-                    SnackbarHost(
-                        hostState = snackbarHostState,
-                        modifier =
-                            Modifier
-                                .fillMaxWidth()
-                                .align(Alignment.TopCenter),
-                    )
-                }
-            }
-        }
-    }
-
-    // Save effect
-    if (saving) {
-        LaunchedEffect(Unit) {
-            // Always include self in all lists (self is hidden from UI but must stay in targets)
-            val selfPkg = context.packageName
-            val kmodPkgs = (allApps.filter { it.kmod }.map { it.packageName } + selfPkg).distinct().sorted()
-            val zygiskPkgs = (allApps.filter { it.zygisk }.map { it.packageName } + selfPkg).distinct().sorted()
-            val lsposedPkgs = (allApps.filter { it.lsposed }.map { it.packageName } + selfPkg).distinct().sorted()
-            val header = resources.getString(R.string.save_header_comment)
-
-            try {
-                val (exitCode, _) =
-                    suExecAsync(
-                        buildSaveCommand(header, kmodPkgs, zygiskPkgs, lsposedPkgs),
-                    )
-                val totalSelected = allApps.count { it.anySelected }
-                if (exitCode == 0) {
-                    snackMessage = resources.getString(R.string.save_success, totalSelected)
-                    TargetsCache.refreshAfterSave(scope, context)
-                } else if (exitCode == -1) {
-                    snackMessage = resources.getString(R.string.save_failed_root)
-                    dirty = true
-                } else {
-                    snackMessage = resources.getString(R.string.save_failed_exit, exitCode)
-                    dirty = true
-                }
-            } catch (e: Exception) {
-                snackMessage = resources.getString(R.string.save_failed_error, e.message ?: "")
-                dirty = true
-            }
-            saving = false
-        }
+            },
+            onToggleAll = {
+                val newState = !app.anySelected
+                onChange(
+                    app.copy(
+                        kmod = if (installed.kmod) newState else false,
+                        zygisk = if (installed.zygisk) newState else false,
+                        lsposed = newState,
+                    ),
+                )
+            },
+        )
     }
 }
 
@@ -406,15 +162,10 @@ private fun buildSaveCommand(
     // enumerating the target UID list to fingerprint vpnhide.
     if (lsposedPkgs.isNotEmpty()) {
         parts += buildUidResolverCommand(lsposedPkgs, SS_UIDS_FILE)
-        parts += "chmod 640 $SS_UIDS_FILE 2>/dev/null"
-        parts += "chown root:system $SS_UIDS_FILE 2>/dev/null"
-        parts += "chcon u:object_r:system_data_file:s0 $SS_UIDS_FILE 2>/dev/null"
     } else {
-        parts +=
-            "echo > $SS_UIDS_FILE 2>/dev/null" +
-            " && chmod 640 $SS_UIDS_FILE 2>/dev/null" +
-            " && chown root:system $SS_UIDS_FILE 2>/dev/null; true"
+        parts += "echo > $SS_UIDS_FILE 2>/dev/null"
     }
+    parts += systemDataFilePermsParts(SS_UIDS_FILE, "640")
 
     return parts.joinToString(" ; ")
 }
@@ -427,69 +178,20 @@ private fun AppRow(
     onToggle: (Layer) -> Unit,
     onToggleAll: () -> Unit,
 ) {
-    Row(
-        modifier =
-            Modifier
-                .fillMaxWidth()
-                .clickable(onClick = onToggleAll)
-                .padding(horizontal = 16.dp, vertical = 10.dp),
-        verticalAlignment = Alignment.CenterVertically,
+    TargetRowShell(
+        label = app.label,
+        packageName = app.packageName,
+        icon = app.icon,
+        userIds = app.userIds,
+        userNames = userNames,
+        modifier = Modifier.clickable(onClick = onToggleAll),
     ) {
-        app.icon?.let { drawable ->
-            Image(
-                bitmap = drawable.toBitmap(48, 48).asImageBitmap(),
-                contentDescription = null,
-                modifier = Modifier.size(40.dp),
-            )
-            Spacer(Modifier.width(12.dp))
+        TargetChip("L", app.lsposed) { onToggle(Layer.LSPOSED) }
+        if (installed.kmod) {
+            TargetChip("K", app.kmod) { onToggle(Layer.KMOD) }
         }
-        Column(modifier = Modifier.weight(1f)) {
-            Text(
-                text = labelWithUsers(app.label, app.userIds, userNames),
-                style = MaterialTheme.typography.bodyLarge,
-                fontWeight = FontWeight.Medium,
-            )
-            Text(
-                text = app.packageName,
-                style = MaterialTheme.typography.bodySmall,
-                fontFamily = FontFamily.Monospace,
-                fontSize = 12.sp,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
-            )
-            Spacer(Modifier.height(4.dp))
-            Row(horizontalArrangement = Arrangement.spacedBy(6.dp)) {
-                LayerChip("L", app.lsposed, true) { onToggle(Layer.LSPOSED) }
-                if (installed.kmod) {
-                    LayerChip("K", app.kmod, true) { onToggle(Layer.KMOD) }
-                }
-                if (installed.zygisk) {
-                    LayerChip("Z", app.zygisk, true) { onToggle(Layer.ZYGISK) }
-                }
-            }
+        if (installed.zygisk) {
+            TargetChip("Z", app.zygisk) { onToggle(Layer.ZYGISK) }
         }
-    }
-}
-
-@Composable
-private fun LayerChip(
-    label: String,
-    enabled: Boolean,
-    available: Boolean,
-    onClick: () -> Unit,
-) {
-    val containerColor = if (enabled) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.surfaceVariant
-    val contentColor = if (enabled) MaterialTheme.colorScheme.onPrimary else MaterialTheme.colorScheme.onSurfaceVariant
-    Surface(
-        shape = RoundedCornerShape(4.dp),
-        color = containerColor,
-        modifier = Modifier.clickable(enabled = available, onClick = onClick),
-    ) {
-        Text(
-            text = label,
-            style = MaterialTheme.typography.labelSmall,
-            fontWeight = FontWeight.Bold,
-            color = contentColor,
-            modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
-        )
     }
 }

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DashboardCache.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DashboardCache.kt
@@ -2,14 +2,9 @@ package dev.okhsunrog.vpnhide
 
 import android.content.Context
 import android.net.ConnectivityManager
-import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.Job
-import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.asStateFlow
-import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 
 /**
@@ -24,25 +19,24 @@ import kotlinx.coroutines.withContext
  * while a refresh is in flight so tab switches feel instant even when
  * data changes underneath.
  */
-internal object DashboardCache {
-    private val _state = MutableStateFlow<DashboardState?>(null)
-    val state: StateFlow<DashboardState?> = _state.asStateFlow()
+internal object DashboardCache : StateCache<DashboardState>(
+    traceName = "dashboard_state",
+    logTag = "VpnHide-Dashboard",
+) {
+    val state: StateFlow<DashboardState?> get() = value
 
-    private val _loading = MutableStateFlow(false)
-    val loading: StateFlow<Boolean> = _loading.asStateFlow()
+    @Volatile private var appContext: Context? = null
 
-    private val _error = MutableStateFlow<String?>(null)
-    val error: StateFlow<String?> = _error.asStateFlow()
-
-    private var inflight: Job? = null
+    @Volatile private var selfNeedsRestart: Boolean = false
 
     fun ensureLoaded(
         scope: CoroutineScope,
         context: Context,
         selfNeedsRestart: Boolean,
     ) {
-        if (_state.value != null || _error.value != null || inflight?.isActive == true) return
-        inflight = scope.launch { reload(context, selfNeedsRestart) }
+        this.appContext = context.applicationContext
+        this.selfNeedsRestart = selfNeedsRestart
+        ensure(scope)
     }
 
     fun refresh(
@@ -50,51 +44,19 @@ internal object DashboardCache {
         context: Context,
         selfNeedsRestart: Boolean,
     ) {
-        inflight?.cancel()
+        this.appContext = context.applicationContext
+        this.selfNeedsRestart = selfNeedsRestart
         RootSnapshotCache.invalidate()
-        _error.value = null
-        inflight = scope.launch { reload(context, selfNeedsRestart, forceRootRefresh = true) }
+        forceRefresh(scope)
     }
 
-    /** Invalidate so the next `ensureLoaded` call reloads. Used after
-     * a Save on a Protection screen changes target-file contents so
-     * that the next Dashboard open reflects the fresh counts without
-     * the user having to tap Refresh.
-     */
-    fun invalidate() {
-        _state.value = null
-        _error.value = null
-    }
-
-    private suspend fun reload(
-        context: Context,
-        selfNeedsRestart: Boolean,
-        forceRootRefresh: Boolean = false,
-    ) {
-        _loading.value = true
-        try {
-            val cm = context.getSystemService(ConnectivityManager::class.java)
-            val rootSnapshot =
-                if (forceRootRefresh) {
-                    RootSnapshotCache.refresh()
-                } else {
-                    RootSnapshotCache.getOrLoad()
-                }
-            val next =
-                withContext(Dispatchers.IO) {
-                    loadDashboardState(cm, context.applicationContext, selfNeedsRestart, rootSnapshot)
-                }
-            StartupTrace.mark("dashboard_state_loaded")
-            _state.value = next
-            _error.value = null
-        } catch (e: CancellationException) {
-            throw e
-        } catch (e: Exception) {
-            StartupTrace.mark("dashboard_state_failed")
-            _error.value = e.message ?: e.javaClass.simpleName
-            VpnHideLog.w("VpnHide-Dashboard", "dashboard reload failed: ${e.message}", e)
-        } finally {
-            _loading.value = false
+    override suspend fun load(force: Boolean): DashboardState {
+        val context = requireNotNull(appContext) { "DashboardCache.load before ensureLoaded/refresh" }
+        val cm = context.getSystemService(ConnectivityManager::class.java)
+        val rootSnapshot =
+            if (force) RootSnapshotCache.refresh() else RootSnapshotCache.getOrLoad()
+        return withContext(Dispatchers.IO) {
+            loadDashboardState(cm, context, selfNeedsRestart, rootSnapshot)
         }
     }
 }

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DashboardData.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DashboardData.kt
@@ -3,29 +3,10 @@ package dev.okhsunrog.vpnhide
 import android.content.pm.PackageManager
 import android.database.sqlite.SQLiteDatabase
 import android.net.ConnectivityManager
-import android.net.NetworkCapabilities
 import android.os.Build
 import android.os.SystemClock
 import android.util.Log
-import dev.okhsunrog.vpnhide.checks.CheckOutput
 import dev.okhsunrog.vpnhide.checks.CheckStatus
-import dev.okhsunrog.vpnhide.checks.checkGetifaddrs
-import dev.okhsunrog.vpnhide.checks.checkIoctlSiocgifconf
-import dev.okhsunrog.vpnhide.checks.checkIoctlSiocgifflags
-import dev.okhsunrog.vpnhide.checks.checkIoctlSiocgifmtu
-import dev.okhsunrog.vpnhide.checks.checkNetlinkGetlink
-import dev.okhsunrog.vpnhide.checks.checkNetlinkGetroute
-import dev.okhsunrog.vpnhide.checks.checkProcNetDev
-import dev.okhsunrog.vpnhide.checks.checkProcNetFibTrie
-import dev.okhsunrog.vpnhide.checks.checkProcNetIfInet6
-import dev.okhsunrog.vpnhide.checks.checkProcNetIpv6Route
-import dev.okhsunrog.vpnhide.checks.checkProcNetRoute
-import dev.okhsunrog.vpnhide.checks.checkProcNetTcp
-import dev.okhsunrog.vpnhide.checks.checkProcNetTcp6
-import dev.okhsunrog.vpnhide.checks.checkProcNetUdp
-import dev.okhsunrog.vpnhide.checks.checkProcNetUdp6
-import dev.okhsunrog.vpnhide.checks.checkSysClassNet
-import dev.okhsunrog.vpnhide.generated.IfaceLists
 import java.io.File
 
 // ── Domain types — invalid states are unrepresentable ────────────────────
@@ -54,6 +35,19 @@ enum class KmodBrokenReason {
     UnknownVariantInactive,
     AmbiguousLoadFailed,
 }
+
+/**
+ * The single kmod problem to surface. [reason] drives the red module-card
+ * color; [text] drives the dashboard error banner. Computed once (see
+ * `loadDashboardState`) so the card and the banner can never disagree —
+ * previously the priority order was hand-mirrored in two separate `when`
+ * blocks. [reason] is null for a generic insmod failure where we only have
+ * raw stderr to show, not a named diagnosis.
+ */
+internal data class KmodProblem(
+    val reason: KmodBrokenReason?,
+    val text: String,
+)
 
 sealed interface LsposedState {
     data object NotInstalled : LsposedState
@@ -409,11 +403,7 @@ internal fun loadDashboardState(
         return ModulePropInfo(true, version, gkiVariant ?: updateJsonKmi)
     }
 
-    fun countTargets(raw: String): Int =
-        raw.lines().count { line ->
-            val trimmed = line.trim()
-            trimmed.isNotEmpty() && !trimmed.startsWith("#") && trimmed != selfPkg
-        }
+    fun countTargets(raw: String): Int = parseConfigLines(raw).count { it != selfPkg }
 
     fun parseProps(raw: String): Map<String, String> =
         raw
@@ -773,22 +763,100 @@ internal fun loadDashboardState(
             )
     val kprobesMissing =
         kmodLoadStatus?.freshForCurrentBoot == true && kmodLoadStatus.kretprobes == "n"
-    // Priority matches the Error emission below so the card color agrees
-    // with the banner: kprobes-missing first, then unsupported-kernel,
-    // then wrong-variant, then unknown-variant-inactive, then
-    // ambiguous-load-failed (falls to this only when the installed kmod is
-    // one of the ambiguous candidates — the mismatch branches above already
-    // excluded both candidates from "wrong variant").
-    val kmodBrokenReason: KmodBrokenReason? =
-        when {
-            kmodRaw !is ModuleState.Installed -> null
-            kprobesMissing -> KmodBrokenReason.MissingKprobes
-            kmodOnUnsupportedKernel -> KmodBrokenReason.UnsupportedKernel
-            kmodVariantMismatch -> KmodBrokenReason.WrongVariant
-            kmodUnknownVariantBroken -> KmodBrokenReason.UnknownVariantInactive
-            kmodAmbiguousLoadFailed -> KmodBrokenReason.AmbiguousLoadFailed
-            else -> null
+    val recommendedArtifact = kernelRecommendation?.recommendedArtifact
+    // Single source of truth for "what's wrong with the installed kmod".
+    // Priority order: kprobes-missing first (no variant will ever work),
+    // then unsupported-kernel (wrong tool), wrong-variant (concrete
+    // mismatch), unknown-variant (old build that didn't stamp gkiVariant),
+    // ambiguous-load-failed (one of two valid candidates failed this boot),
+    // and finally a generic insmod failure when we have stderr to show.
+    // [reason] colors the card, [text] is the banner — deriving both from
+    // this one `when` keeps them from disagreeing. The `recommendedArtifact
+    // != null` guards are redundant in practice (those booleans already
+    // imply a non-null kernel recommendation) but kept so the res.getString
+    // args are provably non-null.
+    val kmodProblem: KmodProblem? =
+        if (kmodRaw !is ModuleState.Installed) {
+            null
+        } else {
+            when {
+                kprobesMissing -> {
+                    KmodProblem(
+                        KmodBrokenReason.MissingKprobes,
+                        res.getString(R.string.dashboard_issue_kprobes_missing),
+                    )
+                }
+
+                kmodOnUnsupportedKernel && recommendedArtifact != null -> {
+                    KmodProblem(
+                        KmodBrokenReason.UnsupportedKernel,
+                        res.getString(
+                            R.string.dashboard_issue_kmod_not_supported_kernel,
+                            kmodLoadStatus?.unameR ?: "?",
+                            recommendedArtifact,
+                        ),
+                    )
+                }
+
+                kmodVariantMismatch -> {
+                    KmodProblem(
+                        KmodBrokenReason.WrongVariant,
+                        res.getString(
+                            R.string.dashboard_issue_kmod_wrong_variant,
+                            kmodRaw.gkiVariant ?: "?",
+                            recommendedKmi ?: "?",
+                            recommendedArtifact ?: "?",
+                        ),
+                    )
+                }
+
+                kmodUnknownVariantBroken && recommendedArtifact != null -> {
+                    KmodProblem(
+                        KmodBrokenReason.UnknownVariantInactive,
+                        res.getString(
+                            R.string.dashboard_issue_kmod_unknown_variant,
+                            recommendedArtifact,
+                        ),
+                    )
+                }
+
+                kmodAmbiguousLoadFailed -> {
+                    val installed = kmodRaw.gkiVariant
+                    val tryArtifact =
+                        if (installed == kernelRecommendation?.recommendedGkiVariant) {
+                            kernelRecommendation.alternativeArtifact
+                        } else {
+                            kernelRecommendation?.recommendedArtifact
+                        }
+                    KmodProblem(
+                        KmodBrokenReason.AmbiguousLoadFailed,
+                        res.getString(
+                            R.string.dashboard_issue_kmod_ambiguous_try_alternative,
+                            installed ?: "?",
+                            tryArtifact ?: "?",
+                        ),
+                    )
+                }
+
+                !kmodRaw.active &&
+                    kmodLoadStatus?.freshForCurrentBoot == true &&
+                    kmodLoadStatus.insmodStderr != null -> {
+                    KmodProblem(
+                        reason = null,
+                        text =
+                            res.getString(
+                                R.string.dashboard_issue_kmod_load_failed,
+                                kmodLoadStatus.insmodStderr,
+                            ),
+                    )
+                }
+
+                else -> {
+                    null
+                }
+            }
         }
+    val kmodBrokenReason = kmodProblem?.reason
     val kmod: ModuleState =
         if (kmodRaw is ModuleState.Installed && kmodBrokenReason != null) {
             kmodRaw.copy(brokenReason = kmodBrokenReason)
@@ -1044,80 +1112,11 @@ internal fun loadDashboardState(
     StartupTrace.mark("dashboard_issues_done")
 
     // ── Errors: kmod variant / load problems ──
-    // Priority ordered: kprobes-missing first (no variant will ever work),
-    // then "kernel has no kmod variant" (user picked the wrong tool),
-    // then wrong-variant (concrete mismatch we can name), then unknown-variant
-    // (old build that didn't stamp gkiVariant), then generic load failure
-    // when we have insmod stderr to show. Only one kmod-failure issue fires
-    // to avoid piling up related banners. All Errors — these mean kmod is
-    // actively broken, not just suboptimal.
-    val recommendedArtifact = kernelRecommendation?.recommendedArtifact
-    if (kmod is ModuleState.Installed) {
-        when {
-            kmodLoadStatus?.freshForCurrentBoot == true &&
-                kmodLoadStatus.kretprobes == "n" -> {
-                err(res.getString(R.string.dashboard_issue_kprobes_missing))
-            }
-
-            kmodOnUnsupportedKernel && recommendedArtifact != null -> {
-                err(
-                    res.getString(
-                        R.string.dashboard_issue_kmod_not_supported_kernel,
-                        kmodLoadStatus?.unameR ?: "?",
-                        recommendedArtifact,
-                    ),
-                )
-            }
-
-            kmodVariantMismatch -> {
-                err(
-                    res.getString(
-                        R.string.dashboard_issue_kmod_wrong_variant,
-                        (kmod as ModuleState.Installed).gkiVariant ?: "?",
-                        recommendedKmi ?: "?",
-                        recommendedArtifact ?: "?",
-                    ),
-                )
-            }
-
-            kmodUnknownVariantBroken && recommendedArtifact != null -> {
-                err(
-                    res.getString(
-                        R.string.dashboard_issue_kmod_unknown_variant,
-                        recommendedArtifact,
-                    ),
-                )
-            }
-
-            kmodAmbiguousLoadFailed -> {
-                val installed = (kmod as ModuleState.Installed).gkiVariant
-                val tryArtifact =
-                    if (installed == kernelRecommendation?.recommendedGkiVariant) {
-                        kernelRecommendation.alternativeArtifact
-                    } else {
-                        kernelRecommendation?.recommendedArtifact
-                    }
-                err(
-                    res.getString(
-                        R.string.dashboard_issue_kmod_ambiguous_try_alternative,
-                        installed ?: "?",
-                        tryArtifact ?: "?",
-                    ),
-                )
-            }
-
-            !kmod.active &&
-                kmodLoadStatus?.freshForCurrentBoot == true &&
-                kmodLoadStatus.insmodStderr != null -> {
-                err(
-                    res.getString(
-                        R.string.dashboard_issue_kmod_load_failed,
-                        kmodLoadStatus.insmodStderr,
-                    ),
-                )
-            }
-        }
-    }
+    // The diagnosis (reason + banner text) was computed once above as
+    // `kmodProblem`; emit its text here. Only one kmod-failure banner fires,
+    // and its priority can't drift from the card color because both come
+    // from the same value.
+    kmodProblem?.let { err(it.text) }
 
     // ── Protection checks ──
     StartupTrace.mark("dashboard_protection_start")
@@ -1172,32 +1171,13 @@ internal fun loadDashboardState(
 }
 
 private fun runNativeProtectionCheck(): NativeResult {
-    val checks: List<Pair<String, () -> CheckOutput>> =
-        listOf(
-            "ioctl_flags" to { checkIoctlSiocgifflags() },
-            "ioctl_mtu" to { checkIoctlSiocgifmtu() },
-            "ioctl_conf" to { checkIoctlSiocgifconf() },
-            "getifaddrs" to { checkGetifaddrs() },
-            "netlink_getlink" to { checkNetlinkGetlink() },
-            "netlink_getroute" to { checkNetlinkGetroute() },
-            "proc_route" to { checkProcNetRoute() },
-            "proc_ipv6_route" to { checkProcNetIpv6Route() },
-            "proc_if_inet6" to { checkProcNetIfInet6() },
-            "proc_tcp" to { checkProcNetTcp() },
-            "proc_tcp6" to { checkProcNetTcp6() },
-            "proc_udp" to { checkProcNetUdp() },
-            "proc_udp6" to { checkProcNetUdp6() },
-            "proc_dev" to { checkProcNetDev() },
-            "proc_fib_trie" to { checkProcNetFibTrie() },
-            "sys_class_net" to { checkSysClassNet() },
-        )
-
     var passed = 0
     var failed = 0
     var skipped = 0
-    for ((name, check) in checks) {
+    for (spec in NATIVE_CHECKS) {
+        val name = spec.id
         try {
-            val out = check()
+            val out = spec.run()
             when (out.status) {
                 CheckStatus.NETWORK_BLOCKED -> {
                     skipped++
@@ -1235,46 +1215,32 @@ private fun runNativeProtectionCheck(): NativeResult {
     }
 }
 
-@Suppress("DEPRECATION")
 private fun runJavaProtectionCheck(cm: ConnectivityManager): JavaResult {
-    val net = cm.activeNetwork
-    if (net == null) {
+    // Same gates the Diagnostics screen uses: with no active network (or no
+    // caps for it) there's nothing for an app to leak, so report OK without
+    // probing. Then reuse the exact CheckResult-producing probes the
+    // Diagnostics screen runs — Dashboard cares only about the five
+    // VPN-presence vectors below (not proxy / route checks), so it runs
+    // precisely that subset and counts the ones that detected a leak. The
+    // probe names are irrelevant here (Dashboard discards the detail text),
+    // hence the empty labels.
+    if (cm.activeNetwork == null) {
         VpnHideLog.d(TAG, "java: no active network")
         return JavaResult.Ok
     }
-    val caps = cm.getNetworkCapabilities(net)
-    if (caps == null) {
+    if (cm.getNetworkCapabilities(cm.activeNetwork) == null) {
         VpnHideLog.d(TAG, "java: no capabilities")
         return JavaResult.Ok
     }
 
-    var failed = 0
-
-    val hasVpn = caps.hasTransport(NetworkCapabilities.TRANSPORT_VPN)
-    if (hasVpn) failed++
-    VpnHideLog.d(TAG, "java: hasTransport(VPN)=$hasVpn")
-
-    val notVpn = caps.hasCapability(NetworkCapabilities.NET_CAPABILITY_NOT_VPN)
-    if (!notVpn) failed++
-    VpnHideLog.d(TAG, "java: hasCapability(NOT_VPN)=$notVpn")
-
-    val info = caps.transportInfo
-    val isVpnTi = info?.javaClass?.name?.contains("VpnTransportInfo") == true
-    if (isVpnTi) failed++
-    VpnHideLog.d(TAG, "java: transportInfo=${info?.javaClass?.name} isVpn=$isVpnTi")
-
-    val vpnNets =
-        cm.allNetworks.count {
-            cm.getNetworkCapabilities(it)?.hasTransport(NetworkCapabilities.TRANSPORT_VPN) == true
-        }
-    if (vpnNets > 0) failed++
-    VpnHideLog.d(TAG, "java: allNetworks vpnCount=$vpnNets")
-
-    val lp = cm.getLinkProperties(net)
-    val ifname = lp?.interfaceName
-    val vpnIfname = ifname != null && IfaceLists.isVpnIface(ifname)
-    if (vpnIfname) failed++
-    VpnHideLog.d(TAG, "java: linkProperties ifname=$ifname isVpn=$vpnIfname")
+    val failed =
+        listOf(
+            checkHasTransportVpn(cm, ""),
+            checkHasCapabilityNotVpn(cm, ""),
+            checkTransportInfo(cm, ""),
+            checkAllNetworksVpn(cm, ""),
+            checkLinkPropertiesIfname(cm, ""),
+        ).count { it.passed == false }
 
     VpnHideLog.i(TAG, "java protection: failed=$failed")
     return if (failed == 0) JavaResult.Ok else JavaResult.Fail(failed)

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DashboardScreen.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DashboardScreen.kt
@@ -2,7 +2,6 @@ package dev.okhsunrog.vpnhide
 
 import android.content.Intent
 import android.net.Uri
-import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -79,11 +78,10 @@ fun DashboardScreen(
         // practice landed on "lavender" and "pink" on user devices — those
         // read as "note", not "problem". Same hardcoded pairs the module-
         // status cards use for active/inactive.
-        val darkTheme = isSystemInDarkTheme()
-        val errorBg = if (darkTheme) Color(0xFFB71C1C).copy(alpha = 0.3f) else Color(0xFFFFEBEE)
-        val errorHeader = if (darkTheme) Color(0xFFEF9A9A) else Color(0xFFC62828)
-        val warningBg = if (darkTheme) Color(0xFFE65100).copy(alpha = 0.2f) else Color(0xFFFFF3E0)
-        val warningHeader = if (darkTheme) Color(0xFFFFB74D) else Color(0xFFE65100)
+        val errorBg = StatusColors.errorContainer()
+        val errorHeader = StatusColors.errorHeader()
+        val warningBg = StatusColors.warningContainer()
+        val warningHeader = StatusColors.warningHeader()
         val onBannerColor = MaterialTheme.colorScheme.onSurface
 
         val s = state
@@ -234,7 +232,6 @@ private fun ModuleCard(
     state: ModuleState,
     selfNeedsRestart: Boolean = false,
 ) {
-    val darkTheme = isSystemInDarkTheme()
     when (state) {
         is ModuleState.NotInstalled -> {
             ModuleCardShell(
@@ -270,23 +267,15 @@ private fun ModuleCard(
                     },
                 dotColor =
                     when {
-                        broken != null -> Color(0xFFB71C1C)
-                        active -> Color(0xFF4CAF50)
-                        else -> Color(0xFFFF9800)
+                        broken != null -> StatusColors.errorDot
+                        active -> StatusColors.successDot
+                        else -> StatusColors.warningAccent
                     },
                 containerColor =
                     when {
-                        broken != null -> {
-                            if (darkTheme) Color(0xFFB71C1C).copy(alpha = 0.3f) else Color(0xFFFFEBEE)
-                        }
-
-                        active -> {
-                            if (darkTheme) Color(0xFF1B5E20).copy(alpha = 0.3f) else Color(0xFFE8F5E9)
-                        }
-
-                        else -> {
-                            if (darkTheme) Color(0xFFE65100).copy(alpha = 0.2f) else Color(0xFFFFF3E0)
-                        }
+                        broken != null -> StatusColors.errorContainer()
+                        active -> StatusColors.successContainer()
+                        else -> StatusColors.warningContainer()
                     },
             )
         }
@@ -295,7 +284,6 @@ private fun ModuleCard(
 
 @Composable
 private fun LsposedCard(state: LsposedState) {
-    val darkTheme = isSystemInDarkTheme()
     val moduleName = stringResource(R.string.dashboard_lsposed_module)
     val installedVersion = BuildConfig.VERSION_NAME
     when (state) {
@@ -314,8 +302,8 @@ private fun LsposedCard(state: LsposedState) {
                 name = moduleName,
                 version = installedVersion,
                 subtitle = stringResource(R.string.dashboard_installed_inactive),
-                dotColor = Color(0xFFFF9800),
-                containerColor = if (darkTheme) Color(0xFFE65100).copy(alpha = 0.2f) else Color(0xFFFFF3E0),
+                dotColor = StatusColors.warningAccent,
+                containerColor = StatusColors.warningContainer(),
             )
         }
 
@@ -324,8 +312,8 @@ private fun LsposedCard(state: LsposedState) {
                 name = moduleName,
                 version = installedVersion,
                 subtitle = stringResource(R.string.dashboard_reboot_needed),
-                dotColor = Color(0xFFFF9800),
-                containerColor = if (darkTheme) Color(0xFFE65100).copy(alpha = 0.2f) else Color(0xFFFFF3E0),
+                dotColor = StatusColors.warningAccent,
+                containerColor = StatusColors.warningContainer(),
             )
         }
 
@@ -341,8 +329,8 @@ private fun LsposedCard(state: LsposedState) {
                 name = moduleName,
                 version = installedVersion,
                 subtitle = subtitle,
-                dotColor = Color(0xFF4CAF50),
-                containerColor = if (darkTheme) Color(0xFF1B5E20).copy(alpha = 0.3f) else Color(0xFFE8F5E9),
+                dotColor = StatusColors.successDot,
+                containerColor = StatusColors.successContainer(),
             )
         }
     }
@@ -399,12 +387,11 @@ private fun ModuleCardShell(
 
 @Composable
 private fun NativeInstallRecommendationCard(recommendation: NativeInstallRecommendation) {
-    val darkTheme = isSystemInDarkTheme()
     val containerColor =
         if (recommendation.preferKmod) {
-            if (darkTheme) Color(0xFF0D47A1).copy(alpha = 0.28f) else Color(0xFFE3F2FD)
+            StatusColors.infoContainer()
         } else {
-            if (darkTheme) Color(0xFF4E342E).copy(alpha = 0.32f) else Color(0xFFFFF3E0)
+            StatusColors.zygiskRecommendContainer()
         }
 
     Card(
@@ -492,14 +479,13 @@ private fun NativeInstallRecommendationCard(recommendation: NativeInstallRecomme
 
 @Composable
 private fun NativeProtectionCard(result: NativeResult) {
-    val darkTheme = isSystemInDarkTheme()
     val (containerColor, statusText, statusColor) =
         when (result) {
             is NativeResult.Ok -> {
                 Triple(
-                    if (darkTheme) Color(0xFF1B5E20).copy(alpha = 0.3f) else Color(0xFFE8F5E9),
+                    StatusColors.successContainer(),
                     stringResource(R.string.dashboard_protection_ok),
-                    Color(0xFF4CAF50),
+                    StatusColors.successDot,
                 )
             }
 
@@ -510,13 +496,8 @@ private fun NativeProtectionCard(result: NativeResult) {
                     } else {
                         stringResource(R.string.dashboard_protection_fail)
                     }
-                val color = if (result.passed > 0) Color(0xFFFF9800) else Color(0xFFC62828)
-                val bg =
-                    if (result.passed > 0) {
-                        if (darkTheme) Color(0xFFE65100).copy(alpha = 0.2f) else Color(0xFFFFF3E0)
-                    } else {
-                        if (darkTheme) Color(0xFFB71C1C).copy(alpha = 0.3f) else Color(0xFFFFEBEE)
-                    }
+                val color = if (result.passed > 0) StatusColors.warningAccent else StatusColors.errorAccent
+                val bg = if (result.passed > 0) StatusColors.warningContainer() else StatusColors.errorContainer()
                 Triple(bg, text, color)
             }
 
@@ -538,22 +519,21 @@ private fun NativeProtectionCard(result: NativeResult) {
 
 @Composable
 private fun JavaProtectionCard(result: JavaResult) {
-    val darkTheme = isSystemInDarkTheme()
     val (containerColor, statusText, statusColor) =
         when (result) {
             is JavaResult.Ok -> {
                 Triple(
-                    if (darkTheme) Color(0xFF1B5E20).copy(alpha = 0.3f) else Color(0xFFE8F5E9),
+                    StatusColors.successContainer(),
                     stringResource(R.string.dashboard_protection_ok),
-                    Color(0xFF4CAF50),
+                    StatusColors.successDot,
                 )
             }
 
             is JavaResult.Fail -> {
                 Triple(
-                    if (darkTheme) Color(0xFFB71C1C).copy(alpha = 0.3f) else Color(0xFFFFEBEE),
+                    StatusColors.errorContainer(),
                     stringResource(R.string.dashboard_protection_fail),
-                    Color(0xFFC62828),
+                    StatusColors.errorAccent,
                 )
             }
 
@@ -606,26 +586,6 @@ private fun ProtectionCardShell(
 }
 
 @Composable
-private fun StatusBanner(
-    text: String,
-    containerColor: Color,
-    contentColor: Color,
-) {
-    Card(
-        shape = RoundedCornerShape(8.dp),
-        colors = CardDefaults.cardColors(containerColor = containerColor),
-        modifier = Modifier.fillMaxWidth(),
-    ) {
-        Text(
-            text = text,
-            style = MaterialTheme.typography.bodyMedium,
-            color = contentColor,
-            modifier = Modifier.padding(12.dp),
-        )
-    }
-}
-
-@Composable
 private fun DashboardLoadErrorCard(
     title: String,
     message: String,
@@ -665,12 +625,11 @@ private fun DashboardLoadErrorCard(
 @Composable
 private fun UpdateAvailableCard(info: UpdateInfo) {
     val context = LocalContext.current
-    val darkTheme = isSystemInDarkTheme()
     Card(
         shape = RoundedCornerShape(12.dp),
         colors =
             CardDefaults.cardColors(
-                containerColor = if (darkTheme) Color(0xFF0D47A1).copy(alpha = 0.28f) else Color(0xFFE3F2FD),
+                containerColor = StatusColors.infoContainer(),
             ),
         modifier = Modifier.fillMaxWidth(),
     ) {

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DiagnosticsCache.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DiagnosticsCache.kt
@@ -2,6 +2,7 @@ package dev.okhsunrog.vpnhide
 
 import android.content.Context
 import android.net.ConnectivityManager
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
@@ -30,11 +31,8 @@ import kotlinx.coroutines.withContext
  *   protection panel and the Diagnostics screen.
  *
  * Once [State.Ready] is reached, [run] becomes a no-op — results don't
- * change mid-process. The only path back to "please retry" requires
- * killing the process (new launch = fresh cache) or calling [reset]
- * (currently unused; reserved for explicit force-refresh flows, e.g.
- * "new kernel module just installed, please verify from a fresh
- * process" style prompts if we ever want them).
+ * change mid-process. The only path back to "please retry" is killing the
+ * process (a new launch starts with a fresh cache).
  */
 internal object DiagnosticsCache {
     sealed interface State {
@@ -77,27 +75,14 @@ internal object DiagnosticsCache {
         inflight = scope.launch { doRun(context.applicationContext) }
     }
 
-    /** Used by the retry button in the "VPN off" banner. Same as [run]
-     * but bypasses the `VpnOff` short-circuit (which [run] doesn't
-     * actually have — the guard above covers NotRun/VpnOff both — so
-     * this is really just a named alias for readability at the
-     * callsite).
+    /** Used by the retry button in the "VPN off" banner — a readable alias
+     * for [run] at the call site (the [run] guard already permits a re-run
+     * from both NotRun and VpnOff).
      */
     fun retry(
         scope: CoroutineScope,
         context: Context,
     ) = run(scope, context)
-
-    /** Drop any cached result. Next [run] will execute fresh.
-     * Not wired to any UI at the moment — reserved for scenarios like
-     * "user installed a new module and wants to force a re-run from the
-     * same process". Normal refreshes never need this because results
-     * are fixed for the process lifetime.
-     */
-    fun reset() {
-        inflight?.cancel()
-        _state.value = State.NotRun
-    }
 
     private suspend fun doRun(appContext: Context) {
         _state.value = State.Running
@@ -116,6 +101,11 @@ internal object DiagnosticsCache {
                 }
             _state.value = State.Ready(results)
             StartupTrace.mark("diagnostics_cache_done")
+        } catch (e: CancellationException) {
+            // A cancelled job (e.g. the screen left) must propagate so
+            // structured concurrency unwinds — never get reinterpreted as a
+            // VpnOff result.
+            throw e
         } catch (e: Exception) {
             // Failures leave us in VpnOff so the user sees the retry UI
             // rather than a frozen spinner. Real-world causes here are

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DiagnosticsScreen.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DiagnosticsScreen.kt
@@ -1,6 +1,5 @@
 package dev.okhsunrog.vpnhide
 
-import android.content.Intent
 import android.net.ConnectivityManager
 import android.net.NetworkCapabilities
 import android.net.Uri
@@ -15,8 +14,6 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.FiberManualRecord
-import androidx.compose.material.icons.filled.Save
-import androidx.compose.material.icons.filled.Share
 import androidx.compose.material.icons.filled.Stop
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
@@ -29,25 +26,8 @@ import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import androidx.core.content.FileProvider
 import dev.okhsunrog.vpnhide.checks.CheckOutput
 import dev.okhsunrog.vpnhide.checks.CheckStatus
-import dev.okhsunrog.vpnhide.checks.checkGetifaddrs
-import dev.okhsunrog.vpnhide.checks.checkIoctlSiocgifconf
-import dev.okhsunrog.vpnhide.checks.checkIoctlSiocgifflags
-import dev.okhsunrog.vpnhide.checks.checkIoctlSiocgifmtu
-import dev.okhsunrog.vpnhide.checks.checkNetlinkGetlink
-import dev.okhsunrog.vpnhide.checks.checkNetlinkGetroute
-import dev.okhsunrog.vpnhide.checks.checkProcNetDev
-import dev.okhsunrog.vpnhide.checks.checkProcNetFibTrie
-import dev.okhsunrog.vpnhide.checks.checkProcNetIfInet6
-import dev.okhsunrog.vpnhide.checks.checkProcNetIpv6Route
-import dev.okhsunrog.vpnhide.checks.checkProcNetRoute
-import dev.okhsunrog.vpnhide.checks.checkProcNetTcp
-import dev.okhsunrog.vpnhide.checks.checkProcNetTcp6
-import dev.okhsunrog.vpnhide.checks.checkProcNetUdp
-import dev.okhsunrog.vpnhide.checks.checkProcNetUdp6
-import dev.okhsunrog.vpnhide.checks.checkSysClassNet
 import dev.okhsunrog.vpnhide.generated.IfaceLists
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
@@ -75,6 +55,18 @@ internal data class CheckResults(
     val java: List<CheckResult>,
 ) {
     val all get() = native + java
+}
+
+/** Number of passed checks out of those that actually ran (NETWORK_BLOCKED
+ * probes report `passed == null` and are excluded from the denominator). */
+internal data class CheckScore(
+    val passed: Int,
+    val total: Int,
+)
+
+internal fun List<CheckResult>.score(): CheckScore {
+    val scored = filter { it.passed != null }
+    return CheckScore(passed = scored.count { it.passed == true }, total = scored.size)
 }
 
 internal suspend fun isVpnActive(): Boolean {
@@ -126,9 +118,8 @@ fun DiagnosticsScreen(
     val networkBlocked = results?.native?.any { it.passed == null } == true
     val summary =
         results?.let { r ->
-            val scored = r.all.filter { it.passed != null }
-            val passed = scored.count { it.passed == true }
-            String.format(summaryFmt, passed, scored.size)
+            val score = r.all.score()
+            String.format(summaryFmt, score.passed, score.total)
         }
 
     Column(
@@ -261,50 +252,13 @@ fun DiagnosticsScreen(
                 )
             }
         } else {
-            // Save / Share buttons
-            Row(
-                modifier = Modifier.fillMaxWidth(),
-                horizontalArrangement = Arrangement.spacedBy(8.dp),
-            ) {
-                OutlinedButton(
-                    onClick = { saveLauncher.launch(debugZipFile!!.name) },
-                    modifier = Modifier.weight(1f),
-                ) {
-                    Icon(
-                        Icons.Default.Save,
-                        contentDescription = null,
-                        modifier = Modifier.size(18.dp),
-                    )
-                    Spacer(Modifier.width(8.dp))
-                    Text(stringResource(R.string.btn_save_debug))
-                }
-                Button(
-                    onClick = {
-                        val uri =
-                            FileProvider.getUriForFile(
-                                context,
-                                "${context.packageName}.fileprovider",
-                                debugZipFile!!,
-                            )
-                        val intent =
-                            Intent(Intent.ACTION_SEND).apply {
-                                type = "application/zip"
-                                putExtra(Intent.EXTRA_STREAM, uri)
-                                addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
-                            }
-                        context.startActivity(Intent.createChooser(intent, null))
-                    },
-                    modifier = Modifier.weight(1f),
-                ) {
-                    Icon(
-                        Icons.Default.Share,
-                        contentDescription = null,
-                        modifier = Modifier.size(18.dp),
-                    )
-                    Spacer(Modifier.width(8.dp))
-                    Text(stringResource(R.string.btn_share_debug))
-                }
-            }
+            FileSaveShareRow(
+                saveLabel = stringResource(R.string.btn_save_debug),
+                shareLabel = stringResource(R.string.btn_share_debug),
+                sharePrimary = true,
+                onSave = { saveLauncher.launch(debugZipFile!!.name) },
+                onShare = { shareFileViaProvider(context, debugZipFile!!, "application/zip") },
+            )
         }
 
         Spacer(Modifier.height(16.dp))
@@ -448,49 +402,13 @@ private fun LogcatRecordCard() {
                             color = MaterialTheme.colorScheme.onSurfaceVariant,
                         )
                         Spacer(Modifier.height(8.dp))
-                        Row(
-                            modifier = Modifier.fillMaxWidth(),
-                            horizontalArrangement = Arrangement.spacedBy(8.dp),
-                        ) {
-                            OutlinedButton(
-                                onClick = { saveLauncher.launch(last.name) },
-                                modifier = Modifier.weight(1f),
-                            ) {
-                                Icon(
-                                    Icons.Default.Save,
-                                    contentDescription = null,
-                                    modifier = Modifier.size(18.dp),
-                                )
-                                Spacer(Modifier.width(8.dp))
-                                Text(stringResource(R.string.btn_save))
-                            }
-                            OutlinedButton(
-                                onClick = {
-                                    val uri =
-                                        FileProvider.getUriForFile(
-                                            context,
-                                            "${context.packageName}.fileprovider",
-                                            last,
-                                        )
-                                    val intent =
-                                        Intent(Intent.ACTION_SEND).apply {
-                                            type = "text/plain"
-                                            putExtra(Intent.EXTRA_STREAM, uri)
-                                            addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
-                                        }
-                                    context.startActivity(Intent.createChooser(intent, null))
-                                },
-                                modifier = Modifier.weight(1f),
-                            ) {
-                                Icon(
-                                    Icons.Default.Share,
-                                    contentDescription = null,
-                                    modifier = Modifier.size(18.dp),
-                                )
-                                Spacer(Modifier.width(8.dp))
-                                Text(stringResource(R.string.btn_share_debug))
-                            }
-                        }
+                        FileSaveShareRow(
+                            saveLabel = stringResource(R.string.btn_save),
+                            shareLabel = stringResource(R.string.btn_share_debug),
+                            sharePrimary = false,
+                            onSave = { saveLauncher.launch(last.name) },
+                            onShare = { shareFileViaProvider(context, last, "text/plain") },
+                        )
                         Spacer(Modifier.height(8.dp))
                     }
                     Button(
@@ -528,26 +446,6 @@ private fun formatSize(bytes: Long): String {
 }
 
 @Composable
-private fun StatusBanner(
-    text: String,
-    containerColor: Color,
-    contentColor: Color,
-) {
-    Card(
-        shape = RoundedCornerShape(8.dp),
-        colors = CardDefaults.cardColors(containerColor = containerColor),
-        modifier = Modifier.fillMaxWidth(),
-    ) {
-        Text(
-            text = text,
-            style = MaterialTheme.typography.bodyMedium,
-            color = contentColor,
-            modifier = Modifier.padding(12.dp),
-        )
-    }
-}
-
-@Composable
 private fun SectionHeader(title: String) {
     Text(
         text = title,
@@ -559,20 +457,11 @@ private fun SectionHeader(title: String) {
 
 @Composable
 private fun CheckCard(r: CheckResult) {
-    val darkTheme = isSystemInDarkTheme()
     val actualColor =
-        if (darkTheme) {
-            when (r.passed) {
-                true -> Color(0xFF1B5E20).copy(alpha = 0.3f)
-                false -> Color(0xFFB71C1C).copy(alpha = 0.3f)
-                null -> MaterialTheme.colorScheme.surfaceVariant
-            }
-        } else {
-            when (r.passed) {
-                true -> Color(0xFFE8F5E9)
-                false -> Color(0xFFFFEBEE)
-                null -> MaterialTheme.colorScheme.surfaceVariant
-            }
+        when (r.passed) {
+            true -> StatusColors.successContainer()
+            false -> StatusColors.errorContainer()
+            null -> MaterialTheme.colorScheme.surfaceVariant
         }
 
     val badgeText =
@@ -586,8 +475,8 @@ private fun CheckCard(r: CheckResult) {
 
     val badgeColor =
         when (r.passed) {
-            true -> Color(0xFF2E7D32)
-            false -> Color(0xFFC62828)
+            true -> StatusColors.successBadge
+            false -> StatusColors.errorAccent
             null -> MaterialTheme.colorScheme.onSurfaceVariant
         }
 
@@ -641,26 +530,9 @@ internal fun runAllChecks(
     val res = context.resources
 
     val native =
-        listOf(
-            nativeCheck(res.getString(R.string.check_ioctl_flags)) { checkIoctlSiocgifflags() },
-            nativeCheck(res.getString(R.string.check_ioctl_mtu)) { checkIoctlSiocgifmtu() },
-            nativeCheck(res.getString(R.string.check_ioctl_conf)) { checkIoctlSiocgifconf() },
-            nativeCheck(res.getString(R.string.check_getifaddrs)) { checkGetifaddrs() },
-            nativeCheck(res.getString(R.string.check_netlink_getlink)) { checkNetlinkGetlink() },
-            nativeCheck(res.getString(R.string.check_netlink_getroute)) { checkNetlinkGetroute() },
-            nativeCheck(res.getString(R.string.check_proc_route)) { checkProcNetRoute() },
-            nativeCheck(res.getString(R.string.check_proc_ipv6_route)) { checkProcNetIpv6Route() },
-            nativeCheck(res.getString(R.string.check_proc_if_inet6)) { checkProcNetIfInet6() },
-            nativeCheck(res.getString(R.string.check_proc_tcp)) { checkProcNetTcp() },
-            nativeCheck(res.getString(R.string.check_proc_tcp6)) { checkProcNetTcp6() },
-            nativeCheck(res.getString(R.string.check_proc_udp)) { checkProcNetUdp() },
-            nativeCheck(res.getString(R.string.check_proc_udp6)) { checkProcNetUdp6() },
-            nativeCheck(res.getString(R.string.check_proc_dev)) { checkProcNetDev() },
-            nativeCheck(res.getString(R.string.check_proc_fib_trie)) { checkProcNetFibTrie() },
-            nativeCheck(res.getString(R.string.check_sys_class_net)) { checkSysClassNet() },
-            checkNetworkInterfaceEnum(res.getString(R.string.check_net_iface_enum)),
-            checkProcNetRouteJava(res.getString(R.string.check_proc_route_java)),
-        )
+        NATIVE_CHECKS.map { spec -> nativeCheck(res.getString(spec.labelRes), spec.run) } +
+            checkNetworkInterfaceEnum(res.getString(R.string.check_net_iface_enum)) +
+            checkProcNetRouteJava(res.getString(R.string.check_proc_route_java))
 
     val java =
         listOf(
@@ -674,10 +546,8 @@ internal fun runAllChecks(
             checkProxyHost(res.getString(R.string.check_proxy_host)),
         )
 
-    val all = native + java
-    val scored = all.filter { it.passed != null }
-    val passed = scored.count { it.passed == true }
-    VpnHideLog.i(TAG, "=== SUMMARY: $passed/${scored.size} passed ===")
+    val score = (native + java).score()
+    VpnHideLog.i(TAG, "=== SUMMARY: ${score.passed}/${score.total} passed ===")
 
     return CheckResults(native = native, java = java)
 }
@@ -706,7 +576,7 @@ private fun nativeCheck(
 //  Java API checks
 // ==========================================================================
 
-private fun checkHasTransportVpn(
+internal fun checkHasTransportVpn(
     cm: ConnectivityManager,
     name: String,
 ): CheckResult {
@@ -724,7 +594,7 @@ private fun checkHasTransportVpn(
     return CheckResult(name, !hasVpn, detail)
 }
 
-private fun checkHasCapabilityNotVpn(
+internal fun checkHasCapabilityNotVpn(
     cm: ConnectivityManager,
     name: String,
 ): CheckResult {
@@ -735,7 +605,7 @@ private fun checkHasCapabilityNotVpn(
     return CheckResult(name, notVpn, detail)
 }
 
-private fun checkTransportInfo(
+internal fun checkTransportInfo(
     cm: ConnectivityManager,
     name: String,
 ): CheckResult {
@@ -771,7 +641,7 @@ private fun checkNetworkInterfaceEnum(name: String): CheckResult =
     }
 
 @Suppress("DEPRECATION")
-private fun checkAllNetworksVpn(
+internal fun checkAllNetworksVpn(
     cm: ConnectivityManager,
     name: String,
 ): CheckResult {
@@ -815,7 +685,7 @@ private fun checkActiveNetworkVpn(
     return CheckResult(name, !hasVpn, detail)
 }
 
-private fun checkLinkPropertiesIfname(
+internal fun checkLinkPropertiesIfname(
     cm: ConnectivityManager,
     name: String,
 ): CheckResult {
@@ -944,9 +814,8 @@ private suspend fun exportDebugZip(
             // Diagnostics results
             val diagText =
                 buildString {
-                    val scored = checkResults.all.filter { it.passed != null }
-                    val passed = scored.count { it.passed == true }
-                    appendLine("=== Diagnostics: $passed/${scored.size} passed ===")
+                    val score = checkResults.all.score()
+                    appendLine("=== Diagnostics: ${score.passed}/${score.total} passed ===")
                     appendLine()
                     appendLine("--- Native level ---")
                     for (c in checkResults.native) {

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/MainActivity.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/MainActivity.kt
@@ -135,10 +135,9 @@ private data class RefreshContext(
 private fun MainScreen(onReady: () -> Unit = {}) {
     val context = LocalContext.current
     val scope = rememberCoroutineScope()
+    val appContext = context.applicationContext
+    val startupCoordinator = remember(appContext) { StartupCoordinator(appContext) }
     var currentTab by remember { mutableStateOf(Tab.Dashboard) }
-    var selfNeedsRestart by remember { mutableStateOf<Boolean?>(null) }
-    var selfTargetError by remember { mutableStateOf<String?>(null) }
-    var selfTargetAttempt by remember { mutableIntStateOf(0) }
     var searchQuery by remember { mutableStateOf("") }
     var searchActive by remember { mutableStateOf(false) }
     var showSystem by remember { mutableStateOf(false) }
@@ -150,28 +149,15 @@ private fun MainScreen(onReady: () -> Unit = {}) {
     val dashboardState by DashboardCache.state.collectAsState()
     val dashboardError by DashboardCache.error.collectAsState()
     val rootSnapshot by RootSnapshotCache.snapshot.collectAsState()
+    val selfTargetState by startupCoordinator.selfTargetState.collectAsState()
+    val selfNeedsRestart =
+        (selfTargetState as? StartupSelfTargetState.Ready)?.selfNeedsRestart
+    val selfTargetError =
+        (selfTargetState as? StartupSelfTargetState.Failed)?.message
     val refreshRestart = selfNeedsRestart ?: false
 
-    LaunchedEffect(selfTargetAttempt) {
-        selfNeedsRestart = null
-        selfTargetError = null
-        StartupTrace.mark("self_targets_start")
-        val preparation =
-            withContext(Dispatchers.IO) {
-                val preparation = ensureSelfInTargets(context.packageName)
-                if (preparation.rootAvailable) {
-                    RootSnapshotCache.seedPmPackages(preparation.pmPackages)
-                    cleanupStaleZygiskStatus(context, preparation.currentBootId)
-                }
-                preparation
-            }
-        StartupTrace.mark("self_targets_done")
-        if (preparation.rootAvailable) {
-            selfNeedsRestart = preparation.selfNeedsRestart
-        } else {
-            StartupTrace.mark("self_targets_failed")
-            selfTargetError = preparation.error ?: "root preparation failed"
-        }
+    LaunchedEffect(startupCoordinator) {
+        startupCoordinator.prepareSelfTargets()
     }
 
     // Start the app-scoped caches as soon as the self-target preparation
@@ -181,10 +167,7 @@ private fun MainScreen(onReady: () -> Unit = {}) {
     // prewarms during splash, but without racing the self-target root shell.
     LaunchedEffect(selfNeedsRestart) {
         val r = selfNeedsRestart ?: return@LaunchedEffect
-        if (selfTargetError != null) return@LaunchedEffect
-        AppListCache.ensureLoaded(scope, context)
-        DashboardCache.ensureLoaded(scope, context, r)
-        if (!r) DiagnosticsCache.run(scope, context)
+        startupCoordinator.ensureInitialCaches(scope, r)
     }
 
     // Protection depends on the same root snapshot as Dashboard. Let
@@ -193,18 +176,14 @@ private fun MainScreen(onReady: () -> Unit = {}) {
     // as that shared snapshot exists, TargetsCache parses it from memory and
     // Protection is still prewarmed before a normal tab switch.
     LaunchedEffect(selfNeedsRestart, rootSnapshot) {
-        if (selfNeedsRestart != null && rootSnapshot != null) {
-            TargetsCache.ensureLoaded(scope, context)
-        }
+        startupCoordinator.ensureProtectionCacheAfterRootSnapshot(scope, selfNeedsRestart, rootSnapshot)
     }
 
     // Hold the splash screen until the first Dashboard frame can render
     // with real content. Without this, the user sees splash → brief
     // selfNeedsRestart-null spinner → brief Dashboard state-null spinner
     // → content, with each spinner swap being visible flicker.
-    val uiReady =
-        selfTargetError != null ||
-            (selfNeedsRestart != null && (dashboardState != null || dashboardError != null))
+    val uiReady = startupCoordinator.isUiReady(dashboardState, dashboardError)
     var fullyDrawnReady by remember { mutableStateOf(false) }
     ReportDrawnWhen { fullyDrawnReady }
     LaunchedEffect(uiReady) {
@@ -223,7 +202,7 @@ private fun MainScreen(onReady: () -> Unit = {}) {
         val observer =
             LifecycleEventObserver { _, event ->
                 if (event == Lifecycle.Event.ON_RESUME) {
-                    UpdateCheckCache.ensureFresh(scope, BuildConfig.VERSION_NAME)
+                    startupCoordinator.ensureUpdateFresh(scope)
                 }
             }
         lifecycleOwner.lifecycle.addObserver(observer)
@@ -283,8 +262,7 @@ private fun MainScreen(onReady: () -> Unit = {}) {
                                     RefreshContext(
                                         loading = dashboardLoading,
                                         onRefresh = {
-                                            DashboardCache.refresh(scope, context, refreshRestart)
-                                            UpdateCheckCache.refresh(scope, BuildConfig.VERSION_NAME)
+                                            startupCoordinator.refreshDashboard(scope, refreshRestart)
                                         },
                                     )
                                 }
@@ -293,8 +271,7 @@ private fun MainScreen(onReady: () -> Unit = {}) {
                                     RefreshContext(
                                         loading = appListLoading || targetsLoading,
                                         onRefresh = {
-                                            AppListCache.refresh(scope, context)
-                                            TargetsCache.refresh(scope, context)
+                                            startupCoordinator.refreshProtection(scope)
                                         },
                                     )
                                 }
@@ -415,7 +392,7 @@ private fun MainScreen(onReady: () -> Unit = {}) {
         if (preparationError != null) {
             RootPreparationErrorScreen(
                 modifier = Modifier.padding(innerPadding),
-                onRetry = { selfTargetAttempt += 1 },
+                onRetry = { startupCoordinator.retrySelfTargets(scope) },
             )
         } else if (restart == null) {
             Box(

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/NativeChecks.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/NativeChecks.kt
@@ -1,0 +1,57 @@
+package dev.okhsunrog.vpnhide
+
+import dev.okhsunrog.vpnhide.checks.CheckOutput
+import dev.okhsunrog.vpnhide.checks.checkGetifaddrs
+import dev.okhsunrog.vpnhide.checks.checkIoctlSiocgifconf
+import dev.okhsunrog.vpnhide.checks.checkIoctlSiocgifflags
+import dev.okhsunrog.vpnhide.checks.checkIoctlSiocgifmtu
+import dev.okhsunrog.vpnhide.checks.checkNetlinkGetlink
+import dev.okhsunrog.vpnhide.checks.checkNetlinkGetroute
+import dev.okhsunrog.vpnhide.checks.checkProcNetDev
+import dev.okhsunrog.vpnhide.checks.checkProcNetFibTrie
+import dev.okhsunrog.vpnhide.checks.checkProcNetIfInet6
+import dev.okhsunrog.vpnhide.checks.checkProcNetIpv6Route
+import dev.okhsunrog.vpnhide.checks.checkProcNetRoute
+import dev.okhsunrog.vpnhide.checks.checkProcNetTcp
+import dev.okhsunrog.vpnhide.checks.checkProcNetTcp6
+import dev.okhsunrog.vpnhide.checks.checkProcNetUdp
+import dev.okhsunrog.vpnhide.checks.checkProcNetUdp6
+import dev.okhsunrog.vpnhide.checks.checkSysClassNet
+
+/**
+ * One native (UniFFI / kmod-or-zygisk-covered) detection probe. [id] is a
+ * stable, non-localized key used for logging on the Dashboard protection
+ * path; [labelRes] is the user-facing localized name shown on the
+ * Diagnostics screen; [run] executes the probe.
+ */
+internal data class NativeCheckSpec(
+    val id: String,
+    val labelRes: Int,
+    val run: () -> CheckOutput,
+)
+
+/**
+ * The native probe suite, in display order. Single source of truth for both
+ * the Dashboard protection summary ([runNativeProtectionCheck]) and the
+ * Diagnostics screen ([runAllChecks]) — they used to carry two hand-kept
+ * copies of this list.
+ */
+internal val NATIVE_CHECKS: List<NativeCheckSpec> =
+    listOf(
+        NativeCheckSpec("ioctl_flags", R.string.check_ioctl_flags) { checkIoctlSiocgifflags() },
+        NativeCheckSpec("ioctl_mtu", R.string.check_ioctl_mtu) { checkIoctlSiocgifmtu() },
+        NativeCheckSpec("ioctl_conf", R.string.check_ioctl_conf) { checkIoctlSiocgifconf() },
+        NativeCheckSpec("getifaddrs", R.string.check_getifaddrs) { checkGetifaddrs() },
+        NativeCheckSpec("netlink_getlink", R.string.check_netlink_getlink) { checkNetlinkGetlink() },
+        NativeCheckSpec("netlink_getroute", R.string.check_netlink_getroute) { checkNetlinkGetroute() },
+        NativeCheckSpec("proc_route", R.string.check_proc_route) { checkProcNetRoute() },
+        NativeCheckSpec("proc_ipv6_route", R.string.check_proc_ipv6_route) { checkProcNetIpv6Route() },
+        NativeCheckSpec("proc_if_inet6", R.string.check_proc_if_inet6) { checkProcNetIfInet6() },
+        NativeCheckSpec("proc_tcp", R.string.check_proc_tcp) { checkProcNetTcp() },
+        NativeCheckSpec("proc_tcp6", R.string.check_proc_tcp6) { checkProcNetTcp6() },
+        NativeCheckSpec("proc_udp", R.string.check_proc_udp) { checkProcNetUdp() },
+        NativeCheckSpec("proc_udp6", R.string.check_proc_udp6) { checkProcNetUdp6() },
+        NativeCheckSpec("proc_dev", R.string.check_proc_dev) { checkProcNetDev() },
+        NativeCheckSpec("proc_fib_trie", R.string.check_proc_fib_trie) { checkProcNetFibTrie() },
+        NativeCheckSpec("sys_class_net", R.string.check_sys_class_net) { checkSysClassNet() },
+    )

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/PackageVisibilityHooks.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/PackageVisibilityHooks.kt
@@ -133,14 +133,7 @@ internal object PackageVisibilityHooks {
     private fun readUidFile(path: String): Set<Int> =
         try {
             val f = File(path)
-            if (!f.exists()) {
-                emptySet()
-            } else {
-                f
-                    .readLines()
-                    .mapNotNull { it.trim().takeIf { s -> s.isNotEmpty() && !s.startsWith("#") }?.toIntOrNull() }
-                    .toSet()
-            }
+            if (!f.exists()) emptySet() else parseConfigLines(f.readText()).mapNotNull { it.toIntOrNull() }.toSet()
         } catch (t: Throwable) {
             HookLog.e("VpnHide/PV: failed to read $path: ${t.message}")
             emptySet()
@@ -149,15 +142,7 @@ internal object PackageVisibilityHooks {
     private fun readLineFile(path: String): Set<String> =
         try {
             val f = File(path)
-            if (!f.exists()) {
-                emptySet()
-            } else {
-                f
-                    .readLines()
-                    .map { it.trim() }
-                    .filter { it.isNotEmpty() && !it.startsWith("#") }
-                    .toSet()
-            }
+            if (!f.exists()) emptySet() else parseConfigLines(f.readText()).toSet()
         } catch (t: Throwable) {
             HookLog.e("VpnHide/PV: failed to read $path: ${t.message}")
             emptySet()

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/PortsHidingScreen.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/PortsHidingScreen.kt
@@ -1,77 +1,33 @@
 package dev.okhsunrog.vpnhide
 
 import android.graphics.drawable.Drawable
-import androidx.compose.animation.core.animateFloatAsState
-import androidx.compose.foundation.Image
 import androidx.compose.foundation.clickable
-import androidx.compose.foundation.interaction.MutableInteractionSource
-import androidx.compose.foundation.interaction.collectIsDraggedAsState
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.defaultMinSize
-import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.layout.wrapContentHeight
-import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.items
-import androidx.compose.foundation.lazy.rememberLazyListState
-import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material3.Button
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
-import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.SnackbarDuration
-import androidx.compose.material3.SnackbarHost
-import androidx.compose.material3.SnackbarHostState
-import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.collectAsState
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.rememberCoroutineScope
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.drawBehind
-import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.asImageBitmap
-import androidx.compose.ui.graphics.graphicsLayer
-import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.platform.LocalResources
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
-import androidx.core.graphics.drawable.toBitmap
-import io.github.oikvpqya.compose.fastscroller.VerticalScrollbar
-import io.github.oikvpqya.compose.fastscroller.indicator.IndicatorConstants
-import io.github.oikvpqya.compose.fastscroller.material3.defaultMaterialScrollbarStyle
-import io.github.oikvpqya.compose.fastscroller.rememberScrollbarAdapter
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.withContext
 
 internal data class PortsEntry(
-    val packageName: String,
-    val label: String,
-    val icon: Drawable?,
-    val isSystem: Boolean,
-    val userIds: List<Int> = emptyList(),
+    override val packageName: String,
+    override val label: String,
+    override val icon: Drawable?,
+    override val isSystem: Boolean,
+    override val userIds: List<Int> = emptyList(),
     val observer: Boolean = false,
-)
+) : TargetEntry {
+    override val anySelected get() = observer
+}
 
 @Composable
 fun PortsHidingScreen(
@@ -80,267 +36,63 @@ fun PortsHidingScreen(
     showRussianOnly: Boolean,
     modifier: Modifier = Modifier,
 ) {
-    val context = LocalContext.current
-    val resources = LocalResources.current
-    val scope = rememberCoroutineScope()
-
-    val cachedApps by AppListCache.apps.collectAsState()
-    val userNames by AppListCache.userNames.collectAsState()
-    val targets by TargetsCache.snapshot.collectAsState()
-    val targetsError by TargetsCache.error.collectAsState()
-
-    var allApps by remember { mutableStateOf<List<PortsEntry>>(emptyList()) }
-    var saving by remember { mutableStateOf(false) }
-    var dirty by remember { mutableStateOf(false) }
-    var snackMessage by remember { mutableStateOf<String?>(null) }
-    val snackbarHostState = remember { SnackbarHostState() }
-
-    LaunchedEffect(snackMessage) {
-        snackMessage?.let {
-            snackbarHostState.showSnackbar(
-                message = it,
-                duration = SnackbarDuration.Long,
+    TargetPickerScreen(
+        searchQuery = searchQuery,
+        showSystem = showSystem,
+        showRussianOnly = showRussianOnly,
+        modifier = modifier,
+        helpPrefKey = "apps_ports",
+        helpTitle = stringResource(R.string.ports_help_title),
+        help = {
+            Text(
+                text = stringResource(R.string.ports_hint_role),
+                style = MaterialTheme.typography.bodyMedium,
             )
-            snackMessage = null
-        }
-    }
-
-    LaunchedEffect(Unit) {
-        TargetsCache.ensureLoaded(scope, context)
-    }
-
-    if (targetsError != null && targets == null) {
-        TargetsLoadErrorCard(
-            onRetry = { TargetsCache.refresh(scope, context) },
-            modifier = modifier,
-        )
-        return
-    }
-
-    // While `dirty` is true the user has unsaved checkbox edits — don't
-    // overwrite them with a fresh snapshot. Caches can refresh under us
-    // (ON_RESUME, another screen calling `TargetsCache.refresh()`) and
-    // silently dropping the edits is the worst outcome.
-    LaunchedEffect(cachedApps, targets) {
-        if (dirty) return@LaunchedEffect
-        val apps = cachedApps ?: return@LaunchedEffect
-        val t = targets ?: return@LaunchedEffect
-        val selfPkg = context.packageName
-        allApps =
-            apps
-                .filter { it.packageName != selfPkg }
-                .map { app ->
-                    PortsEntry(
-                        packageName = app.packageName,
-                        label = app.label,
-                        icon = app.icon,
-                        isSystem = app.isSystem,
-                        userIds = app.userIds,
-                        observer = app.packageName in t.portsObservers,
-                    )
-                }
-        dirty = false
-    }
-
-    val loading = cachedApps == null || targets == null
-
-    if (targets?.portsModuleInstalled == false) {
-        NotInstalledCard(modifier = modifier)
-        return
-    }
-
-    val filteredApps =
-        remember(allApps, searchQuery, showSystem, showRussianOnly) {
-            val q = searchQuery.trim().lowercase()
-            allApps.filter { app ->
-                (showSystem || !app.isSystem || app.observer) &&
-                    (!showRussianOnly || isRussianApp(app.packageName, app.label)) &&
-                    (q.isEmpty() || app.label.lowercase().contains(q) || app.packageName.lowercase().contains(q))
-            }
-        }
-
-    val observerCount = remember(allApps) { allApps.count { it.observer } }
-
-    Column(modifier = modifier.fillMaxSize()) {
-        if (loading) {
-            Box(
-                modifier = Modifier.fillMaxSize(),
-                contentAlignment = Alignment.Center,
-            ) {
-                CircularProgressIndicator()
-            }
-        } else {
-            val listState = rememberLazyListState()
-            Box(modifier = Modifier.weight(1f)) {
-                LazyColumn(
-                    state = listState,
-                    modifier = Modifier.fillMaxSize(),
-                ) {
-                    item {
-                        Box(modifier = Modifier.padding(horizontal = 12.dp, vertical = 8.dp)) {
-                            HelpAccordion(
-                                prefKey = "apps_ports",
-                                title = stringResource(R.string.ports_help_title),
-                            ) {
-                                Text(
-                                    text = stringResource(R.string.ports_hint_role),
-                                    style = MaterialTheme.typography.bodyMedium,
-                                )
-                                Text(
-                                    text = stringResource(R.string.ports_hint_safe),
-                                    style = MaterialTheme.typography.bodyMedium,
-                                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                                )
-                                Text(
-                                    text = stringResource(R.string.ports_hint_reboot),
-                                    style = MaterialTheme.typography.bodyMedium,
-                                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                                )
-                            }
-                        }
-                    }
-                    items(filteredApps, key = { it.packageName }) { app ->
-                        PortsAppRow(
-                            app = app,
-                            userNames = userNames,
-                            onToggle = {
-                                allApps =
-                                    allApps.map {
-                                        if (it.packageName != app.packageName) {
-                                            it
-                                        } else {
-                                            it.copy(observer = !it.observer)
-                                        }
-                                    }
-                                dirty = true
-                            },
+            Text(
+                text = stringResource(R.string.ports_hint_safe),
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            Text(
+                text = stringResource(R.string.ports_hint_reboot),
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        },
+        merge = { apps, t, selfPkg ->
+            MergeResult(
+                apps
+                    .filter { it.packageName != selfPkg }
+                    .map { app ->
+                        PortsEntry(
+                            packageName = app.packageName,
+                            label = app.label,
+                            icon = app.icon,
+                            isSystem = app.isSystem,
+                            userIds = app.userIds,
+                            observer = app.packageName in t.portsObservers,
                         )
-                    }
-                }
-                val interactionSource = remember { MutableInteractionSource() }
-                val isDragging by interactionSource.collectIsDraggedAsState()
-                val indicatorAlpha by animateFloatAsState(
-                    if (isDragging) 1f else 0f,
-                    label = "indicatorAlpha",
-                )
-                VerticalScrollbar(
-                    adapter = rememberScrollbarAdapter(scrollState = listState),
-                    interactionSource = interactionSource,
-                    style = defaultMaterialScrollbarStyle(),
-                    enablePressToScroll = false,
-                    modifier =
-                        Modifier
-                            .align(Alignment.TopEnd)
-                            .fillMaxHeight(),
-                    indicator = { position, isVisible ->
-                        val firstChar =
-                            filteredApps
-                                .getOrNull(listState.firstVisibleItemIndex)
-                                ?.label
-                                ?.firstOrNull()
-                                ?.uppercase() ?: ""
-                        Box(
-                            modifier =
-                                Modifier
-                                    .align(Alignment.TopEnd)
-                                    .padding(end = IndicatorConstants.Default.PADDING)
-                                    .graphicsLayer {
-                                        val y = -(IndicatorConstants.Default.MIN_HEIGHT / 2).toPx()
-                                        translationY = (y + position).coerceAtLeast(0f)
-                                        alpha = indicatorAlpha
-                                    },
-                        ) {
-                            val indicatorColor =
-                                if (isVisible) MaterialTheme.colorScheme.primary else Color.Transparent
-                            val textColor =
-                                if (isVisible) MaterialTheme.colorScheme.onPrimary else Color.Transparent
-                            Box(
-                                modifier =
-                                    Modifier
-                                        .defaultMinSize(
-                                            minHeight = IndicatorConstants.Default.MIN_HEIGHT,
-                                            minWidth = IndicatorConstants.Default.MIN_WIDTH,
-                                        ).graphicsLayer {
-                                            clip = true
-                                            shape = IndicatorConstants.Default.SHAPE
-                                        }.drawBehind { drawRect(indicatorColor) },
-                            )
-                            Text(
-                                text = firstChar,
-                                color = textColor,
-                                textAlign = TextAlign.Center,
-                                style = MaterialTheme.typography.titleMedium,
-                                modifier =
-                                    Modifier
-                                        .align(Alignment.CenterEnd)
-                                        .wrapContentHeight()
-                                        .padding(end = IndicatorConstants.Default.PADDING)
-                                        .width(IndicatorConstants.Default.MIN_HEIGHT),
-                            )
-                        }
                     },
-                )
-            }
-            Surface(tonalElevation = 3.dp) {
-                Box {
-                    Row(
-                        modifier =
-                            Modifier
-                                .fillMaxWidth()
-                                .padding(horizontal = 16.dp, vertical = 12.dp),
-                        verticalAlignment = Alignment.CenterVertically,
-                    ) {
-                        Text(
-                            text = stringResource(R.string.ports_count, observerCount),
-                            style = MaterialTheme.typography.bodyMedium,
-                            color = MaterialTheme.colorScheme.onSurfaceVariant,
-                            modifier = Modifier.weight(1f),
-                        )
-                        Button(
-                            onClick = {
-                                saving = true
-                                dirty = false
-                            },
-                            enabled = dirty && !saving,
-                        ) {
-                            Text(stringResource(R.string.btn_save))
-                        }
-                    }
-
-                    SnackbarHost(
-                        hostState = snackbarHostState,
-                        modifier =
-                            Modifier
-                                .fillMaxWidth()
-                                .align(Alignment.TopCenter),
-                    )
-                }
-            }
-        }
-    }
-
-    if (saving) {
-        LaunchedEffect(Unit) {
-            val observerPkgs = allApps.filter { it.observer }.map { it.packageName }.sorted()
-            val header = resources.getString(R.string.save_header_comment)
-            try {
-                val (exitCode, _) = suExecAsync(buildPortsSaveCommand(header, observerPkgs))
-                if (exitCode == 0) {
-                    snackMessage = resources.getString(R.string.ports_save_success, observerPkgs.size)
-                    TargetsCache.refreshAfterSave(scope, context)
-                } else if (exitCode == -1) {
-                    snackMessage = resources.getString(R.string.save_failed_root)
-                    dirty = true
-                } else {
-                    snackMessage = resources.getString(R.string.save_failed_exit, exitCode)
-                    dirty = true
-                }
-            } catch (e: Exception) {
-                snackMessage = resources.getString(R.string.save_failed_error, e.message ?: "")
-                dirty = true
-            }
-            saving = false
-        }
+            )
+        },
+        countText = { entries, res ->
+            res.getString(R.string.ports_count, entries.count { it.observer })
+        },
+        buildSaveCommand = { entries, _, header ->
+            val observerPkgs = entries.filter { it.observer }.map { it.packageName }.sorted()
+            buildPortsSaveCommand(header, observerPkgs)
+        },
+        successMessage = { entries, res ->
+            res.getString(R.string.ports_save_success, entries.count { it.observer })
+        },
+        moduleMissing = { it.portsModuleInstalled.not() },
+        moduleMissingContent = { m -> NotInstalledCard(modifier = m) },
+    ) { app, userNames, _, onChange ->
+        PortsAppRow(
+            app = app,
+            userNames = userNames,
+            onToggle = { onChange(app.copy(observer = !app.observer)) },
+        )
     }
 }
 
@@ -395,66 +147,18 @@ private fun PortsAppRow(
     userNames: Map<Int, String>,
     onToggle: () -> Unit,
 ) {
-    Row(
-        modifier =
-            Modifier
-                .fillMaxWidth()
-                .clickable(onClick = onToggle)
-                .padding(horizontal = 16.dp, vertical = 10.dp),
-        verticalAlignment = Alignment.CenterVertically,
+    TargetRowShell(
+        label = app.label,
+        packageName = app.packageName,
+        icon = app.icon,
+        userIds = app.userIds,
+        userNames = userNames,
+        modifier = Modifier.clickable(onClick = onToggle),
     ) {
-        app.icon?.let { drawable ->
-            Image(
-                bitmap = drawable.toBitmap(48, 48).asImageBitmap(),
-                contentDescription = null,
-                modifier = Modifier.size(40.dp),
-            )
-            Spacer(Modifier.width(12.dp))
-        }
-        Column(modifier = Modifier.weight(1f)) {
-            Text(
-                text = labelWithUsers(app.label, app.userIds, userNames),
-                style = MaterialTheme.typography.bodyLarge,
-                fontWeight = FontWeight.Medium,
-            )
-            Text(
-                text = app.packageName,
-                style = MaterialTheme.typography.bodySmall,
-                fontFamily = FontFamily.Monospace,
-                fontSize = 12.sp,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
-            )
-            Spacer(Modifier.height(4.dp))
-            Row(horizontalArrangement = Arrangement.spacedBy(6.dp)) {
-                PortsChip(
-                    label = stringResource(R.string.ports_chip),
-                    enabled = app.observer,
-                    onClick = onToggle,
-                )
-            }
-        }
-    }
-}
-
-@Composable
-private fun PortsChip(
-    label: String,
-    enabled: Boolean,
-    onClick: () -> Unit,
-) {
-    val containerColor = if (enabled) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.surfaceVariant
-    val contentColor = if (enabled) MaterialTheme.colorScheme.onPrimary else MaterialTheme.colorScheme.onSurfaceVariant
-    Surface(
-        shape = RoundedCornerShape(4.dp),
-        color = containerColor,
-        modifier = Modifier.clickable(onClick = onClick),
-    ) {
-        Text(
-            text = label,
-            style = MaterialTheme.typography.labelSmall,
-            fontWeight = FontWeight.Bold,
-            color = contentColor,
-            modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
+        TargetChip(
+            label = stringResource(R.string.ports_chip),
+            enabled = app.observer,
+            onClick = onToggle,
         )
     }
 }

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/PortsHidingScreen.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/PortsHidingScreen.kt
@@ -327,8 +327,7 @@ fun PortsHidingScreen(
                 val (exitCode, _) = suExecAsync(buildPortsSaveCommand(header, observerPkgs))
                 if (exitCode == 0) {
                     snackMessage = resources.getString(R.string.ports_save_success, observerPkgs.size)
-                    DashboardCache.invalidate()
-                    TargetsCache.refresh(scope, context)
+                    TargetsCache.refreshAfterSave(scope, context)
                 } else if (exitCode == -1) {
                     snackMessage = resources.getString(R.string.save_failed_root)
                     dirty = true

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/ShellCommandBuilders.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/ShellCommandBuilders.kt
@@ -87,7 +87,7 @@ internal fun buildEnsureSelfInTargetsCommand(selfPkg: String): String =
               fi
               echo "added:${'$'}PATH_TO_UPDATE"
             }
-            """.trimIndent().replace("\n", " "),
+            """.trimIndent(),
         )
         append("; ensure_line $KMOD_TARGETS /data/adb/vpnhide_kmod 644 0 1")
         append("; ensure_line $ZYGISK_TARGETS /data/adb/vpnhide_zygisk 644 0 1")

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/ShellCommandBuilders.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/ShellCommandBuilders.kt
@@ -3,6 +3,31 @@ package dev.okhsunrog.vpnhide
 internal const val SELF_PM_PACKAGES_BEGIN = "__VPNHIDE_SELF_PM_PACKAGES_BEGIN__"
 internal const val SELF_PM_PACKAGES_END = "__VPNHIDE_SELF_PM_PACKAGES_END__"
 
+internal const val SYSTEM_DATA_FILE_CONTEXT = "u:object_r:system_data_file:s0"
+
+/**
+ * The chmod/chown/chcon tail applied to a `/data/system` file so that
+ * system_server (group=system) can read it while untrusted apps get EACCES,
+ * and so anti-tamper SDKs can't read our marker files. Returns the steps as
+ * separate parts meant to be joined with `" ; "` — matching how the save
+ * commands assemble. `chcon` failure is tolerated (`|| true`) for devices/
+ * filesystems without SELinux labelling support, and is the last step so the
+ * overall `su -c` exit code stays 0 on such devices.
+ *
+ * Previously each save path hand-wrote this tail slightly differently (one
+ * omitted `chcon` entirely on the empty branch, one lacked the `|| true`
+ * fail-safe), risking a permission/SELinux drift. Single source now.
+ */
+internal fun systemDataFilePermsParts(
+    path: String,
+    mode: String,
+): List<String> =
+    listOf(
+        "chmod $mode $path 2>/dev/null",
+        "chown root:system $path 2>/dev/null",
+        "chcon $SYSTEM_DATA_FILE_CONTEXT $path 2>/dev/null || true",
+    )
+
 internal fun buildPackageUidsExpression(
     packageName: String,
     outputVariable: String,

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/ShellUtils.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/ShellUtils.kt
@@ -97,6 +97,18 @@ internal suspend fun suExecAsync(
     timeoutSec: Long = SU_DEFAULT_TIMEOUT_SEC,
 ): Pair<Int, String> = withContext(Dispatchers.IO) { suExec(cmd, timeoutSec) }
 
+/**
+ * Lines of a vpnhide config file: trimmed, with blank lines and `#`-comments
+ * dropped. This is the on-disk format shared by every targets / observer /
+ * hidden-packages file, so the parsing rule lives in one place.
+ */
+internal fun parseConfigLines(raw: String): List<String> =
+    raw
+        .lineSequence()
+        .map { it.trim() }
+        .filter { it.isNotEmpty() && !it.startsWith("#") }
+        .toList()
+
 internal fun parseVpnIfaceStates(raw: String): List<Pair<String, String>> =
     raw
         .lineSequence()

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/StartupCoordinator.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/StartupCoordinator.kt
@@ -1,0 +1,108 @@
+package dev.okhsunrog.vpnhide
+
+import android.content.Context
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+
+internal sealed interface StartupSelfTargetState {
+    data object Preparing : StartupSelfTargetState
+
+    data class Ready(
+        val selfNeedsRestart: Boolean,
+    ) : StartupSelfTargetState
+
+    data class Failed(
+        val message: String,
+    ) : StartupSelfTargetState
+}
+
+internal class StartupCoordinator(
+    private val appContext: Context,
+    private val appVersionName: String = BuildConfig.VERSION_NAME,
+    private val prepareSelfTargetsCommand: (String) -> SelfTargetPreparation = ::ensureSelfInTargets,
+    private val cleanupZygiskStatus: (Context, String?) -> Unit = ::cleanupStaleZygiskStatus,
+    private val seedRootSnapshotPackages: (String?) -> Unit = RootSnapshotCache::seedPmPackages,
+    private val markStartupEvent: (String) -> Unit = StartupTrace::mark,
+) {
+    private val _selfTargetState = MutableStateFlow<StartupSelfTargetState>(StartupSelfTargetState.Preparing)
+    val selfTargetState: StateFlow<StartupSelfTargetState> = _selfTargetState.asStateFlow()
+
+    suspend fun prepareSelfTargets() {
+        _selfTargetState.value = StartupSelfTargetState.Preparing
+        markStartupEvent("self_targets_start")
+        val preparation =
+            withContext(Dispatchers.IO) {
+                val next = prepareSelfTargetsCommand(appContext.packageName)
+                if (next.rootAvailable) {
+                    seedRootSnapshotPackages(next.pmPackages)
+                    cleanupZygiskStatus(appContext, next.currentBootId)
+                }
+                next
+            }
+        markStartupEvent("self_targets_done")
+        if (preparation.rootAvailable) {
+            _selfTargetState.value = StartupSelfTargetState.Ready(preparation.selfNeedsRestart)
+        } else {
+            markStartupEvent("self_targets_failed")
+            _selfTargetState.value =
+                StartupSelfTargetState.Failed(
+                    preparation.error ?: "root preparation failed",
+                )
+        }
+    }
+
+    fun retrySelfTargets(scope: CoroutineScope) {
+        scope.launch { prepareSelfTargets() }
+    }
+
+    fun ensureInitialCaches(
+        scope: CoroutineScope,
+        selfNeedsRestart: Boolean,
+    ) {
+        AppListCache.ensureLoaded(scope, appContext)
+        DashboardCache.ensureLoaded(scope, appContext, selfNeedsRestart)
+        if (!selfNeedsRestart) DiagnosticsCache.run(scope, appContext)
+    }
+
+    fun ensureProtectionCacheAfterRootSnapshot(
+        scope: CoroutineScope,
+        selfNeedsRestart: Boolean?,
+        rootSnapshot: RootSnapshot?,
+    ) {
+        if (selfNeedsRestart != null && rootSnapshot != null) {
+            TargetsCache.ensureLoaded(scope, appContext)
+        }
+    }
+
+    fun ensureUpdateFresh(scope: CoroutineScope) {
+        UpdateCheckCache.ensureFresh(scope, appVersionName)
+    }
+
+    fun refreshDashboard(
+        scope: CoroutineScope,
+        selfNeedsRestart: Boolean,
+    ) {
+        DashboardCache.refresh(scope, appContext, selfNeedsRestart)
+        UpdateCheckCache.refresh(scope, appVersionName)
+    }
+
+    fun refreshProtection(scope: CoroutineScope) {
+        AppListCache.refresh(scope, appContext)
+        TargetsCache.refresh(scope, appContext)
+    }
+
+    fun isUiReady(
+        dashboardState: DashboardState?,
+        dashboardError: String?,
+    ): Boolean =
+        when (selfTargetState.value) {
+            is StartupSelfTargetState.Failed -> true
+            StartupSelfTargetState.Preparing -> false
+            is StartupSelfTargetState.Ready -> dashboardState != null || dashboardError != null
+        }
+}

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/StateCache.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/StateCache.kt
@@ -1,0 +1,85 @@
+package dev.okhsunrog.vpnhide
+
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+
+/**
+ * Shared base for the app-scoped, lazily-loaded caches (`DashboardCache`,
+ * `TargetsCache`, `AppListCache`). They are structurally identical — a
+ * nullable value, a loading flag, an error string, and a single in-flight
+ * [Job] guarded so a tab switch doesn't re-run an expensive root-shell load.
+ * Writing each by hand let them drift (one rethrew `CancellationException`,
+ * another had no error state at all); funnelling them through one base keeps
+ * that behaviour uniform.
+ *
+ * Concrete caches implement [load] (the actual work) and expose a typed
+ * accessor over [value] plus their own `ensureLoaded` / `refresh` signatures
+ * that stash any inputs `load` needs before delegating to [ensure] /
+ * [forceRefresh].
+ *
+ * [traceName] is used to emit `<name>_start` / `<name>_done` / `<name>_failed`
+ * StartupTrace events (see scripts/measure-startup.py for the consumers).
+ */
+internal abstract class StateCache<T>(
+    private val traceName: String,
+    private val logTag: String,
+) {
+    private val _value = MutableStateFlow<T?>(null)
+    val value: StateFlow<T?> = _value.asStateFlow()
+
+    private val _loading = MutableStateFlow(false)
+    val loading: StateFlow<Boolean> = _loading.asStateFlow()
+
+    private val _error = MutableStateFlow<String?>(null)
+    val error: StateFlow<String?> = _error.asStateFlow()
+
+    private var inflight: Job? = null
+
+    /** Produce a fresh value. [force] is true on an explicit user refresh,
+     * false on the initial lazy load — concrete caches use it to decide
+     * whether to bust the shared root snapshot. */
+    protected abstract suspend fun load(force: Boolean): T
+
+    /** Kick off the initial load unless a value/error already exists or a
+     * load is in flight. Idempotent — safe to call on every composition. */
+    protected fun ensure(scope: CoroutineScope) {
+        if (_value.value != null || _error.value != null || inflight?.isActive == true) return
+        inflight = scope.launch { reload(force = false) }
+    }
+
+    /** Cancel any in-flight load and start a forced reload. */
+    protected fun forceRefresh(scope: CoroutineScope) {
+        inflight?.cancel()
+        _error.value = null
+        inflight = scope.launch { reload(force = true) }
+    }
+
+    /** Drop the cached value/error so the next [ensure] reloads. */
+    open fun invalidate() {
+        _value.value = null
+        _error.value = null
+    }
+
+    private suspend fun reload(force: Boolean) {
+        _loading.value = true
+        try {
+            StartupTrace.mark("${traceName}_start")
+            _value.value = load(force)
+            _error.value = null
+            StartupTrace.mark("${traceName}_done")
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            StartupTrace.mark("${traceName}_failed")
+            _error.value = e.message ?: e.javaClass.simpleName
+            VpnHideLog.w(logTag, "$traceName reload failed: ${e.message}", e)
+        } finally {
+            _loading.value = false
+        }
+    }
+}

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/StatusUi.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/StatusUi.kt
@@ -1,0 +1,153 @@
+package dev.okhsunrog.vpnhide
+
+import android.content.Context
+import android.content.Intent
+import androidx.compose.foundation.isSystemInDarkTheme
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Save
+import androidx.compose.material.icons.filled.Share
+import androidx.compose.material3.Button
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+import androidx.core.content.FileProvider
+import java.io.File
+
+/**
+ * Centralised status palette.
+ *
+ * Material You remixes `colorScheme.errorContainer` / `tertiaryContainer`
+ * toward the wallpaper, which on real devices landed on "lavender" / "pink"
+ * that read as a note, not a problem. So every status card and banner pins
+ * these hand-picked container + accent colors instead of the theme's.
+ * Defined once here rather than copy-pasted into each card.
+ */
+internal object StatusColors {
+    @Composable
+    private fun container(
+        darkArgb: Long,
+        darkAlpha: Float,
+        lightArgb: Long,
+    ): Color = if (isSystemInDarkTheme()) Color(darkArgb).copy(alpha = darkAlpha) else Color(lightArgb)
+
+    @Composable fun successContainer() = container(0xFF1B5E20, 0.3f, 0xFFE8F5E9)
+
+    @Composable fun warningContainer() = container(0xFFE65100, 0.2f, 0xFFFFF3E0)
+
+    @Composable fun errorContainer() = container(0xFFB71C1C, 0.3f, 0xFFFFEBEE)
+
+    @Composable fun infoContainer() = container(0xFF0D47A1, 0.28f, 0xFFE3F2FD)
+
+    // Distinct from warning only in dark mode — the "install zygisk instead"
+    // recommendation card uses a brown tint where warnings use orange.
+    @Composable fun zygiskRecommendContainer() = container(0xFF4E342E, 0.32f, 0xFFFFF3E0)
+
+    @Composable fun errorHeader() = if (isSystemInDarkTheme()) Color(0xFFEF9A9A) else Color(0xFFC62828)
+
+    @Composable fun warningHeader() = if (isSystemInDarkTheme()) Color(0xFFFFB74D) else Color(0xFFE65100)
+
+    // Accent colors (status dots / status text / pass-fail badges). These are
+    // fixed regardless of theme — they sit on the tinted containers above.
+    val successDot = Color(0xFF4CAF50)
+    val successBadge = Color(0xFF2E7D32)
+    val warningAccent = Color(0xFFFF9800)
+    val errorDot = Color(0xFFB71C1C)
+    val errorAccent = Color(0xFFC62828)
+}
+
+/**
+ * Flat colored banner card. Shared by the Dashboard protection / issues
+ * banners and the Diagnostics status banners (it was a private duplicate in
+ * both screens).
+ */
+@Composable
+internal fun StatusBanner(
+    text: String,
+    containerColor: Color,
+    contentColor: Color,
+    modifier: Modifier = Modifier,
+) {
+    Card(
+        shape = RoundedCornerShape(8.dp),
+        colors = CardDefaults.cardColors(containerColor = containerColor),
+        modifier = modifier.fillMaxWidth(),
+    ) {
+        Text(
+            text = text,
+            style = MaterialTheme.typography.bodyMedium,
+            color = contentColor,
+            modifier = Modifier.padding(12.dp),
+        )
+    }
+}
+
+/** Share a cache file via FileProvider + ACTION_SEND chooser. Identical
+ * logic was inlined for both the debug-zip and the logcat export. */
+internal fun shareFileViaProvider(
+    context: Context,
+    file: File,
+    mimeType: String,
+) {
+    val uri =
+        FileProvider.getUriForFile(
+            context,
+            "${context.packageName}.fileprovider",
+            file,
+        )
+    val intent =
+        Intent(Intent.ACTION_SEND).apply {
+            type = mimeType
+            putExtra(Intent.EXTRA_STREAM, uri)
+            addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
+        }
+    context.startActivity(Intent.createChooser(intent, null))
+}
+
+/**
+ * Save + Share button row used by both Diagnostics export flows. [sharePrimary]
+ * paints the Share button filled (debug-zip) vs outlined (logcat).
+ */
+@Composable
+internal fun FileSaveShareRow(
+    saveLabel: String,
+    shareLabel: String,
+    sharePrimary: Boolean,
+    onSave: () -> Unit,
+    onShare: () -> Unit,
+) {
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
+    ) {
+        OutlinedButton(onClick = onSave, modifier = Modifier.weight(1f)) {
+            Icon(Icons.Default.Save, contentDescription = null, modifier = Modifier.size(18.dp))
+            Spacer(Modifier.width(8.dp))
+            Text(saveLabel)
+        }
+        val shareContent: @Composable () -> Unit = {
+            Icon(Icons.Default.Share, contentDescription = null, modifier = Modifier.size(18.dp))
+            Spacer(Modifier.width(8.dp))
+            Text(shareLabel)
+        }
+        if (sharePrimary) {
+            Button(onClick = onShare, modifier = Modifier.weight(1f)) { shareContent() }
+        } else {
+            OutlinedButton(onClick = onShare, modifier = Modifier.weight(1f)) { shareContent() }
+        }
+    }
+}

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/TargetPickerScaffold.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/TargetPickerScaffold.kt
@@ -1,0 +1,471 @@
+package dev.okhsunrog.vpnhide
+
+import android.content.res.Resources
+import android.graphics.drawable.Drawable
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.interaction.collectIsDraggedAsState
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxScope
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.RowScope
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.defaultMinSize
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.wrapContentHeight
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyListState
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Button
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.SnackbarDuration
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.drawBehind
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.asImageBitmap
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalResources
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.core.graphics.drawable.toBitmap
+import io.github.oikvpqya.compose.fastscroller.VerticalScrollbar
+import io.github.oikvpqya.compose.fastscroller.indicator.IndicatorConstants
+import io.github.oikvpqya.compose.fastscroller.material3.defaultMaterialScrollbarStyle
+import io.github.oikvpqya.compose.fastscroller.rememberScrollbarAdapter
+
+/**
+ * Common per-row fields every Protection picker needs. The three pickers
+ * (Tun targets, App hiding, Ports) layer their own toggle flags on top of
+ * these, but the list scaffold — filtering, scrollbar, save lifecycle,
+ * row chrome — only ever touches this interface.
+ */
+internal interface TargetEntry {
+    val packageName: String
+    val label: String
+    val icon: Drawable?
+    val isSystem: Boolean
+    val userIds: List<Int>
+
+    /** True if the row has at least one role/layer selected. Drives the
+     * "keep selected system apps visible even when system apps are hidden"
+     * filter rule and the system-app filter exemption. */
+    val anySelected: Boolean
+}
+
+/** Result of merging the cached app list with a screen's target snapshot.
+ * [resaveNeeded] lets a screen request the Save button start enabled —
+ * App hiding uses it to persist an auto-fixed hidden+observer conflict. */
+internal data class MergeResult<T : TargetEntry>(
+    val entries: List<T>,
+    val resaveNeeded: Boolean = false,
+)
+
+/**
+ * Shared scaffold for the three Protection picker screens. Owns all the
+ * machinery they had copy-pasted: the cached-apps / targets subscription,
+ * the dirty-guarded merge, search+system+russian filtering, the alphabetical
+ * fast-scrollbar, the bottom save bar, the snackbar, and the save lifecycle
+ * (including the exit-code → message mapping). Screens supply only what is
+ * genuinely screen-specific via the parameters below.
+ *
+ * @param merge map the cached app list + target snapshot into typed rows.
+ * @param moduleMissing optional gate: when it returns true the picker shows
+ *   [moduleMissingContent] instead of the list (Ports, when its module isn't
+ *   installed).
+ * @param countText bottom-bar status text (e.g. "12 selected").
+ * @param row renders one row; call `onChange` with the updated entry to mark
+ *   the list dirty.
+ * @param buildSaveCommand build the root shell command persisting [entries].
+ * @param successMessage snackbar text shown after a successful save.
+ */
+@Composable
+internal fun <T : TargetEntry> TargetPickerScreen(
+    searchQuery: String,
+    showSystem: Boolean,
+    showRussianOnly: Boolean,
+    modifier: Modifier,
+    helpPrefKey: String,
+    helpTitle: String,
+    help: @Composable () -> Unit,
+    merge: (apps: List<AppSummary>, targets: TargetsSnapshot, selfPkg: String) -> MergeResult<T>,
+    countText: (entries: List<T>, resources: Resources) -> String,
+    buildSaveCommand: (entries: List<T>, selfPkg: String, header: String) -> String,
+    successMessage: (entries: List<T>, resources: Resources) -> String,
+    moduleMissing: (TargetsSnapshot) -> Boolean = { false },
+    moduleMissingContent: @Composable (Modifier) -> Unit = {},
+    row: @Composable (entry: T, userNames: Map<Int, String>, targets: TargetsSnapshot, onChange: (T) -> Unit) -> Unit,
+) {
+    val context = LocalContext.current
+    val resources = LocalResources.current
+    val scope = rememberCoroutineScope()
+
+    val cachedApps by AppListCache.apps.collectAsState()
+    val appListError by AppListCache.error.collectAsState()
+    val userNames by AppListCache.userNames.collectAsState()
+    val targets by TargetsCache.snapshot.collectAsState()
+    val targetsError by TargetsCache.error.collectAsState()
+
+    var allApps by remember { mutableStateOf<List<T>>(emptyList()) }
+    var saving by remember { mutableStateOf(false) }
+    var dirty by remember { mutableStateOf(false) }
+    var snackMessage by remember { mutableStateOf<String?>(null) }
+    val snackbarHostState = remember { SnackbarHostState() }
+
+    LaunchedEffect(snackMessage) {
+        snackMessage?.let {
+            snackbarHostState.showSnackbar(
+                message = it,
+                duration = SnackbarDuration.Long,
+            )
+            snackMessage = null
+        }
+    }
+
+    // Both loads are idempotent (no-op when already loaded / in flight).
+    // AppListCache is normally prewarmed at startup, but ensuring it here too
+    // keeps the picker self-sufficient instead of silently depending on that.
+    LaunchedEffect(Unit) {
+        AppListCache.ensureLoaded(scope, context)
+        TargetsCache.ensureLoaded(scope, context)
+    }
+
+    // Surface either cache's failure: a failed app-list scan used to leave
+    // the picker stuck on an endless spinner (it had no error state at all).
+    if ((targetsError != null && targets == null) || (appListError != null && cachedApps == null)) {
+        TargetsLoadErrorCard(
+            onRetry = {
+                AppListCache.refresh(scope, context)
+                TargetsCache.refresh(scope, context)
+            },
+            modifier = modifier,
+        )
+        return
+    }
+
+    // While `dirty` is true the user has unsaved checkbox edits — don't
+    // overwrite them with a fresh snapshot. Caches can refresh under us
+    // (ON_RESUME, another screen calling `TargetsCache.refresh()`) and
+    // silently dropping the edits is the worst outcome.
+    LaunchedEffect(cachedApps, targets) {
+        if (dirty) return@LaunchedEffect
+        val apps = cachedApps ?: return@LaunchedEffect
+        val t = targets ?: return@LaunchedEffect
+        val merged = merge(apps, t, context.packageName)
+        allApps = merged.entries
+        dirty = merged.resaveNeeded
+    }
+
+    val loading = cachedApps == null || targets == null
+
+    targets?.let { t ->
+        if (moduleMissing(t)) {
+            moduleMissingContent(modifier)
+            return
+        }
+    }
+
+    val filteredApps =
+        remember(allApps, searchQuery, showSystem, showRussianOnly) {
+            val q = searchQuery.trim().lowercase()
+            allApps.filter { app ->
+                (showSystem || !app.isSystem || app.anySelected) &&
+                    (!showRussianOnly || isRussianApp(app.packageName, app.label)) &&
+                    (q.isEmpty() || app.label.lowercase().contains(q) || app.packageName.lowercase().contains(q))
+            }
+        }
+
+    val onChange: (T) -> Unit = { updated ->
+        allApps = allApps.map { if (it.packageName == updated.packageName) updated else it }
+        dirty = true
+    }
+
+    Column(modifier = modifier.fillMaxSize()) {
+        if (loading) {
+            Box(
+                modifier = Modifier.fillMaxSize(),
+                contentAlignment = Alignment.Center,
+            ) {
+                CircularProgressIndicator()
+            }
+        } else {
+            val listState = rememberLazyListState()
+            val currentTargets = targets
+            Box(modifier = Modifier.weight(1f)) {
+                LazyColumn(
+                    state = listState,
+                    modifier = Modifier.fillMaxSize(),
+                ) {
+                    item {
+                        Box(modifier = Modifier.padding(horizontal = 12.dp, vertical = 8.dp)) {
+                            HelpAccordion(prefKey = helpPrefKey, title = helpTitle) {
+                                help()
+                            }
+                        }
+                    }
+                    items(filteredApps, key = { it.packageName }) { app ->
+                        if (currentTargets != null) {
+                            row(app, userNames, currentTargets, onChange)
+                        }
+                    }
+                }
+                AppListScrollbar(
+                    listState = listState,
+                    firstVisibleLabel = {
+                        filteredApps
+                            .getOrNull(listState.firstVisibleItemIndex)
+                            ?.label
+                            ?.firstOrNull()
+                            ?.uppercase() ?: ""
+                    },
+                )
+            }
+            Surface(tonalElevation = 3.dp) {
+                Box {
+                    Row(
+                        modifier =
+                            Modifier
+                                .fillMaxWidth()
+                                .padding(horizontal = 16.dp, vertical = 12.dp),
+                        verticalAlignment = Alignment.CenterVertically,
+                    ) {
+                        Text(
+                            text = countText(allApps, resources),
+                            style = MaterialTheme.typography.bodyMedium,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            modifier = Modifier.weight(1f),
+                        )
+                        Button(
+                            onClick = {
+                                saving = true
+                                dirty = false
+                            },
+                            enabled = dirty && !saving,
+                        ) {
+                            Text(stringResource(R.string.btn_save))
+                        }
+                    }
+
+                    SnackbarHost(
+                        hostState = snackbarHostState,
+                        modifier =
+                            Modifier
+                                .fillMaxWidth()
+                                .align(Alignment.TopCenter),
+                    )
+                }
+            }
+        }
+    }
+
+    if (saving) {
+        LaunchedEffect(Unit) {
+            val header = resources.getString(R.string.save_header_comment)
+            val entries = allApps
+            try {
+                val (exitCode, _) =
+                    suExecAsync(buildSaveCommand(entries, context.packageName, header))
+                when (exitCode) {
+                    0 -> {
+                        snackMessage = successMessage(entries, resources)
+                        TargetsCache.refreshAfterSave(scope, context)
+                    }
+
+                    -1 -> {
+                        snackMessage = resources.getString(R.string.save_failed_root)
+                        dirty = true
+                    }
+
+                    else -> {
+                        snackMessage = resources.getString(R.string.save_failed_exit, exitCode)
+                        dirty = true
+                    }
+                }
+            } catch (e: Exception) {
+                snackMessage = resources.getString(R.string.save_failed_error, e.message ?: "")
+                dirty = true
+            }
+            saving = false
+        }
+    }
+}
+
+/**
+ * Alphabetical fast-scrollbar shown only while dragging. Extracted verbatim
+ * from the three picker screens — the indicator bubble shows the first
+ * letter of the row currently at the top of the viewport.
+ */
+@Composable
+internal fun BoxScope.AppListScrollbar(
+    listState: LazyListState,
+    firstVisibleLabel: () -> String,
+) {
+    val interactionSource = remember { MutableInteractionSource() }
+    val isDragging by interactionSource.collectIsDraggedAsState()
+    val indicatorAlpha by animateFloatAsState(
+        if (isDragging) 1f else 0f,
+        label = "indicatorAlpha",
+    )
+    VerticalScrollbar(
+        adapter = rememberScrollbarAdapter(scrollState = listState),
+        interactionSource = interactionSource,
+        style = defaultMaterialScrollbarStyle(),
+        enablePressToScroll = false,
+        modifier =
+            Modifier
+                .align(Alignment.TopEnd)
+                .fillMaxHeight(),
+        indicator = { position, isVisible ->
+            val firstChar = firstVisibleLabel()
+            Box(
+                modifier =
+                    Modifier
+                        .align(Alignment.TopEnd)
+                        .padding(end = IndicatorConstants.Default.PADDING)
+                        .graphicsLayer {
+                            val y = -(IndicatorConstants.Default.MIN_HEIGHT / 2).toPx()
+                            translationY = (y + position).coerceAtLeast(0f)
+                            alpha = indicatorAlpha
+                        },
+            ) {
+                val indicatorColor =
+                    if (isVisible) MaterialTheme.colorScheme.primary else Color.Transparent
+                val textColor =
+                    if (isVisible) MaterialTheme.colorScheme.onPrimary else Color.Transparent
+                Box(
+                    modifier =
+                        Modifier
+                            .defaultMinSize(
+                                minHeight = IndicatorConstants.Default.MIN_HEIGHT,
+                                minWidth = IndicatorConstants.Default.MIN_WIDTH,
+                            ).graphicsLayer {
+                                clip = true
+                                shape = IndicatorConstants.Default.SHAPE
+                            }.drawBehind { drawRect(indicatorColor) },
+                )
+                Text(
+                    text = firstChar,
+                    color = textColor,
+                    textAlign = TextAlign.Center,
+                    style = MaterialTheme.typography.titleMedium,
+                    modifier =
+                        Modifier
+                            .align(Alignment.CenterEnd)
+                            .wrapContentHeight()
+                            .padding(end = IndicatorConstants.Default.PADDING)
+                            .width(IndicatorConstants.Default.MIN_HEIGHT),
+                )
+            }
+        },
+    )
+}
+
+/**
+ * Shared row chrome: app icon, label (with profile suffix), monospace
+ * package name, and a chip strip. The per-screen `chips` slot and the
+ * row-level click behaviour (passed via [modifier]) are all that differ.
+ */
+@Composable
+internal fun TargetRowShell(
+    label: String,
+    packageName: String,
+    icon: Drawable?,
+    userIds: List<Int>,
+    userNames: Map<Int, String>,
+    modifier: Modifier = Modifier,
+    chips: @Composable RowScope.() -> Unit,
+) {
+    Row(
+        modifier =
+            modifier
+                .fillMaxWidth()
+                .padding(horizontal = 16.dp, vertical = 10.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        icon?.let { drawable ->
+            Image(
+                bitmap = drawable.toBitmap(48, 48).asImageBitmap(),
+                contentDescription = null,
+                modifier = Modifier.size(40.dp),
+            )
+            Spacer(Modifier.width(12.dp))
+        }
+        Column(modifier = Modifier.weight(1f)) {
+            Text(
+                text = labelWithUsers(label, userIds, userNames),
+                style = MaterialTheme.typography.bodyLarge,
+                fontWeight = FontWeight.Medium,
+            )
+            Text(
+                text = packageName,
+                style = MaterialTheme.typography.bodySmall,
+                fontFamily = FontFamily.Monospace,
+                fontSize = 12.sp,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            Spacer(Modifier.height(4.dp))
+            Row(horizontalArrangement = Arrangement.spacedBy(6.dp)) {
+                chips()
+            }
+        }
+    }
+}
+
+/**
+ * Toggle chip used by every picker row (Tun layers L/K/Z, hiding roles
+ * Hidden/Observer, Ports). [available] gates interactivity without changing
+ * the visual — used when a layer's module isn't installed.
+ */
+@Composable
+internal fun TargetChip(
+    label: String,
+    enabled: Boolean,
+    available: Boolean = true,
+    onClick: () -> Unit,
+) {
+    val containerColor = if (enabled) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.surfaceVariant
+    val contentColor = if (enabled) MaterialTheme.colorScheme.onPrimary else MaterialTheme.colorScheme.onSurfaceVariant
+    Surface(
+        shape = RoundedCornerShape(4.dp),
+        color = containerColor,
+        modifier = Modifier.clickable(enabled = available, onClick = onClick),
+    ) {
+        Text(
+            text = label,
+            style = MaterialTheme.typography.labelSmall,
+            fontWeight = FontWeight.Bold,
+            color = contentColor,
+            modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
+        )
+    }
+}

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/TargetsCache.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/TargetsCache.kt
@@ -1,13 +1,8 @@
 package dev.okhsunrog.vpnhide
 
 import android.content.Context
-import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Job
-import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.asStateFlow
-import kotlinx.coroutines.launch
 
 /**
  * Per-screen protection state from root-owned files and package
@@ -46,34 +41,26 @@ internal data class TargetsSnapshot(
         get() = observerUids.mapNotNull { uidToPkg[it] }.toSet()
 }
 
-internal object TargetsCache {
-    private val _snapshot = MutableStateFlow<TargetsSnapshot?>(null)
-    val snapshot: StateFlow<TargetsSnapshot?> = _snapshot.asStateFlow()
+internal object TargetsCache : StateCache<TargetsSnapshot>(
+    traceName = "targets_cache",
+    logTag = "VpnHide-Targets",
+) {
+    val snapshot: StateFlow<TargetsSnapshot?> get() = value
 
-    private val _loading = MutableStateFlow(false)
-    val loading: StateFlow<Boolean> = _loading.asStateFlow()
-
-    private val _error = MutableStateFlow<String?>(null)
-    val error: StateFlow<String?> = _error.asStateFlow()
-
-    private var inflight: Job? = null
-
+    // The snapshot is parsed entirely from the shared RootSnapshotCache, so
+    // `load` needs no context — the parameter is kept only for call-site
+    // symmetry with the other caches.
     fun ensureLoaded(
         scope: CoroutineScope,
-        context: Context,
-    ) {
-        if (_snapshot.value != null || _error.value != null || inflight?.isActive == true) return
-        inflight = scope.launch { reload(context.applicationContext) }
-    }
+        @Suppress("UNUSED_PARAMETER") context: Context,
+    ) = ensure(scope)
 
     fun refresh(
         scope: CoroutineScope,
-        context: Context,
+        @Suppress("UNUSED_PARAMETER") context: Context,
     ) {
-        inflight?.cancel()
         RootSnapshotCache.invalidate()
-        _error.value = null
-        inflight = scope.launch { reload(context.applicationContext, forceRootRefresh = true) }
+        forceRefresh(scope)
     }
 
     fun refreshAfterSave(
@@ -84,53 +71,27 @@ internal object TargetsCache {
         refresh(scope, context)
     }
 
-    /** Drop the cached snapshot so the next subscriber triggers a
-     * fresh load. Use [refreshAfterSave] when a Protection save should
-     * also invalidate Dashboard counts.
+    /** Drop the cached snapshot (and the shared root snapshot it derives
+     * from) so the next subscriber triggers a fresh load. Use
+     * [refreshAfterSave] when a Protection save should also invalidate
+     * Dashboard counts.
      */
-    fun invalidate() {
-        _snapshot.value = null
-        _error.value = null
+    override fun invalidate() {
+        super.invalidate()
         RootSnapshotCache.invalidate()
     }
 
-    private suspend fun reload(
-        @Suppress("UNUSED_PARAMETER") appContext: Context,
-        forceRootRefresh: Boolean = false,
-    ) {
-        _loading.value = true
-        try {
-            StartupTrace.mark("targets_cache_start")
-            val rootSnapshot =
-                if (forceRootRefresh) {
-                    RootSnapshotCache.refresh()
-                } else {
-                    RootSnapshotCache.getOrLoad()
-                }
-            _snapshot.value = parseTargetsSnapshot(rootSnapshot)
-            _error.value = null
-            StartupTrace.mark("targets_cache_done")
-        } catch (e: CancellationException) {
-            throw e
-        } catch (e: Exception) {
-            StartupTrace.mark("targets_cache_failed")
-            _error.value = e.message ?: e.javaClass.simpleName
-            VpnHideLog.w("VpnHide-Targets", "targets cache reload failed: ${e.message}", e)
-        } finally {
-            _loading.value = false
-        }
+    override suspend fun load(force: Boolean): TargetsSnapshot {
+        val rootSnapshot =
+            if (force) RootSnapshotCache.refresh() else RootSnapshotCache.getOrLoad()
+        return parseTargetsSnapshot(rootSnapshot)
     }
 }
 
 internal fun parseTargetsSnapshot(rootSnapshot: RootSnapshot): TargetsSnapshot {
     val sections = rootSnapshot.sections
 
-    fun nonEmptyLines(raw: String?): Set<String> =
-        raw
-            ?.lines()
-            ?.map { it.trim() }
-            ?.filter { it.isNotEmpty() && !it.startsWith("#") }
-            ?.toSet() ?: emptySet()
+    fun nonEmptyLines(raw: String?): Set<String> = raw?.let { parseConfigLines(it).toSet() } ?: emptySet()
 
     val portsInstalled = sections["ports_prop"]?.isNotBlank() == true
     val observerUids = nonEmptyLines(sections["observer_uids"]).mapNotNull { it.toIntOrNull() }.toSet()

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/TargetsCache.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/TargetsCache.kt
@@ -76,9 +76,17 @@ internal object TargetsCache {
         inflight = scope.launch { reload(context.applicationContext, forceRootRefresh = true) }
     }
 
+    fun refreshAfterSave(
+        scope: CoroutineScope,
+        context: Context,
+    ) {
+        DashboardCache.invalidate()
+        refresh(scope, context)
+    }
+
     /** Drop the cached snapshot so the next subscriber triggers a
-     * fresh load. Save handlers call this because they just mutated
-     * one of the files this cache mirrors.
+     * fresh load. Use [refreshAfterSave] when a Protection save should
+     * also invalidate Dashboard counts.
      */
     fun invalidate() {
         _snapshot.value = null

--- a/lsposed/app/src/test/kotlin/dev/okhsunrog/vpnhide/ShellCommandBuildersTest.kt
+++ b/lsposed/app/src/test/kotlin/dev/okhsunrog/vpnhide/ShellCommandBuildersTest.kt
@@ -75,6 +75,20 @@ class ShellCommandBuildersTest {
     }
 
     @Test
+    fun `system data file perms set mode group context and tolerate chcon failure`() {
+        val parts = systemDataFilePermsParts("/data/system/vpnhide_uids.txt", "640")
+
+        assertEquals(
+            listOf(
+                "chmod 640 /data/system/vpnhide_uids.txt 2>/dev/null",
+                "chown root:system /data/system/vpnhide_uids.txt 2>/dev/null",
+                "chcon $SYSTEM_DATA_FILE_CONTEXT /data/system/vpnhide_uids.txt 2>/dev/null || true",
+            ),
+            parts,
+        )
+    }
+
+    @Test
     fun `self target output extracts seeded package list`() {
         val output =
             """

--- a/lsposed/app/src/test/kotlin/dev/okhsunrog/vpnhide/ShellCommandBuildersTest.kt
+++ b/lsposed/app/src/test/kotlin/dev/okhsunrog/vpnhide/ShellCommandBuildersTest.kt
@@ -75,6 +75,23 @@ class ShellCommandBuildersTest {
     }
 
     @Test
+    fun `self target command is syntactically valid shell`() {
+        // Guards against the flatten bug: collapsing the ensure_line() shell
+        // function onto one line (`replace("\n", " ")`) dropped the separators
+        // before `fi`, producing `then return fi` — a syntax error that broke
+        // startup on-device. The other tests only do substring checks and
+        // never parse the script, so this one runs `sh -n`.
+        val cmd = buildEnsureSelfInTargetsCommand("dev.okhsunrog.vpnhide")
+        val proc =
+            ProcessBuilder("sh", "-n", "-c", cmd)
+                .redirectErrorStream(true)
+                .start()
+        val out = proc.inputStream.bufferedReader().readText()
+        val exitCode = proc.waitFor()
+        assertEquals("sh -n reported a syntax error: $out", 0, exitCode)
+    }
+
+    @Test
     fun `system data file perms set mode group context and tolerate chcon failure`() {
         val parts = systemDataFilePermsParts("/data/system/vpnhide_uids.txt", "640")
 

--- a/lsposed/app/src/test/kotlin/dev/okhsunrog/vpnhide/StartupCoordinatorTest.kt
+++ b/lsposed/app/src/test/kotlin/dev/okhsunrog/vpnhide/StartupCoordinatorTest.kt
@@ -1,0 +1,79 @@
+package dev.okhsunrog.vpnhide
+
+import android.content.ContextWrapper
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class StartupCoordinatorTest {
+    @Test
+    fun `successful self target preparation seeds package list and cleanup boot id`() =
+        runBlocking {
+            val markers = mutableListOf<String>()
+            var seededPackages: String? = null
+            var cleanupBootId: String? = null
+            val coordinator =
+                StartupCoordinator(
+                    appContext = FakeContext("dev.okhsunrog.vpnhide"),
+                    prepareSelfTargetsCommand = { pkg ->
+                        assertEquals("dev.okhsunrog.vpnhide", pkg)
+                        SelfTargetPreparation(
+                            rootAvailable = true,
+                            selfNeedsRestart = true,
+                            currentBootId = "boot-1",
+                            pmPackages = "package:dev.okhsunrog.vpnhide uid:10123",
+                        )
+                    },
+                    cleanupZygiskStatus = { _, bootId -> cleanupBootId = bootId },
+                    seedRootSnapshotPackages = { seededPackages = it },
+                    markStartupEvent = markers::add,
+                )
+
+            coordinator.prepareSelfTargets()
+
+            assertEquals(StartupSelfTargetState.Ready(selfNeedsRestart = true), coordinator.selfTargetState.value)
+            assertEquals("package:dev.okhsunrog.vpnhide uid:10123", seededPackages)
+            assertEquals("boot-1", cleanupBootId)
+            assertEquals(listOf("self_targets_start", "self_targets_done"), markers)
+        }
+
+    @Test
+    fun `failed self target preparation reports error without seeding or cleanup`() =
+        runBlocking {
+            val markers = mutableListOf<String>()
+            var seededPackages: String? = null
+            var cleanupBootId: String? = null
+            val coordinator =
+                StartupCoordinator(
+                    appContext = FakeContext("dev.okhsunrog.vpnhide"),
+                    prepareSelfTargetsCommand = {
+                        SelfTargetPreparation(
+                            rootAvailable = false,
+                            selfNeedsRestart = false,
+                            currentBootId = null,
+                            error = "exit=-1",
+                        )
+                    },
+                    cleanupZygiskStatus = { _, bootId -> cleanupBootId = bootId },
+                    seedRootSnapshotPackages = { seededPackages = it },
+                    markStartupEvent = markers::add,
+                )
+
+            coordinator.prepareSelfTargets()
+
+            assertEquals(StartupSelfTargetState.Failed("exit=-1"), coordinator.selfTargetState.value)
+            assertNull(seededPackages)
+            assertNull(cleanupBootId)
+            assertEquals(
+                listOf("self_targets_start", "self_targets_done", "self_targets_failed"),
+                markers,
+            )
+        }
+
+    private class FakeContext(
+        private val packageName: String,
+    ) : ContextWrapper(null) {
+        override fun getPackageName(): String = packageName
+    }
+}


### PR DESCRIPTION
Extracts the app's startup orchestration into a testable coordinator, then collapses the large duplication across the lsposed Compose UI and cache layer into shared abstractions. Along the way it fixes three latent bugs, including one that stopped the app from starting at all.

- Extract `StartupCoordinator` from `MainActivity`: self-target prep, cache prewarming, update-freshness and the refresh actions move into one class with injected dependencies and unit tests; `MainActivity` just wires it up.
- Add a generic `TargetPicker` scaffold so the three Protection screens (tun targets, app hiding, ports) share the list machinery, alphabetical fast-scrollbar, save lifecycle, row chrome and chip instead of carrying ~90%-identical copies.
- Add a `StateCache<T>` base for `DashboardCache`/`TargetsCache`/`AppListCache`. This unifies their value/loading/error/inflight handling and fixes two bugs the hand-written copies had drifted into: `DiagnosticsCache` swallowed `CancellationException`, and `AppListCache` had no error state (a failed app-list scan now shows a retry card instead of spinning forever). Drops the now-unused `refreshCounter`.
- Compute the kmod failure diagnosis (card color + banner text) once instead of mirroring the priority order across two `when` blocks that had to be kept in sync by hand.
- Centralize the pinned status palette and share `StatusBanner`, the toggle chip, and the save/share export row across Dashboard and Diagnostics.
- Share the native-check list and pass/fail scoring between Dashboard and Diagnostics, and derive Dashboard's Java protection result from the same check functions Diagnostics uses.
- Unify the `/data/system` chmod/chown/chcon tail behind one tested helper (one save branch previously omitted `chcon` and the `|| true` fail-safe) and share the config-line parser.
- Fix the app failing to launch with "Startup preparation failed": the root-setup command flattened its multi-line shell function onto one line, producing `then return fi` — a syntax error that made every `su -c` exit non-zero. Newlines are valid inside a `su -c` argument, so keep them; add a test that runs `sh -n` on the generated command (the existing builder tests only checked substrings).

Net ~220 fewer lines despite the added scaffolding and tests.

Testing
- CI: `ktlint`, `:app:lintDebug`, and `:app:testDebugUnitTest` all pass. New tests: a `StartupCoordinator` test, a `sh -n` syntax check on the startup command, and a system-data-file perms test.
- On a rooted device: before the fix the app showed "Startup preparation failed"; reproduced by running the exact generated command under `su` (syntax error, exit 1). After the fix the same command exits 0 and the app reaches the Dashboard. The `/data/system` perms tail was confirmed on-device via the startup path, which applies the identical chmod/chown/chcon and leaves the files at mode 640, `root:system`, `u:object_r:system_data_file:s0`.
