### PR TITLE
refactor(lsposed): decompose dashboard logic, dedupe parsers/builders/watchers

### DIFF
--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/AppHidingScreen.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/AppHidingScreen.kt
@@ -133,8 +133,6 @@ private fun buildHidingSaveCommand(
     hiddenPkgs: List<String>,
     observerPkgs: List<String>,
 ): String {
-    fun encode(body: String): String = android.util.Base64.encodeToString(body.toByteArray(), android.util.Base64.NO_WRAP)
-
     val parts = mutableListOf<String>()
 
     // Hidden list: package names, one per line.
@@ -142,9 +140,7 @@ private fun buildHidingSaveCommand(
     // untrusted apps get EACCES because /data/system/ is mode 0775 (the
     // file's "other" bits decide reachability). Prevents apps from
     // enumerating the hidden-package list to fingerprint vpnhide.
-    val hiddenBody = "$header\n" + hiddenPkgs.joinToString("\n") + if (hiddenPkgs.isNotEmpty()) "\n" else ""
-    val hiddenB64 = encode(hiddenBody)
-    parts += "echo '$hiddenB64' | base64 -d > $SS_HIDDEN_PKGS_FILE"
+    parts += buildConfigWriteCommand(SS_HIDDEN_PKGS_FILE, header, hiddenPkgs)
     parts += systemDataFilePermsParts(SS_HIDDEN_PKGS_FILE, "640")
 
     // Observer list: resolved UIDs. Same 0640 root:system rationale.

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/AppPickerScreen.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/AppPickerScreen.kt
@@ -127,26 +127,24 @@ private fun buildSaveCommand(
     zygiskPkgs: List<String>,
     lsposedPkgs: List<String>,
 ): String {
-    fun encodeBody(pkgs: List<String>): String {
-        val body = "$header\n" + pkgs.joinToString("\n") + if (pkgs.isNotEmpty()) "\n" else ""
-        return android.util.Base64.encodeToString(body.toByteArray(), android.util.Base64.NO_WRAP)
-    }
-
     val parts = mutableListOf<String>()
 
     // Write kmod targets
-    val kmodB64 = encodeBody(kmodPkgs)
-    parts += "if [ -d /data/adb/vpnhide_kmod ]; then echo '$kmodB64' | base64 -d > $KMOD_TARGETS && chmod 644 $KMOD_TARGETS; fi"
+    parts +=
+        "if [ -d /data/adb/vpnhide_kmod ]; then ${buildConfigWriteCommand(KMOD_TARGETS, header, kmodPkgs)} && chmod 644 $KMOD_TARGETS; fi"
 
     // Write zygisk targets
-    val zygiskB64 = encodeBody(zygiskPkgs)
-    parts += "if [ -d /data/adb/vpnhide_zygisk ]; then echo '$zygiskB64' | base64 -d > $ZYGISK_TARGETS && chmod 644 $ZYGISK_TARGETS; fi"
+    parts +=
+        "if [ -d /data/adb/vpnhide_zygisk ]; then ${buildConfigWriteCommand(
+            ZYGISK_TARGETS,
+            header,
+            zygiskPkgs,
+        )} && chmod 644 $ZYGISK_TARGETS; fi"
     parts += "cp $ZYGISK_TARGETS $ZYGISK_MODULE_TARGETS 2>/dev/null; true"
 
     // Write lsposed targets (always — the dir is created by service.sh or us)
-    val lsposedB64 = encodeBody(lsposedPkgs)
     parts += "mkdir -p /data/adb/vpnhide_lsposed"
-    parts += "echo '$lsposedB64' | base64 -d > $LSPOSED_TARGETS && chmod 644 $LSPOSED_TARGETS"
+    parts += "${buildConfigWriteCommand(LSPOSED_TARGETS, header, lsposedPkgs)} && chmod 644 $LSPOSED_TARGETS"
 
     // Resolve kmod UIDs -> /proc/vpnhide_targets
     if (kmodPkgs.isNotEmpty()) {

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DashboardData.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DashboardData.kt
@@ -124,15 +124,7 @@ internal fun detectModuleMismatches(
         }
     }
 
-private sealed interface LsposedRuntime {
-    data object Inactive : LsposedRuntime
-
-    data class Active(
-        val version: String?,
-    ) : LsposedRuntime
-}
-
-private sealed interface LsposedFramework {
+internal sealed interface LsposedFramework {
     data object NotInstalled : LsposedFramework
 
     data class Installed(
@@ -140,7 +132,7 @@ private sealed interface LsposedFramework {
     ) : LsposedFramework
 }
 
-private sealed interface LsposedConfig {
+internal sealed interface LsposedConfig {
     data object ModuleNotConfigured : LsposedConfig
 
     data object Disabled : LsposedConfig
@@ -334,6 +326,284 @@ internal fun buildNativeInstallRecommendation(
     )
 }
 
+// ── Module-prop / status-file parsing (pure, unit-tested) ────────────────
+
+// Strip the `v` prefix from module.prop versions at parse time so everything
+// downstream sees a plain semver string (APK versionName has no `v`).
+internal data class ModulePropInfo(
+    val installed: Boolean,
+    val version: String?,
+    val gkiVariant: String?,
+)
+
+// Older CI-built zips didn't stamp `gkiVariant=` but their injected updateJson
+// URL already encodes the KMI: `.../update-kmod-<kmi>.json`. Recover the variant
+// from there so wrong-variant detection works for existing installs.
+private val UPDATE_JSON_KMI_REGEX = Regex("""update-kmod-([^/]+)\.json""")
+
+internal fun parseModuleProp(raw: String): ModulePropInfo {
+    if (raw.isBlank()) return ModulePropInfo(false, null, null)
+    var version: String? = null
+    var gkiVariant: String? = null
+    var updateJsonKmi: String? = null
+    for (line in raw.lines()) {
+        when {
+            line.startsWith("version=") -> {
+                version = normalizeVersion(line.removePrefix("version="))
+            }
+
+            line.startsWith("gkiVariant=") -> {
+                gkiVariant = line.removePrefix("gkiVariant=").trim().ifBlank { null }
+            }
+
+            line.startsWith("updateJson=") -> {
+                updateJsonKmi = UPDATE_JSON_KMI_REGEX.find(line.removePrefix("updateJson="))?.groupValues?.get(1)
+            }
+        }
+    }
+    return ModulePropInfo(true, version, gkiVariant ?: updateJsonKmi)
+}
+
+/** Count configured target packages, excluding the app's own package (it is
+ * always present invisibly and must not inflate the user-facing count). */
+internal fun countTargets(
+    raw: String,
+    selfPkg: String,
+): Int = parseConfigLines(raw).count { it != selfPkg }
+
+internal fun readKmodLoadStatus(
+    currentBootId: String,
+    raw: String,
+    dmesgRaw: String,
+): KmodLoadStatus? {
+    if (raw.isBlank()) return null
+    val props = parseKeyValueLines(raw)
+    val bootId = props["boot_id"]?.trim()
+    return KmodLoadStatus(
+        timestamp = props["timestamp"]?.trim()?.toLongOrNull(),
+        bootId = bootId,
+        unameR = props["uname_r"]?.trim(),
+        gkiVariant = props["gki_variant"]?.trim()?.ifBlank { null },
+        kmodVersion = props["kmod_version"]?.trim()?.ifBlank { null },
+        rootManager = props["root_manager"]?.trim()?.ifBlank { null },
+        kprobes = props["kprobes"]?.trim()?.ifBlank { null },
+        kretprobes = props["kretprobes"]?.trim()?.ifBlank { null },
+        insmodExit = props["insmod_exit"]?.trim()?.toIntOrNull(),
+        loaded = props["loaded"]?.trim() == "1",
+        insmodStderr = props["insmod_stderr"]?.trim()?.ifBlank { null },
+        dmesgTail = dmesgRaw.trim().ifBlank { null },
+        freshForCurrentBoot = bootId != null && bootId == currentBootId,
+    )
+}
+
+// ── kmod problem classification (pure, unit-tested) ──────────────────────
+
+/**
+ * The single diagnosed problem for an installed-but-not-working kmod, as a
+ * data-only value with the exact arguments its banner text needs. [reason]
+ * drives the red module-card color; the [renderKmodProblem] mapping turns the
+ * kind into the localized banner string. Computing the kind in one pure place
+ * keeps the card color and the banner text from ever disagreeing — they used
+ * to be hand-mirrored across two `when` blocks.
+ */
+internal sealed interface KmodProblemKind {
+    val reason: KmodBrokenReason?
+
+    data object KprobesMissing : KmodProblemKind {
+        override val reason get() = KmodBrokenReason.MissingKprobes
+    }
+
+    data class UnsupportedKernel(
+        val unameR: String,
+        val recommendedArtifact: String,
+    ) : KmodProblemKind {
+        override val reason get() = KmodBrokenReason.UnsupportedKernel
+    }
+
+    data class WrongVariant(
+        val installedVariant: String,
+        val recommendedKmi: String,
+        val recommendedArtifact: String,
+    ) : KmodProblemKind {
+        override val reason get() = KmodBrokenReason.WrongVariant
+    }
+
+    data class UnknownVariant(
+        val recommendedArtifact: String,
+    ) : KmodProblemKind {
+        override val reason get() = KmodBrokenReason.UnknownVariantInactive
+    }
+
+    data class AmbiguousLoadFailed(
+        val installedVariant: String,
+        val tryArtifact: String,
+    ) : KmodProblemKind {
+        override val reason get() = KmodBrokenReason.AmbiguousLoadFailed
+    }
+
+    // Generic insmod failure where we only have raw stderr, no named diagnosis.
+    data class LoadFailed(
+        val insmodStderr: String,
+    ) : KmodProblemKind {
+        override val reason: KmodBrokenReason? get() = null
+    }
+}
+
+/**
+ * Diagnose what's wrong with an installed kmod, or null if it's fine / not a
+ * diagnosable failure. Priority order: kprobes-missing first (no variant will
+ * ever work), then unsupported-kernel (wrong tool), wrong-variant (concrete
+ * mismatch), unknown-variant (old build that didn't stamp gkiVariant),
+ * ambiguous-load-failed (one of two valid candidates failed this boot), and
+ * finally a generic insmod failure when we have stderr to show.
+ *
+ * An active kmod (`/proc/vpnhide_targets` present) is empirical proof the
+ * install works, so every check except the activity-independent kprobes probe
+ * is gated on `!active`.
+ */
+internal fun classifyKmodProblem(
+    kmod: ModuleState,
+    recommendation: NativeInstallRecommendation?,
+    loadStatus: KmodLoadStatus?,
+): KmodProblemKind? {
+    if (kmod !is ModuleState.Installed) return null
+    val freshLoad = loadStatus != null && loadStatus.freshForCurrentBoot
+
+    if (freshLoad && loadStatus.kretprobes == "n") {
+        return KmodProblemKind.KprobesMissing
+    }
+    // Past this point every diagnosis means "installed but not loaded".
+    if (kmod.active) return null
+
+    val rec = recommendation
+    // rec.recommendedArtifact is a non-null field, so a non-null rec always
+    // yields a non-null artifact — the `!!` uses below are safe under the
+    // `rec != null` / `rec?.preferKmod == true` guards that precede them.
+    val recommendedArtifact = rec?.recommendedArtifact
+    val installedVariant = kmod.gkiVariant
+
+    if (rec != null && !rec.preferKmod) {
+        return KmodProblemKind.UnsupportedKernel(loadStatus?.unameR ?: "?", recommendedArtifact!!)
+    }
+
+    val recommendedKmi = rec?.recommendedGkiVariant
+    if (rec?.preferKmod == true &&
+        recommendedKmi != null &&
+        installedVariant != null &&
+        installedVariant != recommendedKmi &&
+        installedVariant != rec.alternativeGkiVariant
+    ) {
+        return KmodProblemKind.WrongVariant(installedVariant, recommendedKmi, recommendedArtifact!!)
+    }
+
+    if (installedVariant == null && rec?.preferKmod == true) {
+        return KmodProblemKind.UnknownVariant(recommendedArtifact!!)
+    }
+
+    if (freshLoad &&
+        rec?.variantAmbiguous == true &&
+        installedVariant != null &&
+        (installedVariant == rec.recommendedGkiVariant || installedVariant == rec.alternativeGkiVariant)
+    ) {
+        val tryArtifact =
+            if (installedVariant == rec.recommendedGkiVariant) rec.alternativeArtifact else rec.recommendedArtifact
+        return KmodProblemKind.AmbiguousLoadFailed(installedVariant, tryArtifact ?: "?")
+    }
+
+    if (freshLoad && loadStatus.insmodStderr != null) {
+        return KmodProblemKind.LoadFailed(loadStatus.insmodStderr)
+    }
+
+    return null
+}
+
+private fun renderKmodProblem(
+    kind: KmodProblemKind,
+    res: android.content.res.Resources,
+): KmodProblem =
+    KmodProblem(
+        reason = kind.reason,
+        text =
+            when (kind) {
+                KmodProblemKind.KprobesMissing -> {
+                    res.getString(R.string.dashboard_issue_kprobes_missing)
+                }
+
+                is KmodProblemKind.UnsupportedKernel -> {
+                    res.getString(R.string.dashboard_issue_kmod_not_supported_kernel, kind.unameR, kind.recommendedArtifact)
+                }
+
+                is KmodProblemKind.WrongVariant -> {
+                    res.getString(
+                        R.string.dashboard_issue_kmod_wrong_variant,
+                        kind.installedVariant,
+                        kind.recommendedKmi,
+                        kind.recommendedArtifact,
+                    )
+                }
+
+                is KmodProblemKind.UnknownVariant -> {
+                    res.getString(R.string.dashboard_issue_kmod_unknown_variant, kind.recommendedArtifact)
+                }
+
+                is KmodProblemKind.AmbiguousLoadFailed -> {
+                    res.getString(
+                        R.string.dashboard_issue_kmod_ambiguous_try_alternative,
+                        kind.installedVariant,
+                        kind.tryArtifact,
+                    )
+                }
+
+                is KmodProblemKind.LoadFailed -> {
+                    res.getString(R.string.dashboard_issue_kmod_load_failed, kind.insmodStderr)
+                }
+            },
+    )
+
+// ── LSPosed state resolution (pure, unit-tested) ─────────────────────────
+
+/**
+ * Resolve the user-facing [LsposedState] from the framework presence, the
+ * on-disk module config, and whether the hook heartbeat is fresh for this
+ * boot. A current-boot heartbeat is the strongest signal (module is active);
+ * otherwise the config/framework decide inactive/needs-reboot/not-configured.
+ */
+internal fun resolveLsposedState(
+    hooksActiveThisBoot: Boolean,
+    hookVersion: String?,
+    lsposedTargetCount: Int,
+    framework: LsposedFramework,
+    config: LsposedConfig?,
+): LsposedState {
+    if (hooksActiveThisBoot) {
+        return LsposedState.Active(hookVersion, lsposedTargetCount)
+    }
+    return when (config) {
+        null -> {
+            LsposedState.InstalledInactive(null)
+        }
+
+        LsposedConfig.ModuleNotConfigured -> {
+            when (framework) {
+                LsposedFramework.NotInstalled -> LsposedState.NotInstalled
+                is LsposedFramework.Installed -> LsposedState.InstalledInactive(null)
+            }
+        }
+
+        LsposedConfig.Disabled -> {
+            LsposedState.InstalledInactive(null)
+        }
+
+        is LsposedConfig.Enabled -> {
+            if (config.hasSystemFramework) {
+                LsposedState.NeedsReboot(hookVersion)
+            } else {
+                LsposedState.InstalledInactive(null)
+            }
+        }
+    }
+}
+
 internal fun loadDashboardState(
     cm: ConnectivityManager,
     context: android.content.Context,
@@ -357,61 +627,10 @@ internal fun loadDashboardState(
     val shellSnapshot = rootSnapshot.sections
 
     // ── Module detection ──
-    // Strip the `v` prefix from module.prop versions at parse time so
-    // everything downstream — dashboard rendering, issue text, update
-    // checks — sees a plain semver string. APK versionName has no `v`
-    // (Android convention); stamping `v` into module.prop follows the
-    // Magisk convention but mixes badly when both show side by side.
-    data class ModulePropInfo(
-        val installed: Boolean,
-        val version: String?,
-        val gkiVariant: String?,
-    )
-
-    // Older CI-built zips (between commit 3fc7355 "don't dirty committed
-    // module.prop when injecting updateJson" and the gkiVariant stamping)
-    // didn't stamp `gkiVariant=` but their injected updateJson URL already
-    // encodes the KMI: `.../update-kmod-<kmi>.json`. Recover the variant
-    // from there so wrong-variant detection works for existing installs
-    // without requiring a reinstall.
-    val updateJsonKmiRegex = Regex("""update-kmod-([^/]+)\.json""")
-
-    fun parseModuleProp(raw: String): ModulePropInfo {
-        if (raw.isBlank()) return ModulePropInfo(false, null, null)
-        var version: String? = null
-        var gkiVariant: String? = null
-        var updateJsonKmi: String? = null
-        for (line in raw.lines()) {
-            when {
-                line.startsWith("version=") -> {
-                    version = normalizeVersion(line.removePrefix("version="))
-                }
-
-                line.startsWith("gkiVariant=") -> {
-                    gkiVariant = line.removePrefix("gkiVariant=").trim().ifBlank { null }
-                }
-
-                line.startsWith("updateJson=") -> {
-                    updateJsonKmi =
-                        updateJsonKmiRegex
-                            .find(line.removePrefix("updateJson="))
-                            ?.groupValues
-                            ?.get(1)
-                }
-            }
-        }
-        return ModulePropInfo(true, version, gkiVariant ?: updateJsonKmi)
-    }
-
-    fun countTargets(raw: String): Int = parseConfigLines(raw).count { it != selfPkg }
-
-    fun parseProps(raw: String): Map<String, String> =
-        raw
-            .lines()
-            .mapNotNull {
-                val parts = it.split("=", limit = 2)
-                if (parts.size == 2) parts[0] to parts[1] else null
-            }.toMap()
+    // Module-prop / status parsing lives in pure top-level functions
+    // (parseModuleProp, parseKeyValueLines, countTargets) so they're
+    // unit-testable; only the issue-text rendering below needs `res`.
+    fun countTargets(raw: String): Int = countTargets(raw, selfPkg)
 
     fun buildModuleVersionIssue(
         kind: NativeModuleKind,
@@ -468,31 +687,6 @@ internal fun loadDashboardState(
                 Build.VERSION.RELEASE
             }.substringBefore('.')
         return "Android $release"
-    }
-
-    fun readKmodLoadStatus(
-        currentBootId: String,
-        raw: String,
-        dmesgRaw: String,
-    ): KmodLoadStatus? {
-        if (raw.isBlank()) return null
-        val props = parseProps(raw)
-        val bootId = props["boot_id"]?.trim()
-        return KmodLoadStatus(
-            timestamp = props["timestamp"]?.trim()?.toLongOrNull(),
-            bootId = bootId,
-            unameR = props["uname_r"]?.trim(),
-            gkiVariant = props["gki_variant"]?.trim()?.ifBlank { null },
-            kmodVersion = props["kmod_version"]?.trim()?.ifBlank { null },
-            rootManager = props["root_manager"]?.trim()?.ifBlank { null },
-            kprobes = props["kprobes"]?.trim()?.ifBlank { null },
-            kretprobes = props["kretprobes"]?.trim()?.ifBlank { null },
-            insmodExit = props["insmod_exit"]?.trim()?.toIntOrNull(),
-            loaded = props["loaded"]?.trim() == "1",
-            insmodStderr = props["insmod_stderr"]?.trim()?.ifBlank { null },
-            dmesgTail = dmesgRaw.trim().ifBlank { null },
-            freshForCurrentBoot = bootId != null && bootId == currentBootId,
-        )
     }
 
     fun resolveScopeEntryLabel(entry: String): String {
@@ -608,7 +802,7 @@ internal fun loadDashboardState(
 
     fun detectLsposedFramework(): LsposedFramework {
         val out = shellSnapshot["lsposed_framework"].orEmpty()
-        val props = parseProps(out)
+        val props = parseKeyValueLines(out)
         val probeOk = props["probe_ok"] == "1"
         val installedValue = props["installed"]
         val disabledValue = props["disabled"]
@@ -664,7 +858,7 @@ internal fun loadDashboardState(
             VpnHideLog.w(TAG, "failed to read zygisk status heartbeat: ${e.message}")
             ""
         }
-    val zygiskProps = parseProps(zygiskStatusRaw)
+    val zygiskProps = parseKeyValueLines(zygiskStatusRaw)
     val currentBootId = shellSnapshot["current_boot_id"].orEmpty()
     val zygiskBootId = zygiskProps["boot_id"]
     val zygiskActive = zygiskInstalled && zygiskBootId != null && zygiskBootId == currentBootId.trim()
@@ -705,157 +899,14 @@ internal fun loadDashboardState(
         )
     VpnHideLog.i(TAG, "kmodLoadStatus=$kmodLoadStatus")
 
-    // Decide whether to surface the install-recommendation card.
-    // Show when:
-    //  - neither native module installed (classic first-install flow), or
-    //  - kmod installed but its stamped gkiVariant doesn't match what the
-    //    device needs (wrong zip — user needs to reinstall the correct one), or
-    //  - kmod installed without gkiVariant (old build) AND not loaded —
-    //    variant unknown + broken is almost always a variant mismatch, or
-    //  - kmod installed on a kernel with no matching vpnhide-kmod variant at
-    //    all (non-GKI / unsupported combo) — we recommend zygisk instead so
-    //    the user doesn't wait for the kmod to "just work".
-    val recommendedKmi = kernelRecommendation?.recommendedGkiVariant
-    // Two cross-cutting gates on kmod warnings:
-    //   !kmodRaw.active — an active kmod (/proc/vpnhide_targets present)
-    //     is empirical proof the installation works, so a heuristic
-    //     saying otherwise is wrong. Applied to every warning below.
-    //   kmodLoadStatus?.freshForCurrentBoot == true (AmbiguousLoadFailed
-    //     only) — that warning is specifically about "the module we
-    //     installed tried to insmod this boot and failed, pick the
-    //     other candidate", so it only makes sense once post-fs-data
-    //     has actually attempted a load. The other warnings are
-    //     deterministic from the variant stamp / kernel-series tables
-    //     and are valid even before the first post-install boot.
-    // For an ambiguous recommendation (variantAmbiguous=true), either
-    // candidate is a valid install, so kmodVariantMismatch must check
-    // both recommendedGkiVariant AND alternativeGkiVariant before
-    // deciding it's a real mismatch.
-    val kmodVariantMismatch =
-        kmodRaw is ModuleState.Installed &&
-            !kmodRaw.active &&
-            kernelRecommendation?.preferKmod == true &&
-            recommendedKmi != null &&
-            kmodRaw.gkiVariant != null &&
-            kmodRaw.gkiVariant != recommendedKmi &&
-            kmodRaw.gkiVariant != kernelRecommendation.alternativeGkiVariant
-    val kmodUnknownVariantBroken =
-        kmodRaw is ModuleState.Installed &&
-            !kmodRaw.active &&
-            kmodRaw.gkiVariant == null &&
-            kernelRecommendation?.preferKmod == true
-    val kmodOnUnsupportedKernel =
-        kmodRaw is ModuleState.Installed &&
-            !kmodRaw.active &&
-            kernelRecommendation != null &&
-            !kernelRecommendation.preferKmod
-    // User installed one of the two candidates for an ambiguous GKI series
-    // (5.10 / 5.15) and it failed to load this boot — suggest the other.
-    val kmodAmbiguousLoadFailed =
-        kmodRaw is ModuleState.Installed &&
-            !kmodRaw.active &&
-            kmodLoadStatus?.freshForCurrentBoot == true &&
-            kernelRecommendation?.variantAmbiguous == true &&
-            kmodRaw.gkiVariant != null &&
-            (
-                kmodRaw.gkiVariant == kernelRecommendation.recommendedGkiVariant ||
-                    kmodRaw.gkiVariant == kernelRecommendation.alternativeGkiVariant
-            )
-    val kprobesMissing =
-        kmodLoadStatus?.freshForCurrentBoot == true && kmodLoadStatus.kretprobes == "n"
-    val recommendedArtifact = kernelRecommendation?.recommendedArtifact
-    // Single source of truth for "what's wrong with the installed kmod".
-    // Priority order: kprobes-missing first (no variant will ever work),
-    // then unsupported-kernel (wrong tool), wrong-variant (concrete
-    // mismatch), unknown-variant (old build that didn't stamp gkiVariant),
-    // ambiguous-load-failed (one of two valid candidates failed this boot),
-    // and finally a generic insmod failure when we have stderr to show.
-    // [reason] colors the card, [text] is the banner — deriving both from
-    // this one `when` keeps them from disagreeing. The `recommendedArtifact
-    // != null` guards are redundant in practice (those booleans already
-    // imply a non-null kernel recommendation) but kept so the res.getString
-    // args are provably non-null.
+    // Single source of truth for "what's wrong with the installed kmod" —
+    // classifyKmodProblem (pure, unit-tested) decides the priority-ordered
+    // diagnosis; renderKmodProblem maps it to the localized banner text.
+    // [reason] colors the card, [text] is the banner — both derive from the
+    // one classification so they can't disagree.
     val kmodProblem: KmodProblem? =
-        if (kmodRaw !is ModuleState.Installed) {
-            null
-        } else {
-            when {
-                kprobesMissing -> {
-                    KmodProblem(
-                        KmodBrokenReason.MissingKprobes,
-                        res.getString(R.string.dashboard_issue_kprobes_missing),
-                    )
-                }
-
-                kmodOnUnsupportedKernel && recommendedArtifact != null -> {
-                    KmodProblem(
-                        KmodBrokenReason.UnsupportedKernel,
-                        res.getString(
-                            R.string.dashboard_issue_kmod_not_supported_kernel,
-                            kmodLoadStatus?.unameR ?: "?",
-                            recommendedArtifact,
-                        ),
-                    )
-                }
-
-                kmodVariantMismatch -> {
-                    KmodProblem(
-                        KmodBrokenReason.WrongVariant,
-                        res.getString(
-                            R.string.dashboard_issue_kmod_wrong_variant,
-                            kmodRaw.gkiVariant ?: "?",
-                            recommendedKmi ?: "?",
-                            recommendedArtifact ?: "?",
-                        ),
-                    )
-                }
-
-                kmodUnknownVariantBroken && recommendedArtifact != null -> {
-                    KmodProblem(
-                        KmodBrokenReason.UnknownVariantInactive,
-                        res.getString(
-                            R.string.dashboard_issue_kmod_unknown_variant,
-                            recommendedArtifact,
-                        ),
-                    )
-                }
-
-                kmodAmbiguousLoadFailed -> {
-                    val installed = kmodRaw.gkiVariant
-                    val tryArtifact =
-                        if (installed == kernelRecommendation?.recommendedGkiVariant) {
-                            kernelRecommendation.alternativeArtifact
-                        } else {
-                            kernelRecommendation?.recommendedArtifact
-                        }
-                    KmodProblem(
-                        KmodBrokenReason.AmbiguousLoadFailed,
-                        res.getString(
-                            R.string.dashboard_issue_kmod_ambiguous_try_alternative,
-                            installed ?: "?",
-                            tryArtifact ?: "?",
-                        ),
-                    )
-                }
-
-                !kmodRaw.active &&
-                    kmodLoadStatus?.freshForCurrentBoot == true &&
-                    kmodLoadStatus.insmodStderr != null -> {
-                    KmodProblem(
-                        reason = null,
-                        text =
-                            res.getString(
-                                R.string.dashboard_issue_kmod_load_failed,
-                                kmodLoadStatus.insmodStderr,
-                            ),
-                    )
-                }
-
-                else -> {
-                    null
-                }
-            }
-        }
+        classifyKmodProblem(kmodRaw, kernelRecommendation, kmodLoadStatus)
+            ?.let { renderKmodProblem(it, res) }
     val kmodBrokenReason = kmodProblem?.reason
     val kmod: ModuleState =
         if (kmodRaw is ModuleState.Installed && kmodBrokenReason != null) {
@@ -875,14 +926,13 @@ internal fun loadDashboardState(
     VpnHideLog.i(
         TAG,
         "nativeInstallRecommendation=$nativeInstallRecommendation " +
-            "(raw=$kernelRecommendation variantMismatch=$kmodVariantMismatch " +
-            "unknownVariantBroken=$kmodUnknownVariantBroken)",
+            "(raw=$kernelRecommendation kmodProblem=$kmodProblem)",
     )
     StartupTrace.mark("dashboard_kernel_done")
 
     // lsposed hook status
     val hookStatusRaw = shellSnapshot["hook_status"].orEmpty()
-    val hookProps = parseProps(hookStatusRaw)
+    val hookProps = parseKeyValueLines(hookStatusRaw)
     val hookVersion = hookProps["version"]
     val hookBootId = hookProps["boot_id"]
     val hooksActiveThisBoot = hookBootId != null && hookBootId == currentBootId.trim()
@@ -910,49 +960,18 @@ internal fun loadDashboardState(
             }
         }
     StartupTrace.mark("dashboard_lsposed_config_done")
-    val lsposedRuntime: LsposedRuntime =
-        if (hooksActiveThisBoot) {
-            LsposedRuntime.Active(hookVersion)
-        } else {
-            LsposedRuntime.Inactive
-        }
-
     val lsposed: LsposedState =
-        when (lsposedRuntime) {
-            is LsposedRuntime.Active -> {
-                LsposedState.Active(lsposedRuntime.version, lsposedTargetCount)
-            }
-
-            LsposedRuntime.Inactive -> {
-                when (lsposedConfig) {
-                    null -> {
-                        LsposedState.InstalledInactive(null)
-                    }
-
-                    LsposedConfig.ModuleNotConfigured -> {
-                        when (lsposedFramework) {
-                            LsposedFramework.NotInstalled -> LsposedState.NotInstalled
-                            is LsposedFramework.Installed -> LsposedState.InstalledInactive(null)
-                        }
-                    }
-
-                    LsposedConfig.Disabled -> {
-                        LsposedState.InstalledInactive(null)
-                    }
-
-                    is LsposedConfig.Enabled -> {
-                        if (lsposedConfig.hasSystemFramework) {
-                            LsposedState.NeedsReboot(hookVersion)
-                        } else {
-                            LsposedState.InstalledInactive(null)
-                        }
-                    }
-                }
-            }
-        }
+        resolveLsposedState(
+            hooksActiveThisBoot = hooksActiveThisBoot,
+            hookVersion = hookVersion,
+            lsposedTargetCount = lsposedTargetCount,
+            framework = lsposedFramework,
+            config = lsposedConfig,
+        )
     VpnHideLog.i(
         TAG,
-        "lsposed: $lsposed (hookBootId=$hookBootId currentBootId=${currentBootId.trim()} framework=$lsposedFramework runtime=$lsposedRuntime config=$lsposedConfig)",
+        "lsposed: $lsposed (hookBootId=$hookBootId currentBootId=${currentBootId.trim()} " +
+            "framework=$lsposedFramework hooksActive=$hooksActiveThisBoot config=$lsposedConfig)",
     )
     StartupTrace.mark("dashboard_lsposed_done")
 
@@ -1095,16 +1114,10 @@ internal fun loadDashboardState(
     // profile (PackageManager.getInstalledApplications is per-user). A
     // Save from a profile that doesn't see all the targets would silently
     // drop them. Recommend uninstalling everywhere except the main profile.
-    // Literal field match via awk — grep would treat dots in `selfPkg`
-    // as regex wildcards.
-    val selfPmRaw = shellSnapshot["pm_packages"].orEmpty()
     val selfUidCount =
-        selfPmRaw
-            .lines()
-            .firstOrNull { it.startsWith("package:$selfPkg ") }
-            ?.substringAfter("uid:", "")
-            ?.split(',')
-            ?.count { it.trim().toIntOrNull() != null }
+        parsePackageUidMap(shellSnapshot["pm_packages"].orEmpty())[selfPkg]
+            ?.distinct()
+            ?.size
             ?: 0
     if (selfUidCount > 1) {
         warn(res.getString(R.string.dashboard_issue_self_multi_profile, selfUidCount))

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DashboardScreen.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DashboardScreen.kt
@@ -47,7 +47,10 @@ fun DashboardScreen(
     LaunchedEffect(Unit) {
         if (shouldShowChangelog(context)) {
             val data = withContext(Dispatchers.IO) { loadChangelog(context) }
-            if (data != null) {
+            // Only raise the dialog when there's something to show — the
+            // emptiness guard lives here (a side-effect scope) rather than
+            // inside ChangelogDialog's composition body.
+            if (data != null && data.history.isNotEmpty()) {
                 changelogData = data
                 showChangelog = true
             }
@@ -669,11 +672,9 @@ private fun ChangelogDialog(
     data: ChangelogData,
     onDismiss: () -> Unit,
 ) {
+    // Non-empty by construction — the caller only shows this dialog when
+    // changelog history has entries (see the load effect above).
     val entries = remember(data) { data.history }
-    if (entries.isEmpty()) {
-        onDismiss()
-        return
-    }
     var index by remember { mutableIntStateOf(0) }
     val entry = entries[index]
     val locale =

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DiagnosticsScreen.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DiagnosticsScreen.kt
@@ -1,6 +1,7 @@
 package dev.okhsunrog.vpnhide
 
 import android.net.ConnectivityManager
+import android.net.LinkProperties
 import android.net.NetworkCapabilities
 import android.net.Uri
 import android.os.Build
@@ -19,7 +20,6 @@ import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontFamily
@@ -27,7 +27,6 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import dev.okhsunrog.vpnhide.checks.CheckOutput
-import dev.okhsunrog.vpnhide.checks.CheckStatus
 import dev.okhsunrog.vpnhide.generated.IfaceLists
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
@@ -166,7 +165,7 @@ fun DiagnosticsScreen(
             diagState is DiagnosticsCache.State.Ready -> {
                 StatusBanner(
                     text = stringResource(R.string.banner_ready),
-                    containerColor = Color(0xFF1B5E20).copy(alpha = 0.15f),
+                    containerColor = StatusColors.successContainer(),
                     contentColor = MaterialTheme.colorScheme.onSurface,
                 )
 
@@ -174,8 +173,8 @@ fun DiagnosticsScreen(
                     Spacer(Modifier.height(6.dp))
                     StatusBanner(
                         text = stringResource(R.string.banner_network_blocked),
-                        containerColor = MaterialTheme.colorScheme.errorContainer,
-                        contentColor = MaterialTheme.colorScheme.onErrorContainer,
+                        containerColor = StatusColors.errorContainer(),
+                        contentColor = MaterialTheme.colorScheme.onSurface,
                     )
                 }
 
@@ -558,14 +557,8 @@ private fun nativeCheck(
 ): CheckResult =
     try {
         val out = block()
-        val passed =
-            when (out.status) {
-                CheckStatus.PASS -> true
-                CheckStatus.NETWORK_BLOCKED -> null
-                CheckStatus.FAIL -> false
-            }
         VpnHideLog.i(TAG, "[$name] ${out.status}: ${out.detail}")
-        CheckResult(name, passed, out.detail)
+        CheckResult(name, out.status.toPassed(), out.detail)
     } catch (e: Exception) {
         val detail = e.message ?: e.javaClass.simpleName
         Log.e(TAG, "[$name] $detail", e)
@@ -576,47 +569,68 @@ private fun nativeCheck(
 //  Java API checks
 // ==========================================================================
 
-internal fun checkHasTransportVpn(
+/** Shared preamble for the capability-based checks: resolve the active
+ * network's [NetworkCapabilities], reporting "no active network" / "no
+ * capabilities" (both PASS — nothing for an app to leak) when absent. */
+private inline fun withActiveCaps(
     cm: ConnectivityManager,
     name: String,
+    body: (NetworkCapabilities) -> CheckResult,
 ): CheckResult {
     val net = cm.activeNetwork ?: return CheckResult(name, true, "no active network")
     val caps = cm.getNetworkCapabilities(net) ?: return CheckResult(name, true, "no capabilities")
-    val hasVpn = caps.hasTransport(NetworkCapabilities.TRANSPORT_VPN)
-    val hasWifi = caps.hasTransport(NetworkCapabilities.TRANSPORT_WIFI)
-    val hasCellular = caps.hasTransport(NetworkCapabilities.TRANSPORT_CELLULAR)
-    val detail =
-        if (!hasVpn) {
-            "hasTransport(VPN)=false, WIFI=$hasWifi, CELLULAR=$hasCellular"
-        } else {
-            "hasTransport(VPN)=true, WIFI=$hasWifi, CELLULAR=$hasCellular"
-        }
-    return CheckResult(name, !hasVpn, detail)
+    return body(caps)
 }
+
+/** Shared preamble for the LinkProperties-based checks. */
+private inline fun withActiveLinkProperties(
+    cm: ConnectivityManager,
+    name: String,
+    body: (LinkProperties) -> CheckResult,
+): CheckResult {
+    val net = cm.activeNetwork ?: return CheckResult(name, true, "no active network")
+    val lp = cm.getLinkProperties(net) ?: return CheckResult(name, true, "no link properties")
+    return body(lp)
+}
+
+internal fun checkHasTransportVpn(
+    cm: ConnectivityManager,
+    name: String,
+): CheckResult =
+    withActiveCaps(cm, name) { caps ->
+        val hasVpn = caps.hasTransport(NetworkCapabilities.TRANSPORT_VPN)
+        val hasWifi = caps.hasTransport(NetworkCapabilities.TRANSPORT_WIFI)
+        val hasCellular = caps.hasTransport(NetworkCapabilities.TRANSPORT_CELLULAR)
+        val detail =
+            if (!hasVpn) {
+                "hasTransport(VPN)=false, WIFI=$hasWifi, CELLULAR=$hasCellular"
+            } else {
+                "hasTransport(VPN)=true, WIFI=$hasWifi, CELLULAR=$hasCellular"
+            }
+        CheckResult(name, !hasVpn, detail)
+    }
 
 internal fun checkHasCapabilityNotVpn(
     cm: ConnectivityManager,
     name: String,
-): CheckResult {
-    val net = cm.activeNetwork ?: return CheckResult(name, true, "no active network")
-    val caps = cm.getNetworkCapabilities(net) ?: return CheckResult(name, true, "no capabilities")
-    val notVpn = caps.hasCapability(NetworkCapabilities.NET_CAPABILITY_NOT_VPN)
-    val detail = if (notVpn) "NOT_VPN capability present" else "NOT_VPN capability MISSING"
-    return CheckResult(name, notVpn, detail)
-}
+): CheckResult =
+    withActiveCaps(cm, name) { caps ->
+        val notVpn = caps.hasCapability(NetworkCapabilities.NET_CAPABILITY_NOT_VPN)
+        val detail = if (notVpn) "NOT_VPN capability present" else "NOT_VPN capability MISSING"
+        CheckResult(name, notVpn, detail)
+    }
 
 internal fun checkTransportInfo(
     cm: ConnectivityManager,
     name: String,
-): CheckResult {
-    val net = cm.activeNetwork ?: return CheckResult(name, true, "no active network")
-    val caps = cm.getNetworkCapabilities(net) ?: return CheckResult(name, true, "no capabilities")
-    val info = caps.transportInfo
-    val className = info?.javaClass?.name ?: "null"
-    val isVpn = className.contains("VpnTransportInfo")
-    val detail = if (!isVpn) "transportInfo=$className" else "VpnTransportInfo: $info"
-    return CheckResult(name, !isVpn, detail)
-}
+): CheckResult =
+    withActiveCaps(cm, name) { caps ->
+        val info = caps.transportInfo
+        val className = info?.javaClass?.name ?: "null"
+        val isVpn = className.contains("VpnTransportInfo")
+        val detail = if (!isVpn) "transportInfo=$className" else "VpnTransportInfo: $info"
+        CheckResult(name, !isVpn, detail)
+    }
 
 private fun checkNetworkInterfaceEnum(name: String): CheckResult =
     try {
@@ -663,67 +677,64 @@ internal fun checkAllNetworksVpn(
 private fun checkActiveNetworkVpn(
     cm: ConnectivityManager,
     name: String,
-): CheckResult {
-    val net = cm.activeNetwork ?: return CheckResult(name, true, "no active network")
-    val caps = cm.getNetworkCapabilities(net) ?: return CheckResult(name, true, "no capabilities")
-    val transports = mutableListOf<String>()
-    mapOf(
-        NetworkCapabilities.TRANSPORT_CELLULAR to "CELLULAR",
-        NetworkCapabilities.TRANSPORT_WIFI to "WIFI",
-        NetworkCapabilities.TRANSPORT_BLUETOOTH to "BLUETOOTH",
-        NetworkCapabilities.TRANSPORT_ETHERNET to "ETHERNET",
-        NetworkCapabilities.TRANSPORT_VPN to "VPN",
-        NetworkCapabilities.TRANSPORT_WIFI_AWARE to "WIFI_AWARE",
-    ).forEach { (id, label) -> if (caps.hasTransport(id)) transports.add(label) }
-    val hasVpn = caps.hasTransport(NetworkCapabilities.TRANSPORT_VPN)
-    val detail =
-        if (!hasVpn) {
-            "transports=[${transports.joinToString()}], no VPN"
-        } else {
-            "transports include VPN: [${transports.joinToString()}]"
-        }
-    return CheckResult(name, !hasVpn, detail)
-}
+): CheckResult =
+    withActiveCaps(cm, name) { caps ->
+        val transports = mutableListOf<String>()
+        mapOf(
+            NetworkCapabilities.TRANSPORT_CELLULAR to "CELLULAR",
+            NetworkCapabilities.TRANSPORT_WIFI to "WIFI",
+            NetworkCapabilities.TRANSPORT_BLUETOOTH to "BLUETOOTH",
+            NetworkCapabilities.TRANSPORT_ETHERNET to "ETHERNET",
+            NetworkCapabilities.TRANSPORT_VPN to "VPN",
+            NetworkCapabilities.TRANSPORT_WIFI_AWARE to "WIFI_AWARE",
+        ).forEach { (id, label) -> if (caps.hasTransport(id)) transports.add(label) }
+        val hasVpn = caps.hasTransport(NetworkCapabilities.TRANSPORT_VPN)
+        val detail =
+            if (!hasVpn) {
+                "transports=[${transports.joinToString()}], no VPN"
+            } else {
+                "transports include VPN: [${transports.joinToString()}]"
+            }
+        CheckResult(name, !hasVpn, detail)
+    }
 
 internal fun checkLinkPropertiesIfname(
     cm: ConnectivityManager,
     name: String,
-): CheckResult {
-    val net = cm.activeNetwork ?: return CheckResult(name, true, "no active network")
-    val lp = cm.getLinkProperties(net) ?: return CheckResult(name, true, "no link properties")
-    val ifname = lp.interfaceName ?: "(null)"
-    val routes = lp.routes.map { "${it.destination} via ${it.gateway} dev ${it.`interface`}" }
-    val dns = lp.dnsServers.map { it.hostAddress ?: "?" }
-    val isVpn = IfaceLists.isVpnIface(ifname)
-    val detail =
-        if (!isVpn) {
-            "ifname=$ifname, ${routes.size} routes, dns=[${dns.joinToString()}]"
-        } else {
-            "ifname=$ifname is a VPN interface"
-        }
-    return CheckResult(name, !isVpn, detail)
-}
+): CheckResult =
+    withActiveLinkProperties(cm, name) { lp ->
+        val ifname = lp.interfaceName ?: "(null)"
+        val routes = lp.routes.map { "${it.destination} via ${it.gateway} dev ${it.`interface`}" }
+        val dns = lp.dnsServers.map { it.hostAddress ?: "?" }
+        val isVpn = IfaceLists.isVpnIface(ifname)
+        val detail =
+            if (!isVpn) {
+                "ifname=$ifname, ${routes.size} routes, dns=[${dns.joinToString()}]"
+            } else {
+                "ifname=$ifname is a VPN interface"
+            }
+        CheckResult(name, !isVpn, detail)
+    }
 
 private fun checkLinkPropertiesRoutes(
     cm: ConnectivityManager,
     name: String,
-): CheckResult {
-    val net = cm.activeNetwork ?: return CheckResult(name, true, "no active network")
-    val lp = cm.getLinkProperties(net) ?: return CheckResult(name, true, "no link properties")
-    val routes = lp.routes
-    val vpnRoutes =
-        routes.filter { route ->
-            val iface = route.`interface` ?: return@filter false
-            IfaceLists.isVpnIface(iface)
-        }
-    val detail =
-        if (vpnRoutes.isEmpty()) {
-            "${routes.size} routes, none via VPN interfaces"
-        } else {
-            "${vpnRoutes.size} route(s) via VPN"
-        }
-    return CheckResult(name, vpnRoutes.isEmpty(), detail)
-}
+): CheckResult =
+    withActiveLinkProperties(cm, name) { lp ->
+        val routes = lp.routes
+        val vpnRoutes =
+            routes.filter { route ->
+                val iface = route.`interface` ?: return@filter false
+                IfaceLists.isVpnIface(iface)
+            }
+        val detail =
+            if (vpnRoutes.isEmpty()) {
+                "${routes.size} routes, none via VPN interfaces"
+            } else {
+                "${vpnRoutes.size} route(s) via VPN"
+            }
+        CheckResult(name, vpnRoutes.isEmpty(), detail)
+    }
 
 private fun checkProxyHost(name: String): CheckResult {
     val httpHost = System.getProperty("http.proxyHost")

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/HookEntry.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/HookEntry.kt
@@ -344,31 +344,15 @@ class HookEntry : IXposedHookLoadPackage {
      * cached UID set so the next writeToParcel call re-reads it.
      */
     private fun watchTargetUidsFile() {
-        val dir = "/data/system"
         val filename = "vpnhide_uids.txt"
-        val observer =
-            object : android.os.FileObserver(
-                File(dir),
-                // CLOSE_WRITE + MOVED_TO is enough: the writers we control
-                // either do a single short `> file` redirect (one write +
-                // close) or atomic-rename via `mv`. MODIFY would fire
-                // mid-write on multi-write writers and let the hook read
-                // a partially-populated file before the writer closes.
-                CREATE or CLOSE_WRITE or MOVED_TO,
-            ) {
-                override fun onEvent(
-                    event: Int,
-                    path: String?,
-                ) {
-                    if (path == filename) {
-                        HookLog.i("VpnHide: $filename changed (event=$event), invalidating UID cache")
-                        systemServerTargetUids = null
-                    }
+        targetUidsFileObserver =
+            watchSystemDataDir { path ->
+                if (path == filename) {
+                    HookLog.i("VpnHide: $filename changed, invalidating UID cache")
+                    systemServerTargetUids = null
                 }
             }
-        targetUidsFileObserver = observer
-        observer.startWatching()
-        HookLog.i("VpnHide: watching $dir for $filename changes (inotify)")
+        HookLog.i("VpnHide: watching /data/system for $filename changes (inotify)")
     }
 
     /**

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/HookLog.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/HookLog.kt
@@ -26,20 +26,13 @@ internal object HookLog {
     fun install() {
         reload()
         if (watcher != null) return
-        val observer =
-            object : FileObserver(
-                File("/data/system"),
-                CREATE or CLOSE_WRITE or MOVED_TO or MODIFY,
-            ) {
-                override fun onEvent(
-                    event: Int,
-                    path: String?,
-                ) {
-                    if (path == "vpnhide_debug_logging") reload()
-                }
+        // MODIFY is enabled here (unlike the UID / hidden-pkg watchers): this
+        // flag is a single byte, so a transient mid-write read is harmless and
+        // we'd rather react to an in-place `echo > file` immediately.
+        watcher =
+            watchSystemDataDir(extraEvents = FileObserver.MODIFY) { path ->
+                if (path == "vpnhide_debug_logging") reload()
             }
-        watcher = observer
-        observer.startWatching()
     }
 
     private fun reload() {

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/MainActivity.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/MainActivity.kt
@@ -68,10 +68,10 @@ class MainActivity : ComponentActivity() {
     }
 }
 
-private sealed class RootState {
-    data object Granted : RootState()
+private sealed interface RootState {
+    data object Granted : RootState
 
-    data object Denied : RootState()
+    data object Denied : RootState
 }
 
 private fun checkRootAccess(): Boolean {

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/NativeChecks.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/NativeChecks.kt
@@ -1,6 +1,7 @@
 package dev.okhsunrog.vpnhide
 
 import dev.okhsunrog.vpnhide.checks.CheckOutput
+import dev.okhsunrog.vpnhide.checks.CheckStatus
 import dev.okhsunrog.vpnhide.checks.checkGetifaddrs
 import dev.okhsunrog.vpnhide.checks.checkIoctlSiocgifconf
 import dev.okhsunrog.vpnhide.checks.checkIoctlSiocgifflags
@@ -29,6 +30,20 @@ internal data class NativeCheckSpec(
     val labelRes: Int,
     val run: () -> CheckOutput,
 )
+
+/**
+ * Map a native probe status to the tri-state the UI uses: PASS → true (leak
+ * blocked), FAIL → false (leak detected), NETWORK_BLOCKED → null (probe
+ * couldn't run, e.g. ECONNREFUSED from `socket()` when the app has no network
+ * permission). Single source so the Diagnostics list and the Dashboard summary
+ * read the status the same way.
+ */
+internal fun CheckStatus.toPassed(): Boolean? =
+    when (this) {
+        CheckStatus.PASS -> true
+        CheckStatus.FAIL -> false
+        CheckStatus.NETWORK_BLOCKED -> null
+    }
 
 /**
  * The native probe suite, in display order. Single source of truth for both

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/PackageVisibilityHooks.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/PackageVisibilityHooks.kt
@@ -149,29 +149,20 @@ internal object PackageVisibilityHooks {
         }
 
     private fun watchConfigFiles() {
-        val observer =
-            // CLOSE_WRITE + MOVED_TO only — see HookEntry.watchTargetUidsFile
-            // for why MODIFY is intentionally absent.
-            object : FileObserver(File("/data/system"), CREATE or CLOSE_WRITE or MOVED_TO) {
-                override fun onEvent(
-                    event: Int,
-                    path: String?,
-                ) {
-                    when (path) {
-                        "vpnhide_hidden_pkgs.txt" -> {
-                            HookLog.i("VpnHide/PV: hidden_pkgs changed, invalidating")
-                            hiddenPackages = null
-                        }
+        fileObserver =
+            watchSystemDataDir { path ->
+                when (path) {
+                    "vpnhide_hidden_pkgs.txt" -> {
+                        HookLog.i("VpnHide/PV: hidden_pkgs changed, invalidating")
+                        hiddenPackages = null
+                    }
 
-                        "vpnhide_observer_uids.txt" -> {
-                            HookLog.i("VpnHide/PV: observer_uids changed, invalidating")
-                            observerUids = null
-                        }
+                    "vpnhide_observer_uids.txt" -> {
+                        HookLog.i("VpnHide/PV: observer_uids changed, invalidating")
+                        observerUids = null
                     }
                 }
             }
-        fileObserver = observer
-        observer.startWatching()
         HookLog.i("VpnHide/PV: watching /data/system for config changes")
     }
 

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/PortsHidingScreen.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/PortsHidingScreen.kt
@@ -103,11 +103,9 @@ private fun buildPortsSaveCommand(
     // observers.txt stores package names (one per line). UID resolution lives
     // entirely inside vpnhide_ports_apply.sh so app reinstalls (which rotate
     // the UID) get picked up automatically on the next apply.
-    val body = (listOf(header) + observerPkgs).joinToString(separator = "\n", postfix = "\n")
-    val b64 = android.util.Base64.encodeToString(body.toByteArray(), android.util.Base64.NO_WRAP)
     return listOf(
         "mkdir -p /data/adb/vpnhide_ports",
-        "echo '$b64' | base64 -d > $PORTS_OBSERVERS_FILE",
+        buildConfigWriteCommand(PORTS_OBSERVERS_FILE, header, observerPkgs),
         "chmod 644 $PORTS_OBSERVERS_FILE",
         "sh $PORTS_APPLY_SCRIPT",
     ).joinToString(" && ")

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/ShellCommandBuilders.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/ShellCommandBuilders.kt
@@ -6,6 +6,37 @@ internal const val SELF_PM_PACKAGES_END = "__VPNHIDE_SELF_PM_PACKAGES_END__"
 internal const val SYSTEM_DATA_FILE_CONTEXT = "u:object_r:system_data_file:s0"
 
 /**
+ * Canonical on-disk body for a managed vpnhide config file: the `# Managed …`
+ * header comment followed by [lines], newline-terminated. This is the format
+ * [parseConfigLines] reads back (the header comment and blank lines are
+ * dropped on read), so every Save path produces an identical file shape.
+ */
+internal fun managedConfigBody(
+    header: String,
+    lines: List<String>,
+): String = (listOf(header) + lines).joinToString(separator = "\n", postfix = "\n")
+
+/**
+ * Shell fragment writing a managed config file via a base64 round-trip:
+ * `echo '<b64>' | base64 -d > path`. base64 sidesteps every quoting/escaping
+ * hazard from package names or the header text inside the single `su -c`
+ * string. Callers append their own `chmod` / dir-guard / perms tail — those
+ * differ per file (644 vs system_data_file 640), see [systemDataFilePermsParts].
+ */
+internal fun buildConfigWriteCommand(
+    path: String,
+    header: String,
+    lines: List<String>,
+): String {
+    val b64 =
+        android.util.Base64.encodeToString(
+            managedConfigBody(header, lines).toByteArray(),
+            android.util.Base64.NO_WRAP,
+        )
+    return "echo '$b64' | base64 -d > $path"
+}
+
+/**
  * The chmod/chown/chcon tail applied to a `/data/system` file so that
  * system_server (group=system) can read it while untrusted apps get EACCES,
  * and so anti-tamper SDKs can't read our marker files. Returns the steps as

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/ShellUtils.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/ShellUtils.kt
@@ -109,6 +109,42 @@ internal fun parseConfigLines(raw: String): List<String> =
         .filter { it.isNotEmpty() && !it.startsWith("#") }
         .toList()
 
+/**
+ * Parse `key=value` lines into a map. Values are kept verbatim (not trimmed) —
+ * callers that need trimming do it themselves. Lines without an `=` are
+ * dropped; the value keeps any further `=` (split limit 2). Single source for
+ * every status-file / module.prop style blob this app reads back over root.
+ */
+internal fun parseKeyValueLines(raw: String): Map<String, String> =
+    raw
+        .lineSequence()
+        .mapNotNull {
+            val parts = it.split("=", limit = 2)
+            if (parts.size == 2) parts[0] to parts[1] else null
+        }.toMap()
+
+private val PM_PACKAGE_UID_LINE = Regex("^package:(\\S+) uid:(\\S+)")
+
+/**
+ * Parse `pm list packages -U [--user all]` output (the form *without* `-f`,
+ * so the token after `package:` is the package name, not an APK path) into
+ * `package → uids`. Multi-profile packages report comma-separated UIDs
+ * (`uid:10187,1010187`); repeated lines for the same package are unioned.
+ * UIDs that aren't integers are dropped. The `-f` variant has a different
+ * shape and is parsed separately in [AppListCache].
+ */
+internal fun parsePackageUidMap(raw: String): Map<String, List<Int>> {
+    val out = LinkedHashMap<String, MutableList<Int>>()
+    raw.lineSequence().forEach { line ->
+        val m = PM_PACKAGE_UID_LINE.find(line) ?: return@forEach
+        val uids = out.getOrPut(m.groupValues[1]) { mutableListOf() }
+        m.groupValues[2].split(',').forEach { token ->
+            token.trim().toIntOrNull()?.let(uids::add)
+        }
+    }
+    return out
+}
+
 internal fun parseVpnIfaceStates(raw: String): List<Pair<String, String>> =
     raw
         .lineSequence()
@@ -176,12 +212,7 @@ internal fun cleanupStaleZygiskStatus(
 
     val props =
         try {
-            statusFile
-                .readLines()
-                .mapNotNull {
-                    val parts = it.split("=", limit = 2)
-                    if (parts.size == 2) parts[0] to parts[1] else null
-                }.toMap()
+            parseKeyValueLines(statusFile.readText())
         } catch (e: Exception) {
             VpnHideLog.w(TAG, "cleanupStaleZygiskStatus: failed to read heartbeat: ${e.message}")
             emptyMap()

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/SystemDataFileWatcher.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/SystemDataFileWatcher.kt
@@ -1,0 +1,42 @@
+package dev.okhsunrog.vpnhide
+
+import android.os.FileObserver
+import java.io.File
+
+private val SYSTEM_DATA_DIR = File("/data/system")
+
+/**
+ * Watch `/data/system` for the events our config writers produce and invoke
+ * [onChange] with the affected filename. Shared by the three system_server
+ * LSPosed watchers (HookEntry's UID cache, PackageVisibilityHooks' hidden /
+ * observer caches, HookLog's debug-logging flag) — each reacts to a different
+ * file, so the per-file dispatch stays in the caller's [onChange] lambda.
+ *
+ * CLOSE_WRITE + MOVED_TO catch our writers (a single `> file` redirect or an
+ * atomic `mv`) only once they finish. MODIFY would fire mid-write and let a
+ * reader see a half-populated file, so it is opt-in via [extraEvents] — only
+ * HookLog enables it, where a transient partial read of a one-byte flag is
+ * harmless.
+ *
+ * Returns the already-started observer; the caller holds the reference so it
+ * isn't garbage-collected (which would silently stop the watch).
+ */
+internal fun watchSystemDataDir(
+    extraEvents: Int = 0,
+    onChange: (filename: String) -> Unit,
+): FileObserver {
+    val observer =
+        object : FileObserver(
+            SYSTEM_DATA_DIR,
+            CREATE or CLOSE_WRITE or MOVED_TO or extraEvents,
+        ) {
+            override fun onEvent(
+                event: Int,
+                path: String?,
+            ) {
+                if (path != null) onChange(path)
+            }
+        }
+    observer.startWatching()
+    return observer
+}

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/TargetsCache.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/TargetsCache.kt
@@ -100,14 +100,9 @@ internal fun parseTargetsSnapshot(rootSnapshot: RootSnapshot): TargetsSnapshot {
     // UIDs: `package:com.android.chrome uid:10187,1010187`. Each UID
     // becomes its own entry in the reverse map so observer lookups
     // from any profile resolve back to the same package name.
-    val pmLine = Regex("^package:(\\S+) uid:(\\S+)")
     val uidToPkg = mutableMapOf<Int, String>()
-    sections["pm_packages"]?.lines()?.forEach { line ->
-        val m = pmLine.find(line) ?: return@forEach
-        val pkg = m.groupValues[1]
-        for (id in m.groupValues[2].split(',')) {
-            id.toIntOrNull()?.let { uidToPkg[it] = pkg }
-        }
+    parsePackageUidMap(sections["pm_packages"].orEmpty()).forEach { (pkg, uids) ->
+        uids.forEach { uidToPkg[it] = pkg }
     }
 
     return TargetsSnapshot(

--- a/lsposed/app/src/test/kotlin/dev/okhsunrog/vpnhide/CheckStatusToPassedTest.kt
+++ b/lsposed/app/src/test/kotlin/dev/okhsunrog/vpnhide/CheckStatusToPassedTest.kt
@@ -1,0 +1,15 @@
+package dev.okhsunrog.vpnhide
+
+import dev.okhsunrog.vpnhide.checks.CheckStatus
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class CheckStatusToPassedTest {
+    @Test
+    fun `pass maps to true, fail to false, network blocked to null`() {
+        assertEquals(true, CheckStatus.PASS.toPassed())
+        assertEquals(false, CheckStatus.FAIL.toPassed())
+        assertNull(CheckStatus.NETWORK_BLOCKED.toPassed())
+    }
+}

--- a/lsposed/app/src/test/kotlin/dev/okhsunrog/vpnhide/ClassifyKmodProblemTest.kt
+++ b/lsposed/app/src/test/kotlin/dev/okhsunrog/vpnhide/ClassifyKmodProblemTest.kt
@@ -1,0 +1,170 @@
+package dev.okhsunrog.vpnhide
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class ClassifyKmodProblemTest {
+    private fun installed(
+        active: Boolean,
+        gkiVariant: String? = null,
+    ) = ModuleState.Installed(version = "0.6.3", active = active, targetCount = 0, gkiVariant = gkiVariant)
+
+    private fun loadStatus(
+        fresh: Boolean,
+        kretprobes: String? = "y",
+        unameR: String? = "5.10.0-android12",
+        insmodStderr: String? = null,
+    ) = KmodLoadStatus(
+        timestamp = null,
+        bootId = "boot",
+        unameR = unameR,
+        gkiVariant = null,
+        kmodVersion = null,
+        rootManager = null,
+        kprobes = "y",
+        kretprobes = kretprobes,
+        insmodExit = null,
+        loaded = false,
+        insmodStderr = insmodStderr,
+        dmesgTail = null,
+        freshForCurrentBoot = fresh,
+    )
+
+    private fun kmodRecommendation(
+        kmi: String,
+        artifact: String = "vpnhide-kmod-$kmi.zip",
+        ambiguous: Boolean = false,
+        altKmi: String? = null,
+        altArtifact: String? = null,
+        preferKmod: Boolean = true,
+    ) = NativeInstallRecommendation(
+        androidVersion = "Android 13",
+        kernelVersion = "5.10",
+        kernelBranch = "Android 13",
+        recommendedArtifact = artifact,
+        recommendedGkiVariant = kmi,
+        preferKmod = preferKmod,
+        variantAmbiguous = ambiguous,
+        alternativeArtifact = altArtifact,
+        alternativeGkiVariant = altKmi,
+    )
+
+    @Test
+    fun `not installed produces no problem`() {
+        assertNull(classifyKmodProblem(ModuleState.NotInstalled, kmodRecommendation("android13-5.10"), null))
+    }
+
+    @Test
+    fun `active kmod with no kprobe issue is fine`() {
+        assertNull(classifyKmodProblem(installed(active = true), kmodRecommendation("android13-5.10"), loadStatus(fresh = true)))
+    }
+
+    @Test
+    fun `missing kretprobes is reported even for an active module`() {
+        // The kprobes probe is activity-independent and runs before the
+        // active short-circuit.
+        val kind =
+            classifyKmodProblem(
+                installed(active = true),
+                kmodRecommendation("android13-5.10"),
+                loadStatus(fresh = true, kretprobes = "n"),
+            )
+        assertEquals(KmodProblemKind.KprobesMissing, kind)
+        assertEquals(KmodBrokenReason.MissingKprobes, kind?.reason)
+    }
+
+    @Test
+    fun `unsupported kernel falls back to question mark uname without load status`() {
+        val rec = kmodRecommendation("", artifact = "vpnhide-zygisk.zip", preferKmod = false)
+        val kind = classifyKmodProblem(installed(active = false), rec, loadStatus = null)
+        assertEquals(KmodProblemKind.UnsupportedKernel("?", "vpnhide-zygisk.zip"), kind)
+    }
+
+    @Test
+    fun `unsupported kernel uses load-status uname when available`() {
+        val rec = kmodRecommendation("", artifact = "vpnhide-zygisk.zip", preferKmod = false)
+        val kind = classifyKmodProblem(installed(active = false), rec, loadStatus(fresh = true, unameR = "4.19.7"))
+        assertEquals(KmodProblemKind.UnsupportedKernel("4.19.7", "vpnhide-zygisk.zip"), kind)
+    }
+
+    @Test
+    fun `wrong stamped variant is a concrete mismatch`() {
+        val rec = kmodRecommendation("android13-5.10")
+        val kind = classifyKmodProblem(installed(active = false, gkiVariant = "android12-5.10"), rec, null)
+        assertEquals(
+            KmodProblemKind.WrongVariant("android12-5.10", "android13-5.10", "vpnhide-kmod-android13-5.10.zip"),
+            kind,
+        )
+    }
+
+    @Test
+    fun `unknown variant for a kmod-capable kernel`() {
+        val rec = kmodRecommendation("android13-5.10")
+        val kind = classifyKmodProblem(installed(active = false, gkiVariant = null), rec, null)
+        assertEquals(KmodProblemKind.UnknownVariant("vpnhide-kmod-android13-5.10.zip"), kind)
+    }
+
+    @Test
+    fun `ambiguous series suggests the other candidate`() {
+        val rec =
+            kmodRecommendation(
+                "android12-5.10",
+                ambiguous = true,
+                altKmi = "android13-5.10",
+                altArtifact = "vpnhide-kmod-android13-5.10.zip",
+            )
+        val kind =
+            classifyKmodProblem(
+                installed(active = false, gkiVariant = "android12-5.10"),
+                rec,
+                loadStatus(fresh = true),
+            )
+        assertEquals(
+            KmodProblemKind.AmbiguousLoadFailed("android12-5.10", "vpnhide-kmod-android13-5.10.zip"),
+            kind,
+        )
+    }
+
+    @Test
+    fun `installed alternative of an ambiguous series is not a wrong-variant mismatch`() {
+        // installed == alternative, so WrongVariant must not fire; it falls
+        // through to AmbiguousLoadFailed and suggests the primary.
+        val rec =
+            kmodRecommendation(
+                "android12-5.10",
+                ambiguous = true,
+                altKmi = "android13-5.10",
+                altArtifact = "vpnhide-kmod-android13-5.10.zip",
+            )
+        val kind =
+            classifyKmodProblem(
+                installed(active = false, gkiVariant = "android13-5.10"),
+                rec,
+                loadStatus(fresh = true),
+            )
+        assertEquals(
+            KmodProblemKind.AmbiguousLoadFailed("android13-5.10", "vpnhide-kmod-android12-5.10.zip"),
+            kind,
+        )
+    }
+
+    @Test
+    fun `generic insmod failure surfaces stderr when nothing else matches`() {
+        // No recommendation, stamped variant present, fresh load with stderr.
+        val kind =
+            classifyKmodProblem(
+                installed(active = false, gkiVariant = "android13-5.10"),
+                recommendation = null,
+                loadStatus = loadStatus(fresh = true, insmodStderr = "exec format error"),
+            )
+        assertEquals(KmodProblemKind.LoadFailed("exec format error"), kind)
+        assertNull(kind?.reason)
+    }
+
+    @Test
+    fun `inactive with no diagnosable cause is null`() {
+        // No recommendation, no fresh load status: nothing to say.
+        assertNull(classifyKmodProblem(installed(active = false, gkiVariant = "android13-5.10"), null, null))
+    }
+}

--- a/lsposed/app/src/test/kotlin/dev/okhsunrog/vpnhide/DashboardParsersTest.kt
+++ b/lsposed/app/src/test/kotlin/dev/okhsunrog/vpnhide/DashboardParsersTest.kt
@@ -1,0 +1,143 @@
+package dev.okhsunrog.vpnhide
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class DashboardParsersTest {
+    @Test
+    fun `parseModuleProp returns not-installed for blank input`() {
+        assertEquals(ModulePropInfo(false, null, null), parseModuleProp(""))
+        assertEquals(ModulePropInfo(false, null, null), parseModuleProp("   \n  "))
+    }
+
+    @Test
+    fun `parseModuleProp strips v prefix and reads gki variant`() {
+        val raw =
+            """
+            id=vpnhide_kmod
+            version=v0.6.3
+            gkiVariant=android13-5.10
+            """.trimIndent()
+        assertEquals(ModulePropInfo(true, "0.6.3", "android13-5.10"), parseModuleProp(raw))
+    }
+
+    @Test
+    fun `parseModuleProp recovers variant from updateJson when not stamped`() {
+        val raw =
+            """
+            version=0.6.2
+            updateJson=https://example.com/update-kmod-android14-6.1.json
+            """.trimIndent()
+        assertEquals(ModulePropInfo(true, "0.6.2", "android14-6.1"), parseModuleProp(raw))
+    }
+
+    @Test
+    fun `parseModuleProp prefers stamped gki variant over updateJson`() {
+        val raw =
+            """
+            version=0.6.3
+            gkiVariant=android13-5.10
+            updateJson=https://example.com/update-kmod-android14-6.1.json
+            """.trimIndent()
+        assertEquals("android13-5.10", parseModuleProp(raw).gkiVariant)
+    }
+
+    @Test
+    fun `countTargets excludes self and drops comments and blanks`() {
+        val raw =
+            """
+            # Managed by VPN Hide app
+            dev.okhsunrog.vpnhide
+            com.bank.app
+
+            com.chat.app
+            """.trimIndent()
+        assertEquals(2, countTargets(raw, "dev.okhsunrog.vpnhide"))
+    }
+
+    @Test
+    fun `readKmodLoadStatus returns null for blank`() {
+        assertNull(readKmodLoadStatus("boot", "", ""))
+    }
+
+    @Test
+    fun `readKmodLoadStatus parses fields and marks fresh for current boot`() {
+        val raw =
+            """
+            boot_id=boot-123
+            uname_r=5.10.0-android13
+            gki_variant=android13-5.10
+            kretprobes=y
+            insmod_exit=0
+            loaded=1
+            """.trimIndent()
+        val status = readKmodLoadStatus("boot-123", raw, "dmesg line")
+        assertEquals("boot-123", status?.bootId)
+        assertEquals("5.10.0-android13", status?.unameR)
+        assertEquals("android13-5.10", status?.gkiVariant)
+        assertEquals(0, status?.insmodExit)
+        assertEquals(true, status?.loaded)
+        assertEquals("dmesg line", status?.dmesgTail)
+        assertEquals(true, status?.freshForCurrentBoot)
+    }
+
+    @Test
+    fun `readKmodLoadStatus is not fresh when boot id differs`() {
+        val status = readKmodLoadStatus("current-boot", "boot_id=old-boot\nloaded=0", "")
+        assertEquals(false, status?.freshForCurrentBoot)
+        assertEquals(false, status?.loaded)
+        assertNull(status?.dmesgTail)
+    }
+
+    @Test
+    fun `resolveLsposedState active heartbeat wins`() {
+        val state =
+            resolveLsposedState(
+                hooksActiveThisBoot = true,
+                hookVersion = "0.6.3",
+                lsposedTargetCount = 4,
+                framework = LsposedFramework.NotInstalled,
+                config = null,
+            )
+        assertEquals(LsposedState.Active("0.6.3", 4), state)
+    }
+
+    @Test
+    fun `resolveLsposedState not configured maps to framework presence`() {
+        assertEquals(
+            LsposedState.NotInstalled,
+            resolveLsposedState(false, null, 0, LsposedFramework.NotInstalled, LsposedConfig.ModuleNotConfigured),
+        )
+        assertEquals(
+            LsposedState.InstalledInactive(null),
+            resolveLsposedState(false, null, 0, LsposedFramework.Installed(disabled = false), LsposedConfig.ModuleNotConfigured),
+        )
+    }
+
+    @Test
+    fun `resolveLsposedState enabled with system scope needs reboot`() {
+        val enabled = LsposedConfig.Enabled(entries = listOf("system"), hasSystemFramework = true, extraEntries = emptyList())
+        assertEquals(
+            LsposedState.NeedsReboot("0.6.3"),
+            resolveLsposedState(false, "0.6.3", 0, LsposedFramework.Installed(disabled = false), enabled),
+        )
+    }
+
+    @Test
+    fun `resolveLsposedState enabled without system scope is inactive`() {
+        val enabled = LsposedConfig.Enabled(entries = emptyList(), hasSystemFramework = false, extraEntries = emptyList())
+        assertEquals(
+            LsposedState.InstalledInactive(null),
+            resolveLsposedState(false, "0.6.3", 0, LsposedFramework.Installed(disabled = false), enabled),
+        )
+    }
+
+    @Test
+    fun `resolveLsposedState null config is inactive`() {
+        assertEquals(
+            LsposedState.InstalledInactive(null),
+            resolveLsposedState(false, null, 0, LsposedFramework.Installed(disabled = true), null),
+        )
+    }
+}

--- a/lsposed/app/src/test/kotlin/dev/okhsunrog/vpnhide/ShellCommandBuildersTest.kt
+++ b/lsposed/app/src/test/kotlin/dev/okhsunrog/vpnhide/ShellCommandBuildersTest.kt
@@ -106,6 +106,19 @@ class ShellCommandBuildersTest {
     }
 
     @Test
+    fun `managed config body is header plus newline-terminated lines`() {
+        assertEquals(
+            "# Managed by VPN Hide app\ncom.a\ncom.b\n",
+            managedConfigBody("# Managed by VPN Hide app", listOf("com.a", "com.b")),
+        )
+    }
+
+    @Test
+    fun `managed config body for an empty list is just the header line`() {
+        assertEquals("# Managed by VPN Hide app\n", managedConfigBody("# Managed by VPN Hide app", emptyList()))
+    }
+
+    @Test
     fun `self target output extracts seeded package list`() {
         val output =
             """

--- a/lsposed/app/src/test/kotlin/dev/okhsunrog/vpnhide/ShellUtilsParsersTest.kt
+++ b/lsposed/app/src/test/kotlin/dev/okhsunrog/vpnhide/ShellUtilsParsersTest.kt
@@ -1,0 +1,55 @@
+package dev.okhsunrog.vpnhide
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class ShellUtilsParsersTest {
+    @Test
+    fun `parseKeyValueLines splits on first equals and keeps the rest of the value`() {
+        val raw =
+            """
+            version=0.6.3
+            updateJson=https://example.com/x?a=1&b=2
+            not a kv line
+            boot_id=abc
+            """.trimIndent()
+        val map = parseKeyValueLines(raw)
+        assertEquals("0.6.3", map["version"])
+        assertEquals("https://example.com/x?a=1&b=2", map["updateJson"])
+        assertEquals("abc", map["boot_id"])
+        assertEquals(3, map.size)
+    }
+
+    @Test
+    fun `parsePackageUidMap reads single-profile uid`() {
+        val map = parsePackageUidMap("package:com.example uid:10123")
+        assertEquals(listOf(10123), map["com.example"])
+    }
+
+    @Test
+    fun `parsePackageUidMap splits comma-separated multi-profile uids`() {
+        val map = parsePackageUidMap("package:com.example uid:10123,1010123")
+        assertEquals(listOf(10123, 1010123), map["com.example"])
+    }
+
+    @Test
+    fun `parsePackageUidMap unions repeated lines for the same package`() {
+        val raw =
+            """
+            package:com.example uid:10123
+            package:com.example uid:1010123
+            """.trimIndent()
+        assertEquals(listOf(10123, 1010123), parsePackageUidMap(raw)["com.example"])
+    }
+
+    @Test
+    fun `parsePackageUidMap drops non-integer uids and non-package lines`() {
+        val raw =
+            """
+            package:com.example uid:10123,bogus
+            random noise
+            """.trimIndent()
+        assertEquals(listOf(10123), parsePackageUidMap(raw)["com.example"])
+        assertEquals(1, parsePackageUidMap(raw).size)
+    }
+}


### PR DESCRIPTION
Internal cleanup of the lsposed Kotlin module to remove duplication and shrink the largest functions, with no behavior change. The biggest target was the ~830-line `loadDashboardState` god function: its trickiest logic (kmod failure diagnosis) was a dense block of interrelated booleans hand-mirrored against the card/banner rendering, which the compiler flagged for dead null-safety. That and several other one-off helpers are now pure, top-level, unit-tested functions.

- Extract `classifyKmodProblem` + `KmodProblemKind` sealed type + `renderKmodProblem`, replacing the interrelated-boolean block (single source for card color and banner text)
- Lift `parseModuleProp`, `countTargets`, `readKmodLoadStatus`, `resolveLsposedState` to pure top-level functions
- Add `parseKeyValueLines` + `parsePackageUidMap` to ShellUtils, replacing the `parseProps` duplications and the three separate `pm list` parsers
- Centralize the base64 managed-config-file write (`managedConfigBody`/`buildConfigWriteCommand`) shared by the three Save builders
- Collapse the repeated activeNetwork/caps preamble in the Java checks behind `withActiveCaps`/`withActiveLinkProperties`; add `CheckStatus.toPassed()` as the single tri-state mapping
- Share one `watchSystemDataDir` FileObserver factory across the three system_server watchers (HookEntry, PackageVisibilityHooks, HookLog)
- DiagnosticsScreen banners use the pinned StatusColors palette; `RootState` is a sealed interface; ChangelogDialog's empty guard moved out of composition
- Add unit tests covering all extracted pure functions (classifyKmodProblem priority order, parsers, lsposed resolution, config-body)