### PR TITLE
chore(lsposed): add detekt + CPD quality tooling (local, not yet in CI)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,6 +25,7 @@ These short files cover everything specific to this repo. Skipping them leads to
 - [docs/changelog.md](docs/changelog.md) — changelog storage (`changelog.d/` fragments + history JSON), `./scripts/changelog.py` usage
 - [docs/releasing.md](docs/releasing.md) — `./scripts/release.py` usage, version-bump flow
 - [kmod/BUILDING.md](kmod/BUILDING.md) — kernel-module build (one-command DDK via `./kmod/build.py`, GKI matrix, troubleshooting)
+- [lsposed/AGENTS.md](lsposed/AGENTS.md) — Kotlin module: architecture, the load-bearing abstractions to reuse (don't reinvent), and quality gates (ktlint + detekt). Read before adding Kotlin code.
 
 ## Workflow rules
 

--- a/lsposed/AGENTS.md
+++ b/lsposed/AGENTS.md
@@ -1,0 +1,82 @@
+# lsposed module — architecture & reuse rules
+
+Scoped guidance for the Kotlin module (LSPosed hooks + Compose target-picker
+app). Read before adding code here. The point of this file: stop the
+duplication / god-function drift that AI-assisted edits cause when each change
+only sees its local neighbourhood. **Reuse the abstractions below — don't
+reinvent them.** `grep` for an existing helper before writing a new one.
+
+## Data flow
+
+- **Read path:** one batched root shell → `RootSnapshotCache` → typed snapshots
+  (`DashboardState`, `TargetsSnapshot`) derived in pure functions → Compose.
+  Dashboard and Protection derive from the *same* snapshot so their counts
+  can't drift.
+- **Write path (Save):** typed entries → `ShellCommandBuilders` → base64 →
+  root-owned text files in `/data/adb` + `/data/system` (the kmod/service.sh
+  contract). See `docs/state.md` for every path's owner/reader/lifetime.
+
+## Load-bearing abstractions — reuse these
+
+- **`StateCache<T>`** — base for every app-scoped, lazily-loaded cache
+  (loading/error/value flows + single-flight job). A new cache **extends this**;
+  never hand-roll `inflight`/`loading` again.
+- **`RootSnapshotCache`** — the single batched root read. Need new system state
+  on the Dashboard/Protection path? Add a section to its shell snapshot; don't
+  add an ad-hoc `suExec` that races the snapshot.
+- **`ShellUtils`** — `suExec`/`suExecAsync`, and the parsers `parseConfigLines`,
+  `parseKeyValueLines`, `parsePackageUidMap`. **Never write another `pm list`
+  or `key=value` parser** — there used to be four; there is now one of each.
+- **`ShellCommandBuilders`** — `buildConfigWriteCommand` / `managedConfigBody` /
+  `systemDataFilePermsParts` / `buildUidResolverCommand`. Every managed-config
+  file write goes through here so the on-disk format lives in one place.
+- **`TargetPickerScaffold`** — `TargetPickerScreen<T>`, `TargetRowShell`,
+  `TargetChip`, `AppListScrollbar`. All three picker screens (tun / hiding /
+  ports) are thin configs over this; a new picker is too.
+- **`StatusUi`** — `StatusColors` (pinned status palette — **never** use
+  `MaterialTheme.colorScheme.errorContainer` etc. for status; Material You
+  remixes them off-meaning), `StatusBanner`, `FileSaveShareRow`,
+  `shareFileViaProvider`.
+- **`NativeChecks`** — `NATIVE_CHECKS` is the single probe list (Dashboard
+  summary + Diagnostics share it); `CheckStatus.toPassed()` is the single
+  tri-state mapping.
+- **`watchSystemDataDir`** — the shared `/data/system` FileObserver factory for
+  the three system_server watchers (HookEntry / PackageVisibilityHooks /
+  HookLog).
+- **`VpnHideLog` / `HookLog`** — gated logging; don't `Log.*` directly on hot
+  paths (stealth).
+
+## Rules
+
+- **Pure logic goes in top-level functions in `*Data.kt`, with a unit test** —
+  not inside a composable or an orchestrator. `classifyKmodProblem`,
+  `resolveLsposedState`, `buildNativeInstallRecommendation` are the pattern:
+  data in, data out, no Android deps, tested. This is what keeps orchestrators
+  (`loadDashboardState`) from rotting back into god-functions.
+- **Keep functions short** (detekt fails new non-`@Composable` methods over
+  ~60 lines). If an orchestrator grows, extract a pure helper.
+- **Add a unit test** for any new pure function (JUnit, `src/test`; run shell
+  fragments through `ProcessBuilder("sh", ...)` like `ShellCommandBuildersTest`).
+- **`grep` before adding** any parser / formatter / shell-builder / status
+  colour — it probably already exists above.
+
+## Quality gates
+
+- **ktlint** — formatting/style. Pre-commit hook (`.githooks/pre-commit`) + CI.
+  Fix with `ktlint --format "lsposed/**/*.kt"`.
+- **detekt** — complexity, function/file length, dead private members, bug
+  patterns (the smell ktlint can't see). Config + baseline in
+  `config/detekt/`. The baseline freezes pre-existing findings so the gate
+  only fails on **new** smell. Run with `./gradlew :app:detekt`.
+  **Don't regenerate the baseline to silence a new finding** — fix the code,
+  or, if it's a genuine false positive, tune a rule in `config/detekt/detekt.yml`
+  with a comment saying why. Regenerate (`./gradlew :app:detektBaseline`) only
+  when intentionally accepting legacy debt.
+  *Not in CI yet* — the plan is to pay down the baseline to zero first, then
+  wire `:app:detekt` into the CI lint job (and drop the baseline).
+- **CPD** (copy-paste detector) — finds cross-file duplicated blocks that
+  detekt can't (re-implemented parsers / save-builders are the classic
+  AI-duplication smell). Run with `./gradlew cpdCheck`; report at
+  `build/reports/cpd/`. Advisory for now (doesn't fail the build); tune
+  `minimumTokenCount` in the root `build.gradle.kts`. Also slated for CI once
+  the current duplicates are cleaned up.

--- a/lsposed/app/build.gradle.kts
+++ b/lsposed/app/build.gradle.kts
@@ -9,6 +9,36 @@ plugins {
     alias(libs.plugins.compose.compiler)
     alias(libs.plugins.gobley.cargo)
     alias(libs.plugins.gobley.uniffi)
+    alias(libs.plugins.detekt)
+}
+
+// Static analysis that ktlint (style only) can't do: function/file length,
+// cyclomatic/cognitive complexity, dead private members, common bug patterns.
+// The baseline (config/detekt/baseline.xml) freezes pre-existing findings so
+// the gate only fails on NEW smell — regenerate with `./gradlew :app:detektBaseline`.
+detekt {
+    config.setFrom(rootProject.files("config/detekt/detekt.yml"))
+    baseline = rootProject.file("config/detekt/baseline.xml")
+    buildUponDefaultConfig = true
+    parallel = true
+    source.setFrom(files("src/main/kotlin", "src/test/kotlin"))
+}
+
+tasks.withType<io.gitlab.arturbosch.detekt.Detekt>().configureEach {
+    // Codegen output (IfaceLists) and UniFFI bindings aren't hand-written.
+    exclude("**/generated/**")
+    jvmTarget = "17"
+    reports {
+        html.required.set(true)
+        sarif.required.set(false)
+        md.required.set(false)
+        txt.required.set(false)
+    }
+}
+
+tasks.withType<io.gitlab.arturbosch.detekt.DetektCreateBaselineTask>().configureEach {
+    exclude("**/generated/**")
+    jvmTarget = "17"
 }
 
 cargo {

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/HookEntry.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/HookEntry.kt
@@ -191,15 +191,6 @@ class HookEntry : IXposedHookLoadPackage {
         }
     }
 
-    private fun isTargetCaller(): Boolean {
-        val uid = Binder.getCallingUid()
-        return loadTargetUids().contains(uid)
-    }
-
-    private fun invalidateTargetUids() {
-        systemServerTargetUids = null
-    }
-
     // Smoke-check at install time: every private AOSP field/ctor we touch
     // by reflection in the writeToParcel hooks. Returns the keys that
     // failed (missing or wrong-typed). Empty list = all good.

--- a/lsposed/build.gradle.kts
+++ b/lsposed/build.gradle.kts
@@ -1,5 +1,35 @@
+import de.aaschmid.gradle.plugins.cpd.Cpd
+
 plugins {
     alias(libs.plugins.android.application) apply false
     alias(libs.plugins.kotlin.android) apply false
     alias(libs.plugins.compose.compiler) apply false
+    alias(libs.plugins.cpd)
+}
+
+// Copy-paste detector (PMD CPD): finds cross-file duplicated blocks that
+// detekt can't — the re-implemented-parser / re-implemented-save-builder
+// smell that AI-assisted edits produce. Advisory for now (ignoreFailures);
+// run with `./gradlew cpdCheck`, report at build/reports/cpd/. Will go into
+// CI once the current duplicates are cleaned up.
+cpd {
+    toolVersion = "7.8.0"
+    language = "kotlin"
+    // Tune up if too noisy / down to catch smaller clones. ~100 tokens ≈ a
+    // small duplicated function.
+    minimumTokenCount = 100
+}
+
+tasks.named<Cpd>("cpdCheck") {
+    ignoreFailures = true
+    reports {
+        text.required.set(true)
+        xml.required.set(false)
+    }
+    // Hand-written Kotlin only — skip codegen (IfaceLists) and UniFFI bindings.
+    source =
+        fileTree("app/src/main/kotlin") {
+            include("**/*.kt")
+            exclude("**/generated/**")
+        }
 }

--- a/lsposed/config/detekt/baseline.xml
+++ b/lsposed/config/detekt/baseline.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" ?>
+<SmellBaseline>
+  <ManuallySuppressedIssues/>
+  <CurrentIssues>
+    <ID>ComplexCondition:DashboardData.kt$freshLoad &amp;&amp; rec?.variantAmbiguous == true &amp;&amp; installedVariant != null &amp;&amp; (installedVariant == rec.recommendedGkiVariant || installedVariant == rec.alternativeGkiVariant)</ID>
+    <ID>ComplexCondition:DashboardData.kt$kmod is ModuleState.Installed &amp;&amp; kmod.active &amp;&amp; zygisk is ModuleState.Installed &amp;&amp; zygisk.active</ID>
+    <ID>ComplexCondition:DashboardData.kt$rec?.preferKmod == true &amp;&amp; recommendedKmi != null &amp;&amp; installedVariant != null &amp;&amp; installedVariant != recommendedKmi &amp;&amp; installedVariant != rec.alternativeGkiVariant</ID>
+    <ID>ComplexCondition:DiagnosticsScreen.kt$magiskVer.isBlank() &amp;&amp; ksuVer.isBlank() &amp;&amp; (exitKsuNext != 0 || ksuNextVer.isBlank())</ID>
+    <ID>ComplexCondition:TargetPickerScaffold.kt$(targetsError != null &amp;&amp; targets == null) || (appListError != null &amp;&amp; cachedApps == null)</ID>
+    <ID>CyclomaticComplexMethod:DashboardData.kt$internal fun classifyKmodProblem( kmod: ModuleState, recommendation: NativeInstallRecommendation?, loadStatus: KmodLoadStatus?, ): KmodProblemKind?</ID>
+    <ID>CyclomaticComplexMethod:DashboardData.kt$internal fun loadDashboardState( cm: ConnectivityManager, context: android.content.Context, selfNeedsRestart: Boolean, rootSnapshot: RootSnapshot, ): DashboardState</ID>
+    <ID>CyclomaticComplexMethod:DiagnosticsScreen.kt$private suspend fun exportDebugZip( cm: ConnectivityManager, context: android.content.Context, selfNeedsRestart: Boolean, ): File?</ID>
+    <ID>LongMethod:DashboardData.kt$fun readLsposedConfig(): LsposedConfig?</ID>
+    <ID>LongMethod:DashboardData.kt$internal fun buildNativeInstallRecommendation( kernelRaw: String, deviceAndroidLabel: String, ): NativeInstallRecommendation?</ID>
+    <ID>LongMethod:DashboardData.kt$internal fun loadDashboardState( cm: ConnectivityManager, context: android.content.Context, selfNeedsRestart: Boolean, rootSnapshot: RootSnapshot, ): DashboardState</ID>
+    <ID>LongMethod:DiagnosticsScreen.kt$private suspend fun exportDebugZip( cm: ConnectivityManager, context: android.content.Context, selfNeedsRestart: Boolean, ): File?</ID>
+    <ID>LongMethod:HookEntry.kt$HookEntry$private fun sanitizeLinkProperties(copy: LinkProperties): Boolean</ID>
+    <ID>LongMethod:RootSnapshotCache.kt$internal fun buildRootShellSnapshotCommand(includePmPackages: Boolean = true): String</ID>
+    <ID>LongMethod:ShellCommandBuilders.kt$internal fun buildEnsureSelfInTargetsCommand(selfPkg: String): String</ID>
+    <ID>LoopWithTooManyJumpStatements:HookEntry.kt$HookEntry$for</ID>
+    <ID>MatchingDeclarationName:NativeChecks.kt$NativeCheckSpec</ID>
+    <ID>MatchingDeclarationName:PortsHidingScreen.kt$PortsEntry : TargetEntry</ID>
+    <ID>MatchingDeclarationName:ProtectionScreen.kt$ProtectionMode</ID>
+    <ID>MatchingDeclarationName:StatusUi.kt$StatusColors</ID>
+    <ID>NestedBlockDepth:DashboardData.kt$internal fun loadDashboardState( cm: ConnectivityManager, context: android.content.Context, selfNeedsRestart: Boolean, rootSnapshot: RootSnapshot, ): DashboardState</ID>
+    <ID>NestedBlockDepth:HookEntry.kt$HookEntry$private fun sanitizeLinkProperties(copy: LinkProperties): Boolean</ID>
+    <ID>SpreadOperator:HookEntry.kt$HookEntry$(*probe.params)</ID>
+  </CurrentIssues>
+</SmellBaseline>

--- a/lsposed/config/detekt/detekt.yml
+++ b/lsposed/config/detekt/detekt.yml
@@ -1,0 +1,76 @@
+# detekt overrides on top of the bundled default config
+# (buildUponDefaultConfig = true in app/build.gradle.kts).
+#
+# Goal: catch the smell ktlint can't — god-functions, high complexity,
+# dead code, common bug patterns — without bikeshedding AI-written Compose
+# code to death. Pre-existing findings are frozen in baseline.xml, so this
+# only bites NEW code. Tune thresholds here as the team learns what's noise.
+
+build:
+  # Any finding not in the baseline fails the build.
+  maxIssues: 0
+
+complexity:
+  LongMethod:
+    # The whole reason for this gate: loadDashboardState was 830 lines.
+    # @Composable UI builders are legitimately long, so they're exempt —
+    # LargeClass / file length still bounds god-screens.
+    threshold: 60
+    ignoreAnnotated: ['Composable']
+  CyclomaticComplexMethod:
+    threshold: 20
+    ignoreAnnotated: ['Composable']
+  CognitiveComplexMethod:
+    threshold: 20
+    ignoreAnnotated: ['Composable']
+  LongParameterList:
+    # Data classes (KmodLoadStatus has 13 fields) and Compose slot APIs
+    # (TargetPickerScreen) legitimately take many params.
+    functionThreshold: 8
+    constructorThreshold: 14
+    ignoreDefaultParameters: true
+    ignoreAnnotated: ['Composable']
+  LargeClass:
+    threshold: 600
+  NestedBlockDepth:
+    threshold: 5
+  TooManyFunctions:
+    # Noisy on Compose files (one @Composable per UI piece) and DAOs.
+    active: false
+
+exceptions:
+  # This codebase deliberately catches Throwable/Exception around reflection,
+  # root shells, and AOSP-drift fail-open paths. Flagging every one is pure noise.
+  TooGenericExceptionCaught:
+    active: false
+  SwallowedException:
+    active: false
+  TooGenericExceptionThrown:
+    active: false
+
+style:
+  # Line length is already enforced by ktlint (pre-commit + CI) — no double-up.
+  MaxLineLength:
+    active: false
+  # Pinned dp/color/bit constants are everywhere in UI + hook code.
+  MagicNumber:
+    active: false
+  # Compose imports use foundation.layout.* / material3.* / runtime.* idiomatically.
+  WildcardImport:
+    active: false
+  ReturnCount:
+    # Guard-clause-heavy parsers (classifyKmodProblem) read better with early returns.
+    active: false
+  ForbiddenComment:
+    active: false
+  # Keep UnusedPrivateMember / UnusedPrivateProperty ON — they catch dead code
+  # like the fork's never-called parsePmList.
+
+comments:
+  # KDoc-presence opinions are noise for an internal module.
+  active: false
+
+naming:
+  FunctionNaming:
+    # @Composable functions are PascalCase by Compose convention.
+    ignoreAnnotated: ['Composable']

--- a/lsposed/gradle/libs.versions.toml
+++ b/lsposed/gradle/libs.versions.toml
@@ -5,6 +5,7 @@ compose-bom = "2026.06.00"
 activity-compose = "1.13.0"
 core-ktx = "1.18.0"
 gobley = "0.3.7"
+detekt = "1.23.8"
 
 [libraries]
 core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "core-ktx" }
@@ -22,3 +23,4 @@ kotlin-atomicfu = { id = "org.jetbrains.kotlin.plugin.atomicfu", version.ref = "
 compose-compiler = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
 gobley-cargo = { id = "dev.gobley.cargo", version.ref = "gobley" }
 gobley-uniffi = { id = "dev.gobley.uniffi", version.ref = "gobley" }
+detekt = { id = "io.gitlab.arturbosch.detekt", version.ref = "detekt" }

--- a/lsposed/gradle/libs.versions.toml
+++ b/lsposed/gradle/libs.versions.toml
@@ -6,6 +6,7 @@ activity-compose = "1.13.0"
 core-ktx = "1.18.0"
 gobley = "0.3.7"
 detekt = "1.23.8"
+cpd = "3.5"
 
 [libraries]
 core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "core-ktx" }
@@ -24,3 +25,4 @@ compose-compiler = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "
 gobley-cargo = { id = "dev.gobley.cargo", version.ref = "gobley" }
 gobley-uniffi = { id = "dev.gobley.uniffi", version.ref = "gobley" }
 detekt = { id = "io.gitlab.arturbosch.detekt", version.ref = "detekt" }
+cpd = { id = "de.aaschmid.cpd", version.ref = "cpd" }


### PR DESCRIPTION
Adds the Kotlin static-analysis tooling that ktlint (style only) can't provide, plus a reuse-rules doc. **Deliberately not wired into CI yet** — the plan is to pay the detekt baseline down to zero and clean any CPD duplicates first, then enforce both in CI in a follow-up (and drop the baseline).

- **detekt** — the Kotlin analogue of `clippy -D warnings`: function/file length, cyclomatic/cognitive complexity, dead private members, common bug patterns. Config in `config/detekt/detekt.yml`, tuned for this Compose + root-shell codebase (`@Composable`-aware thresholds, intentional generic `catch`es and pinned dp/colour/bit constants allowed, ktlint-overlapping rules off). `config/detekt/baseline.xml` freezes the 23 pre-existing findings. Run with `./gradlew :app:detekt`; verified it fails a fresh >60-line method.
- **CPD** (PMD copy-paste detector via `de.aaschmid.cpd`) — finds cross-file duplicated blocks detekt can't (re-implemented parsers / save-builders). Advisory (`ignoreFailures`), run with `./gradlew cpdCheck`. Clean at the 100-token default after #137; lowering `minimumTokenCount` surfaces smaller structural clones.
- removed two dead private functions detekt flagged (`HookEntry.isTargetCaller`, `invalidateTargetUids`)
- `lsposed/AGENTS.md` — the load-bearing abstractions to reuse instead of reinventing (root cause of AI-assisted duplication), the "grep before adding / pure logic + test" rules, and how the gates work; linked from the root conventions file

Next: merge → work through the detekt baseline findings → once clean, a follow-up PR enables `:app:detekt` (+ `cpdCheck`) in the CI lint job.