### PR TITLE
fix(lsposed): hide VPN from apps that detect it via network callbacks (ВТБ)

### DIFF
--- a/changelog.d/fixed-hide-the-vpn-from-apps-that-be8e.md
+++ b/changelog.d/fixed-hide-the-vpn-from-apps-that-be8e.md
@@ -1,0 +1,9 @@
+_2026-06-23_
+
+## English
+
+Hide the VPN from apps that detect it only through network callbacks (e.g. VTB) — on Android 13+ the ConnectivityService callback hook now installs against the Connectivity APEX classloader instead of silently failing, so pushed NetworkCapabilities are sanitized for target apps just like synchronous queries
+
+## Русский
+
+Скрытие VPN от приложений, которые палят его только через сетевые колбэки (например, ВТБ): на Android 13+ хук колбэков ConnectivityService теперь ставится через classloader Connectivity APEX, а не молча падает — push-данные о сети санитизируются для целевых приложений так же, как синхронные запросы

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DiagnosticsScreen.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DiagnosticsScreen.kt
@@ -2,6 +2,7 @@ package dev.okhsunrog.vpnhide
 
 import android.net.ConnectivityManager
 import android.net.LinkProperties
+import android.net.Network
 import android.net.NetworkCapabilities
 import android.net.Uri
 import android.os.Build
@@ -38,6 +39,9 @@ import java.net.NetworkInterface
 import java.text.SimpleDateFormat
 import java.util.Date
 import java.util.Locale
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicReference
 import java.util.zip.ZipEntry
 import java.util.zip.ZipOutputStream
 
@@ -540,6 +544,7 @@ internal fun runAllChecks(
             checkTransportInfo(cm, res.getString(R.string.check_transport_info)),
             checkAllNetworksVpn(cm, res.getString(R.string.check_all_networks_vpn)),
             checkActiveNetworkVpn(cm, res.getString(R.string.check_active_network_vpn)),
+            checkNetworkCallbackVpn(cm, res.getString(R.string.check_network_callback)),
             checkLinkPropertiesIfname(cm, res.getString(R.string.check_link_properties)),
             checkLinkPropertiesRoutes(cm, res.getString(R.string.check_link_properties_routes)),
             checkProxyHost(res.getString(R.string.check_proxy_host)),
@@ -697,6 +702,54 @@ private fun checkActiveNetworkVpn(
             }
         CheckResult(name, !hasVpn, detail)
     }
+
+// Push-callback leak (issue #70, e.g. VTB): apps using
+// registerDefaultNetworkCallback receive NetworkCapabilities *pushed* from
+// system_server. The writeToParcel hook keys off Binder.getCallingUid(), which
+// on the callback path is system_server (1000), not the app — so it doesn't
+// sanitize, and the app sees the real VPN through the callback even though the
+// synchronous getNetworkCapabilities() is clean. We read caps via the callback
+// and fail if VPN is still visible.
+internal fun checkNetworkCallbackVpn(
+    cm: ConnectivityManager,
+    name: String,
+): CheckResult {
+    val latch = CountDownLatch(1)
+    val seen = AtomicReference<NetworkCapabilities?>(null)
+    val callback =
+        object : ConnectivityManager.NetworkCallback() {
+            override fun onCapabilitiesChanged(
+                network: Network,
+                caps: NetworkCapabilities,
+            ) {
+                seen.set(caps)
+                latch.countDown()
+            }
+        }
+    return try {
+        cm.registerDefaultNetworkCallback(callback)
+        val fired = latch.await(3, TimeUnit.SECONDS)
+        val caps = seen.get()
+        if (!fired || caps == null) {
+            CheckResult(name, true, "no callback delivered")
+        } else {
+            val hasVpn = caps.hasTransport(NetworkCapabilities.TRANSPORT_VPN)
+            val notVpn = caps.hasCapability(NetworkCapabilities.NET_CAPABILITY_NOT_VPN)
+            val leaked = hasVpn || !notVpn
+            val detail =
+                if (!leaked) {
+                    "callback caps clean (no VPN transport, NOT_VPN present)"
+                } else {
+                    "callback leaks VPN: hasTransport(VPN)=$hasVpn, NOT_VPN=$notVpn"
+                }
+            CheckResult(name, !leaked, detail)
+        }
+    } catch (e: Exception) {
+        CheckResult(name, false, e.message ?: e.javaClass.simpleName)
+    } finally {
+        runCatching { cm.unregisterNetworkCallback(callback) }
+    }
+}
 
 internal fun checkLinkPropertiesIfname(
     cm: ConnectivityManager,

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/HookEntry.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/HookEntry.kt
@@ -586,14 +586,15 @@ class HookEntry : IXposedHookLoadPackage {
     }
 
     /**
-     * Hook ConnectivityService.callCallbackForRequest — the dispatch point for
-     * registerNetworkCallback. system_server *pushes* NetworkCapabilities to the
-     * app here, so the writeToParcel hooks would see getCallingUid()==1000
-     * instead of the app and skip sanitizing. We stash the recipient UID in
-     * currentCallbackUid for the duration of the dispatch so those hooks treat
-     * the pushed data like a synchronous call. If the app explicitly requested a
-     * VPN network, drop the callback entirely — don't reveal a VPN exists.
-     * Fixes apps (e.g. VTB, issue #70) that detect VPN only via callbacks.
+     * Hook the two ConnectivityService dispatch points that *push* network state
+     * to apps: callCallbackForRequest (registerNetworkCallback with a callback
+     * object) and sendPendingIntentForRequest (registerNetworkCallback with a
+     * PendingIntent). On both, the writeToParcel hooks would see
+     * getCallingUid()==1000 instead of the recipient app and skip sanitizing, so
+     * we stash the recipient UID in currentCallbackUid for the dispatch's
+     * duration. If the app explicitly requested a VPN network, drop the dispatch
+     * entirely — don't reveal a VPN exists. Fixes apps (e.g. VTB, issue #70) that
+     * detect VPN only via callbacks.
      */
     private fun hookConnectivityService(classLoader: ClassLoader) {
         val csClass =
@@ -608,36 +609,38 @@ class HookEntry : IXposedHookLoadPackage {
                 XposedHelpers.findClass("com.android.server.ConnectivityService", classLoader)
             }
 
-        val hooked =
-            XposedBridge.hookAllMethods(
-                csClass,
-                "callCallbackForRequest",
-                object : XC_MethodHook() {
-                    override fun beforeHookedMethod(param: MethodHookParam) {
-                        val nri = param.args.firstOrNull() ?: return
-                        val uid = extractRecipientUid(nri)
-                        if (uid < 0 || !loadTargetUids().contains(uid)) return
+        // Both methods take the NetworkRequestInfo as their first arg, so the
+        // same handler covers the callback-object and PendingIntent paths.
+        val dispatchHook =
+            object : XC_MethodHook() {
+                override fun beforeHookedMethod(param: MethodHookParam) {
+                    val nri = param.args.firstOrNull() ?: return
+                    val uid = extractRecipientUid(nri)
+                    if (uid < 0 || !loadTargetUids().contains(uid)) return
 
-                        val request = extractNetworkRequest(nri)
-                        if (request != null && request.hasTransport(NetworkCapabilities.TRANSPORT_VPN)) {
-                            // App is specifically listening for a VPN network —
-                            // suppress so it never learns one exists.
-                            param.result = null
-                            HookLog.i("VpnHide-CB: uid=$uid suppressed VPN-request callback")
-                            return
-                        }
-                        currentCallbackUid.set(uid)
+                    val request = extractNetworkRequest(nri)
+                    if (request != null && request.hasTransport(NetworkCapabilities.TRANSPORT_VPN)) {
+                        // App is specifically listening for a VPN network —
+                        // suppress so it never learns one exists.
+                        param.result = null
+                        HookLog.i("VpnHide-CB: uid=$uid suppressed VPN-request dispatch")
+                        return
                     }
+                    currentCallbackUid.set(uid)
+                }
 
-                    override fun afterHookedMethod(param: MethodHookParam) {
-                        currentCallbackUid.remove()
-                    }
-                },
-            )
-        if (hooked.isEmpty()) {
-            HookLog.e("VpnHide: no callCallbackForRequest on ${csClass.name}")
-        } else {
-            HookLog.i("VpnHide: hooked ConnectivityService.callCallbackForRequest (${hooked.size})")
+                override fun afterHookedMethod(param: MethodHookParam) {
+                    currentCallbackUid.remove()
+                }
+            }
+
+        for (method in CALLBACK_DISPATCH_METHODS) {
+            val hooked = XposedBridge.hookAllMethods(csClass, method, dispatchHook)
+            if (hooked.isEmpty()) {
+                HookLog.e("VpnHide: no $method on ${csClass.name}")
+            } else {
+                HookLog.i("VpnHide: hooked ConnectivityService.$method (${hooked.size})")
+            }
         }
     }
 
@@ -680,6 +683,7 @@ class HookEntry : IXposedHookLoadPackage {
     companion object {
         private const val SYSTEM_UID = 1000
         private val RECIPIENT_UID_FIELDS = listOf("mAsUid", "mUid", "uid")
+        private val CALLBACK_DISPATCH_METHODS = listOf("callCallbackForRequest", "sendPendingIntentForRequest")
         private const val TYPE_VPN = 17
         private const val TYPE_WIFI = 1
         const val HOOK_STATUS_FILE = "/data/system/vpnhide_hook_active"

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/HookEntry.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/HookEntry.kt
@@ -8,6 +8,7 @@ import android.os.Binder
 import android.os.Build
 import de.robv.android.xposed.IXposedHookLoadPackage
 import de.robv.android.xposed.XC_MethodHook
+import de.robv.android.xposed.XposedBridge
 import de.robv.android.xposed.XposedHelpers
 import de.robv.android.xposed.callbacks.XC_LoadPackage
 import dev.okhsunrog.vpnhide.generated.IfaceLists
@@ -38,6 +39,23 @@ import java.util.concurrent.atomic.AtomicBoolean
 class HookEntry : IXposedHookLoadPackage {
     private val hookInstalled = AtomicBoolean(false)
 
+    // Guards installing the ConnectivityService callback hook exactly once —
+    // it can be triggered from either the direct lookup or the addService catch.
+    private val connectivityHooked = AtomicBoolean(false)
+
+    // During a push callback (registerNetworkCallback dispatch), the
+    // writeToParcel hooks run under system_server's identity, so
+    // Binder.getCallingUid() is 1000 — not the recipient app. hookConnectivity-
+    // Service stashes the real recipient UID here so those hooks sanitize the
+    // pushed data exactly like a synchronous call. See issue #70 (VTB and other
+    // apps that detect VPN only via registerDefaultNetworkCallback).
+    private val currentCallbackUid = ThreadLocal<Int>()
+
+    private fun effectiveCallerUid(): Int {
+        val uid = Binder.getCallingUid()
+        return if (uid == SYSTEM_UID) currentCallbackUid.get() ?: uid else uid
+    }
+
     override fun handleLoadPackage(lpparam: XC_LoadPackage.LoadPackageParam) {
         // Only hook system_server. handleLoadPackage fires multiple times
         // in system_server (once per hosted package / APEX), so we use
@@ -54,6 +72,7 @@ class HookEntry : IXposedHookLoadPackage {
             HookLog.i("VpnHide: system_server detected, installing Binder hooks")
             val brokenFields = installSystemServerHooks()
             tryHook("PackageVisibility") { PackageVisibilityHooks.install(lpparam.classLoader) }
+            tryHook("ConnectivityService") { installConnectivityServiceHook(lpparam.classLoader) }
             writeHookStatusFile(brokenFields)
         }
     }
@@ -366,7 +385,7 @@ class HookEntry : IXposedHookLoadPackage {
             object : XC_MethodHook() {
                 override fun beforeHookedMethod(param: MethodHookParam) {
                     if (writingCopy.get() == true) return
-                    val callerUid = Binder.getCallingUid()
+                    val callerUid = effectiveCallerUid()
                     val targets = loadTargetUids()
                     val isTarget = targets.contains(callerUid)
                     val nc = param.thisObject as NetworkCapabilities
@@ -433,7 +452,7 @@ class HookEntry : IXposedHookLoadPackage {
             object : XC_MethodHook() {
                 override fun beforeHookedMethod(param: MethodHookParam) {
                     if (writingCopy.get() == true) return
-                    val callerUid = Binder.getCallingUid()
+                    val callerUid = effectiveCallerUid()
                     val isTarget = loadTargetUids().contains(callerUid)
                     val ni = param.thisObject as NetworkInfo
                     val type = XposedHelpers.getIntField(ni, "mNetworkType")
@@ -492,7 +511,7 @@ class HookEntry : IXposedHookLoadPackage {
             object : XC_MethodHook() {
                 override fun beforeHookedMethod(param: MethodHookParam) {
                     if (writingCopy.get() == true) return
-                    val callerUid = Binder.getCallingUid()
+                    val callerUid = effectiveCallerUid()
                     val isTarget = loadTargetUids().contains(callerUid)
                     val lp = param.thisObject as LinkProperties
                     val ifname = XposedHelpers.getObjectField(lp, "mIfaceName") as? String
@@ -523,7 +542,140 @@ class HookEntry : IXposedHookLoadPackage {
         HookLog.i("VpnHide: hooked LinkProperties.writeToParcel")
     }
 
+    /**
+     * Install the ConnectivityService callback hook once the service is up.
+     *
+     * On Android 13+ ConnectivityService ships in the Connectivity APEX and is
+     * loaded by a classloader the system_server boot classloader can't resolve —
+     * findClass(...) on [bootClassLoader] throws ClassNotFound, so the hook never
+     * installs and push callbacks leak (issue #70). The reliable classloader is
+     * the one that loaded the registered "connectivity" binder, so we take it
+     * from there. The binder isn't registered yet when hooks install at early
+     * boot, so we catch ServiceManager.addService("connectivity", ...) — and also
+     * try a direct lookup first to cover a late module load. Works on both the
+     * APEX (A13+) and in-boot-classpath (A12-) layouts.
+     */
+    private fun installConnectivityServiceHook(bootClassLoader: ClassLoader) {
+        val serviceManager = XposedHelpers.findClass("android.os.ServiceManager", bootClassLoader)
+        (XposedHelpers.callStaticMethod(serviceManager, "getService", "connectivity") as? android.os.IBinder)
+            ?.let { hookConnectivityFromBinder(it) }
+        XposedBridge.hookAllMethods(
+            serviceManager,
+            "addService",
+            object : XC_MethodHook() {
+                override fun beforeHookedMethod(param: MethodHookParam) {
+                    if (param.args.getOrNull(0) != "connectivity") return
+                    (param.args.getOrNull(1) as? android.os.IBinder)?.let { hookConnectivityFromBinder(it) }
+                }
+            },
+        )
+    }
+
+    private fun hookConnectivityFromBinder(binder: android.os.IBinder) {
+        if (!connectivityHooked.compareAndSet(false, true)) return
+        val classLoader =
+            binder.javaClass.classLoader ?: run {
+                connectivityHooked.set(false)
+                return
+            }
+        tryHook("ConnectivityService") { hookConnectivityService(classLoader) }
+    }
+
+    /**
+     * Hook ConnectivityService.callCallbackForRequest — the dispatch point for
+     * registerNetworkCallback. system_server *pushes* NetworkCapabilities to the
+     * app here, so the writeToParcel hooks would see getCallingUid()==1000
+     * instead of the app and skip sanitizing. We stash the recipient UID in
+     * currentCallbackUid for the duration of the dispatch so those hooks treat
+     * the pushed data like a synchronous call. If the app explicitly requested a
+     * VPN network, drop the callback entirely — don't reveal a VPN exists.
+     * Fixes apps (e.g. VTB, issue #70) that detect VPN only via callbacks.
+     */
+    private fun hookConnectivityService(classLoader: ClassLoader) {
+        val csClass =
+            try {
+                // Android 14+ ships ConnectivityService in the repackaged
+                // Connectivity APEX namespace; older releases use the original.
+                XposedHelpers.findClass(
+                    "android.net.connectivity.com.android.server.ConnectivityService",
+                    classLoader,
+                )
+            } catch (_: Throwable) {
+                XposedHelpers.findClass("com.android.server.ConnectivityService", classLoader)
+            }
+
+        val hooked =
+            XposedBridge.hookAllMethods(
+                csClass,
+                "callCallbackForRequest",
+                object : XC_MethodHook() {
+                    override fun beforeHookedMethod(param: MethodHookParam) {
+                        val nri = param.args.firstOrNull() ?: return
+                        val uid = extractRecipientUid(nri)
+                        if (uid < 0 || !loadTargetUids().contains(uid)) return
+
+                        val request = extractNetworkRequest(nri)
+                        if (request != null && request.hasTransport(TRANSPORT_VPN)) {
+                            // App is specifically listening for a VPN network —
+                            // suppress so it never learns one exists.
+                            param.result = null
+                            HookLog.i("VpnHide-CB: uid=$uid suppressed VPN-request callback")
+                            return
+                        }
+                        currentCallbackUid.set(uid)
+                    }
+
+                    override fun afterHookedMethod(param: MethodHookParam) {
+                        currentCallbackUid.remove()
+                    }
+                },
+            )
+        if (hooked.isEmpty()) {
+            HookLog.e("VpnHide: no callCallbackForRequest on ${csClass.name}")
+        } else {
+            HookLog.i("VpnHide: hooked ConnectivityService.callCallbackForRequest (${hooked.size})")
+        }
+    }
+
+    // The callback recipient UID lives on the NetworkRequestInfo arg under
+    // different field names across AOSP versions (mAsUid is the UID the callback
+    // is delivered as). Returns -1 if none found.
+    private fun extractRecipientUid(nri: Any): Int {
+        for (field in RECIPIENT_UID_FIELDS) {
+            try {
+                return XposedHelpers.getIntField(nri, field)
+            } catch (_: Throwable) {
+            }
+        }
+        return -1
+    }
+
+    // Find the NetworkRequest on the NRI by type — field name varies, and some
+    // versions hold a list of requests (take the first). Flattened to a field
+    // sequence over the class hierarchy to keep nesting shallow.
+    private fun extractNetworkRequest(nri: Any): android.net.NetworkRequest? =
+        generateSequence(nri.javaClass as Class<*>?) { it.superclass }
+            .takeWhile { it != Any::class.java }
+            .flatMap { it.declaredFields.asSequence() }
+            .firstNotNullOfOrNull { field ->
+                asNetworkRequest(
+                    runCatching {
+                        field.isAccessible = true
+                        field.get(nri)
+                    }.getOrNull(),
+                )
+            }
+
+    private fun asNetworkRequest(value: Any?): android.net.NetworkRequest? =
+        when (value) {
+            is android.net.NetworkRequest -> value
+            is List<*> -> value.firstOrNull { it is android.net.NetworkRequest } as? android.net.NetworkRequest
+            else -> null
+        }
+
     companion object {
+        private const val SYSTEM_UID = 1000
+        private val RECIPIENT_UID_FIELDS = listOf("mAsUid", "mUid", "uid")
         private const val TRANSPORT_VPN = 4
         private const val NET_CAPABILITY_NOT_VPN = 15
         private const val TYPE_VPN = 17

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/HookEntry.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/HookEntry.kt
@@ -390,7 +390,7 @@ class HookEntry : IXposedHookLoadPackage {
                     val isTarget = targets.contains(callerUid)
                     val nc = param.thisObject as NetworkCapabilities
                     val transportTypes = XposedHelpers.getLongField(nc, "mTransportTypes")
-                    val hasVpn = (transportTypes and (1L shl TRANSPORT_VPN)) != 0L
+                    val hasVpn = (transportTypes and (1L shl NetworkCapabilities.TRANSPORT_VPN)) != 0L
                     // Per-request diagnostic line. Gated by the debug-logging
                     // toggle: these fire on every NC.writeToParcel inside
                     // system_server and directly name the target UIDs we hook,
@@ -403,13 +403,17 @@ class HookEntry : IXposedHookLoadPackage {
                     if (!isTarget) return
 
                     try {
-                        val vpnBit = 1L shl TRANSPORT_VPN
+                        val vpnBit = 1L shl NetworkCapabilities.TRANSPORT_VPN
                         if (transportTypes and vpnBit == 0L) return
 
                         val copy = NetworkCapabilities(nc)
                         XposedHelpers.setLongField(copy, "mTransportTypes", transportTypes and vpnBit.inv())
                         val caps = XposedHelpers.getLongField(copy, "mNetworkCapabilities")
-                        XposedHelpers.setLongField(copy, "mNetworkCapabilities", caps or (1L shl NET_CAPABILITY_NOT_VPN))
+                        XposedHelpers.setLongField(
+                            copy,
+                            "mNetworkCapabilities",
+                            caps or (1L shl NetworkCapabilities.NET_CAPABILITY_NOT_VPN),
+                        )
                         try {
                             val ti = XposedHelpers.getObjectField(copy, "mTransportInfo")
                             if (ti != null && ti.javaClass.name == "android.net.VpnTransportInfo") {
@@ -615,7 +619,7 @@ class HookEntry : IXposedHookLoadPackage {
                         if (uid < 0 || !loadTargetUids().contains(uid)) return
 
                         val request = extractNetworkRequest(nri)
-                        if (request != null && request.hasTransport(TRANSPORT_VPN)) {
+                        if (request != null && request.hasTransport(NetworkCapabilities.TRANSPORT_VPN)) {
                             // App is specifically listening for a VPN network —
                             // suppress so it never learns one exists.
                             param.result = null
@@ -676,8 +680,6 @@ class HookEntry : IXposedHookLoadPackage {
     companion object {
         private const val SYSTEM_UID = 1000
         private val RECIPIENT_UID_FIELDS = listOf("mAsUid", "mUid", "uid")
-        private const val TRANSPORT_VPN = 4
-        private const val NET_CAPABILITY_NOT_VPN = 15
         private const val TYPE_VPN = 17
         private const val TYPE_WIFI = 1
         const val HOOK_STATUS_FILE = "/data/system/vpnhide_hook_active"

--- a/lsposed/app/src/main/res/values/strings.xml
+++ b/lsposed/app/src/main/res/values/strings.xml
@@ -201,6 +201,7 @@
     <string name="check_transport_info" translatable="false">getTransportInfo()</string>
     <string name="check_all_networks_vpn" translatable="false">getAllNetworks() VPN scan</string>
     <string name="check_active_network_vpn" translatable="false">ActiveNetwork transports</string>
+    <string name="check_network_callback" translatable="false">NetworkCallback (push)</string>
     <string name="check_link_properties" translatable="false">LinkProperties ifname</string>
     <string name="check_link_properties_routes" translatable="false">LinkProperties routes</string>
     <string name="check_proxy_host" translatable="false">System proxy properties</string>


### PR DESCRIPTION
Apps like ВТБ detect a VPN by registering a default-network callback rather than querying the network synchronously. On Android 13+ that path leaked: ConnectivityService ships in the Connectivity APEX and is loaded by a classloader the system_server boot classloader can't resolve, so `findClass` threw ClassNotFound and the `callCallbackForRequest` hook silently never installed. Synchronous queries were sanitized (their `writeToParcel` runs under the app's UID), but pushed `NetworkCapabilities` ran under system_server (uid 1000) with no recipient context, so target apps still saw `TRANSPORT_VPN`. The hook resolves the class against the classloader of the registered `connectivity` binder instead, caught at `ServiceManager.addService` with a direct-lookup fast path, so the recipient UID is stashed during dispatch and the existing writeToParcel hooks sanitize pushed data exactly like a synchronous call.

- Add a `NetworkCallback (push)` diagnostic that registers a default-network callback and flags a leak if the delivered capabilities still carry VPN — reproduces the ВТБ vector
- Install the `ConnectivityService.callCallbackForRequest` hook via the `connectivity` binder's classloader (APEX on A13+, boot classpath on A12-) instead of the unresolvable boot classloader
- Stash the recipient UID in a ThreadLocal during callback dispatch; the NC/NI/LP writeToParcel hooks fall back to it when `getCallingUid()` is system_server, and VPN-specific callback requests from target apps are suppressed outright

Testing: verified on a Pixel-class device on Android 13 with a full-tunnel VPN and the app as a target — the push NetworkCallback diagnostic went from FAIL ("callback leaks VPN: hasTransport(VPN)=true") to PASS ("callback caps clean"), full run 27/27, with system_server logs confirming `hooked ConnectivityService.callCallbackForRequest (1)` and `uid=<app> STRIPPED VPN` on the push path.

Fixes #70