### PR TITLE
fix(lsposed): copy NetworkInfo state enums as objects in VPN disguise

### DIFF
--- a/changelog.d/fixed-restore-the-vpn-to-wi-fi-37ac.md
+++ b/changelog.d/fixed-restore-the-vpn-to-wi-fi-37ac.md
@@ -1,0 +1,9 @@
+_2026-06-23_
+
+## English
+
+Restore the VPN to Wi-Fi disguise for the legacy NetworkInfo API (getActiveNetworkInfo): the hook copied NetworkInfo's connection-state enum fields with an int accessor and threw on every call, so target apps could still see a VPN NetworkInfo
+
+## Русский
+
+Восстановлен дизгайз VPN под Wi-Fi для устаревшего API NetworkInfo (getActiveNetworkInfo): хук копировал enum-поля состояния через int-аксессор и падал на каждом вызове, из-за чего целевые приложения могли видеть VPN-NetworkInfo

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/HookEntry.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/HookEntry.kt
@@ -1,5 +1,6 @@
 package dev.okhsunrog.vpnhide
 
+import android.net.ConnectivityManager
 import android.net.LinkProperties
 import android.net.NetworkCapabilities
 import android.net.NetworkInfo
@@ -460,7 +461,7 @@ class HookEntry : IXposedHookLoadPackage {
                     val isTarget = loadTargetUids().contains(callerUid)
                     val ni = param.thisObject as NetworkInfo
                     val type = XposedHelpers.getIntField(ni, "mNetworkType")
-                    val isVpn = type == TYPE_VPN
+                    val isVpn = type == ConnectivityManager.TYPE_VPN
                     HookLog.i(
                         "VpnHide-NI: uid=$callerUid target=$isTarget isVpn=$isVpn type=$type",
                     )
@@ -476,7 +477,7 @@ class HookEntry : IXposedHookLoadPackage {
                                 String::class.java,
                             )
                         ctor.isAccessible = true
-                        val copy = ctor.newInstance(TYPE_WIFI, 0, "WIFI", "") as NetworkInfo
+                        val copy = ctor.newInstance(ConnectivityManager.TYPE_WIFI, 0, "WIFI", "") as NetworkInfo
                         // mState / mDetailedState are NetworkInfo.State /
                         // NetworkInfo.DetailedState enums, not ints — copy them as
                         // objects (getIntField throws "Not a primitive field",
@@ -688,8 +689,6 @@ class HookEntry : IXposedHookLoadPackage {
         private const val SYSTEM_UID = 1000
         private val RECIPIENT_UID_FIELDS = listOf("mAsUid", "mUid", "uid")
         private val CALLBACK_DISPATCH_METHODS = listOf("callCallbackForRequest", "sendPendingIntentForRequest")
-        private const val TYPE_VPN = 17
-        private const val TYPE_WIFI = 1
         const val HOOK_STATUS_FILE = "/data/system/vpnhide_hook_active"
 
         private val FIELD_PROBES =

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/HookEntry.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/HookEntry.kt
@@ -477,8 +477,12 @@ class HookEntry : IXposedHookLoadPackage {
                             )
                         ctor.isAccessible = true
                         val copy = ctor.newInstance(TYPE_WIFI, 0, "WIFI", "") as NetworkInfo
-                        XposedHelpers.setIntField(copy, "mState", XposedHelpers.getIntField(ni, "mState"))
-                        XposedHelpers.setIntField(copy, "mDetailedState", XposedHelpers.getIntField(ni, "mDetailedState"))
+                        // mState / mDetailedState are NetworkInfo.State /
+                        // NetworkInfo.DetailedState enums, not ints — copy them as
+                        // objects (getIntField throws "Not a primitive field",
+                        // which aborted the whole disguise on every push).
+                        XposedHelpers.setObjectField(copy, "mState", XposedHelpers.getObjectField(ni, "mState"))
+                        XposedHelpers.setObjectField(copy, "mDetailedState", XposedHelpers.getObjectField(ni, "mDetailedState"))
                         XposedHelpers.setBooleanField(copy, "mIsAvailable", XposedHelpers.getBooleanField(ni, "mIsAvailable"))
 
                         val parcel = param.args[0] as android.os.Parcel


### PR DESCRIPTION
The legacy `NetworkInfo` VPN→Wi-Fi disguise (what `getActiveNetworkInfo()` returns for a target app) was throwing on every call: `mState` and `mDetailedState` are `NetworkInfo.State` / `NetworkInfo.DetailedState` enums, but the hook copied them with `getIntField`, which throws "Not a primitive field". The exception aborted the whole disguise mid-way, so target apps could still see a VPN `NetworkInfo`. Copy those fields with the object accessors instead.

- Use `getObjectField`/`setObjectField` for `mState` and `mDetailedState` in the `NetworkInfo.writeToParcel` hook

This surfaced in system_server logs as `VpnHide: NI.writeToParcel error: Not a primitive field ... mState` on every push for a target app. The fix is a straightforward accessor correction (these AOSP fields are enums, not ints); it is not covered by a dedicated diagnostic, so there is no on-device repro step beyond the disappearance of that error.