### PR TITLE
refactor(lsposed): one check run feeding Dashboard + Diagnostics

### DIFF
--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DashboardCache.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DashboardCache.kt
@@ -1,7 +1,6 @@
 package dev.okhsunrog.vpnhide
 
 import android.content.Context
-import android.net.ConnectivityManager
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.StateFlow
@@ -52,11 +51,10 @@ internal object DashboardCache : StateCache<DashboardState>(
 
     override suspend fun load(force: Boolean): DashboardState {
         val context = requireNotNull(appContext) { "DashboardCache.load before ensureLoaded/refresh" }
-        val cm = context.getSystemService(ConnectivityManager::class.java)
         val rootSnapshot =
             if (force) RootSnapshotCache.refresh() else RootSnapshotCache.getOrLoad()
         return withContext(Dispatchers.IO) {
-            loadDashboardState(cm, context, selfNeedsRestart, rootSnapshot)
+            loadDashboardState(context, selfNeedsRestart, rootSnapshot)
         }
     }
 }

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DashboardData.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DashboardData.kt
@@ -2,11 +2,8 @@ package dev.okhsunrog.vpnhide
 
 import android.content.pm.PackageManager
 import android.database.sqlite.SQLiteDatabase
-import android.net.ConnectivityManager
 import android.os.Build
 import android.os.SystemClock
-import android.util.Log
-import dev.okhsunrog.vpnhide.checks.CheckStatus
 import java.io.File
 
 // ── Domain types — invalid states are unrepresentable ────────────────────
@@ -857,8 +854,7 @@ private fun readLsposedConfig(
 // Kept as one top-to-bottom narrative — splitting the flat guard list behind a
 // parameter bundle would add indirection without improving clarity.
 @Suppress("LongMethod", "CyclomaticComplexMethod")
-internal fun loadDashboardState(
-    cm: ConnectivityManager,
+internal suspend fun loadDashboardState(
     context: android.content.Context,
     selfNeedsRestart: Boolean,
     rootSnapshot: RootSnapshot,
@@ -1160,23 +1156,26 @@ internal fun loadDashboardState(
             }
 
             else -> {
-                val native =
-                    if (hasNative) {
-                        runNativeProtectionCheck()
-                    } else {
-                        NativeResult.NoModule
-                    }
-                VpnHideLog.i(TAG, "nativeResult=$native")
-
-                val java =
-                    if (lsposed is LsposedState.Active) {
-                        runJavaProtectionCheck(cm)
-                    } else {
-                        JavaResult.HooksInactive
-                    }
-                VpnHideLog.i(TAG, "javaResult=$java")
-
-                ProtectionCheck.Checked(native, java)
+                // Single source of truth: reuse the cached check run instead of
+                // probing again here. Wait only for the fast core phase — the
+                // slow Diagnostics-only probes don't feed this summary.
+                val core = DiagnosticsCache.awaitCoreResults(context)
+                if (core == null) {
+                    // No active VPN per the check run (or it failed) — nothing to
+                    // summarize; fall back to the same retry path as no-VPN.
+                    ProtectionCheck.NoVpn
+                } else {
+                    val native =
+                        if (hasNative) core.native.toNativeResult() else NativeResult.NoModule
+                    val java =
+                        if (lsposed is LsposedState.Active) {
+                            core.coreJava.toJavaResult()
+                        } else {
+                            JavaResult.HooksInactive
+                        }
+                    VpnHideLog.i(TAG, "nativeResult=$native javaResult=$java")
+                    ProtectionCheck.Checked(native, java)
+                }
             }
         }
 
@@ -1196,78 +1195,29 @@ internal fun loadDashboardState(
     )
 }
 
-private fun runNativeProtectionCheck(): NativeResult {
-    var passed = 0
-    var failed = 0
-    var skipped = 0
-    for (spec in NATIVE_CHECKS) {
-        val name = spec.id
-        try {
-            val out = spec.run()
-            when (out.status) {
-                CheckStatus.NETWORK_BLOCKED -> {
-                    skipped++
-                    VpnHideLog.d(TAG, "native[$name]: NETWORK_BLOCKED")
-                }
-
-                CheckStatus.PASS -> {
-                    passed++
-                    VpnHideLog.d(TAG, "native[$name]: PASS")
-                }
-
-                CheckStatus.FAIL -> {
-                    failed++
-                    VpnHideLog.w(TAG, "native[$name]: FAIL — ${out.detail}")
-                }
-            }
-        } catch (e: Exception) {
-            failed++
-            Log.e(TAG, "native[$name]: exception — ${e.message}")
-        }
-    }
-
-    VpnHideLog.i(TAG, "native protection: passed=$passed failed=$failed skipped=$skipped")
+/**
+ * Roll up the UniFFI native probe results into the Dashboard "Native level"
+ * summary. NETWORK_BLOCKED probes report `passed == null` and don't count
+ * either way; if nothing actually ran, that's OK (a dedicated banner covers the
+ * no-network-permission case).
+ */
+internal fun List<CheckResult>.toNativeResult(): NativeResult {
+    val passed = count { it.passed == true }
+    val failed = count { it.passed == false }
     return when {
-        // Nothing ran (all NETWORK_BLOCKED) — treat as OK so the UI doesn't
-        // paint a scary red when the real issue is the app having no network
-        // permission; a dedicated banner covers that case separately.
         passed == 0 && failed == 0 -> NativeResult.Ok
-
         failed == 0 -> NativeResult.Ok
-
         passed > 0 -> NativeResult.Fail(passed, failed)
-
         else -> NativeResult.Fail(0, failed)
     }
 }
 
-private fun runJavaProtectionCheck(cm: ConnectivityManager): JavaResult {
-    // Same gates the Diagnostics screen uses: with no active network (or no
-    // caps for it) there's nothing for an app to leak, so report OK without
-    // probing. Then reuse the exact CheckResult-producing probes the
-    // Diagnostics screen runs — Dashboard cares only about the five
-    // VPN-presence vectors below (not proxy / route checks), so it runs
-    // precisely that subset and counts the ones that detected a leak. The
-    // probe names are irrelevant here (Dashboard discards the detail text),
-    // hence the empty labels.
-    if (cm.activeNetwork == null) {
-        VpnHideLog.d(TAG, "java: no active network")
-        return JavaResult.Ok
-    }
-    if (cm.getNetworkCapabilities(cm.activeNetwork) == null) {
-        VpnHideLog.d(TAG, "java: no capabilities")
-        return JavaResult.Ok
-    }
-
-    val failed =
-        listOf(
-            checkHasTransportVpn(cm, ""),
-            checkHasCapabilityNotVpn(cm, ""),
-            checkTransportInfo(cm, ""),
-            checkAllNetworksVpn(cm, ""),
-            checkLinkPropertiesIfname(cm, ""),
-        ).count { it.passed == false }
-
-    VpnHideLog.i(TAG, "java protection: failed=$failed")
+/**
+ * Roll up the VPN-presence Java probe results into the Dashboard "Java API
+ * level" summary — the count that detected a leak. Probes with no active
+ * network report `passed == true` ("nothing to leak"), so they don't trip it.
+ */
+internal fun List<CheckResult>.toJavaResult(): JavaResult {
+    val failed = count { it.passed == false }
     return if (failed == 0) JavaResult.Ok else JavaResult.Fail(failed)
 }

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DiagnosticsCache.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DiagnosticsCache.kt
@@ -6,9 +6,11 @@ import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 
@@ -44,6 +46,10 @@ internal object DiagnosticsCache {
 
         data class Ready(
             val results: CheckResults,
+            // false after the fast core phase (native + VPN-presence Java) —
+            // enough for the Dashboard summary; true once the slow Diagnostics-
+            // only probes (push callback etc.) have filled in too.
+            val complete: Boolean,
         ) : State
     }
 
@@ -51,6 +57,10 @@ internal object DiagnosticsCache {
     val state: StateFlow<State> = _state.asStateFlow()
 
     private var inflight: Job? = null
+
+    // Owns runs kicked off from a non-UI caller (the Dashboard's protection
+    // summary), so they survive even if no screen scope is active.
+    private val cacheScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
 
     /** Start a run if one isn't already in flight and we don't have a
      * completed result yet. Idempotent — safe to call from both
@@ -84,6 +94,19 @@ internal object DiagnosticsCache {
         context: Context,
     ) = run(scope, context)
 
+    /**
+     * Suspend until the fast core phase is available, returning its results
+     * (native + VPN-presence Java) — the Dashboard protection summary's source.
+     * Returns null if there's no active VPN (or the run failed): nothing to
+     * summarize. Ensures a run is in flight, so it's safe to call standalone.
+     * Does not wait for the slow Diagnostics-only phase.
+     */
+    suspend fun awaitCoreResults(context: Context): CheckResults? {
+        run(cacheScope, context)
+        val terminal = state.first { it is State.Ready || it is State.VpnOff }
+        return (terminal as? State.Ready)?.results
+    }
+
     private suspend fun doRun(appContext: Context) {
         _state.value = State.Running
         try {
@@ -94,12 +117,17 @@ internal object DiagnosticsCache {
                 StartupTrace.mark("diagnostics_cache_vpn_off")
                 return
             }
-            val results =
-                withContext(Dispatchers.IO) {
-                    val cm = appContext.getSystemService(ConnectivityManager::class.java)
-                    runAllChecks(cm, appContext)
-                }
-            _state.value = State.Ready(results)
+            val cm = appContext.getSystemService(ConnectivityManager::class.java)
+            // Phase 1 (fast): native + VPN-presence Java probes. Publish
+            // immediately so the Dashboard summary can render without waiting
+            // for the slow phase below.
+            val core = withContext(Dispatchers.IO) { runCoreChecks(cm, appContext) }
+            _state.value = State.Ready(core, complete = false)
+            StartupTrace.mark("diagnostics_cache_core_done")
+            // Phase 2 (slow): Diagnostics-only Java probes, incl. the push
+            // callback that blocks for up to 3s.
+            val extraJava = withContext(Dispatchers.IO) { runExtraJavaChecks(cm, appContext) }
+            _state.value = State.Ready(core.copy(extraJava = extraJava), complete = true)
             StartupTrace.mark("diagnostics_cache_done")
         } catch (e: CancellationException) {
             // A cancelled job (e.g. the screen left) must propagate so

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DiagnosticsScreen.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DiagnosticsScreen.kt
@@ -54,10 +54,22 @@ data class CheckResult(
 )
 
 internal data class CheckResults(
+    // UniFFI native probes — the Dashboard "Native level" summary rolls up
+    // exactly this group.
     val native: List<CheckResult>,
-    val java: List<CheckResult>,
+    // Java-implemented native-level probes (NetworkInterface enum, /proc/net/route)
+    // — shown under "Native level" on Diagnostics, not part of any summary.
+    val nativeExtra: List<CheckResult> = emptyList(),
+    // VPN-presence probes — the Dashboard "Java API level" summary rolls up
+    // exactly this group.
+    val coreJava: List<CheckResult> = emptyList(),
+    // Diagnostics-only Java probes (active-network, push callback, routes, proxy)
+    // — the slow push-callback check lives here, so it runs in a second phase.
+    val extraJava: List<CheckResult> = emptyList(),
 ) {
-    val all get() = native + java
+    val nativeAll get() = native + nativeExtra
+    val java get() = coreJava + extraJava
+    val all get() = nativeAll + java
 }
 
 /** Number of passed checks out of those that actually ran (NETWORK_BLOCKED
@@ -197,7 +209,7 @@ fun DiagnosticsScreen(
                     SectionHeader(stringResource(R.string.section_native))
                     Spacer(Modifier.height(6.dp))
                     Column(verticalArrangement = Arrangement.spacedBy(6.dp)) {
-                        for (check in r.native) {
+                        for (check in r.nativeAll) {
                             CheckCard(check)
                         }
                     }
@@ -522,39 +534,76 @@ private fun CheckCard(r: CheckResult) {
 //  Check runner — runs directly in the main process
 // ==========================================================================
 
-internal fun runAllChecks(
+/**
+ * The checks split into two phases so the Dashboard can show its protection
+ * summary without waiting for the slow probes. [runCoreChecks] runs everything
+ * the Dashboard summary needs (UniFFI native + the VPN-presence Java probes)
+ * plus the cheap native-extra probes; [runExtraJavaChecks] runs the
+ * Diagnostics-only Java probes, including the push-callback probe that blocks
+ * for up to 3s. DiagnosticsCache publishes after each phase.
+ */
+internal fun runCoreChecks(
     cm: ConnectivityManager,
     context: android.content.Context,
 ): CheckResults {
     VpnHideLog.i(TAG, "========================================")
-    VpnHideLog.i(TAG, "=== VPNHide — starting all checks ===")
+    VpnHideLog.i(TAG, "=== VPNHide — starting checks (core phase) ===")
     VpnHideLog.i(TAG, "========================================")
 
     val res = context.resources
 
-    val native =
-        NATIVE_CHECKS.map { spec -> nativeCheck(res.getString(spec.labelRes), spec.run) } +
-            checkNetworkInterfaceEnum(res.getString(R.string.check_net_iface_enum)) +
-            checkProcNetRouteJava(res.getString(R.string.check_proc_route_java))
+    val native = NATIVE_CHECKS.map { spec -> nativeCheck(res.getString(spec.labelRes), spec.run) }
 
-    val java =
+    val nativeExtra =
+        listOf(
+            checkNetworkInterfaceEnum(res.getString(R.string.check_net_iface_enum)),
+            checkProcNetRouteJava(res.getString(R.string.check_proc_route_java)),
+        ).logged()
+
+    val coreJava =
         listOf(
             checkHasTransportVpn(cm, res.getString(R.string.check_has_transport_vpn)),
             checkHasCapabilityNotVpn(cm, res.getString(R.string.check_has_capability_not_vpn)),
             checkTransportInfo(cm, res.getString(R.string.check_transport_info)),
             checkAllNetworksVpn(cm, res.getString(R.string.check_all_networks_vpn)),
-            checkActiveNetworkVpn(cm, res.getString(R.string.check_active_network_vpn)),
-            checkNetworkCallbackVpn(cm, res.getString(R.string.check_network_callback)),
             checkLinkPropertiesIfname(cm, res.getString(R.string.check_link_properties)),
-            checkLinkPropertiesRoutes(cm, res.getString(R.string.check_link_properties_routes)),
-            checkProxyHost(res.getString(R.string.check_proxy_host)),
-        )
+        ).logged()
 
-    val score = (native + java).score()
-    VpnHideLog.i(TAG, "=== SUMMARY: ${score.passed}/${score.total} passed ===")
-
-    return CheckResults(native = native, java = java)
+    return CheckResults(native = native, nativeExtra = nativeExtra, coreJava = coreJava)
 }
+
+internal fun runExtraJavaChecks(
+    cm: ConnectivityManager,
+    context: android.content.Context,
+): List<CheckResult> {
+    val res = context.resources
+    return listOf(
+        checkActiveNetworkVpn(cm, res.getString(R.string.check_active_network_vpn)),
+        checkNetworkCallbackVpn(cm, res.getString(R.string.check_network_callback)),
+        checkLinkPropertiesRoutes(cm, res.getString(R.string.check_link_properties_routes)),
+        checkProxyHost(res.getString(R.string.check_proxy_host)),
+    ).logged()
+}
+
+/** Log each Java check result; native probes already log via [nativeCheck]. */
+private fun List<CheckResult>.logged(): List<CheckResult> =
+    onEach { c ->
+        val status =
+            when (c.passed) {
+                true -> "PASS"
+                false -> "FAIL"
+                null -> "SKIP"
+            }
+        VpnHideLog.i(TAG, "[${c.name}] $status: ${c.detail}")
+    }
+
+/** Run both phases and return the complete results. Used where blocking on the
+ * slow probes is fine (debug export); the live cache runs the phased builders
+ * directly so the Dashboard summary needn't wait for the slow phase. */
+internal fun runAllChecks(
+    cm: ConnectivityManager,
+    context: android.content.Context,
+): CheckResults = runCoreChecks(cm, context).copy(extraJava = runExtraJavaChecks(cm, context))
 
 private fun nativeCheck(
     name: String,
@@ -919,7 +968,7 @@ private fun buildDiagnosticsText(results: CheckResults): String =
         appendLine("=== Diagnostics: ${score.passed}/${score.total} passed ===")
         appendLine()
         appendLine("--- Native level ---")
-        for (c in results.native) {
+        for (c in results.nativeAll) {
             appendLine("[${badge(c.passed)}] ${c.name}")
             appendLine("  ${c.detail}")
         }

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/NativeChecks.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/NativeChecks.kt
@@ -46,10 +46,9 @@ internal fun CheckStatus.toPassed(): Boolean? =
     }
 
 /**
- * The native probe suite, in display order. Single source of truth for both
- * the Dashboard protection summary ([runNativeProtectionCheck]) and the
- * Diagnostics screen ([runAllChecks]) — they used to carry two hand-kept
- * copies of this list.
+ * The native probe suite, in display order. Run once by [runCoreChecks]; the
+ * Diagnostics screen lists the results and the Dashboard summary rolls them up
+ * via [toNativeResult] — no second copy of this list or second execution.
  */
 internal val NATIVE_CHECKS: List<NativeCheckSpec> =
     listOf(


### PR DESCRIPTION
The Dashboard protection summary re-ran its own native + VPN-presence subset (`runNativeProtectionCheck` / `runJavaProtectionCheck`) alongside `DiagnosticsCache`'s `runAllChecks`, so the same probes executed twice on every startup. This makes `DiagnosticsCache` the single executor and the Dashboard derive its summary from the cached results — and runs the checks in two phases so the Dashboard needn't wait for the slow probes.

- `DiagnosticsCache` runs a fast **core phase** (UniFFI native + the 5 VPN-presence Java probes) and publishes it, then a **slow phase** (active-network, the push-callback probe that can block ~3s, routes, proxy); `awaitCoreResults` lets the Dashboard wait only for the core
- Dashboard derives `ProtectionCheck` from the cached `CheckResults` via new pure `toNativeResult` / `toJavaResult`; deletes the duplicate `runNativeProtectionCheck` / `runJavaProtectionCheck`
- `CheckResults` now groups results (native / nativeExtra / coreJava / extraJava) so each summary rolls up exactly its set; summary sets are unchanged (native = UniFFI probes, java = the 5 VPN-presence probes)
- Every Java check logs its result like the native ones already did

Pure refactor — no user-visible behavior change, so no changelog entry. Stacked on #140 (the push-callback probe it phases lives there); base will revert to main once that merges.

Testing: on Android 13 with a full-tunnel VPN — `dashboard_protection_done` fires 1ms after the core phase (well before the full run completes), all 27 checks log per-result, dashboard shows native=Ok java=Ok, Diagnostics renders 27/27.