### PR TITLE
feat(lsposed): hide VPN Network handles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ zygisk/.idea/
 
 # LSPosed (Kotlin/Gradle)
 lsposed/.gradle/
+lsposed/.kotlin/
 lsposed/build/
 lsposed/app/build/
 lsposed/.idea/

--- a/changelog.d/added-lsposed-hides-vpn-network-handles-3f20.md
+++ b/changelog.d/added-lsposed-hides-vpn-network-handles-3f20.md
@@ -2,8 +2,8 @@ _2026-06-23_
 
 ## English
 
-LSPosed now hides VPN `Network` handles from Java Connectivity APIs: `getActiveNetwork`, `getAllNetworks`, `getNetworkForType(TYPE_VPN)` and `Network.writeToParcel` no longer expose the VPN network to target apps.
+LSPosed now hides VPN `Network` handles from Java Connectivity APIs: `getActiveNetwork` replaces the active VPN handle with a physical network when available, while `getAllNetworks`, `getNetworkForType(TYPE_VPN)` and `Network.writeToParcel` no longer expose the VPN network to target apps.
 
 ## Русский
 
-LSPosed теперь скрывает VPN-дескрипторы `Network` из Java Connectivity API: `getActiveNetwork`, `getAllNetworks`, `getNetworkForType(TYPE_VPN)` и `Network.writeToParcel` больше не отдают VPN-сеть целевым приложениям.
+LSPosed теперь скрывает VPN-дескрипторы `Network` из Java Connectivity API: `getActiveNetwork` заменяет активный VPN-дескриптор физической сетью, когда она доступна, а `getAllNetworks`, `getNetworkForType(TYPE_VPN)` и `Network.writeToParcel` больше не отдают VPN-сеть целевым приложениям.

--- a/changelog.d/added-lsposed-hides-vpn-network-handles-3f20.md
+++ b/changelog.d/added-lsposed-hides-vpn-network-handles-3f20.md
@@ -1,0 +1,9 @@
+_2026-06-23_
+
+## English
+
+LSPosed now hides VPN `Network` handles from Java Connectivity APIs: `getActiveNetwork`, `getAllNetworks`, `getNetworkForType(TYPE_VPN)` and `Network.writeToParcel` no longer expose the VPN network to target apps.
+
+## Русский
+
+LSPosed теперь скрывает VPN-дескрипторы `Network` из Java Connectivity API: `getActiveNetwork`, `getAllNetworks`, `getNetworkForType(TYPE_VPN)` и `Network.writeToParcel` больше не отдают VPN-сеть целевым приложениям.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,0 +1,61 @@
+# Roadmap
+
+This document tracks larger product directions that are too broad for a
+single changelog entry. It is not a release commitment; concrete work should
+still be tracked in GitHub issues and pull requests.
+
+## VPN Hiding Modes
+
+### VPN-preserving concealment
+
+Current Java `Network` handle hiding is optimized for the recommended
+split-tunnel setup: target apps are kept outside the VPN, so returning a
+physical `Network` handle is consistent with where their traffic should go.
+
+There is a second valid use case: target apps must keep their traffic inside
+the VPN while the VPN remains hidden from local detection APIs. This matters
+for users who intentionally route banking, media, work, or home-network apps
+through a VPN endpoint in a specific country.
+
+The current physical-handle replacement can affect that use case when a target
+app explicitly binds traffic to the returned `Network` with APIs such as
+`bindProcessToNetwork`, `Network.bindSocket`, or `Network.openConnection`.
+Ordinary sockets still follow Android VPN policy, but explicitly-bound traffic
+may bypass the VPN on setups that allow physical-network use.
+
+Follow-up work:
+
+- Add a VPN-preserving concealment mode that hides VPN state without steering
+  explicitly-bound target-app traffic away from the VPN.
+- Decide whether this should be a global mode, per-target setting, or automatic
+  behavior based on VPN bypassability / split-tunnel policy.
+- Extend Diagnostics with a routing-oriented check that can distinguish
+  "VPN hidden and traffic outside VPN" from "VPN hidden and traffic still
+  inside VPN".
+
+Tracking: [issue 130](https://github.com/okhsunrog/vpnhide/issues/130).
+
+### Network handle edge cases
+
+Improve the physical replacement path used by LSPosed Java hooks:
+
+- Treat future non-VPN transports as physical candidates when safe, instead of
+  limiting candidates to Wi-Fi, cellular, Ethernet, and Bluetooth.
+- Avoid returning `null` from `getActiveNetwork()` when a non-VPN replacement
+  exists but uses a newer Android transport type.
+- Consider short-lived caching for the selected replacement network if real
+  devices show measurable overhead from repeated `ConnectivityService` lookups.
+
+## Diagnostics And Observability
+
+- Add optional per-hook interception counters so users can see which apps are
+  probing VPN state and through which API family.
+- Keep install-time hook status detailed enough to diagnose Android framework
+  drift, especially private-field changes in new Android releases.
+
+## Configuration
+
+- Consider user-defined VPN interface prefixes for uncommon tunnels or renamed
+  interfaces, while keeping generated defaults as the primary path.
+- Keep split-tunnel guidance prominent in user-facing docs because server-side
+  IP, DNS, and latency checks cannot be fixed client-side.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -37,12 +37,15 @@ Tracking: [issue 130](https://github.com/okhsunrog/vpnhide/issues/130).
 
 ### Network handle edge cases
 
-Improve the physical replacement path used by LSPosed Java hooks:
+The physical replacement path used by LSPosed Java hooks intentionally prefers
+connectivity over perfect concealment in rare fallback cases: if no non-VPN
+replacement exists for `getActiveNetwork()`, the original active network is left
+unchanged instead of reporting that there is no active network.
 
-- Treat future non-VPN transports as physical candidates when safe, instead of
-  limiting candidates to Wi-Fi, cellular, Ethernet, and Bluetooth.
-- Avoid returning `null` from `getActiveNetwork()` when a non-VPN replacement
-  exists but uses a newer Android transport type.
+Follow-up work:
+
+- Watch real app compatibility reports for APIs that are intentionally
+  suppressed to `null`, especially `getNetworkForType(TYPE_VPN)`.
 - Consider short-lived caching for the selected replacement network if real
   devices show measurable overhead from repeated `ConnectivityService` lookups.
 

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DiagnosticsScreen.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DiagnosticsScreen.kt
@@ -578,6 +578,9 @@ internal fun runExtraJavaChecks(
 ): List<CheckResult> {
     val res = context.resources
     return listOf(
+        checkNetworkForTypeVpn(cm, res.getString(R.string.check_network_for_type_vpn)),
+        checkActiveNetworkHandle(cm, res.getString(R.string.check_active_network_handle)),
+        checkAllNetworksHandles(cm, res.getString(R.string.check_all_networks_handles)),
         checkActiveNetworkVpn(cm, res.getString(R.string.check_active_network_vpn)),
         checkNetworkCallbackVpn(cm, res.getString(R.string.check_network_callback)),
         checkLinkPropertiesRoutes(cm, res.getString(R.string.check_link_properties_routes)),
@@ -751,6 +754,90 @@ private fun checkActiveNetworkVpn(
             }
         CheckResult(name, !hasVpn, detail)
     }
+
+private data class NetworkForTypeResult(
+    val network: Network? = null,
+    val unavailable: Boolean = false,
+    val error: String? = null,
+)
+
+@Suppress("DEPRECATION")
+private fun queryNetworkForType(
+    cm: ConnectivityManager,
+    type: Int,
+): NetworkForTypeResult =
+    try {
+        val method = ConnectivityManager::class.java.getMethod("getNetworkForType", Integer.TYPE)
+        method.isAccessible = true
+        NetworkForTypeResult(network = method.invoke(cm, type) as? Network)
+    } catch (_: NoSuchMethodException) {
+        NetworkForTypeResult(unavailable = true)
+    } catch (t: Throwable) {
+        NetworkForTypeResult(error = t.cause?.message ?: t.message ?: t.javaClass.simpleName)
+    }
+
+@Suppress("DEPRECATION")
+private fun checkNetworkForTypeVpn(
+    cm: ConnectivityManager,
+    name: String,
+): CheckResult {
+    val result = queryNetworkForType(cm, ConnectivityManager.TYPE_VPN)
+    result.error?.let { return CheckResult(name, false, it) }
+    if (result.unavailable) return CheckResult(name, true, "getNetworkForType unavailable")
+    val vpnNetwork = result.network ?: return CheckResult(name, true, "TYPE_VPN returned null")
+
+    val caps = cm.getNetworkCapabilities(vpnNetwork)
+    val hasVpn = caps?.hasTransport(NetworkCapabilities.TRANSPORT_VPN) == true
+    val detail =
+        if (hasVpn) {
+            "TYPE_VPN returned $vpnNetwork with VPN capabilities"
+        } else {
+            "TYPE_VPN returned $vpnNetwork"
+        }
+    return CheckResult(name, false, detail)
+}
+
+@Suppress("DEPRECATION")
+private fun checkActiveNetworkHandle(
+    cm: ConnectivityManager,
+    name: String,
+): CheckResult {
+    val active = cm.activeNetwork ?: return CheckResult(name, true, "no active network")
+    val vpnResult = queryNetworkForType(cm, ConnectivityManager.TYPE_VPN)
+    vpnResult.error?.let { return CheckResult(name, false, it) }
+    if (vpnResult.unavailable) return CheckResult(name, true, "active=$active, getNetworkForType unavailable")
+    val vpnNetwork = vpnResult.network ?: return CheckResult(name, true, "active=$active, TYPE_VPN not exposed")
+
+    val leaksVpnHandle = active == vpnNetwork
+    val detail =
+        if (leaksVpnHandle) {
+            "activeNetwork equals TYPE_VPN network $active"
+        } else {
+            "active=$active, TYPE_VPN=$vpnNetwork"
+        }
+    return CheckResult(name, !leaksVpnHandle, detail)
+}
+
+@Suppress("DEPRECATION")
+private fun checkAllNetworksHandles(
+    cm: ConnectivityManager,
+    name: String,
+): CheckResult {
+    val networks = cm.allNetworks
+    val vpnResult = queryNetworkForType(cm, ConnectivityManager.TYPE_VPN)
+    vpnResult.error?.let { return CheckResult(name, false, it) }
+    if (vpnResult.unavailable) return CheckResult(name, true, "${networks.size} networks, getNetworkForType unavailable")
+    val vpnNetwork = vpnResult.network ?: return CheckResult(name, true, "${networks.size} networks, TYPE_VPN not exposed")
+
+    val containsVpnHandle = networks.any { it == vpnNetwork }
+    val detail =
+        if (containsVpnHandle) {
+            "allNetworks includes TYPE_VPN network $vpnNetwork"
+        } else {
+            "${networks.size} networks, TYPE_VPN=$vpnNetwork not listed"
+        }
+    return CheckResult(name, !containsVpnHandle, detail)
+}
 
 // Push-callback leak (issue #70, e.g. VTB): apps using
 // registerDefaultNetworkCallback receive NetworkCapabilities *pushed* from

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/HookEntry.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/HookEntry.kt
@@ -284,11 +284,22 @@ class HookEntry : IXposedHookLoadPackage {
         network: Network,
     ): Boolean = rawNetworkCapabilities(cs, network)?.hasTransport(NetworkCapabilities.TRANSPORT_VPN) == true
 
-    private fun hasPhysicalTransport(caps: NetworkCapabilities): Boolean =
-        caps.hasTransport(NetworkCapabilities.TRANSPORT_WIFI) ||
+    private fun hasPhysicalTransport(caps: NetworkCapabilities): Boolean {
+        val transportTypes =
+            try {
+                XposedHelpers.callMethod(caps, "getTransportTypes") as? IntArray
+            } catch (_: Throwable) {
+                null
+            }
+        if (transportTypes != null) {
+            return transportTypes.any { it != NetworkCapabilities.TRANSPORT_VPN }
+        }
+
+        return caps.hasTransport(NetworkCapabilities.TRANSPORT_WIFI) ||
             caps.hasTransport(NetworkCapabilities.TRANSPORT_CELLULAR) ||
             caps.hasTransport(NetworkCapabilities.TRANSPORT_ETHERNET) ||
             caps.hasTransport(NetworkCapabilities.TRANSPORT_BLUETOOTH)
+    }
 
     private fun physicalNetworkScore(caps: NetworkCapabilities): Int {
         var score = 0
@@ -296,6 +307,7 @@ class HookEntry : IXposedHookLoadPackage {
         if (caps.hasTransport(NetworkCapabilities.TRANSPORT_WIFI)) score += 30
         if (caps.hasTransport(NetworkCapabilities.TRANSPORT_CELLULAR)) score += 20
         if (caps.hasTransport(NetworkCapabilities.TRANSPORT_BLUETOOTH)) score += 10
+        if (hasPhysicalTransport(caps)) score += 1
         if (caps.hasCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET)) score += 4
         if (caps.hasCapability(NetworkCapabilities.NET_CAPABILITY_VALIDATED)) score += 8
         return score
@@ -859,6 +871,16 @@ class HookEntry : IXposedHookLoadPackage {
      */
     private fun hookConnectivityService(classLoader: ClassLoader) {
         val csClass = findConnectivityServiceClass(classLoader)
+        tryHook("ConnectivityService constructors") {
+            XposedBridge.hookAllConstructors(
+                csClass,
+                object : XC_MethodHook() {
+                    override fun afterHookedMethod(param: MethodHookParam) {
+                        rememberConnectivityService(param.thisObject)
+                    }
+                },
+            )
+        }
         installConnectivityServiceResultHooks(csClass)
         installConnectivityServiceNetworkHooks(csClass)
 
@@ -956,7 +978,15 @@ class HookEntry : IXposedHookLoadPackage {
         val network = param.result as? Network ?: return
         val cs = param.thisObject ?: return
         if (!isVpnNetwork(cs, network)) return
-        param.result = findPhysicalNetwork(cs)
+        val replacement = findPhysicalNetwork(cs)
+        if (replacement == null) {
+            HookLog.i(
+                "VpnHide: kept active VPN Network handle for uid=${effectiveCallerUid()}; " +
+                    "no physical replacement found",
+            )
+            return
+        }
+        param.result = replacement
         HookLog.i("VpnHide: replaced active VPN Network handle for uid=${effectiveCallerUid()}")
     }
 

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/HookEntry.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/HookEntry.kt
@@ -301,6 +301,12 @@ class HookEntry : IXposedHookLoadPackage {
         return score
     }
 
+    // Physical replacement follows the recommended split-tunnel model: target
+    // apps see a non-VPN Network and may bind sockets to it. That is right for
+    // apps kept outside the VPN, but it can bypass the VPN for apps that must
+    // keep traffic inside the tunnel while hiding VPN state.
+    // TODO: add a VPN-preserving concealment mode for that use case
+    // (tracked by GitHub issue 130).
     private fun findPhysicalNetwork(cs: Any): Network? {
         val scored =
             rawAllNetworks(cs).mapNotNull { network ->

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/HookEntry.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/HookEntry.kt
@@ -2,6 +2,7 @@ package dev.okhsunrog.vpnhide
 
 import android.net.ConnectivityManager
 import android.net.LinkProperties
+import android.net.Network
 import android.net.NetworkCapabilities
 import android.net.NetworkInfo
 import android.net.RouteInfo
@@ -53,6 +54,9 @@ class HookEntry : IXposedHookLoadPackage {
     // pushed data exactly like a synchronous call. See issue #70 (VTB and other
     // apps that detect VPN only via registerDefaultNetworkCallback).
     private val currentCallbackUid = ThreadLocal<Int>()
+    private val bypassConnectivitySanitize = ThreadLocal<Boolean>()
+
+    @Volatile private var connectivityServiceInstance: Any? = null
 
     private fun effectiveCallerUid(): Int {
         val uid = Binder.getCallingUid()
@@ -62,6 +66,10 @@ class HookEntry : IXposedHookLoadPackage {
     private fun isTargetCallerOrUid(uid: Int? = null): Boolean {
         val targets = loadTargetUids()
         return targets.contains(effectiveCallerUid()) || (uid != null && targets.contains(uid))
+    }
+
+    private fun rememberConnectivityService(instance: Any?) {
+        if (instance != null) connectivityServiceInstance = instance
     }
 
     override fun handleLoadPackage(lpparam: XC_LoadPackage.LoadPackageParam) {
@@ -209,6 +217,103 @@ class HookEntry : IXposedHookLoadPackage {
         )
     }
 
+    private inline fun <T> withConnectivitySanitizeBypassed(block: () -> T): T {
+        val wasBypassed = bypassConnectivitySanitize.get() == true
+        bypassConnectivitySanitize.set(true)
+        return try {
+            block()
+        } finally {
+            if (wasBypassed) {
+                bypassConnectivitySanitize.set(true)
+            } else {
+                bypassConnectivitySanitize.remove()
+            }
+        }
+    }
+
+    private inline fun <T> withClearedCallingIdentity(block: () -> T): T {
+        val token = Binder.clearCallingIdentity()
+        return try {
+            block()
+        } finally {
+            Binder.restoreCallingIdentity(token)
+        }
+    }
+
+    private fun rawNetworkCapabilities(
+        cs: Any,
+        network: Network,
+    ): NetworkCapabilities? =
+        withClearedCallingIdentity {
+            withConnectivitySanitizeBypassed {
+                callNetworkCapabilities(cs, network)
+            }
+        }
+
+    private fun callNetworkCapabilities(
+        cs: Any,
+        network: Network,
+    ): NetworkCapabilities? {
+        val typedArgs = arrayOf<Any?>(network, "android", null)
+        try {
+            return XposedHelpers.callMethod(
+                cs,
+                "getNetworkCapabilities",
+                arrayOf(Network::class.java, String::class.java, String::class.java),
+                *typedArgs,
+            ) as? NetworkCapabilities
+        } catch (_: Throwable) {
+        }
+        return try {
+            XposedHelpers.callMethod(cs, "getNetworkCapabilities", network) as? NetworkCapabilities
+        } catch (_: Throwable) {
+            null
+        }
+    }
+
+    private fun rawAllNetworks(cs: Any): List<Network> =
+        withClearedCallingIdentity {
+            withConnectivitySanitizeBypassed {
+                ((XposedHelpers.callMethod(cs, "getAllNetworks") as? Array<*>) ?: emptyArray<Any>())
+                    .filterIsInstance<Network>()
+            }
+        }
+
+    private fun isVpnNetwork(
+        cs: Any,
+        network: Network,
+    ): Boolean = rawNetworkCapabilities(cs, network)?.hasTransport(NetworkCapabilities.TRANSPORT_VPN) == true
+
+    private fun hasPhysicalTransport(caps: NetworkCapabilities): Boolean =
+        caps.hasTransport(NetworkCapabilities.TRANSPORT_WIFI) ||
+            caps.hasTransport(NetworkCapabilities.TRANSPORT_CELLULAR) ||
+            caps.hasTransport(NetworkCapabilities.TRANSPORT_ETHERNET) ||
+            caps.hasTransport(NetworkCapabilities.TRANSPORT_BLUETOOTH)
+
+    private fun physicalNetworkScore(caps: NetworkCapabilities): Int {
+        var score = 0
+        if (caps.hasTransport(NetworkCapabilities.TRANSPORT_ETHERNET)) score += 40
+        if (caps.hasTransport(NetworkCapabilities.TRANSPORT_WIFI)) score += 30
+        if (caps.hasTransport(NetworkCapabilities.TRANSPORT_CELLULAR)) score += 20
+        if (caps.hasTransport(NetworkCapabilities.TRANSPORT_BLUETOOTH)) score += 10
+        if (caps.hasCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET)) score += 4
+        if (caps.hasCapability(NetworkCapabilities.NET_CAPABILITY_VALIDATED)) score += 8
+        return score
+    }
+
+    private fun findPhysicalNetwork(cs: Any): Network? {
+        val scored =
+            rawAllNetworks(cs).mapNotNull { network ->
+                val caps = rawNetworkCapabilities(cs, network) ?: return@mapNotNull null
+                if (caps.hasTransport(NetworkCapabilities.TRANSPORT_VPN) || !hasPhysicalTransport(caps)) {
+                    null
+                } else {
+                    network to physicalNetworkScore(caps)
+                }
+            }
+        return scored.maxByOrNull { it.second }?.first
+    }
+
     private fun sanitizedNetworkCapabilities(nc: NetworkCapabilities): NetworkCapabilities {
         val copy = NetworkCapabilities(nc)
         return if (sanitizeNetworkCapabilities(copy)) copy else nc
@@ -277,6 +382,7 @@ class HookEntry : IXposedHookLoadPackage {
         param: XC_MethodHook.MethodHookParam,
         explicitUid: Int? = null,
     ) {
+        if (bypassConnectivitySanitize.get() == true) return
         if (!isTargetCallerOrUid(explicitUid)) return
         try {
             param.result = sanitizedValue(param.result)
@@ -382,6 +488,7 @@ class HookEntry : IXposedHookLoadPackage {
         } else {
             tryHook("NI.writeToParcel") { hookNIWriteToParcel() }
         }
+        tryHook("Network.writeToParcel") { hookNetworkWriteToParcel() }
 
         tryHook("FileObserver") { watchTargetUidsFile() }
         return brokenFields
@@ -542,6 +649,40 @@ class HookEntry : IXposedHookLoadPackage {
             },
         )
         HookLog.i("VpnHide: hooked NetworkCapabilities.writeToParcel")
+    }
+
+    private fun hookNetworkWriteToParcel() {
+        val writingCopy = ThreadLocal<Boolean>()
+        XposedHelpers.findAndHookMethod(
+            Network::class.java,
+            "writeToParcel",
+            android.os.Parcel::class.java,
+            Integer.TYPE,
+            object : XC_MethodHook() {
+                override fun beforeHookedMethod(param: MethodHookParam) {
+                    if (writingCopy.get() == true || !isTargetCallerOrUid()) return
+                    val cs = connectivityServiceInstance ?: return
+                    val network = param.thisObject as Network
+                    try {
+                        if (!isVpnNetwork(cs, network)) return
+                        val replacement = findPhysicalNetwork(cs) ?: return
+                        val parcel = param.args[0] as android.os.Parcel
+                        val flags = param.args[1] as Int
+                        writingCopy.set(true)
+                        try {
+                            replacement.writeToParcel(parcel, flags)
+                        } finally {
+                            writingCopy.set(false)
+                        }
+                        param.result = null
+                        HookLog.i("VpnHide: replaced VPN Network parcel for uid=${effectiveCallerUid()}")
+                    } catch (t: Throwable) {
+                        HookLog.e("VpnHide: Network.writeToParcel error: ${t.message}")
+                    }
+                }
+            },
+        )
+        HookLog.i("VpnHide: hooked Network.writeToParcel")
     }
 
     /**
@@ -713,6 +854,7 @@ class HookEntry : IXposedHookLoadPackage {
     private fun hookConnectivityService(classLoader: ClassLoader) {
         val csClass = findConnectivityServiceClass(classLoader)
         installConnectivityServiceResultHooks(csClass)
+        installConnectivityServiceNetworkHooks(csClass)
 
         // Both methods take the NetworkRequestInfo as their first arg, so the
         // same handler covers the callback-object and PendingIntent paths.
@@ -720,6 +862,7 @@ class HookEntry : IXposedHookLoadPackage {
             object : XC_MethodHook() {
                 override fun beforeHookedMethod(param: MethodHookParam) {
                     val nri = param.args.firstOrNull() ?: return
+                    rememberConnectivityService(param.thisObject)
                     val uid = extractRecipientUid(nri)
                     if (uid < 0 || !loadTargetUids().contains(uid)) return
 
@@ -758,6 +901,7 @@ class HookEntry : IXposedHookLoadPackage {
                     method,
                     object : XC_MethodHook() {
                         override fun afterHookedMethod(param: MethodHookParam) {
+                            rememberConnectivityService(param.thisObject)
                             val explicitUid = uidArgIndex?.let { param.args.getOrNull(it) as? Int }
                             sanitizeMethodResult(param, explicitUid)
                         }
@@ -769,6 +913,64 @@ class HookEntry : IXposedHookLoadPackage {
                 HookLog.i("VpnHide: hooked ConnectivityService.$method result (${hooked.size})")
             }
         }
+    }
+
+    private fun installConnectivityServiceNetworkHooks(csClass: Class<*>) {
+        hookConnectivityNetworkMethod(csClass, "getActiveNetwork", ::sanitizeActiveNetworkResult)
+        hookConnectivityNetworkMethod(csClass, "getAllNetworks", ::sanitizeAllNetworksResult)
+        hookConnectivityNetworkMethod(csClass, "getNetworkForType", ::sanitizeNetworkForTypeResult)
+    }
+
+    private fun hookConnectivityNetworkMethod(
+        csClass: Class<*>,
+        method: String,
+        sanitizer: (XC_MethodHook.MethodHookParam) -> Unit,
+    ) {
+        val hooked =
+            XposedBridge.hookAllMethods(
+                csClass,
+                method,
+                object : XC_MethodHook() {
+                    override fun afterHookedMethod(param: MethodHookParam) {
+                        rememberConnectivityService(param.thisObject)
+                        if (bypassConnectivitySanitize.get() == true) return
+                        if (!isTargetCallerOrUid()) return
+                        sanitizer(param)
+                    }
+                },
+            )
+        if (hooked.isEmpty()) {
+            HookLog.e("VpnHide: no ConnectivityService.$method network hook target on ${csClass.name}")
+        } else {
+            HookLog.i("VpnHide: hooked ConnectivityService.$method network result (${hooked.size})")
+        }
+    }
+
+    private fun sanitizeActiveNetworkResult(param: XC_MethodHook.MethodHookParam) {
+        val network = param.result as? Network ?: return
+        val cs = param.thisObject ?: return
+        if (!isVpnNetwork(cs, network)) return
+        param.result = findPhysicalNetwork(cs)
+        HookLog.i("VpnHide: replaced active VPN Network handle for uid=${effectiveCallerUid()}")
+    }
+
+    private fun sanitizeAllNetworksResult(param: XC_MethodHook.MethodHookParam) {
+        val networks = (param.result as? Array<*>)?.filterIsInstance<Network>() ?: return
+        val cs = param.thisObject ?: return
+        val filtered = networks.filterNot { isVpnNetwork(cs, it) }
+        if (filtered.size == networks.size) return
+        param.result = filtered.toTypedArray()
+        HookLog.i(
+            "VpnHide: filtered ${networks.size - filtered.size} VPN Network handle(s) " +
+                "for uid=${effectiveCallerUid()}",
+        )
+    }
+
+    private fun sanitizeNetworkForTypeResult(param: XC_MethodHook.MethodHookParam) {
+        val type = param.args.getOrNull(0) as? Int ?: return
+        if (type != ConnectivityManager.TYPE_VPN || param.result == null) return
+        param.result = null
+        HookLog.i("VpnHide: suppressed getNetworkForType(TYPE_VPN) for uid=${effectiveCallerUid()}")
     }
 
     // The callback recipient UID lives on the NetworkRequestInfo arg under

--- a/lsposed/app/src/main/res/values/strings.xml
+++ b/lsposed/app/src/main/res/values/strings.xml
@@ -200,6 +200,9 @@
     <string name="check_has_capability_not_vpn" translatable="false">hasCapability(NOT_VPN)</string>
     <string name="check_transport_info" translatable="false">getTransportInfo()</string>
     <string name="check_all_networks_vpn" translatable="false">getAllNetworks() VPN scan</string>
+    <string name="check_network_for_type_vpn" translatable="false">getNetworkForType(TYPE_VPN)</string>
+    <string name="check_active_network_handle" translatable="false">ActiveNetwork handle</string>
+    <string name="check_all_networks_handles" translatable="false">getAllNetworks() handles</string>
     <string name="check_active_network_vpn" translatable="false">ActiveNetwork transports</string>
     <string name="check_network_callback" translatable="false">NetworkCallback (push)</string>
     <string name="check_link_properties" translatable="false">LinkProperties ifname</string>


### PR DESCRIPTION
## What changed

LSPosed now hides VPN `Network` handles exposed by Java Connectivity APIs:

- replaces VPN `Network` parcels with the best physical network in `Network.writeToParcel`
- replaces `getActiveNetwork()` when it points at the VPN network and a non-VPN replacement is available
- keeps the original active `Network` instead of returning `null` when no replacement can be found, preserving app connectivity in rare fallback cases
- filters VPN handles out of `getAllNetworks()`
- suppresses `getNetworkForType(TYPE_VPN)` for target apps
- captures `ConnectivityService` earlier so parcel hooks can resolve replacement networks more reliably
- adds Diagnostics checks for these handle-based leak paths
- adds `docs/ROADMAP.md` to track larger follow-ups, including VPN-preserving concealment mode

## Why

The existing Java hooks sanitized `NetworkCapabilities`, `NetworkInfo`, `LinkProperties`, direct getter results, and callback payloads, but apps could still detect the VPN by comparing or enumerating raw `Network` handles. For example, `activeNetwork` could still equal the `TYPE_VPN` network even when its capabilities were sanitized.

## Routing caveat

Replacing VPN `Network` handles with physical `Network` handles matches the recommended split-tunnel setup, where target apps stay outside the VPN and should see/use the carrier or Wi-Fi network.

This is not a VPN-preserving concealment mode. If a target app is intentionally kept inside a VPN, but explicitly binds traffic to the returned `Network` (`bindProcessToNetwork`, `network.bindSocket`, `network.openConnection`), this PR may route that explicitly bound traffic outside the VPN on setups that allow bypass. The follow-up use case is tracked by issue 130 and in `docs/ROADMAP.md`: hiding VPN state while preserving VPN routing for target apps.

## Validation

- `ktlint "lsposed/app/src/**/*.kt"`
- `cd lsposed && ./gradlew :app:compileDebugKotlin :app:detekt :app:assembleDebug`
- `cd lsposed && ./gradlew cpdCheck`
- `git diff --check`
- `./scripts/preview-changelog.py`
- Android 13 device verification with VPN enabled: Diagnostics reported `PASS=30 FAIL=0`, including the new handle checks.
- Pixel 8 Pro / Android 17 (`SDK 37`) verification with VPN enabled after the active-network fallback change: hook status showed `aosp_sdk=37` with no `broken_fields`; raw `dumpsys connectivity` showed VPN `network{102}` on `tun0`; Diagnostics reported `PASS=30 FAIL=0`; system_server logs confirmed `replaced active VPN Network handle`, `filtered 1 VPN Network handle(s)`, `suppressed getNetworkForType(TYPE_VPN)`, and `replaced VPN Network parcel` for target uid `10332`.
