### PR TITLE
fix(lsposed): emit hook logs to logcat

### DIFF
--- a/changelog.d/fixed-emit-lsposed-hook-debug-logs-to-6f9a.md
+++ b/changelog.d/fixed-emit-lsposed-hook-debug-logs-to-6f9a.md
@@ -1,0 +1,9 @@
+_2026-06-24_
+
+## English
+
+Emit LSPosed hook debug logs to logcat and include them in debug exports.
+
+## Русский
+
+Выводить отладочные логи LSPosed-хуков в logcat и включать их в отладочный экспорт.

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DiagnosticsScreen.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DiagnosticsScreen.kt
@@ -1015,7 +1015,7 @@ private suspend fun exportDebugZip(
                     "targets.txt" to buildTargetsText(),
                     "interfaces.txt" to buildInterfacesText(),
                     "proc_net.txt" to buildProcNetText(),
-                    "logcat.txt" to captureAppLogcat().ifEmpty { "(no logcat entries)" },
+                    "logcat.txt" to captureDebugLogcat().ifEmpty { "(no logcat entries)" },
                 )
 
             // Create zip
@@ -1205,27 +1205,17 @@ private fun buildProcNetText(): String =
         }
     }
 
-// App-level logs only — the app can read its own logcat without root.
-private fun captureAppLogcat(): String =
-    try {
-        val proc =
-            Runtime.getRuntime().exec(
-                arrayOf(
-                    "logcat",
-                    "-d",
-                    "-s",
-                    "VPNHideTest:*",
-                    "VpnHide:*",
-                    "VpnHide-Dashboard:*",
-                    // zygisk's android_logger uses this tag (see zygisk/src/lib.rs:LOG_TAG);
-                    // without it the export is missing all native-side hook logs.
-                    "vpnhide-zygisk:*",
-                ),
-            )
-        val output = proc.inputStream.bufferedReader().readText()
-        proc.waitFor()
-        proc.destroy()
-        output
-    } catch (e: Exception) {
-        "(logcat failed: ${e.message})"
-    }
+private fun captureDebugLogcat(): String {
+    val tags =
+        listOf(
+            "VPNHideTest:*",
+            "VpnHide:*",
+            "VpnHide-Dashboard:*",
+            "VpnHide-LSPosed:*",
+            // zygisk's android_logger uses this tag (see zygisk/src/lib.rs:LOG_TAG);
+            // without it the export is missing all native-side hook logs.
+            "vpnhide-zygisk:*",
+        ).joinToString(" ")
+    val (exit, output) = suExec("logcat -d -b all -v threadtime -s $tags 2>/dev/null")
+    return if (exit == 0) output else "(logcat failed: exit=$exit)\n$output"
+}

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/HookLog.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/HookLog.kt
@@ -1,24 +1,30 @@
 package dev.okhsunrog.vpnhide
 
 import android.os.FileObserver
+import android.util.Log
 import de.robv.android.xposed.XposedBridge
 import java.io.File
 
 /**
- * [XposedBridge.log] wrapper gated by a filesystem flag set from the app.
- * Used by LSPosed hooks running inside `system_server`, where we don't
- * have access to the app's SharedPreferences.
+ * Log wrapper gated by a filesystem flag set from the app. Used by LSPosed
+ * hooks running inside `system_server`, where we don't have access to the
+ * app's SharedPreferences.
  *
  * Source of truth is [SS_DEBUG_LOGGING_FILE] — the app rewrites it when
  * the user toggles the setting. We read it on [install] and via an
  * inotify watcher so a flip takes effect without restarting system_server.
  *
- * Only per-request / hot-path logs should go through [i]. Hook install
- * failures and other one-time errors use [e], which always prints —
- * losing those would make diagnosing "hooks didn't attach" reports
- * impossible.
+ * The logcat sink makes Diagnostics → Debug logging visible through ordinary
+ * bug-report captures. The Xposed sink is kept for framework UIs / files that
+ * expose `XposedBridge.log` separately.
+ *
+ * Only per-request / hot-path logs should go through [i]. Hook install failures
+ * and other one-time errors use [e], which always prints — losing those would
+ * make diagnosing "hooks didn't attach" reports impossible.
  */
 internal object HookLog {
+    private const val LOGCAT_TAG = "VpnHide-LSPosed"
+
     @Volatile private var enabled: Boolean = false
 
     @Volatile private var watcher: FileObserver? = null
@@ -45,11 +51,14 @@ internal object HookLog {
     }
 
     fun i(msg: String) {
-        if (enabled) XposedBridge.log(msg)
+        if (!enabled) return
+        Log.i(LOGCAT_TAG, msg)
+        XposedBridge.log(msg)
     }
 
     /** Always prints — used for install failures and other diagnostics we can't afford to lose. */
     fun e(msg: String) {
+        Log.e(LOGCAT_TAG, msg)
         XposedBridge.log(msg)
     }
 }


### PR DESCRIPTION
## Summary

Make Diagnostics → Debug logging emit LSPosed hook logs to ordinary logcat, while still preserving the existing `XposedBridge.log` sink for framework logs.

## Root Cause

`HookLog` was gated by `/data/system/vpnhide_debug_logging`, but it only wrote through `XposedBridge.log`. On Vector/LSPosed that output may be stored outside normal `adb logcat`, so Debug logging could be enabled while hook lines such as `VpnHide/PV` were still missing from captured logcat.

## Changes

- Add a `VpnHide-LSPosed` logcat sink to `HookLog.i/e`.
- Keep `XposedBridge.log` output for LSPosed/Vector framework views and files.
- Capture debug-export logcat via root from all buffers and include the new `VpnHide-LSPosed` tag.
- Add a changelog fragment for the diagnostics logging fix.

## Validation

- `ktlint "lsposed/app/src/**/*.kt"`
- `cd lsposed && ./gradlew :app:compileDebugKotlin :app:detekt cpdCheck :app:lintDebug :app:testDebugUnitTest`
