### PR TITLE
Fix LSPosed system_server UID cache refresh

### DIFF
--- a/changelog.d/fixed-lsposed-system-server-hooks-now-refresh-91bf.md
+++ b/changelog.d/fixed-lsposed-system-server-hooks-now-refresh-91bf.md
@@ -1,0 +1,9 @@
+_2026-06-24_
+
+## English
+
+LSPosed system_server hooks now refresh target UID files even when Android misses the inotify update.
+
+## Русский
+
+LSPosed-хуки в system_server теперь обновляют список целевых UID даже если Android пропустил inotify-событие.

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/HookEntry.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/HookEntry.kt
@@ -425,44 +425,11 @@ class HookEntry : IXposedHookLoadPackage {
     //  system_server hooks — per-UID Binder filtering
     // ==================================================================
 
-    @Volatile private var systemServerTargetUids: Set<Int>? = null
+    private val targetUidCache = SystemServerTargetUidCache()
 
     @Volatile private var targetUidsFileObserver: android.os.FileObserver? = null
-    private val uidLock = Any()
 
-    private fun loadTargetUids(): Set<Int> {
-        // Fast path: already cached (volatile read)
-        systemServerTargetUids?.let { return it }
-
-        // Slow path: only one thread reads the file
-        synchronized(uidLock) {
-            systemServerTargetUids?.let { return it }
-
-            val uids = mutableSetOf<Int>()
-
-            // Read pre-resolved numeric UIDs written by vpnhide-kmod's
-            // service.sh into /data/system/vpnhide_uids.txt.
-            // system_server can read /data/system/ (SELinux: system_data_file).
-            try {
-                val file = File("/data/system/vpnhide_uids.txt")
-                if (file.exists()) {
-                    file.readLines().forEach { line ->
-                        line.trim().toIntOrNull()?.let { uids.add(it) }
-                    }
-                }
-            } catch (t: Throwable) {
-                HookLog.e("VpnHide: failed to read UIDs: ${t.message}")
-            }
-
-            val result: Set<Int> = uids.toSet()
-            if (result.isNotEmpty()) {
-                HookLog.i("VpnHide: system_server loaded ${result.size} target UIDs: $result")
-            }
-            // Always cache (even if empty) to avoid re-reading until invalidated
-            systemServerTargetUids = result
-            return result
-        }
-    }
+    private fun loadTargetUids(): Set<Int> = targetUidCache.load()
 
     // Smoke-check at install time: every private AOSP field/ctor we touch
     // by reflection in the writeToParcel hooks. Returns the keys that
@@ -608,7 +575,7 @@ class HookEntry : IXposedHookLoadPackage {
             watchSystemDataDir { path ->
                 if (path == filename) {
                     HookLog.i("VpnHide: $filename changed, invalidating UID cache")
-                    systemServerTargetUids = null
+                    targetUidCache.invalidate()
                 }
             }
         HookLog.i("VpnHide: watching /data/system for $filename changes (inotify)")

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/SystemServerTargetUidCache.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/SystemServerTargetUidCache.kt
@@ -1,0 +1,96 @@
+package dev.okhsunrog.vpnhide
+
+import android.os.SystemClock
+import java.io.File
+
+/**
+ * Numeric target UIDs consumed by system_server hooks.
+ *
+ * FileObserver is only a fast invalidation path: on some devices /data/system
+ * writes are not reported to the hooked process reliably, so the cache also
+ * validates the backing file's cheap stat fingerprint on every read.
+ */
+internal class SystemServerTargetUidCache(
+    private val file: File = File(SS_UIDS_FILE),
+) {
+    private companion object {
+        const val STAT_CHECK_INTERVAL_MS = 1_000L
+    }
+
+    private data class Fingerprint(
+        val exists: Boolean,
+        val lastModified: Long,
+        val length: Long,
+    )
+
+    private data class Cache(
+        val fingerprint: Fingerprint,
+        val uids: Set<Int>,
+        val nextStatCheckUptimeMs: Long,
+    )
+
+    @Volatile private var cache: Cache? = null
+    private val lock = Any()
+
+    fun load(): Set<Int> {
+        val now = SystemClock.uptimeMillis()
+        cache?.let { cached ->
+            if (now < cached.nextStatCheckUptimeMs) return cached.uids
+        }
+
+        synchronized(lock) {
+            val lockedNow = SystemClock.uptimeMillis()
+            cache?.let { cached ->
+                if (lockedNow < cached.nextStatCheckUptimeMs) return cached.uids
+                val fingerprint = fingerprint()
+                if (cached.fingerprint == fingerprint) {
+                    val refreshed = cached.withNextCheck(lockedNow)
+                    cache = refreshed
+                    return refreshed.uids
+                }
+            }
+
+            val result = readUids()
+            val loadedFingerprint = fingerprint()
+            HookLog.i("VpnHide: system_server loaded ${result.size} target UIDs: $result")
+            cache = Cache(loadedFingerprint, result, nextStatCheck(lockedNow))
+            return result
+        }
+    }
+
+    fun invalidate() {
+        cache = null
+    }
+
+    private fun Cache.withNextCheck(now: Long): Cache = copy(nextStatCheckUptimeMs = nextStatCheck(now))
+
+    private fun nextStatCheck(now: Long): Long = now + STAT_CHECK_INTERVAL_MS
+
+    private fun readUids(): Set<Int> =
+        try {
+            if (!file.exists()) {
+                emptySet()
+            } else {
+                parseConfigLines(file.readText()).mapNotNull { it.toIntOrNull() }.toSet()
+            }
+        } catch (t: Throwable) {
+            HookLog.e("VpnHide: failed to read UIDs: ${t.message}")
+            emptySet()
+        }
+
+    private fun fingerprint(): Fingerprint =
+        try {
+            if (!file.exists()) {
+                Fingerprint(exists = false, lastModified = 0L, length = 0L)
+            } else {
+                Fingerprint(
+                    exists = true,
+                    lastModified = file.lastModified(),
+                    length = file.length(),
+                )
+            }
+        } catch (t: Throwable) {
+            HookLog.e("VpnHide: failed to stat UIDs file: ${t.message}")
+            Fingerprint(exists = false, lastModified = 0L, length = 0L)
+        }
+}


### PR DESCRIPTION
## Summary
- Move the LSPosed `system_server` target UID cache into `SystemServerTargetUidCache`.
- Keep `FileObserver` as the fast invalidation path, but add a periodic stat fingerprint fallback for `/data/system/vpnhide_uids.txt`.
- Add a changelog fragment for the user-visible fix.

## Root Cause
`system_server` hooks cached target UIDs after the first read and only refreshed when the `/data/system` `FileObserver` delivered an update. On some devices that event can be missed, leaving the hooks with a stale UID set and causing newly selected apps to be treated as `target=false` until a process restart or reboot.

## Validation
- `ktlint --format ...`
- `ktlint ...`
- `cd lsposed && ./gradlew :app:detekt cpdCheck`
- `cd lsposed && ./gradlew :app:assembleRelease`
- Pixel 4a / Android 13: verified the polling fallback after touching `/data/system/vpnhide_uids.txt` without relying on a file observer event.
- Pixel 8 Pro / Android 17: verified RKN Hardering is treated as `target=true`; LSPosed filtered VPN network handles and Java/indirect checks were clean.