### PR TITLE
test(kmod): QEMU runtime test harness + CI image baking

### DIFF
--- a/.github/docker/ddk-qemu/Dockerfile
+++ b/.github/docker/ddk-qemu/Dockerfile
@@ -1,0 +1,43 @@
+# Per-KMI image for the kmod QEMU test harness.
+#
+#   ghcr.io/ylarod/ddk-min:<kmi>   (toolchain + module-build headers)
+#   + qemu-system-aarch64          (boot the kernel; TCG, no KVM needed)
+#   + a prebuilt virtio GKI kernel that boots in `qemu -machine virt`
+#   + the Alpine minirootfs tarball (so the test needs no download at run time)
+#
+# Stock GKI boot images can't boot in plain QEMU (no virtio/console drivers),
+# so we build kernel/common@<kmi> with kmod/test/qemu.config merged onto
+# gki_defconfig, using the DDK container's matching clang. The module itself is
+# NOT baked — it's built per-PR by the kmod CI job and passed in via
+# VPNHIDE_QEMU_KO (a kdir-built module loads fine here: same source, same
+# vermagic). Built rarely by qemu-image.yml since kernels change seldom.
+ARG KMI
+FROM ghcr.io/ylarod/ddk-min:${KMI}-20260313
+ARG KMI
+
+ENV DEBIAN_FRONTEND=noninteractive
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        qemu-system-arm cpio gzip curl ca-certificates git \
+        bc bison flex libelf-dev libssl-dev && \
+    rm -rf /var/lib/apt/lists/*
+
+COPY kmod/test/qemu.config /tmp/qemu.config
+RUN CLANG_BIN="$(ls -d /opt/ddk/clang/*/bin | head -1)" && export PATH="$CLANG_BIN:$PATH" && \
+    git clone --depth=1 -b "${KMI}" \
+        https://android.googlesource.com/kernel/common /tmp/linux && \
+    cd /tmp/linux && \
+    make ARCH=arm64 LLVM=1 gki_defconfig && \
+    ./scripts/kconfig/merge_config.sh -m .config /tmp/qemu.config && \
+    make ARCH=arm64 LLVM=1 olddefconfig && \
+    make ARCH=arm64 LLVM=1 -j"$(nproc)" Image && \
+    mkdir -p /opt/qemu && \
+    cp arch/arm64/boot/Image /opt/qemu/Image && \
+    cd / && rm -rf /tmp/linux /tmp/qemu.config
+
+RUN curl -fsSL \
+        https://dl-cdn.alpinelinux.org/alpine/v3.21/releases/aarch64/alpine-minirootfs-3.21.2-aarch64.tar.gz \
+        -o /opt/qemu/alpine-minirootfs.tar.gz
+
+# run.sh reads these to use the baked kernel + rootfs instead of the local cache.
+ENV VPNHIDE_QEMU_IMAGE=/opt/qemu/Image
+ENV VPNHIDE_QEMU_ROOTFS=/opt/qemu/alpine-minirootfs.tar.gz

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -131,7 +131,8 @@ jobs:
             zygisk/module/customize.sh zygisk/module/service.sh \
             portshide/module/customize.sh portshide/module/service.sh \
             portshide/module/uninstall.sh portshide/module/vpnhide_ports_apply.sh \
-            scripts/clean-device.sh scripts/update-json.sh
+            scripts/clean-device.sh scripts/update-json.sh \
+            kmod/test/run.sh kmod/test/build-kernel.sh kmod/test/init.sh
 
       # C (kernel module)
       - name: clang-format

--- a/.github/workflows/qemu-image.yml
+++ b/.github/workflows/qemu-image.yml
@@ -1,0 +1,86 @@
+name: QEMU Test Images
+
+# Bakes the per-KMI kmod test images (ddk-min + qemu + a virtio GKI kernel)
+# used by the kmod QEMU runtime gate. Kernels change seldom, so this runs only
+# when the recipe changes, monthly, or on demand — not per PR.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - .github/docker/ddk-qemu/Dockerfile
+      - .github/workflows/qemu-image.yml
+      - kmod/test/qemu.config
+  schedule:
+    - cron: '0 4 1 * *'
+  workflow_dispatch:
+
+permissions:
+  packages: write
+  contents: read
+
+concurrency:
+  group: qemu-image-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-push:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        kmi:
+          - android12-5.10
+          - android13-5.10
+          - android13-5.15
+          - android14-5.15
+          - android14-6.1
+          - android15-6.6
+          - android16-6.12
+    steps:
+      - uses: actions/checkout@v7
+
+      # LTO is per-KMI (gki_defconfig): the android12/13-5.10 + 5.15 kernels are
+      # full-LTO and disk/RAM-hungry to build; 6.1+ are LTO_NONE and light. Size
+      # for the heaviest: reclaim ~30 GB of preinstalled toolchains and add swap
+      # so the full-LTO link doesn't get OOM-killed. No fallback — if a full-LTO
+      # kernel still won't build, the bake fails loudly.
+      - name: Free up disk space
+        uses: jlumbroso/free-disk-space@main
+        with:
+          tool-cache: true
+          large-packages: false
+
+      - name: Add swap for the full-LTO link
+        run: |
+          sudo fallocate -l 16G /mnt/swapfile
+          sudo chmod 600 /mnt/swapfile
+          sudo mkswap /mnt/swapfile
+          sudo swapon /mnt/swapfile
+          free -h && df -h /
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - id: img
+        env:
+          REPO: ${{ github.repository }}
+        run: echo "image=ghcr.io/${REPO,,}/ddk-qemu:${{ matrix.kmi }}" >> "$GITHUB_OUTPUT"
+
+      - name: Build and push
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: .github/docker/ddk-qemu/Dockerfile
+          build-args: KMI=${{ matrix.kmi }}
+          push: true
+          tags: ${{ steps.img.outputs.image }}
+          cache-from: type=gha,scope=ddk-qemu-${{ matrix.kmi }}
+          cache-to: type=gha,mode=max,scope=ddk-qemu-${{ matrix.kmi }}

--- a/kmod/test/.gitignore
+++ b/kmod/test/.gitignore
@@ -1,0 +1,3 @@
+# Built kernels, modules, and downloaded rootfs — large, reproducible via
+# build-kernel.sh / run.sh.
+.cache/

--- a/kmod/test/README.md
+++ b/kmod/test/README.md
@@ -1,0 +1,68 @@
+# kmod QEMU test harness
+
+Boots a real GKI kernel under `qemu-system-aarch64` and runs the vpnhide
+kernel module against fabricated VPN state, asserting that every detection
+vector is hidden from a *target* UID but still visible to a *non-target* UID.
+
+This exists because compilation and source-level signature checks are **not
+sufficient** for this module: it reads syscall/netlink arguments straight out
+of `pt_regs` by register index, so correctness depends on the *actual* argument
+→ register mapping in the built kernel — which a compiler can change (notably
+for `static`, directly-called functions). Only running the module on the real
+kernel proves the registers are right. (This is exactly how the `rt_fill_info`
+register bug was found.)
+
+## What it checks (and what it can't)
+
+Per kernel version, the harness validates:
+
+- the module **loads** (symbol resolution against that kernel),
+- all hooks **register**,
+- each detection vector is actually **filtered** for a target UID (A/B: a
+  non-target sees the fabricated `vpn0`, a target does not),
+- **no kernel panic** across the whole hook set.
+
+Vectors exercised (`init.sh`):
+
+| Vector | Trigger | Hook |
+|---|---|---|
+| getifaddrs | `ip addr show` | `rtnl_fill_ifinfo` + `inet*_fill_ifaddr` |
+| SIOCGIFCONF | `ifconfig -a` | `sock_ioctl` |
+| /proc/net/route | `cat /proc/net/route` | `fib_route_seq_show` |
+| /proc/net/ipv6_route | `cat /proc/net/ipv6_route` | `ipv6_route_seq_show` |
+| netlink route dump v4 | `ip route show table all` | `fib_dump_info` |
+| netlink route dump v6 | `ip -6 route show table all` | `rt6_fill_node` |
+| policy rules | `ip rule show` | `fib_nl_fill_rule` |
+
+**Limits:** GitHub/QEMU runners have no KVM, so the VM runs under TCG (software
+emulation) — correct, just slow. The test kernel is *our* `kernel/common` build
+with `qemu.config` merged, not a byte-identical vendor GKI release, so it does
+not cover vendor patches. A device smoke-test is still the final word — but the
+gate is far tighter than "it compiled". With LTO left on (the gki_defconfig
+default), inlining and static-function calling conventions match real devices.
+
+## Usage
+
+```sh
+# 1. Build a bootable kernel + module for a KMI (slow; clones kernel/common,
+#    builds Image with the DDK container's clang, caches under .cache/<kmi>/).
+kmod/test/build-kernel.sh android12-5.10
+
+# 2. Boot it in QEMU and run the vector tests.
+kmod/test/run.sh android12-5.10
+```
+
+`run.sh` exits 0 only if every vector passes and there was no panic. Artifacts
+(kernels, modules, the Alpine rootfs) are cached under `.cache/` (gitignored).
+
+Requirements: `docker` (for build-kernel.sh), `qemu-system-aarch64`, `cpio`,
+`curl`.
+
+## CI
+
+Building a virtio GKI kernel takes ~30 min, so it must not run per-PR. The plan
+(next change) is to **bake** the per-KMI bootable kernel + a ready rootfs into
+per-KMI images (`FROM ghcr.io/ylarod/ddk-min:<kmi>` + qemu + Image + rootfs),
+rebuilt rarely like `ci-image.yml`. The kmod CI matrix then, per KMI, builds the
+module and boots QEMU with the baked kernel — turning the build-only matrix into
+a real per-version runtime gate.

--- a/kmod/test/README.md
+++ b/kmod/test/README.md
@@ -38,8 +38,17 @@ Vectors exercised (`init.sh`):
 emulation) — correct, just slow. The test kernel is *our* `kernel/common` build
 with `qemu.config` merged, not a byte-identical vendor GKI release, so it does
 not cover vendor patches. A device smoke-test is still the final word — but the
-gate is far tighter than "it compiled". With LTO left on (the gki_defconfig
-default), inlining and static-function calling conventions match real devices.
+gate is far tighter than "it compiled".
+
+LTO is left to each KMI's `gki_defconfig` (not pinned in `qemu.config`), which
+is the device-faithful setting and varies by generation: android12/13-5.10 +
+5.15 ship **full LTO + CFI** (5.10's CFI requires LTO), while android14-6.1+
+ship **LTO_NONE + CFI via KCFI** (confirmed against the shipped Pixel 8 Pro
+factory image). Forcing one mode breaks both fidelity and the build — e.g.
+forcing `LTO_NONE` on 5.10 also drops CFI (unmet dependency), yielding a kernel
+no device runs and on which a GKI-built module won't register its kretprobes.
+The full-LTO generations are heavier to build; `qemu-image.yml` frees disk and
+adds swap to fit them.
 
 ## Usage
 
@@ -60,9 +69,53 @@ Requirements: `docker` (for build-kernel.sh), `qemu-system-aarch64`, `cpio`,
 
 ## CI
 
-Building a virtio GKI kernel takes ~30 min, so it must not run per-PR. The plan
-(next change) is to **bake** the per-KMI bootable kernel + a ready rootfs into
-per-KMI images (`FROM ghcr.io/ylarod/ddk-min:<kmi>` + qemu + Image + rootfs),
-rebuilt rarely like `ci-image.yml`. The kmod CI matrix then, per KMI, builds the
-module and boots QEMU with the baked kernel — turning the build-only matrix into
-a real per-version runtime gate.
+Building a virtio GKI kernel takes ~30 min, so it must not run per-PR. Instead
+the bootable kernel + Alpine rootfs are **baked** into per-KMI images
+(`.github/docker/ddk-qemu/Dockerfile` = `FROM ddk-min:<kmi>` + qemu + Image +
+rootfs), built rarely by `.github/workflows/qemu-image.yml` (matrix over the 7
+KMIs; triggers on `qemu.config`/Dockerfile changes, monthly, or manually).
+
+The module is **not** baked — a `kdir`-built module (what the `kmod` job already
+produces for devices) loads on the baked virtio kernel (same source → same
+vermagic), so CI reuses that artifact and passes it in via `VPNHIDE_QEMU_KO`.
+`run.sh` reads `VPNHIDE_QEMU_IMAGE` / `VPNHIDE_QEMU_ROOTFS` / `VPNHIDE_QEMU_KO`
+to use the baked artifacts instead of the local cache.
+
+GitHub runners have no KVM, so QEMU runs under TCG — slow but fine (~1-3 min per
+job, matrix runs in parallel). `init.sh` apk-adds iproute2 over QEMU user-mode
+networking (the runner has internet); prebaking iproute2 into the rootfs is a
+possible later optimization if the Alpine CDN proves flaky.
+
+### Rollout (two steps — images must exist before the gate)
+
+1. Merge this (Dockerfile + workflow + harness), then run **qemu-image.yml**
+   once (it triggers on the Dockerfile/`qemu.config` paths, or dispatch it
+   manually) so `ghcr.io/<owner>/vpnhide/ddk-qemu:<kmi>` exist for all 7 KMIs.
+2. Add the gate job to `ci.yml` (so PRs don't reference images that don't exist
+   yet):
+
+   ```yaml
+   kmod-qemu:
+     needs: kmod
+     runs-on: ubuntu-latest
+     strategy:
+       fail-fast: false
+       matrix:
+         kmi: [android12-5.10, android13-5.10, android13-5.15,
+               android14-5.15, android14-6.1, android15-6.6, android16-6.12]
+     container:
+       image: ghcr.io/${{ github.repository }}/ddk-qemu:${{ matrix.kmi }}
+     steps:
+       - uses: actions/checkout@v7
+       - uses: actions/download-artifact@v7
+         with:
+           name: vpnhide-kmod-${{ matrix.kmi }}
+       - name: Extract module
+         run: unzip -p vpnhide-kmod-${{ matrix.kmi }}.zip vpnhide_kmod.ko > /tmp/vpnhide_kmod.ko
+       - name: QEMU runtime test
+         env:
+           VPNHIDE_QEMU_KO: /tmp/vpnhide_kmod.ko
+         run: kmod/test/run.sh ${{ matrix.kmi }}
+   ```
+
+   (`VPNHIDE_QEMU_IMAGE`/`VPNHIDE_QEMU_ROOTFS` come from the image's `ENV`.)

--- a/kmod/test/build-kernel.sh
+++ b/kmod/test/build-kernel.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# Build a QEMU-bootable GKI kernel + the vpnhide module for <kmi> into the
+# per-KMI cache, so run.sh can boot them. This is the expensive, canonical
+# producer: it clones kernel/common at the matching branch, merges qemu.config
+# on top of gki_defconfig, builds Image with the DDK container's matching
+# clang, then builds the module against that exact tree (so it loads cleanly).
+#
+# Stock GKI boot images can't boot in `qemu -machine virt` (no virtio/console
+# drivers); this is how the bootable test kernel is produced. Output is cached
+# and reused — only re-run when the kernel branch or qemu.config changes.
+#
+# Usage:  kmod/test/build-kernel.sh <kmi>          e.g. android14-6.1
+# Output: kmod/test/.cache/<kmi>/{Image,vpnhide_kmod.ko}
+set -euo pipefail
+
+KMI="${1:?usage: build-kernel.sh <kmi>  (e.g. android14-6.1)}"
+HERE="$(cd "$(dirname "$0")" && pwd)"
+REPO="$(cd "$HERE/../.." && pwd)"
+CACHE="$HERE/.cache/$KMI"
+FRAG="$HERE/qemu.config"
+
+# Mirror DDK_IMAGE_TAG in kmod/build.py so the kernel + module use the same
+# toolchain as the module CI build.
+DDK_IMAGE_TAG="20260313"
+DDK="ghcr.io/ylarod/ddk-min:${KMI}-${DDK_IMAGE_TAG}"
+
+mkdir -p "$CACHE"
+echo "[build-kernel] $KMI: cloning kernel/common + building Image (this is slow)…"
+
+docker run --rm \
+	-v "$REPO:/repo:ro" -v "$CACHE:/out" -v "$FRAG:/qemu.config:ro" \
+	-e KMI="$KMI" "$DDK" bash -euo pipefail -c '
+	CLANG_BIN="$(ls -d /opt/ddk/clang/*/bin | head -1)"
+	export PATH="$CLANG_BIN:$PATH"
+
+	# kernel/common branch name == the KMI label
+	git clone --depth=1 -b "$KMI" \
+		https://android.googlesource.com/kernel/common /tmp/linux
+	cd /tmp/linux
+	make ARCH=arm64 LLVM=1 gki_defconfig
+	./scripts/kconfig/merge_config.sh -m .config /qemu.config
+	make ARCH=arm64 LLVM=1 olddefconfig
+	make ARCH=arm64 LLVM=1 -j"$(nproc)" Image
+	cp arch/arm64/boot/Image /out/Image
+
+	# build the module against THIS tree (matching vermagic/config), not the
+	# GKI kdir — otherwise it would not load on this kernel.
+	cp -r /repo/kmod /tmp/kmod-build
+	make -C /tmp/kmod-build KERNEL_SRC=/tmp/linux CLANG_DIR="$CLANG_BIN" clean || true
+	make -C /tmp/kmod-build KERNEL_SRC=/tmp/linux CLANG_DIR="$CLANG_BIN"
+	cp /tmp/kmod-build/vpnhide_kmod.ko /out/vpnhide_kmod.ko
+'
+
+echo "[build-kernel] $KMI: done"
+echo "  Image:  $CACHE/Image"
+echo "  module: $CACHE/vpnhide_kmod.ko"

--- a/kmod/test/init.sh
+++ b/kmod/test/init.sh
@@ -1,0 +1,81 @@
+#!/bin/sh
+# In-VM test driver (PID 1 / rdinit) for the vpnhide kmod QEMU harness.
+#
+# Boots inside a minimal Alpine initramfs, loads /vpnhide_kmod.ko, fabricates
+# a VPN-like interface (`vpn0`, a dummy netdev whose name matches the VPN
+# prefix list), then exercises every detection vector twice — once as a
+# non-target UID (must still see vpn0) and once as a target UID (must NOT
+# see vpn0). Emits machine-parseable `RESULT <vector>=PASS|FAIL` lines plus a
+# final `SUMMARY` line, then powers off so QEMU exits.
+#
+# Output is consumed by run.sh on the host via the serial console.
+set +e
+export PATH=/usr/sbin:/usr/bin:/sbin:/bin
+
+mount -t proc proc /proc 2>/dev/null
+mount -t sysfs sys /sys 2>/dev/null
+mount -t devtmpfs dev /dev 2>/dev/null
+
+echo "##### VPNHIDE-QEMU-TEST START #####"
+echo "KREL=$(uname -r)"
+
+# --- bring up user-mode networking so apk can fetch iproute2 ----------------
+ip link set eth0 up 2>/dev/null
+ip addr add 10.0.2.15/24 dev eth0 2>/dev/null
+ip route add default via 10.0.2.2 2>/dev/null
+echo "nameserver 10.0.2.3" > /etc/resolv.conf
+echo "https://dl-cdn.alpinelinux.org/alpine/v3.21/main" > /etc/apk/repositories
+if apk add --no-cache iproute2 >/dev/null 2>&1; then echo "IPROUTE2=ok"; else echo "IPROUTE2=FAIL"; fi
+
+# --- load the module --------------------------------------------------------
+if insmod /vpnhide_kmod.ko; then echo "INSMOD=ok"; else echo "INSMOD=FAIL"; fi
+REGISTERED=$(dmesg | grep -c 'vpnhide:.*registered')
+echo "REGISTERED=$REGISTERED"
+echo 1 > /proc/vpnhide_debug 2>/dev/null
+
+# --- fabricate a VPN-like interface + routes + a per-uid policy rule ---------
+ip link add vpn0 type dummy 2>/dev/null
+ip link set vpn0 up 2>/dev/null
+ip addr add 10.9.0.1/24 dev vpn0 2>/dev/null
+ip route add 10.9.9.0/24 dev vpn0 2>/dev/null
+ip -6 addr add fd00:9::1/64 dev vpn0 2>/dev/null
+ip -6 route add fd00:99::/64 dev vpn0 2>/dev/null
+ip rule add uidrange 0-0 table 199 2>/dev/null
+
+PASS=0
+FAIL=0
+
+# check <name> <shell-command> <grep-pattern>
+# Asserts: non-target (uid 5555) sees the pattern, target (uid 0) does not.
+check() {
+	_name=$1
+	_cmd=$2
+	_pat=$3
+	echo 5555 > /proc/vpnhide_targets 2>/dev/null
+	_nt=$(eval "$_cmd" 2>/dev/null | grep -c -- "$_pat")
+	echo 0 > /proc/vpnhide_targets 2>/dev/null
+	_tg=$(eval "$_cmd" 2>/dev/null | grep -c -- "$_pat")
+	if [ "$_nt" -gt 0 ] && [ "$_tg" -eq 0 ]; then
+		echo "RESULT $_name=PASS (nontarget=$_nt target=$_tg)"
+		PASS=$((PASS + 1))
+	else
+		echo "RESULT $_name=FAIL (nontarget=$_nt target=$_tg)"
+		FAIL=$((FAIL + 1))
+	fi
+}
+
+# vector -> hook it exercises
+check getifaddrs      "ip addr show"                 "vpn0"   # rtnl_fill_ifinfo + inet*_fill_ifaddr
+check siocgifconf     "ifconfig -a"                  "vpn0"   # sock_ioctl
+check proc_route_v4   "cat /proc/net/route"          "vpn0"   # fib_route_seq_show
+check proc_route_v6   "cat /proc/net/ipv6_route"     "vpn0"   # ipv6_route_seq_show
+check netlink_route4  "ip route show table all"      "vpn0"   # fib_dump_info
+check netlink_route6  "ip -6 route show table all"   "vpn0"   # rt6_fill_node
+check policy_rule     "ip rule show"                 "199"    # fib_nl_fill_rule
+
+PANIC=$(dmesg | grep -ci 'Unable to handle\|Internal error\|Oops\|BUG:\|Kernel panic')
+echo "PANIC=$PANIC"
+echo "SUMMARY pass=$PASS fail=$FAIL panic=$PANIC registered=$REGISTERED"
+echo "##### VPNHIDE-QEMU-TEST END #####"
+
+poweroff -f

--- a/kmod/test/qemu.config
+++ b/kmod/test/qemu.config
@@ -1,0 +1,36 @@
+# Kconfig fragment that makes a stock GKI kernel boot in `qemu-system-aarch64
+# -machine virt` and run our initramfs test. Merged on top of gki_defconfig by
+# build-kernel.sh. Stock GKI images don't carry virtio/virt-console drivers, so
+# they can't boot in plain QEMU — this adds exactly what's needed and nothing
+# that changes the ABI we're testing (arg/register layout, struct layout).
+#
+# LTO is intentionally left at the gki_defconfig default (full LTO): it keeps
+# the build faithful to real devices for inlining and static-function calling
+# conventions. Flip to CONFIG_LTO_NONE locally only if you want faster builds
+# and readable symbols and accept lower fidelity.
+
+# virtio transport + block/net so QEMU virt can provide disk and network
+CONFIG_VIRTIO=y
+CONFIG_VIRTIO_MENU=y
+CONFIG_VIRTIO_PCI=y
+CONFIG_VIRTIO_PCI_LEGACY=y
+CONFIG_VIRTIO_BLK=y
+CONFIG_VIRTIO_NET=y
+CONFIG_VIRTIO_MMIO=y
+
+# PL011 serial = the QEMU virt console (ttyAMA0)
+CONFIG_SERIAL_AMBA_PL011=y
+CONFIG_SERIAL_AMBA_PL011_CONSOLE=y
+
+# initramfs as rootfs + devtmpfs so /dev exists without an installer
+CONFIG_BLK_DEV_INITRD=y
+CONFIG_DEVTMPFS=y
+CONFIG_DEVTMPFS_MOUNT=y
+CONFIG_TMPFS=y
+
+# dummy netdev: the test fabricates `vpn0` (a dummy) as the fake VPN interface
+CONFIG_DUMMY=y
+
+# allow loading our out-of-tree module without signing / ksym trimming
+# CONFIG_MODULE_SIG is not set
+# CONFIG_TRIM_UNUSED_KSYMS is not set

--- a/kmod/test/qemu.config
+++ b/kmod/test/qemu.config
@@ -4,10 +4,17 @@
 # they can't boot in plain QEMU — this adds exactly what's needed and nothing
 # that changes the ABI we're testing (arg/register layout, struct layout).
 #
-# LTO is intentionally left at the gki_defconfig default (full LTO): it keeps
-# the build faithful to real devices for inlining and static-function calling
-# conventions. Flip to CONFIG_LTO_NONE locally only if you want faster builds
-# and readable symbols and accept lower fidelity.
+# LTO is deliberately NOT pinned here — it's left to each KMI's gki_defconfig,
+# which is the device-faithful setting per generation and varies on purpose:
+#   - android12-5.10: CONFIG_LTO_CLANG_FULL=y + CFI (5.10's CFI requires LTO)
+#   - android14-6.1+: CONFIG_LTO_NONE=y       + CFI via KCFI (no LTO needed)
+# (the 6.1 value is confirmed against the shipped Pixel 8 Pro factory image).
+# Forcing a single mode breaks fidelity AND the build: forcing LTO_NONE on 5.10
+# also drops CFI (an unmet dependency), producing a kernel no real device runs,
+# on which a GKI-built (CFI/LTO) module won't register its kretprobes. So we
+# inherit the defconfig default and let the full-LTO generations be heavy — the
+# CI bake (qemu-image.yml) frees disk + adds swap to fit them; if a full-LTO
+# kernel still won't build, the bake fails loudly.
 
 # virtio transport + block/net so QEMU virt can provide disk and network
 CONFIG_VIRTIO=y
@@ -34,3 +41,6 @@ CONFIG_DUMMY=y
 # allow loading our out-of-tree module without signing / ksym trimming
 # CONFIG_MODULE_SIG is not set
 # CONFIG_TRIM_UNUSED_KSYMS is not set
+
+# (LTO intentionally not set here — inherited from gki_defconfig per KMI; see
+# header note)

--- a/kmod/test/run.sh
+++ b/kmod/test/run.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# Boot a GKI kernel for <kmi> in QEMU (TCG) and run the vpnhide kmod vector
+# tests inside it. Consumes a prebuilt kernel Image + module .ko from the
+# per-KMI cache (produced by build-kernel.sh); assembles a throwaway Alpine
+# initramfs around init.sh, boots, and parses the serial console for the
+# RESULT/SUMMARY lines.
+#
+# Usage:  kmod/test/run.sh [kmi]      (default: android12-5.10)
+# Exit:   0 = all vectors PASS, no panic; non-zero otherwise.
+set -euo pipefail
+
+KMI="${1:-android12-5.10}"
+HERE="$(cd "$(dirname "$0")" && pwd)"
+CACHE="$HERE/.cache"
+KDIR="$CACHE/$KMI"
+IMAGE="$KDIR/Image"
+KO="$KDIR/vpnhide_kmod.ko"
+
+ALPINE_VER="3.21.2"
+ALPINE_TAR="$CACHE/alpine-minirootfs-$ALPINE_VER-aarch64.tar.gz"
+ALPINE_URL="https://dl-cdn.alpinelinux.org/alpine/v3.21/releases/aarch64/alpine-minirootfs-$ALPINE_VER-aarch64.tar.gz"
+
+command -v qemu-system-aarch64 >/dev/null || { echo "ERROR: qemu-system-aarch64 not installed"; exit 2; }
+[ -f "$IMAGE" ] || { echo "ERROR: kernel missing: $IMAGE"; echo "  run: $HERE/build-kernel.sh $KMI"; exit 2; }
+[ -f "$KO" ]    || { echo "ERROR: module missing: $KO";   echo "  run: $HERE/build-kernel.sh $KMI"; exit 2; }
+
+mkdir -p "$CACHE"
+[ -f "$ALPINE_TAR" ] || { echo "[run] fetching Alpine minirootfs…"; curl -fsSL "$ALPINE_URL" -o "$ALPINE_TAR"; }
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+RFS="$WORK/rootfs"
+mkdir -p "$RFS"
+tar xzf "$ALPINE_TAR" -C "$RFS"
+cp "$KO" "$RFS/vpnhide_kmod.ko"
+cp "$HERE/init.sh" "$RFS/init"
+chmod +x "$RFS/init"
+( cd "$RFS" && find . | cpio -o -H newc 2>/dev/null | gzip > "$WORK/initramfs.cpio.gz" )
+
+LOG="$WORK/serial.log"
+echo "[run] $KMI: booting $(basename "$IMAGE") in QEMU (TCG, no KVM)…"
+timeout 300 qemu-system-aarch64 \
+	-machine virt -cpu max -accel tcg,thread=multi,tb-size=1024 \
+	-smp 4 -m 2G \
+	-kernel "$IMAGE" -initrd "$WORK/initramfs.cpio.gz" \
+	-append "console=ttyAMA0 panic=-1 rdinit=/init" \
+	-netdev user,id=n0 -device virtio-net-pci,netdev=n0 \
+	-display none -no-reboot -serial "file:$LOG" >/dev/null 2>&1 || true
+
+echo "------------------------- test output -------------------------"
+if ! sed -n '/VPNHIDE-QEMU-TEST START/,/VPNHIDE-QEMU-TEST END/p' "$LOG" |
+	grep -E 'KREL|IPROUTE2|INSMOD|REGISTERED|RESULT|PANIC|SUMMARY'; then
+	echo "ERROR: no test output — kernel did not boot or init failed"
+	echo "--- last 30 serial lines ---"; tail -30 "$LOG"
+	exit 1
+fi
+echo "---------------------------------------------------------------"
+
+summary="$(grep -oE 'SUMMARY pass=[0-9]+ fail=[0-9]+ panic=[0-9]+ registered=[0-9]+' "$LOG" | tail -1 || true)"
+[ -n "$summary" ] || { echo "ERROR: VM did not reach SUMMARY (boot/insmod failure)"; exit 1; }
+fail="$(sed -E 's/.*fail=([0-9]+).*/\1/' <<<"$summary")"
+panic="$(sed -E 's/.*panic=([0-9]+).*/\1/' <<<"$summary")"
+
+if [ "$fail" -eq 0 ] && [ "$panic" -eq 0 ]; then
+	echo "[run] $KMI: PASS ($summary)"
+	exit 0
+fi
+echo "[run] $KMI: FAIL ($summary)"
+exit 1

--- a/kmod/test/run.sh
+++ b/kmod/test/run.sh
@@ -13,11 +13,18 @@ KMI="${1:-android12-5.10}"
 HERE="$(cd "$(dirname "$0")" && pwd)"
 CACHE="$HERE/.cache"
 KDIR="$CACHE/$KMI"
-IMAGE="$KDIR/Image"
-KO="$KDIR/vpnhide_kmod.ko"
+
+# Inputs default to the local cache (populated by build-kernel.sh), but each
+# can be overridden by env so CI can point at artifacts baked into the
+# ddk-qemu image / downloaded from the kmod build job:
+#   VPNHIDE_QEMU_IMAGE  - kernel Image (baked in the image)
+#   VPNHIDE_QEMU_KO     - module .ko   (from the kmod build artifact)
+#   VPNHIDE_QEMU_ROOTFS - Alpine minirootfs tarball (baked in the image)
+IMAGE="${VPNHIDE_QEMU_IMAGE:-$KDIR/Image}"
+KO="${VPNHIDE_QEMU_KO:-$KDIR/vpnhide_kmod.ko}"
 
 ALPINE_VER="3.21.2"
-ALPINE_TAR="$CACHE/alpine-minirootfs-$ALPINE_VER-aarch64.tar.gz"
+ALPINE_TAR="${VPNHIDE_QEMU_ROOTFS:-$CACHE/alpine-minirootfs-$ALPINE_VER-aarch64.tar.gz}"
 ALPINE_URL="https://dl-cdn.alpinelinux.org/alpine/v3.21/releases/aarch64/alpine-minirootfs-$ALPINE_VER-aarch64.tar.gz"
 
 command -v qemu-system-aarch64 >/dev/null || { echo "ERROR: qemu-system-aarch64 not installed"; exit 2; }
@@ -39,12 +46,15 @@ chmod +x "$RFS/init"
 
 LOG="$WORK/serial.log"
 echo "[run] $KMI: booting $(basename "$IMAGE") in QEMU (TCG, no KVM)…"
+# romfile= disables the virtio-net PCI option ROM (iPXE) so we don't need the
+# ipxe-qemu package — only matters for PXE boot, which we never do; networking
+# (for apk in the VM) still works.
 timeout 300 qemu-system-aarch64 \
 	-machine virt -cpu max -accel tcg,thread=multi,tb-size=1024 \
 	-smp 4 -m 2G \
 	-kernel "$IMAGE" -initrd "$WORK/initramfs.cpio.gz" \
 	-append "console=ttyAMA0 panic=-1 rdinit=/init" \
-	-netdev user,id=n0 -device virtio-net-pci,netdev=n0 \
+	-netdev user,id=n0 -device virtio-net-pci,netdev=n0,romfile= \
 	-display none -no-reboot -serial "file:$LOG" >/dev/null 2>&1 || true
 
 echo "------------------------- test output -------------------------"


### PR DESCRIPTION
Adds a QEMU-based runtime test harness for the kernel module. Compilation and source-signature checks can't verify the module's `pt_regs` register reads against the *actual* built kernel — a compiler can change the argument→register mapping (notably for `static`, directly-called functions), which is exactly how the `rt_fill_info` register bug was found. The harness boots a real GKI kernel under QEMU and asserts every detection vector is hidden from a target UID but still visible to a non-target UID, with no panic. It also adds the CI infrastructure to bake per-KMI bootable kernels into images so the build matrix can run this as a real per-version runtime gate.

- `kmod/test/`: `run.sh` (orchestrator), `init.sh` (in-VM A/B assertions over 7 vectors: getifaddrs, SIOCGIFCONF, /proc/net/route[6], netlink route dumps v4/v6, policy rules), `build-kernel.sh` (clones `kernel/common@<kmi>`, merges `qemu.config` onto `gki_defconfig`, builds a bootable Image), `qemu.config`, `README.md`.
- `.github/docker/ddk-qemu/Dockerfile`: per-KMI image = `ddk-min:<kmi>` + `qemu-system-aarch64` + a baked virtio GKI kernel + the Alpine rootfs. The module is **not** baked — a `kdir`-built module (what the `kmod` job already produces) loads on the virtio kernel (same source → same vermagic), so CI reuses that artifact.
- `.github/workflows/qemu-image.yml`: matrix build+push of `ddk-qemu:<kmi>` for all 7 KMIs; runs only on recipe changes, monthly, or on demand.
- `run.sh` honors `VPNHIDE_QEMU_IMAGE`/`ROOTFS`/`KO` so the same script runs from the local cache or the baked CI image.
- `ci.yml`: lint the new harness scripts via shellcheck.

The `kmod-qemu` gate job for `ci.yml` is documented (ready-to-paste in the README) and intentionally **not** added here — it lands after the images are built, so PRs don't reference images that don't exist yet (two-step rollout: merge → run `qemu-image.yml` → add the gate job).

Testing:
- Local: `kmod/test/run.sh android12-5.10` → 7/7 vectors PASS, 0 panics, 10 hooks registered.
- Full CI flow validated inside a freshly-built `ddk-qemu:android12-5.10` image: kernel built from the live `android12-5.10` tip (`5.10.257`), `kdir`-built module loaded, iproute2 over QEMU user-net, 7/7 PASS.