### PR TITLE
fix(lsposed): null getNetworkInfo(TYPE_VPN) for target apps

### DIFF
--- a/changelog.d/fixed-hide-vpn-from-apps-that-probe-0b4b.md
+++ b/changelog.d/fixed-hide-vpn-from-apps-that-probe-0b4b.md
@@ -1,0 +1,9 @@
+_2026-06-24_
+
+## English
+
+Hide VPN from apps that probe `getNetworkInfo(TYPE_VPN)` directly (e.g. Улыбка радуги) — the result is now null instead of a disguised connected network
+
+## Русский
+
+Скрытие VPN от приложений, которые проверяют `getNetworkInfo(TYPE_VPN)` напрямую (например, Улыбка радуги) — результат теперь null вместо подменённой подключённой сети

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/HookEntry.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/HookEntry.kt
@@ -897,6 +897,13 @@ class HookEntry : IXposedHookLoadPackage {
                     object : XC_MethodHook() {
                         override fun afterHookedMethod(param: MethodHookParam) {
                             rememberConnectivityService(param.thisObject)
+                            // getNetworkInfo(int networkType): an app that probes the
+                            // legacy VPN type directly (getNetworkInfo(TYPE_VPN)) must
+                            // get null — disguising the result as a *connected* WIFI
+                            // NetworkInfo still answers "a VPN-type network exists and
+                            // is connected", which isConnectedOrConnecting() reports as
+                            // true. See issue #85 (Улыбка радуги).
+                            if (method in LEGACY_TYPE_INFO_METHODS && suppressLegacyVpnTypeQuery(param)) return
                             val explicitUid = uidArgIndex?.let { param.args.getOrNull(it) as? Int }
                             sanitizeMethodResult(param, explicitUid)
                         }
@@ -976,6 +983,21 @@ class HookEntry : IXposedHookLoadPackage {
         HookLog.i("VpnHide: suppressed getNetworkForType(TYPE_VPN) for uid=${effectiveCallerUid()}")
     }
 
+    // getNetworkInfo(int networkType) — null the result for a target caller that
+    // probes TYPE_VPN directly. Returns true when the call was a TYPE_VPN query
+    // (handled: either already null or nulled here), so the caller skips the
+    // disguise-as-WIFI path that would otherwise leak a connected NetworkInfo.
+    // Non-VPN types and non-target callers fall through to normal sanitizing.
+    private fun suppressLegacyVpnTypeQuery(param: XC_MethodHook.MethodHookParam): Boolean {
+        val type = param.args.getOrNull(0) as? Int ?: return false
+        if (type != ConnectivityManager.TYPE_VPN) return false
+        if (param.result == null) return true
+        if (!isTargetCallerOrUid()) return false
+        param.result = null
+        HookLog.i("VpnHide: suppressed getNetworkInfo(TYPE_VPN) for uid=${effectiveCallerUid()}")
+        return true
+    }
+
     // The callback recipient UID lives on the NetworkRequestInfo arg under
     // different field names across AOSP versions (mAsUid is the UID the callback
     // is delivered as). Returns -1 if none found.
@@ -1017,6 +1039,10 @@ class HookEntry : IXposedHookLoadPackage {
         private const val CALLBACK_BUNDLE_ARG_INDEX = 2
         private val RECIPIENT_UID_FIELDS = listOf("mAsUid", "mUid", "uid")
         private val CALLBACK_DISPATCH_METHODS = listOf("callCallbackForRequest", "sendPendingIntentForRequest")
+
+        // Result methods that take a legacy connectivity type as arg 0 and may be
+        // queried with TYPE_VPN to probe for an active VPN (issue #85).
+        private val LEGACY_TYPE_INFO_METHODS = setOf("getNetworkInfo", "getNetworkInfoForType")
         private val CONNECTIVITY_RESULT_METHODS =
             listOf(
                 "getActiveLinkProperties" to null,


### PR DESCRIPTION
Улыбка радуги (com.platfomni.rulybka) and similar apps kept detecting the VPN even with both the LSPosed module and the kernel module active. Decompiling the app shows its check is `ConnectivityManager.getNetworkInfo(TYPE_VPN).isConnectedOrConnecting()`. The ConnectivityService result hook disguised the VPN `NetworkInfo` as WIFI but preserved `mState=CONNECTED`, so a direct `getNetworkInfo(TYPE_VPN)` probe still returned a non-null, connected `NetworkInfo` — answering "yes, a VPN-type network is connected".

For target callers, `getNetworkInfo(TYPE_VPN)` now returns null, the same answer the existing `getNetworkForType(TYPE_VPN)` hook already gives. Non-VPN types and non-target callers fall through to the normal sanitizing path unchanged.

- Add `suppressLegacyVpnTypeQuery()` to the ConnectivityService result hook: null `getNetworkInfo(TYPE_VPN)` results for target UIDs
- Add `LEGACY_TYPE_INFO_METHODS` so only legacy-type queries get the type-aware treatment

Fixes #85

## Testing

Reproduced on a Pixel 8 Pro (Android 17, kernel 6.1, GKI), VPN via WG Tunnel with split tunneling, app targeted in both the LSPosed and kernel modules. Before: the app showed its VPN-detected snackbar; after installing this build and rebooting, the app no longer detects the VPN. Confirmed by the device owner.