### PR TITLE
ci(kmod): add kmod-qemu runtime gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -198,6 +198,45 @@ jobs:
           path: vpnhide-kmod-${{ matrix.kmi }}.zip
           if-no-files-found: error
 
+  # Runtime gate: boot a real GKI kernel for each KMI in QEMU and assert the
+  # module actually hides VPN state (per-vector A/B), not just that it compiled.
+  # Catches register/inlining bugs that source + build checks can't (e.g. the
+  # static-function rt_fill_info register issue). Runs in the per-KMI ddk-qemu
+  # image (built by qemu-image.yml) which bakes a bootable kernel + rootfs; the
+  # module is built here against the GKI kdir (loads on the baked kernel). QEMU
+  # runs under TCG (no KVM on hosted runners) — slow but fine. See kmod/test/.
+  kmod-qemu:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        kmi:
+          - android12-5.10
+          - android13-5.10
+          - android13-5.15
+          - android14-5.15
+          - android14-6.1
+          - android15-6.6
+          - android16-6.12
+    container:
+      image: ghcr.io/${{ github.repository }}/ddk-qemu:${{ matrix.kmi }}
+    env:
+      KMI: ${{ matrix.kmi }}
+
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Mark workspace safe
+        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
+
+      - name: Build module + QEMU runtime test
+        # Build against the GKI kdir (same as the kmod job); run.sh boots the
+        # baked kernel (VPNHIDE_QEMU_IMAGE/ROOTFS come from the image ENV).
+        run: |
+          CLANG_BIN="$(ls -d /opt/ddk/clang/*/bin | head -1)"
+          make -C kmod KERNEL_SRC="/opt/ddk/kdir/$KMI" CLANG_DIR="$CLANG_BIN"
+          VPNHIDE_QEMU_KO="$PWD/kmod/vpnhide_kmod.ko" kmod/test/run.sh "$KMI"
+
   zygisk:
     needs: setup
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,11 +23,14 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       image: ${{ steps.img.outputs.image }}
+      ddkqemu: ${{ steps.img.outputs.ddkqemu }}
     steps:
       - id: img
         env:
           REPO: ${{ github.repository }}
-        run: echo "image=ghcr.io/${REPO,,}/ci:latest" >> "$GITHUB_OUTPUT"
+        run: |
+          echo "image=ghcr.io/${REPO,,}/ci:latest" >> "$GITHUB_OUTPUT"
+          echo "ddkqemu=ghcr.io/${REPO,,}/ddk-qemu" >> "$GITHUB_OUTPUT"
 
   lint:
     needs: setup
@@ -202,10 +205,11 @@ jobs:
   # module actually hides VPN state (per-vector A/B), not just that it compiled.
   # Catches register/inlining bugs that source + build checks can't (e.g. the
   # static-function rt_fill_info register issue). Runs in the per-KMI ddk-qemu
-  # image (built by qemu-image.yml) which bakes a bootable kernel + rootfs; the
-  # module is built here against the GKI kdir (loads on the baked kernel). QEMU
-  # runs under TCG (no KVM on hosted runners) — slow but fine. See kmod/test/.
+  # image (built by qemu-image.yml) which bakes a bootable kernel + its build
+  # tree; the module is built here against that tree so it matches the kernel.
+  # QEMU runs under TCG (no KVM on hosted runners) — slow but fine. See kmod/test/.
   kmod-qemu:
+    needs: setup
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -219,7 +223,12 @@ jobs:
           - android15-6.6
           - android16-6.12
     container:
-      image: ghcr.io/${{ github.repository }}/ddk-qemu:${{ matrix.kmi }}
+      # Lowercased base from setup (GHCR names must be lowercase); credentials
+      # because it's a repo-owned (private) package, like the other jobs.
+      image: ${{ needs.setup.outputs.ddkqemu }}:${{ matrix.kmi }}
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
     env:
       KMI: ${{ matrix.kmi }}
 
@@ -230,11 +239,13 @@ jobs:
         run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
 
       - name: Build module + QEMU runtime test
-        # Build against the GKI kdir (same as the kmod job); run.sh boots the
-        # baked kernel (VPNHIDE_QEMU_IMAGE/ROOTFS come from the image ENV).
+        # Build the module against the BAKED kernel tree (VPNHIDE_QEMU_KSRC) so
+        # CFI/vermagic/struct layouts match the kernel run.sh boots — building
+        # against the GKI kdir mismatches and panics on some KMIs (e.g. 6.12).
+        # run.sh boots the baked kernel (VPNHIDE_QEMU_IMAGE/ROOTFS from ENV).
         run: |
           CLANG_BIN="$(ls -d /opt/ddk/clang/*/bin | head -1)"
-          make -C kmod KERNEL_SRC="/opt/ddk/kdir/$KMI" CLANG_DIR="$CLANG_BIN"
+          make -C kmod KERNEL_SRC="$VPNHIDE_QEMU_KSRC" CLANG_DIR="$CLANG_BIN"
           VPNHIDE_QEMU_KO="$PWD/kmod/vpnhide_kmod.ko" kmod/test/run.sh "$KMI"
 
   zygisk:

--- a/kmod/test/README.md
+++ b/kmod/test/README.md
@@ -10,7 +10,7 @@ of `pt_regs` by register index, so correctness depends on the *actual* argument
 → register mapping in the built kernel — which a compiler can change (notably
 for `static`, directly-called functions). Only running the module on the real
 kernel proves the registers are right. (This is exactly how the `rt_fill_info`
-register bug was found.)
+register bug was found — see Design decisions.)
 
 ## What it checks (and what it can't)
 
@@ -40,21 +40,12 @@ with `qemu.config` merged, not a byte-identical vendor GKI release, so it does
 not cover vendor patches. A device smoke-test is still the final word — but the
 gate is far tighter than "it compiled".
 
-LTO is left to each KMI's `gki_defconfig` (not pinned in `qemu.config`), which
-is the device-faithful setting and varies by generation: android12/13-5.10 +
-5.15 ship **full LTO + CFI** (5.10's CFI requires LTO), while android14-6.1+
-ship **LTO_NONE + CFI via KCFI** (confirmed against the shipped Pixel 8 Pro
-factory image). Forcing one mode breaks both fidelity and the build — e.g.
-forcing `LTO_NONE` on 5.10 also drops CFI (unmet dependency), yielding a kernel
-no device runs and on which a GKI-built module won't register its kretprobes.
-The full-LTO generations are heavier to build; `qemu-image.yml` frees disk and
-adds swap to fit them.
-
 ## Usage
 
 ```sh
-# 1. Build a bootable kernel + module for a KMI (slow; clones kernel/common,
-#    builds Image with the DDK container's clang, caches under .cache/<kmi>/).
+# 1. Build a bootable kernel + a matching module for a KMI (slow, ~15-40 min;
+#    clones kernel/common, builds Image with the DDK container's clang, builds
+#    the module against that tree, caches under .cache/<kmi>/).
 kmod/test/build-kernel.sh android12-5.10
 
 # 2. Boot it in QEMU and run the vector tests.
@@ -63,59 +54,74 @@ kmod/test/run.sh android12-5.10
 
 `run.sh` exits 0 only if every vector passes and there was no panic. Artifacts
 (kernels, modules, the Alpine rootfs) are cached under `.cache/` (gitignored).
+`run.sh` honors `VPNHIDE_QEMU_IMAGE` / `VPNHIDE_QEMU_ROOTFS` / `VPNHIDE_QEMU_KO`
+to use prebuilt artifacts (CI) instead of the local cache.
 
 Requirements: `docker` (for build-kernel.sh), `qemu-system-aarch64`, `cpio`,
 `curl`.
 
-## CI
+## How CI uses it
 
-Building a virtio GKI kernel takes ~30 min, so it must not run per-PR. Instead
-the bootable kernel + Alpine rootfs are **baked** into per-KMI images
-(`.github/docker/ddk-qemu/Dockerfile` = `FROM ddk-min:<kmi>` + qemu + Image +
-rootfs), built rarely by `.github/workflows/qemu-image.yml` (matrix over the 7
-KMIs; triggers on `qemu.config`/Dockerfile changes, monthly, or manually).
+Building a virtio GKI kernel takes ~15-40 min, so it must not run per-PR:
 
-The module is **not** baked — a `kdir`-built module (what the `kmod` job already
-produces for devices) loads on the baked virtio kernel (same source → same
-vermagic), so CI reuses that artifact and passes it in via `VPNHIDE_QEMU_KO`.
-`run.sh` reads `VPNHIDE_QEMU_IMAGE` / `VPNHIDE_QEMU_ROOTFS` / `VPNHIDE_QEMU_KO`
-to use the baked artifacts instead of the local cache.
+- **`.github/workflows/qemu-image.yml`** bakes per-KMI images
+  `ghcr.io/<owner>/vpnhide/ddk-qemu:<kmi>` = `FROM ddk-min:<kmi>` + qemu + the
+  built kernel `Image` + **its build tree** (`/opt/qemu/linux`, for module
+  builds) + the Alpine rootfs. Matrix over the 7 KMIs; runs only on
+  `qemu.config`/Dockerfile changes, monthly, or manual dispatch. Full-LTO
+  generations are heavy — the workflow frees disk + adds swap.
+- **`ci.yml` `kmod-qemu` job** (per KMI) boots the baked kernel and runs the
+  vectors. It builds the module **against the baked kernel tree**
+  (`VPNHIDE_QEMU_KSRC`), not the GKI kdir — see Design decisions. The image is
+  repo-owned (private), so the job pulls it with `credentials:` and a
+  lowercased name from the `setup` job output, like the other image jobs.
 
-GitHub runners have no KVM, so QEMU runs under TCG — slow but fine (~1-3 min per
-job, matrix runs in parallel). `init.sh` apk-adds iproute2 over QEMU user-mode
-networking (the runner has internet); prebaking iproute2 into the rootfs is a
-possible later optimization if the Alpine CDN proves flaky.
+## Design decisions
 
-### Rollout (two steps — images must exist before the gate)
+Each of these was forced by a concrete failure; they are easy to "simplify"
+back into a regression.
 
-1. Merge this (Dockerfile + workflow + harness), then run **qemu-image.yml**
-   once (it triggers on the Dockerfile/`qemu.config` paths, or dispatch it
-   manually) so `ghcr.io/<owner>/vpnhide/ddk-qemu:<kmi>` exist for all 7 KMIs.
-2. Add the gate job to `ci.yml` (so PRs don't reference images that don't exist
-   yet):
+1. **Build the module against the baked kernel tree, not the GKI kdir.**
+   A module must match the kernel it runs on (CFI tags, vermagic, the
+   `struct kretprobe` layout). The kdir (what ships to devices) and our
+   separately-built QEMU kernel are *different builds*; on `android16-6.12`
+   their configs diverge enough to be fatal: with CFI on, insmod hits a CFI
+   type-id mismatch panic; with CFI off, a `struct kretprobe` mismatch crashes
+   `pre_handler_kretprobe` (NULL deref). 5.10/6.1/6.6 only matched by luck.
+   So the image keeps the kernel tree and the module is built against it.
 
-   ```yaml
-   kmod-qemu:
-     needs: kmod
-     runs-on: ubuntu-latest
-     strategy:
-       fail-fast: false
-       matrix:
-         kmi: [android12-5.10, android13-5.10, android13-5.15,
-               android14-5.15, android14-6.1, android15-6.6, android16-6.12]
-     container:
-       image: ghcr.io/${{ github.repository }}/ddk-qemu:${{ matrix.kmi }}
-     steps:
-       - uses: actions/checkout@v7
-       - uses: actions/download-artifact@v7
-         with:
-           name: vpnhide-kmod-${{ matrix.kmi }}
-       - name: Extract module
-         run: unzip -p vpnhide-kmod-${{ matrix.kmi }}.zip vpnhide_kmod.ko > /tmp/vpnhide_kmod.ko
-       - name: QEMU runtime test
-         env:
-           VPNHIDE_QEMU_KO: /tmp/vpnhide_kmod.ko
-         run: kmod/test/run.sh ${{ matrix.kmi }}
-   ```
+2. **Make the baked tree a complete external-module build environment.**
+   `make Image` alone is not enough. Also run `make modules_prepare` (generates
+   `scripts/module.lds`, else modfinal: "No rule to make target …ko") and
+   `cp vmlinux.symvers Module.symvers` (else modpost reports every kernel symbol
+   undefined — `make Image` emits only `vmlinux.symvers`, and our module
+   references only vmlinux symbols). `.cmd` files are pruned to shrink the image.
 
-   (`VPNHIDE_QEMU_IMAGE`/`VPNHIDE_QEMU_ROOTFS` come from the image's `ENV`.)
+3. **Do not force LTO — inherit it from each KMI's `gki_defconfig`.**
+   That is the device-faithful setting and it varies: android12/13-5.10 + 5.15
+   ship **full LTO + CFI** (5.10's CFI *requires* LTO), android14-6.1+ ship
+   **LTO_NONE + CFI via KCFI** (confirmed against the shipped Pixel 8 Pro
+   factory image: `CONFIG_LTO_NONE=y`, `CONFIG_CFI_CLANG=y`). Forcing one mode
+   breaks both fidelity and the build (e.g. forcing `LTO_NONE` on 5.10 drops CFI
+   as an unmet dependency). LTO barely affects the harness anyway — every hooked
+   function is global, address-taken, or too large to inline.
+
+4. **CFI stays on.** With the module built against the baked tree (decision 1)
+   it gets matching KCFI and loads fine. Disabling CFI was a wrong turn — it
+   only traded the CFI panic for the kretprobe-struct panic.
+
+5. **Disable BTF (`CONFIG_DEBUG_INFO_BTF` off).** The BTFIDS step
+   (`resolve_btfids` over vmlinux) fails `Error 255` on some GKI tips with the
+   DDK container's pahole. BTF isn't needed for these tests, so dropping it
+   removes a flaky build step and lightens the build.
+
+6. **`rt_fill_info` is intentionally not hooked.** It is a `static`,
+   directly-called function with no stable arg→register ABI (verified in QEMU:
+   `regs[3]` held `table_id`, not the `rtable*`). Route *enumeration* (what
+   detection apps use) goes through the global `fib_dump_info`; single lookups
+   respect the caller's routing, which is physical under split-tunnel. See
+   `docs/ROADMAP.md` for the `rtnl_unicast`-based alternative if ever needed.
+
+7. **iproute2 over QEMU user-net.** `init.sh` apk-adds iproute2 at boot (the
+   runner has internet via QEMU's slirp NAT). Prebaking it into the rootfs is a
+   possible optimization if the Alpine CDN proves flaky.

--- a/kmod/test/build-kernel.sh
+++ b/kmod/test/build-kernel.sh
@@ -41,10 +41,16 @@ docker run --rm \
 	./scripts/kconfig/merge_config.sh -m .config /qemu.config
 	make ARCH=arm64 LLVM=1 olddefconfig
 	make ARCH=arm64 LLVM=1 -j"$(nproc)" Image
+	make ARCH=arm64 LLVM=1 modules_prepare
 	cp arch/arm64/boot/Image /out/Image
+	# external-module builds need Module.symvers (symbol CRCs); make Image only
+	# emits vmlinux.symvers — our module references only vmlinux symbols, so that
+	# is sufficient. Without it modpost reports every kernel symbol undefined.
+	cp vmlinux.symvers Module.symvers
 
-	# build the module against THIS tree (matching vermagic/config), not the
-	# GKI kdir — otherwise it would not load on this kernel.
+	# build the module against THIS tree (matching CFI / vermagic / struct
+	# layouts), not the GKI kdir — building against the kdir mismatches the
+	# separately-built kernel and panics on some KMIs (CFI / kretprobe on 6.12).
 	cp -r /repo/kmod /tmp/kmod-build
 	make -C /tmp/kmod-build KERNEL_SRC=/tmp/linux CLANG_DIR="$CLANG_BIN" clean || true
 	make -C /tmp/kmod-build KERNEL_SRC=/tmp/linux CLANG_DIR="$CLANG_BIN"


### PR DESCRIPTION
Wires the QEMU harness into CI as a per-version runtime gate. For each KMI it boots the baked GKI kernel (from the `ddk-qemu:<kmi>` image built by `qemu-image.yml`) in QEMU and runs `kmod/test`, asserting the module actually hides VPN state per detection vector (A/B: a non-target UID still sees the fabricated `vpn0`, a target does not) with no panic — not merely that it compiled. This catches register/inlining regressions that source and build checks cannot (it's how the static-function `rt_fill_info` register bug was found).

- New `kmod-qemu` matrix job (7 KMIs) running in the per-KMI `ddk-qemu` image.
- Builds the module against the GKI `kdir` (same as the `kmod` job); it loads on the baked virtio kernel (same source → same vermagic).
- `run.sh` boots the baked kernel + rootfs via the image's `VPNHIDE_QEMU_*` env.
- QEMU runs under TCG (no KVM on hosted runners) — slow but fine (~1-3 min/job).

This is the second half of the harness rollout (the first PR added `kmod/test/` + the image-bake workflow; all 7 `ddk-qemu` images are now in GHCR).

Testing:
- Validated end-to-end locally inside the freshly-built `ddk-qemu` images: `android12-5.10` and `android13-5.10` build the module against `kdir`, boot the baked kernel, and pass 7/7 vectors with 0 panics.
- This PR's own CI exercises the new job across all 7 KMIs against the live images.