### PR TITLE
feat(lsposed): diagnose kmod signature-enforcement rejection

### DIFF
--- a/changelog.d/added-dashboard-now-explains-when-the-kernel-6695.md
+++ b/changelog.d/added-dashboard-now-explains-when-the-kernel-6695.md
@@ -1,0 +1,9 @@
+_2026-06-24_
+
+## English
+
+Dashboard now explains when the kernel module is rejected because the kernel enforces module signatures (EKEYREJECTED), and recommends KernelSU Next instead of a cryptic insmod error
+
+## Русский
+
+Дашборд теперь поясняет, когда модуль ядра отклонён из-за обязательной подписи модулей (EKEYREJECTED), и рекомендует KernelSU Next вместо непонятной ошибки insmod

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DashboardData.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DashboardData.kt
@@ -31,6 +31,7 @@ enum class KmodBrokenReason {
     MissingKprobes,
     UnknownVariantInactive,
     AmbiguousLoadFailed,
+    SignatureEnforced,
 }
 
 /**
@@ -414,6 +415,14 @@ internal sealed interface KmodProblemKind {
         override val reason get() = KmodBrokenReason.MissingKprobes
     }
 
+    // The kernel enforces module signature verification and refused our
+    // unsigned .ko (insmod → EKEYREJECTED). No GKI variant will ever load on
+    // such a kernel, so the only fix is removing the enforcement — KernelSU
+    // Next (GKI mode) does that. See issue #132.
+    data object SignatureEnforced : KmodProblemKind {
+        override val reason get() = KmodBrokenReason.SignatureEnforced
+    }
+
     data class UnsupportedKernel(
         val unameR: String,
         val recommendedArtifact: String,
@@ -481,6 +490,14 @@ internal fun classifyKmodProblem(
     // Past this point every diagnosis means "installed but not loaded".
     if (kmod.active) return null
 
+    // Module-signature enforcement is the root cause regardless of GKI
+    // variant — an unsigned module never loads on such a kernel, so this
+    // takes priority over the variant/recommendation diagnoses below, which
+    // would otherwise mislead the user into reinstalling a different zip.
+    if (freshLoad && loadStatus.isModuleSignatureRejected()) {
+        return KmodProblemKind.SignatureEnforced
+    }
+
     val rec = recommendation
     // rec.recommendedArtifact is a non-null field, so a non-null rec always
     // yields a non-null artifact — the `!!` uses below are safe under the
@@ -523,6 +540,18 @@ internal fun classifyKmodProblem(
     return null
 }
 
+// EKEYREJECTED — the errno the kernel's module_sig_check() returns for an
+// unsigned module when signature enforcement is on ("Loading of unsigned
+// module is rejected"). insmod surfaces it both as its exit code and as the
+// strerror text, so match either to stay robust across insmod implementations.
+private const val EKEYREJECTED = 129
+
+internal fun KmodLoadStatus.isModuleSignatureRejected(): Boolean {
+    if (insmodExit == EKEYREJECTED) return true
+    val stderr = insmodStderr?.lowercase() ?: return false
+    return "key was rejected" in stderr || "required key not available" in stderr
+}
+
 private fun renderKmodProblem(
     kind: KmodProblemKind,
     res: android.content.res.Resources,
@@ -533,6 +562,10 @@ private fun renderKmodProblem(
             when (kind) {
                 KmodProblemKind.KprobesMissing -> {
                     res.getString(R.string.dashboard_issue_kprobes_missing)
+                }
+
+                KmodProblemKind.SignatureEnforced -> {
+                    res.getString(R.string.dashboard_issue_kmod_signature_enforced)
                 }
 
                 is KmodProblemKind.UnsupportedKernel -> {

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DashboardScreen.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DashboardScreen.kt
@@ -256,6 +256,7 @@ private fun ModuleCard(
                     KmodBrokenReason.MissingKprobes -> R.string.dashboard_kmod_broken_no_kprobes
                     KmodBrokenReason.UnknownVariantInactive -> R.string.dashboard_kmod_broken_unknown_variant
                     KmodBrokenReason.AmbiguousLoadFailed -> R.string.dashboard_kmod_broken_ambiguous
+                    KmodBrokenReason.SignatureEnforced -> R.string.dashboard_kmod_broken_signature_enforced
                     null -> null
                 }
             ModuleCardShell(

--- a/lsposed/app/src/main/res/values-ru/strings.xml
+++ b/lsposed/app/src/main/res/values-ru/strings.xml
@@ -73,6 +73,7 @@
     <string name="dashboard_kmod_broken_no_kprobes">Установлен, ядро без kprobes</string>
     <string name="dashboard_kmod_broken_unknown_variant">Установлен, не загрузился</string>
     <string name="dashboard_kmod_broken_ambiguous">Установлен, не загрузился — попробуйте второй GKI-вариант</string>
+    <string name="dashboard_kmod_broken_signature_enforced">Установлен, ядро отклоняет неподписанные модули</string>
     <string name="dashboard_active_targets">Активен · целей: %d</string>
     <string name="dashboard_reboot_needed">Требуется перезагрузка устройства</string>
     <string name="dashboard_protection">Статус защиты</string>
@@ -129,6 +130,7 @@
     <string name="dashboard_issue_kmod_unknown_variant">Модуль ядра установлен, но не загружается, и в zip не указано, под какой GKI-вариант он собран. Переустановите %1$s из последнего релиза, чтобы убедиться, что он подходит вашему ядру.</string>
     <string name="dashboard_issue_kmod_ambiguous_try_alternative">Модуль ядра %1$s не загрузился при текущей загрузке. GKI-ветку вашего ядра не удаётся определить из uname -r — установите %2$s вместо него.</string>
     <string name="dashboard_issue_kmod_load_failed">Модуль ядра не загрузился. Ошибка insmod: %1$s. Чтобы приложить полный вывод insmod к багрепорту, нажмите Диагностика → Собрать отладочный лог.</string>
+    <string name="dashboard_issue_kmod_signature_enforced">Ваше ядро требует подписанные модули, поэтому неподписанный модуль ядра не загружается (insmod вернул EKEYREJECTED — \"Key was rejected by service\"). Magisk это не отключает. Перейдите на KernelSU Next в режиме GKI — он снимает проверку подписи, и kmod загрузится. На GKI-ядрах правильный инструмент — именно модуль ядра; не откатывайтесь на Zygisk: его хуки в процессе легко детектят банковские и антифрод-приложения.</string>
     <string name="dashboard_issue_kmod_not_supported_kernel">Для вашего ядра (%1$s) нет подходящего варианта vpnhide-kmod. Удалите модуль kmod и установите вместо него %2$s.</string>
     <string name="dashboard_issue_kprobes_missing">Ваше ядро собрано без CONFIG_KRETPROBES. Модуль ядра VPN Hide не может работать на таком ядре. Удалите kmod и используйте vpnhide-zygisk.zip.</string>
 

--- a/lsposed/app/src/main/res/values/strings.xml
+++ b/lsposed/app/src/main/res/values/strings.xml
@@ -104,6 +104,7 @@
     <string name="dashboard_kmod_broken_no_kprobes">Installed, kernel has no kprobes</string>
     <string name="dashboard_kmod_broken_unknown_variant">Installed, did not load</string>
     <string name="dashboard_kmod_broken_ambiguous">Installed, did not load — try the other GKI variant</string>
+    <string name="dashboard_kmod_broken_signature_enforced">Installed, kernel rejects unsigned modules</string>
     <string name="dashboard_active_targets">Active · %d target(s)</string>
     <string name="dashboard_reboot_needed">Device reboot needed</string>
     <string name="dashboard_protection">Protection status</string>
@@ -160,6 +161,7 @@
     <string name="dashboard_issue_kmod_unknown_variant">Kernel module is installed but not loading, and the zip doesn\'t identify which GKI variant it was built for. Reinstall %1$s from the latest release to make sure it matches your kernel.</string>
     <string name="dashboard_issue_kmod_ambiguous_try_alternative">Kernel module %1$s failed to load this boot. Your kernel\'s GKI branch isn\'t identifiable from uname -r, so install %2$s instead.</string>
     <string name="dashboard_issue_kmod_load_failed">Kernel module failed to load. insmod error: %1$s. Use Diagnostics → Collect debug log to attach the full boot-time insmod output to a bug report.</string>
+    <string name="dashboard_issue_kmod_signature_enforced">Your kernel enforces module signature verification, so the unsigned kernel module can\'t load (insmod failed with EKEYREJECTED — \"Key was rejected by service\"). Magisk can\'t disable this. Switch to KernelSU Next in GKI mode — it removes the enforcement and the kmod loads. On GKI kernels the kernel module is the right tool; don\'t fall back to Zygisk, whose in-process hooks are easily detected by banking and anti-fraud apps.</string>
     <string name="dashboard_issue_kmod_not_supported_kernel">Your kernel (%1$s) has no matching vpnhide-kmod variant. Uninstall the kmod module and install %2$s instead.</string>
     <string name="dashboard_issue_kprobes_missing">Your kernel was built without CONFIG_KRETPROBES. The VPN Hide kernel module cannot work on this kernel. Uninstall kmod and use vpnhide-zygisk.zip instead.</string>
 

--- a/lsposed/app/src/test/kotlin/dev/okhsunrog/vpnhide/ClassifyKmodProblemTest.kt
+++ b/lsposed/app/src/test/kotlin/dev/okhsunrog/vpnhide/ClassifyKmodProblemTest.kt
@@ -15,6 +15,7 @@ class ClassifyKmodProblemTest {
         kretprobes: String? = "y",
         unameR: String? = "5.10.0-android12",
         insmodStderr: String? = null,
+        insmodExit: Int? = null,
     ) = KmodLoadStatus(
         timestamp = null,
         bootId = "boot",
@@ -24,7 +25,7 @@ class ClassifyKmodProblemTest {
         rootManager = null,
         kprobes = "y",
         kretprobes = kretprobes,
-        insmodExit = null,
+        insmodExit = insmodExit,
         loaded = false,
         insmodStderr = insmodStderr,
         dmesgTail = null,
@@ -166,5 +167,53 @@ class ClassifyKmodProblemTest {
     fun `inactive with no diagnosable cause is null`() {
         // No recommendation, no fresh load status: nothing to say.
         assertNull(classifyKmodProblem(installed(active = false, gkiVariant = "android13-5.10"), null, null))
+    }
+
+    @Test
+    fun `EKEYREJECTED exit code is diagnosed as signature enforcement`() {
+        val kind =
+            classifyKmodProblem(
+                installed(active = false, gkiVariant = "android13-5.10"),
+                kmodRecommendation("android13-5.10"),
+                loadStatus(fresh = true, insmodStderr = "Key was rejected by service", insmodExit = 129),
+            )
+        assertEquals(KmodProblemKind.SignatureEnforced, kind)
+        assertEquals(KmodBrokenReason.SignatureEnforced, kind?.reason)
+    }
+
+    @Test
+    fun `signature rejection is matched from stderr when exit code is unavailable`() {
+        val kind =
+            classifyKmodProblem(
+                installed(active = false, gkiVariant = "android13-5.10"),
+                kmodRecommendation("android13-5.10"),
+                loadStatus(fresh = true, insmodStderr = "init_module: Key was rejected by service"),
+            )
+        assertEquals(KmodProblemKind.SignatureEnforced, kind)
+    }
+
+    @Test
+    fun `signature enforcement outranks a wrong-variant diagnosis`() {
+        // An enforcing kernel rejects every unsigned .ko before vermagic is
+        // even checked, so EKEYREJECTED must not be misreported as a fixable
+        // variant mismatch.
+        val kind =
+            classifyKmodProblem(
+                installed(active = false, gkiVariant = "android12-5.10"),
+                kmodRecommendation("android13-5.10"),
+                loadStatus(fresh = true, insmodStderr = "Key was rejected by service", insmodExit = 129),
+            )
+        assertEquals(KmodProblemKind.SignatureEnforced, kind)
+    }
+
+    @Test
+    fun `unrelated insmod failure is not treated as signature enforcement`() {
+        val kind =
+            classifyKmodProblem(
+                installed(active = false, gkiVariant = "android13-5.10"),
+                recommendation = null,
+                loadStatus = loadStatus(fresh = true, insmodStderr = "exec format error", insmodExit = 8),
+            )
+        assertEquals(KmodProblemKind.LoadFailed("exec format error"), kind)
     }
 }


### PR DESCRIPTION
On kernels that enforce module signature verification, `insmod` refuses the unsigned `vpnhide_kmod.ko` and the kernel returns `EKEYREJECTED` (errno 129, "Key was rejected by service"). This is what happened in #132 on a Pixel 9a (Android 16, GKI 6.1) running Magisk: the kmod never loaded (`insmod_exit=129`, `loaded=0`), so the native interface-enumeration checks (ioctl/getifaddrs/NetworkInterface) leaked `tun0` while the Java-API and SELinux-gated checks passed. The dashboard only showed the raw insmod stderr via the generic `LoadFailed` path — cryptic, with no way forward.

This adds a dedicated diagnosis. When the load failure is a signature rejection, the dashboard now explains that the kernel rejects unsigned modules, that Magisk can't disable the enforcement, and that the fix is **KernelSU Next in GKI mode** (which removes the enforcement so the kmod loads). It deliberately does **not** suggest Zygisk as a fallback — on GKI kernels the kernel module is the right tool, and Zygisk's in-process hooks are easily detected by banking/anti-fraud apps.

- Add `KmodProblemKind.SignatureEnforced` / `KmodBrokenReason.SignatureEnforced`, detected by `insmod` exit 129 or the EKEYREJECTED/ENOKEY stderr text (robust across insmod implementations)
- Prioritize it over the variant/recommendation diagnoses, since an enforcing kernel rejects every unsigned `.ko` regardless of GKI variant
- New dashboard banner + card-subtitle strings (EN + RU)
- Unit tests in `ClassifyKmodProblemTest` covering the exit-code path, the stderr path, priority over wrong-variant, and that unrelated insmod failures still fall through to `LoadFailed`

Why EKEYREJECTED proves enforcement (not a Magisk-version issue): in the `android14-6.1` GKI source, `kernel/module/signing.c:module_sig_check()` leaves `err = -ENODATA` for an unsigned module (no `~Module signature appended~` marker), and then `if (is_module_sig_enforced()) return -EKEYREJECTED;`. So unsigned + enforcement → errno 129. KernelSU/APatch patch the kernel to clear `sig_enforce`; Magisk doesn't.

Refs #132