### PR TITLE
fix(lsposed): bound netlink diagnostic read loops to prevent OOM crash

### DIFF
--- a/changelog.d/fixed-fix-app-crash-out-of-memory-849f.md
+++ b/changelog.d/fixed-fix-app-crash-out-of-memory-849f.md
@@ -1,0 +1,9 @@
+_2026-06-24_
+
+## English
+
+Fix app crash (out-of-memory abort) when running diagnostics with a VPN connected on some kernels — the native netlink interface/route checks now bound their read loop and time out instead of looping until the allocator aborts
+
+## Русский
+
+Исправлен вылет приложения (аварийное завершение из-за нехватки памяти) при запуске диагностики с подключённым VPN на некоторых ядрах — нативные проверки интерфейсов/маршрутов через netlink теперь ограничивают цикл чтения и завершаются по таймауту вместо зацикливания до аварии аллокатора

--- a/lsposed/native/src/lib.rs
+++ b/lsposed/native/src/lib.rs
@@ -307,6 +307,13 @@ fn check_proc_file(path: &str) -> CheckOutput {
     }
 }
 
+/// Upper bound on recvmsg iterations for a single netlink dump. A real
+/// RTM_GETLINK / RTM_GETROUTE dump completes in a few 32 KiB reads; a stream
+/// that exceeds this is looping (a kernel iface filter re-sending without
+/// NLMSG_DONE — issue #61), so we stop instead of growing the result `Vec`
+/// without bound until Scudo aborts the process with an OOM map failure.
+const MAX_NETLINK_RECV_ITERS: usize = 256;
+
 /// Wrapper around recvmsg for netlink sockets. Uses recvmsg (not recv/recvfrom)
 /// so that zygisk's recvmsg hook can filter the response.
 unsafe fn netlink_recv(fd: i32, buf: &mut [u8]) -> isize {
@@ -354,6 +361,24 @@ fn open_netlink() -> Result<i32, CheckOutput> {
                 CheckOutput::fail(format!("bind error: {e}"))
             });
         }
+
+        // Receive timeout: a kernel-side interface filter can, on some kernels,
+        // re-send a dump without ever emitting NLMSG_DONE (issue #61, observed
+        // on android14-6.1). Without a timeout the next blocking recvmsg hangs
+        // the diagnostics thread forever; with it the read returns EAGAIN and
+        // the loop exits. Best-effort — the per-call iteration cap is the hard
+        // backstop, so a setsockopt failure is non-fatal.
+        let tv = libc::timeval {
+            tv_sec: 2,
+            tv_usec: 0,
+        };
+        libc::setsockopt(
+            fd,
+            libc::SOL_SOCKET,
+            libc::SO_RCVTIMEO,
+            std::ptr::from_ref(&tv).cast(),
+            std::mem::size_of::<libc::timeval>() as libc::socklen_t,
+        );
         Ok(fd)
     }
 }
@@ -453,7 +478,7 @@ fn check_netlink_getlink() -> CheckOutput {
         let hdr_plus_ifinfo =
             std::mem::size_of::<libc::nlmsghdr>() + std::mem::size_of::<Ifinfomsg>();
 
-        loop {
+        for _ in 0..MAX_NETLINK_RECV_ITERS {
             let len = netlink_recv(fd, &mut buf);
             if len <= 0 {
                 break;
@@ -528,7 +553,7 @@ fn check_netlink_getroute() -> CheckOutput {
         let mut total = 0u32;
         let hdr_plus_rtmsg = std::mem::size_of::<libc::nlmsghdr>() + std::mem::size_of::<Rtmsg>();
 
-        loop {
+        for _ in 0..MAX_NETLINK_RECV_ITERS {
             let len = netlink_recv(fd, &mut buf);
             if len <= 0 {
                 break;


### PR DESCRIPTION
The app crashes (or hangs, then crashes) when diagnostics run with a VPN connected. The crash logs in #61 are a native `SIGABRT` — `Scudo ERROR: internal map failure (Out of memory)` — with the top frame in `Java_dev_okhsunrog_vpnhide_NativeChecks_checkNetlinkGetlink`.

Root cause: `check_netlink_getlink` / `check_netlink_getroute` read an `RTM_GETLINK` / `RTM_GETROUTE` dump in an unbounded blocking loop that only exits on `NLMSG_DONE`, an error, or EOF. The kernel module filters VPN interfaces out of that dump for target UIDs (the app is its own target so diagnostics self-test the filter). On some kernels — the reporter is on **android14-6.1**, which the kmod's own `rtnl_fill_ifinfo` comment already flags as fragile — the filtered dump can fail to terminate, so the loop either blocks forever (the "spins forever" the user describes) or keeps appending interfaces until the allocator aborts the process.

Rather than chase a device-specific kernel quirk, harden the app so no kernel-side behavior can crash or hang diagnostics:

- set `SO_RCVTIMEO` (2s) on the netlink socket so a stalled dump returns `EAGAIN` instead of blocking the diagnostics thread forever
- cap the receive loop at `MAX_NETLINK_RECV_ITERS` (256) so a re-sending dump can't grow the result `Vec` without bound (a real dump completes in a handful of 32 KiB reads)

The check then returns a bounded result instead of crashing. The SELinux-denied path (bind fails before the loop) is unchanged — verified no regression on a device where the netlink bind is denied.

Fixes #61

## Testing

Could not reproduce the crash locally (on the test device SELinux denies the netlink bind, so the loop is never reached). The fix is confirmed to compile and not regress the denied path; the bound/timeout only affect the loop path that crashes on the reporter's HyperOS / android14-6.1 device.