### PR TITLE
Refine Android UI surface colors

### DIFF
--- a/changelog.d/changed-refined-android-ui-surface-colors-to-9723.md
+++ b/changelog.d/changed-refined-android-ui-surface-colors-to-9723.md
@@ -1,0 +1,9 @@
+_2026-06-25_
+
+## English
+
+Refined Android UI surface colors to avoid overly black Material You backgrounds.
+
+## Русский
+
+Уточнены цвета поверхностей Android-интерфейса, чтобы Material You в темной теме не давал чрезмерно черные фоны.

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DashboardScreen.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DashboardScreen.kt
@@ -35,6 +35,7 @@ import dev.okhsunrog.vpnhide.ui.components.EnhancedButton
 import dev.okhsunrog.vpnhide.ui.components.EnhancedCard
 import dev.okhsunrog.vpnhide.ui.components.GroupedCard
 import dev.okhsunrog.vpnhide.ui.components.pulse
+import dev.okhsunrog.vpnhide.ui.theme.AppColors
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 
@@ -308,7 +309,7 @@ private fun DashboardHeroCard(
     EnhancedCard(
         modifier = Modifier.fillMaxWidth(),
         shape = MaterialTheme.shapes.extraLarge,
-        color = MaterialTheme.colorScheme.surfaceContainerLow,
+        color = AppColors.cardContainer,
     ) {
         Column(modifier = Modifier.padding(18.dp).fillMaxWidth()) {
             Row(
@@ -449,7 +450,7 @@ private fun HeroMetric(
         modifier =
             modifier
                 .clip(MaterialTheme.shapes.medium)
-                .background(MaterialTheme.colorScheme.surfaceContainerHigh)
+                .background(AppColors.cardContainerStrong)
                 .padding(horizontal = 12.dp, vertical = 10.dp),
     ) {
         Text(
@@ -593,7 +594,7 @@ private fun ModuleCard(
                 version = null,
                 subtitle = stringResource(R.string.dashboard_not_installed),
                 accentColor = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.55f),
-                accentContainerColor = MaterialTheme.colorScheme.surfaceContainerHighest,
+                accentContainerColor = AppColors.neutralAccentContainer,
             )
         }
 
@@ -658,7 +659,7 @@ private fun LsposedCard(
                 version = installedVersion,
                 subtitle = stringResource(R.string.dashboard_not_installed),
                 accentColor = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.55f),
-                accentContainerColor = MaterialTheme.colorScheme.surfaceContainerHighest,
+                accentContainerColor = AppColors.neutralAccentContainer,
             )
         }
 
@@ -725,7 +726,7 @@ private fun ModuleCardShell(
         index = index,
         count = count,
         modifier = Modifier.fillMaxWidth(),
-        color = MaterialTheme.colorScheme.surfaceContainerLow,
+        color = AppColors.cardContainer,
     ) {
         Row(
             modifier = Modifier.padding(16.dp).fillMaxWidth(),
@@ -995,7 +996,7 @@ private fun ProtectionCardShell(
         index = index,
         count = count,
         modifier = Modifier.fillMaxWidth(),
-        color = MaterialTheme.colorScheme.surfaceContainerLow,
+        color = AppColors.cardContainer,
     ) {
         Row(
             modifier = Modifier.padding(16.dp).fillMaxWidth(),

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/MainActivity.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/MainActivity.kt
@@ -50,6 +50,7 @@ import dev.okhsunrog.vpnhide.ui.components.EnhancedButton
 import dev.okhsunrog.vpnhide.ui.components.EnhancedCard
 import dev.okhsunrog.vpnhide.ui.components.pulse
 import dev.okhsunrog.vpnhide.ui.components.rememberHapticTick
+import dev.okhsunrog.vpnhide.ui.theme.AppColors
 import dev.okhsunrog.vpnhide.ui.theme.AppEasing
 import dev.okhsunrog.vpnhide.ui.theme.VpnHideTheme
 import kotlinx.coroutines.Dispatchers
@@ -200,7 +201,7 @@ private fun TopBarActionButton(
         if (active) {
             MaterialTheme.colorScheme.primaryContainer
         } else {
-            MaterialTheme.colorScheme.surfaceContainerHigh
+            AppColors.toolbarActionContainer
         }
     val contentColor =
         if (active) {
@@ -319,6 +320,7 @@ private fun MainScreen(onReady: () -> Unit = {}) {
     }
 
     Scaffold(
+        containerColor = AppColors.screenBackground,
         topBar = {
             if (searchActive && currentTab == Tab.Protection) {
                 SearchBar(
@@ -350,8 +352,8 @@ private fun MainScreen(onReady: () -> Unit = {}) {
                     title = { AppTopBarTitle(currentTab) },
                     colors =
                         TopAppBarDefaults.topAppBarColors(
-                            containerColor = MaterialTheme.colorScheme.surfaceContainerLowest,
-                            scrolledContainerColor = MaterialTheme.colorScheme.surfaceContainerLow,
+                            containerColor = AppColors.topBarContainer,
+                            scrolledContainerColor = AppColors.topBarScrolledContainer,
                             titleContentColor = MaterialTheme.colorScheme.onSurface,
                             actionIconContentColor = MaterialTheme.colorScheme.onSurfaceVariant,
                         ),
@@ -479,7 +481,7 @@ private fun MainScreen(onReady: () -> Unit = {}) {
         bottomBar = {
             val tabHaptic = rememberHapticTick()
             NavigationBar(
-                containerColor = MaterialTheme.colorScheme.surfaceContainerLow,
+                containerColor = AppColors.navigationBarContainer,
                 tonalElevation = 0.dp,
             ) {
                 NavigationBarItem(

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/SettingsScreen.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/SettingsScreen.kt
@@ -33,6 +33,7 @@ import dev.okhsunrog.vpnhide.settings.LocalSettingsState
 import dev.okhsunrog.vpnhide.settings.ThemeMode
 import dev.okhsunrog.vpnhide.ui.components.PreferenceRow
 import dev.okhsunrog.vpnhide.ui.components.PreferenceRowSwitch
+import dev.okhsunrog.vpnhide.ui.theme.AppColors
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -41,6 +42,7 @@ fun SettingsScreen(onBack: () -> Unit) {
     val interactor = LocalSettingsInteractor.current
 
     Scaffold(
+        containerColor = AppColors.screenBackground,
         topBar = {
             TopAppBar(
                 title = { Text(stringResource(R.string.settings_title)) },
@@ -54,7 +56,7 @@ fun SettingsScreen(onBack: () -> Unit) {
                 },
                 colors =
                     TopAppBarDefaults.topAppBarColors(
-                        containerColor = MaterialTheme.colorScheme.surfaceContainerLowest,
+                        containerColor = AppColors.topBarContainer,
                         titleContentColor = MaterialTheme.colorScheme.onSurface,
                         navigationIconContentColor = MaterialTheme.colorScheme.onSurfaceVariant,
                     ),

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/ui/components/Enhanced.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/ui/components/Enhanced.kt
@@ -31,6 +31,7 @@ import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.graphics.takeOrElse
 import androidx.compose.ui.graphics.vector.ImageVector
+import dev.okhsunrog.vpnhide.ui.theme.AppColors
 import dev.okhsunrog.vpnhide.ui.theme.AppMotion
 import dev.okhsunrog.vpnhide.ui.theme.groupCornerRadii
 import dev.okhsunrog.vpnhide.ui.theme.groupedShape
@@ -51,7 +52,7 @@ import dev.okhsunrog.vpnhide.ui.theme.shapeByInteraction
 fun EnhancedCard(
     modifier: Modifier = Modifier,
     shape: Shape = MaterialTheme.shapes.large,
-    color: Color = MaterialTheme.colorScheme.surfaceContainerLow,
+    color: Color = AppColors.cardContainer,
     contentColor: Color = contentColorFor(color).takeOrElse { MaterialTheme.colorScheme.onSurface },
     onClick: (() -> Unit)? = null,
     content: @Composable ColumnScope.() -> Unit,
@@ -80,7 +81,7 @@ fun GroupedCard(
     index: Int,
     count: Int,
     modifier: Modifier = Modifier,
-    color: Color = MaterialTheme.colorScheme.surfaceContainerLow,
+    color: Color = AppColors.cardContainer,
     contentColor: Color = contentColorFor(color).takeOrElse { MaterialTheme.colorScheme.onSurface },
     onClick: (() -> Unit)? = null,
     content: @Composable ColumnScope.() -> Unit,

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/ui/components/Modifiers.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/ui/components/Modifiers.kt
@@ -26,6 +26,7 @@ import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import dev.okhsunrog.vpnhide.settings.LocalSettingsState
+import dev.okhsunrog.vpnhide.ui.theme.AppColors
 import dev.okhsunrog.vpnhide.ui.theme.AppEasing
 
 /*
@@ -44,7 +45,7 @@ import dev.okhsunrog.vpnhide.ui.theme.AppEasing
 @Composable
 fun Modifier.container(
     shape: Shape = MaterialTheme.shapes.large,
-    color: Color = MaterialTheme.colorScheme.surfaceContainerLow,
+    color: Color = AppColors.cardContainer,
     borderColor: Color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.35f),
     drawBorder: Boolean = true,
     shadowElevation: Dp = 1.dp,

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/ui/theme/AppColors.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/ui/theme/AppColors.kt
@@ -1,0 +1,55 @@
+package dev.okhsunrog.vpnhide.ui.theme
+
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.ReadOnlyComposable
+import androidx.compose.ui.graphics.Color
+
+/**
+ * App-level color roles layered on top of Material 3's generated ColorScheme.
+ *
+ * Dynamic Color can map `surfaceContainerLowest` to pure black in dark mode, so
+ * large app surfaces use lifted roles here while still following the user's
+ * wallpaper palette.
+ */
+object AppColors {
+    val screenBackground: Color
+        @Composable
+        @ReadOnlyComposable
+        get() = MaterialTheme.colorScheme.surfaceContainer
+
+    val topBarContainer: Color
+        @Composable
+        @ReadOnlyComposable
+        get() = MaterialTheme.colorScheme.surfaceContainer
+
+    val topBarScrolledContainer: Color
+        @Composable
+        @ReadOnlyComposable
+        get() = MaterialTheme.colorScheme.surfaceContainerHigh
+
+    val navigationBarContainer: Color
+        @Composable
+        @ReadOnlyComposable
+        get() = MaterialTheme.colorScheme.surfaceContainer
+
+    val cardContainer: Color
+        @Composable
+        @ReadOnlyComposable
+        get() = MaterialTheme.colorScheme.surfaceContainerHigh
+
+    val cardContainerStrong: Color
+        @Composable
+        @ReadOnlyComposable
+        get() = MaterialTheme.colorScheme.surfaceContainerHighest
+
+    val toolbarActionContainer: Color
+        @Composable
+        @ReadOnlyComposable
+        get() = MaterialTheme.colorScheme.surfaceContainerHighest
+
+    val neutralAccentContainer: Color
+        @Composable
+        @ReadOnlyComposable
+        get() = MaterialTheme.colorScheme.surfaceContainerHighest
+}


### PR DESCRIPTION
## Summary
- Add app-level surface color roles on top of Material 3 Dynamic Color.
- Move large app surfaces away from `surfaceContainerLowest`, which maps to pure black in dark Material You on Pixel.
- Apply the lifted roles to scaffold backgrounds, app bars, navigation, shared cards, grouped cards, and dashboard surface accents.

## Why
Pixel Dynamic Color currently returns `surfaceContainerLowest = #000000` in dark mode. Using that role for large surfaces made VPN Hide look much darker than Google apps using the same Material You palette.

## Validation
- `./gradlew :app:assembleDebug`
- `./gradlew :app:detekt`
- `ktlint` on changed Kotlin files
- `git diff --check`
- Installed the debug APK via adb and checked the dashboard in dark Material You mode.