### PR TITLE
Add detection-vector coverage map and fix README coverage table

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,6 +22,7 @@ These short files cover everything specific to this repo. Skipping them leads to
 - [CONTRIBUTING.md](CONTRIBUTING.md) — PR process, commit conventions, changelog requirement
 - [docs/development.md](docs/development.md) — prereqs, per-module build quickstart, keystore setup, device install, CI lints
 - [docs/state.md](docs/state.md) — every persistent path / proc entry / iptables chain the project touches; who writes, who reads, lifetime
+- [docs/detection-vectors.md](docs/detection-vectors.md) — what an app can probe to detect the VPN (or a hidden package), which component (kmod / zygisk / lsposed / SELinux) covers each vector, how it manifests. Read before adding or changing a hook.
 - [docs/changelog.md](docs/changelog.md) — changelog storage (`changelog.d/` fragments + history JSON), `./scripts/changelog.py` usage
 - [docs/releasing.md](docs/releasing.md) — `./scripts/release.py` usage, version-bump flow
 - [kmod/BUILDING.md](kmod/BUILDING.md) — kernel-module build (one-command DDK via `./kmod/build.py`, GKI matrix, troubleshooting)

--- a/README.en.md
+++ b/README.en.md
@@ -167,13 +167,13 @@ Any issues found are shown as actionable cards with specific instructions.
 | 4 | `ioctl(SIOCGIFCONF)` interface enumeration | | x | x | |
 | 5 | All other `SIOCGIF*` (INDEX, HWADDR, ADDR, etc.) | | x | x | |
 | 6 | `getifaddrs()` (uses netlink internally) | | x | x | |
-| 7 | netlink `RTM_GETLINK` dump | blocked | x | x | |
-| 8 | netlink `RTM_GETADDR` dump (IPv4 + IPv6) | blocked | x | | |
-| 9 | netlink `RTM_GETROUTE` dump | blocked | | | |
+| 7 | netlink `RTM_GETLINK` dump | | x | x | |
+| 8 | netlink `RTM_GETADDR` dump (IPv4 + IPv6) | | x | x | |
+| 9 | netlink `RTM_GETROUTE` dump | | x | x | |
 | 10 | `/proc/net/route` | blocked | x | x | |
-| 11 | `/proc/net/ipv6_route` | blocked | | x | |
+| 11 | `/proc/net/ipv6_route` | blocked | x | x | |
 | 12 | `/proc/net/if_inet6` | blocked | | x | |
-| 13 | `/proc/net/tcp`, `tcp6` | blocked | | | |
+| 13 | `/proc/net/tcp`, `tcp6` | blocked | | x | |
 | 14 | `/proc/net/udp`, `udp6` | blocked | | | |
 | 15 | `/proc/net/dev` | blocked | | | |
 | 16 | `/proc/net/fib_trie` | blocked | | | |
@@ -188,9 +188,11 @@ Any issues found are shown as actionable cards with specific instructions.
 | 25 | `System.getProperty` (proxy settings) | | | x | |
 | 26 | `/proc/net/route` via Java `FileInputStream` | blocked | x | x | |
 
-**blocked** = SELinux denies access for untrusted apps (Android 10+). No hook needed.
+**blocked** = on stock-enforcing builds (Android 10+) SELinux usually denies untrusted apps access to that `/proc/net/*` / `/sys` file. But **SELinux policy is configured differently across devices and ROMs** (OEM and custom ROMs, `permissive` builds), so the vpnhide layers filter these paths anyway and never rely on SELinux.
 
-Rows 1-6, 21, and 24 are the only vectors reachable by regular apps. Everything else is either blocked by SELinux or goes through Java APIs (covered by lsposed).
+Important: **netlink dumps (rows 7-9) are not restricted by SELinux** — a regular app reads interfaces, addresses, and routes directly over `NETLINK_ROUTE`. This is exactly how detectors like RKNHardering bypass the `/proc/net/route` denial (see [issue #86](https://github.com/okhsunrog/vpnhide/issues/86)). So the vectors actually reachable by a regular app are rows 1-9 and 24, closed by kmod / zygisk; everything else is either often SELinux-blocked on stock (device-dependent) or goes through Java APIs and is covered by lsposed.
+
+The full vector map — per-layer breakdown, SELinux caveats, and known gaps — lives in [docs/detection-vectors.md](docs/detection-vectors.md).
 
 ## Building from source
 

--- a/README.md
+++ b/README.md
@@ -167,13 +167,13 @@ vpnhide — это не один переключатель, а три разн�
 | 4 | `ioctl(SIOCGIFCONF)` перечисление интерфейсов | | x | x | |
 | 5 | Все остальные `SIOCGIF*` (INDEX, HWADDR, ADDR и т.д.) | | x | x | |
 | 6 | `getifaddrs()` (использует netlink внутри) | | x | x | |
-| 7 | netlink `RTM_GETLINK` дамп | блок. | x | x | |
-| 8 | netlink `RTM_GETADDR` дамп (IPv4 + IPv6) | блок. | x | | |
-| 9 | netlink `RTM_GETROUTE` дамп | блок. | | | |
+| 7 | netlink `RTM_GETLINK` дамп | | x | x | |
+| 8 | netlink `RTM_GETADDR` дамп (IPv4 + IPv6) | | x | x | |
+| 9 | netlink `RTM_GETROUTE` дамп | | x | x | |
 | 10 | `/proc/net/route` | блок. | x | x | |
-| 11 | `/proc/net/ipv6_route` | блок. | | x | |
+| 11 | `/proc/net/ipv6_route` | блок. | x | x | |
 | 12 | `/proc/net/if_inet6` | блок. | | x | |
-| 13 | `/proc/net/tcp`, `tcp6` | блок. | | | |
+| 13 | `/proc/net/tcp`, `tcp6` | блок. | | x | |
 | 14 | `/proc/net/udp`, `udp6` | блок. | | | |
 | 15 | `/proc/net/dev` | блок. | | | |
 | 16 | `/proc/net/fib_trie` | блок. | | | |
@@ -188,9 +188,11 @@ vpnhide — это не один переключатель, а три разн�
 | 25 | `System.getProperty` (настройки прокси) | | | x | |
 | 26 | `/proc/net/route` через Java `FileInputStream` | блок. | x | x | |
 
-**блок.** = SELinux запрещает доступ для обычных приложений (Android 10+). Хуки не нужны.
+**блок.** = на сток-enforcing сборках (Android 10+) SELinux обычно запрещает обычным приложениям доступ к этому файлу `/proc/net/*` / `/sys`. Но политика SELinux настроена **по-разному на разных устройствах и прошивках** (OEM- и кастомные ROM, `permissive`-сборки), поэтому слои vpnhide всё равно фильтруют эти пути и не полагаются на SELinux.
 
-Строки 1–6, 21 и 24 — единственные векторы, доступные обычным приложениям. Всё остальное либо заблокировано SELinux, либо проходит через Java API (покрывается lsposed).
+Важно: **netlink-дампы (строки 7–9) SELinux не ограничивает** — обычное приложение читает интерфейсы, адреса и маршруты через `NETLINK_ROUTE` напрямую. Именно так детекторы вроде RKNHardering обходят блокировку `/proc/net/route` (см. [issue #86](https://github.com/okhsunrog/vpnhide/issues/86)). Поэтому векторы, реально доступные обычному приложению, — это строки 1–9 и 24; их закрывают kmod / zygisk. Остальное либо часто блокируется SELinux на стоке (но это зависит от устройства), либо идёт через Java API и покрывается lsposed.
+
+Полная карта векторов — с разбивкой по слоям, нюансами SELinux и известными пробелами — в [docs/detection-vectors.md](docs/detection-vectors.md).
 
 ## Сборка из исходников
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -4,6 +4,11 @@ This document tracks larger product directions that are too broad for a
 single changelog entry. It is not a release commitment; concrete work should
 still be tracked in GitHub issues and pull requests.
 
+For the current state — which detection vectors exist and which component
+covers each — see [detection-vectors.md](detection-vectors.md). This file is
+the *forward-looking* counterpart: vectors that are partially covered or
+intentionally deferred are described there and cross-linked from here.
+
 ## VPN Hiding Modes
 
 ### VPN-preserving concealment

--- a/docs/detection-vectors.md
+++ b/docs/detection-vectors.md
@@ -1,0 +1,238 @@
+# Detection vectors — what an app can probe, and who hides it
+
+Authoritative coverage map for "how can an app tell a VPN is up (or that a
+package is installed), and which component stops it?". If you add or change a
+hook, update the matrix here so the picture stays in one place.
+
+Scope: this file is about **detection vectors and their coverage**. For where
+runtime state is *stored* see [state.md](state.md); for forward-looking work
+see [ROADMAP.md](ROADMAP.md).
+
+---
+
+## 1. Threat model
+
+A *target* app (banking, store, anti-fraud SDK, censorship-detector like
+RKNHardering) runs on the user's device and tries to decide "is this device
+behind a VPN?" or "is app X installed?". It is **unprivileged** (`untrusted_app`
+SELinux domain, its own UID) and cannot load kernel modules or read other
+apps' memory. Its toolbox is exactly the OS interfaces below.
+
+vpnhide does **not** tear down the VPN. It makes those interfaces *lie* to
+selected apps: the tunnel keeps working, but the listed targets see a device
+that looks like it is on plain Wi-Fi/cellular, and (optionally) cannot see the
+VPN-manager app at all.
+
+Two recurring assumptions, both documented in ROADMAP:
+
+- **Split tunnel** ([split-tunnel guidance](ROADMAP.md)): the recommended setup
+  keeps target apps *outside* the tunnel, so handing them a physical network
+  identity is consistent with where their traffic actually goes.
+- Server-side signals (egress IP geolocation, DNS, latency) **cannot** be fixed
+  on-device. vpnhide hides *local* VPN evidence only.
+
+---
+
+## 2. The four enforcement layers
+
+Coverage comes from three vpnhide components plus the platform. They differ in
+*where* they sit, *which APIs* they can touch, *how* targets are selected, and
+*whether a raw-syscall detector can bypass them*.
+
+| Layer | Where it runs | Selects targets by | Sees | Bypassable by raw syscalls? |
+|---|---|---|---|---|
+| **kmod** | Linux kernel (kretprobes) | **UID** (`/proc/vpnhide_targets`) | Everything below libc — the syscall/skb/seq_file source | **No** — filters at the source regardless of how userspace calls |
+| **zygisk** | target process, inline `libc` hooks (shadowhook) | **package** (`targets.txt`, per-fork) | Only calls routed through the hooked `libc` symbols | **Yes** — a direct `svc #0` / unhooked libc entry slips past |
+| **lsposed** | `system_server`, Binder hooks (Vector framework) | **UID** (`/data/system/vpnhide_uids.txt`) | Java/framework Binder results *before* serialization to the app | N/A — the data is built in another process; the app only gets the sanitized parcel |
+| **SELinux** | platform policy | domain (`untrusted_app`) | n/a — it *denies* access rather than filtering | n/a — a denial is a denial |
+
+Key consequences:
+
+- **kmod is the only bypass-proof layer.** A detector reading `/proc/net/route`
+  with a raw `openat` syscall, or driving netlink without libc, defeats zygisk
+  but not kmod. zygisk's value is that it works **without a custom kernel**
+  (stock GKI, Magisk/KSU) and reaches the same native APIs for libc-routed
+  callers.
+- **lsposed is the only layer that can fake the high-level Java network model**
+  (`ConnectivityManager`, `LinkProperties`, capabilities, callbacks) and
+  **package visibility**. Native layers cannot synthesize a coherent
+  `NetworkCapabilities` parcel; framework layers cannot touch `getifaddrs`.
+- The layers are **complementary, not redundant**. The recommended install is
+  all three; each closes vectors the others structurally cannot. Where only one
+  layer covers a vector, that is called out below.
+
+> **SELinux is a free but unreliable backstop.** On a Pixel 4a / Android 13,
+> `untrusted_app` is already *denied* `read` on `/proc/net/route` and `search`
+> on `/sys/class/net` (`avc: denied … permissive=0`). That closes some procfs
+> vectors for free — but **SELinux policy is configured differently on every
+> device and ROM**, so you cannot count on it:
+>
+> - It tightened over Android versions; older releases were far laxer about
+>   `/proc/net/*` and `/sys/class/net`.
+> - OEM and custom ROMs add their own `te` rules — some relabel or *grant*
+>   accesses that stock AOSP denies, widening what an app can read.
+> - A device booted `permissive` (many custom-kernel / dev setups), or an app
+>   running in a more privileged domain, sees these paths wide open.
+> - **The netlink path is not restricted** even on stock-enforcing devices, so
+>   a detector just asks the kernel over `NETLINK_ROUTE` instead — exactly how
+>   issue #86 surfaced.
+>
+> So a 🔒 below means "often denied on stock-enforcing builds", not "safe".
+> Never treat a SELinux denial observed on one device as coverage; the vpnhide
+> layers must stand on their own everywhere. (The same per-device caveat
+> applies to the SELinux *labels* in [state.md](state.md).)
+
+---
+
+## 3. Coverage matrix
+
+Legend: ✅ covered · ⚠️ partial / conditional · — not applicable to that layer ·
+🔒 often closed by SELinux (varies by device).
+
+### 3A. Interface enumeration — "is there a tun/wg/ppp interface?"
+
+| Vector | How it manifests | kmod | zygisk | lsposed | SELinux |
+|---|---|:--:|:--:|:--:|:--:|
+| `getifaddrs()` | native list of ifaces+addrs | ✅ via netlink hooks | ✅ unlinks VPN nodes | — | |
+| `NetworkInterface.getNetworkInterfaces()` (Java) | JNI → `getifaddrs` | ✅ | ✅ | — | |
+| `ioctl(SIOCGIFNAME)` index→name | native | ✅ `dev_ioctl` | ✅ | — | |
+| `ioctl(SIOCGIFCONF)` enumerate | native | ✅ `sock_ioctl` | ✅ `filter_ifconf` | — | |
+| `ioctl(SIOCGIF{FLAGS,MTU,INDEX,HWADDR,ADDR})` by name | native | ✅ `dev_ioctl` | ✅ pre-screen | — | |
+| netlink `RTM_GETLINK` dump | `recvmsg`/`recvfrom` of `RTM_NEWLINK` | ✅ `rtnl_fill_ifinfo` | ✅ filter by index | — | |
+| netlink `RTM_GETADDR` dump | `RTM_NEWADDR` | ✅ `inet*_fill_ifaddr` | ✅ filter by index | — | |
+| `/sys/class/net/<iface>/*` | reads iface type/mtu/operstate | — | — | — | 🔒 usually denied |
+
+Notes: bionic's `getifaddrs` itself runs over netlink, so the kmod
+`rtnl_fill_ifinfo` / `inet*_fill_ifaddr` hooks cover the Java and native paths
+at once. zygisk additionally unlinks entries from the `getifaddrs` result list
+directly, so it works even if a future bionic stops using netlink.
+
+### 3B. Route table — "is the default route a tunnel?"
+
+| Vector | How it manifests | kmod | zygisk | lsposed | SELinux |
+|---|---|:--:|:--:|:--:|:--:|
+| `/proc/net/route` (IPv4) | text, iface in col 1 | ✅ `fib_route_seq_show` | ✅ `filter_route_buf` | — | 🔒 often denied |
+| `/proc/net/ipv6_route` | text, iface last field | ✅ `ipv6_route_seq_show` | ✅ | — | 🔒 |
+| netlink `RTM_GETROUTE` **dump** | `RTA_OIF` index per route | ✅ `fib_dump_info` / `rt6_fill_node` | ✅ `RTM_NEWROUTE` filter (issue #86) | — | |
+| netlink `RTM_GETROUTE` **single** (`ip route get`) | one `rt_fill_info` reply | ⚠️ intentionally unhooked (see ROADMAP) | ⚠️ not filtered | — | |
+| netlink `RTM_GETRULE` (policy rules) | per-UID lookup tables | ✅ `fib_nl_fill_rule` | — | — | |
+| host-route to the VPN **server** | `/32`·`/128` to a public IP via a *physical* iface | ✅ `is_public_host_route_via_physical` | — | — | |
+| `LinkProperties.getRoutes()` (Java) | framework route list | — | — | ✅ filter `mRoutes` | |
+
+The **`if<N>` leak (issue #86)** lived here: a hidden tun still has an index, and
+a route dump exposes that index even when the *name* is hidden, so the detector
+renders it as the synthetic `if33`. Fixed in zygisk by filtering `RTM_NEWROUTE`
+on `RTA_OIF` *and* hooking the FORTIFY'd `recvfrom`/`__recvfrom_chk` that
+fortified native code actually calls (plain `recv` is never emitted for a
+fixed-size buffer). kmod already covered it via `fib_dump_info`.
+
+**Host-route to the server** is a desktop-VPN pattern: OpenVPN / kernel
+WireGuard / root VPNs pin a `/32` (or `/128`) route to the server's public IP
+out the physical interface so tunnel packets don't loop. That route names a
+*physical* iface, so name-based hiding misses it — kmod matches it by *shape*
+(host prefix + public dst + physical dev) instead. **On Android `VpnService`
+apps this route usually does not exist**: they reach the server via
+`protect(socket)` (an `SO_MARK` fwmark that bypasses VPN routing), so no host
+route is installed. The kmod logic is therefore *inert* on the typical Android
+setup and matters for desktop-style / non-`VpnService` VPNs. Kept because it is
+cheap and correct when such a route is present; see issue discussion.
+
+### 3C. Socket / address leaks — "any socket bound to a tunnel IP?"
+
+| Vector | How it manifests | kmod | zygisk | lsposed | SELinux |
+|---|---|:--:|:--:|:--:|:--:|
+| `/proc/net/tcp` | local addr hex per socket | — | ✅ `filter_tcp4_buf` (by VPN addr) | — | 🔒 often denied |
+| `/proc/net/tcp6` | 32-hex local addr | — | ✅ `filter_tcp6_buf` | — | 🔒 |
+| `/proc/net/if_inet6` | IPv6 addrs, iface last field | — | ✅ `filter_if_inet6_buf` | — | 🔒 |
+
+These three are **zygisk-only** today: kmod hides IPv6 addresses on the netlink
+`RTM_GETADDR` path but does **not** hook `if_inet6_seq_show`, `tcp4_seq_show`,
+or `tcp6_seq_show`, so the procfs equivalents leak under a raw-syscall reader
+that SELinux happens to allow. Candidate kmod work if a real detector uses them.
+
+### 3D. Framework network APIs (Java) — lsposed territory
+
+All `system_server` Binder results, sanitized before they reach the app. Native
+and kernel layers cannot fake these coherently. See
+[lsposed/AGENTS.md](../lsposed/AGENTS.md) and `HookEntry.kt` for the full list;
+summary:
+
+| Vector | API | Sanitization (lsposed) |
+|---|---|---|
+| VPN transport flag | `NetworkCapabilities.hasTransport(TRANSPORT_VPN)` | strip `TRANSPORT_VPN`, add `NET_CAPABILITY_NOT_VPN`, clear `TransportInfo` |
+| Active network is VPN | `getActiveNetwork()` / `Network.writeToParcel` | swap VPN `Network` handle for best physical one |
+| Network enumeration | `getAllNetworks()` | drop VPN handles from the array |
+| Legacy VPN type | `getNetworkInfo(TYPE_VPN)` / `getNetworkForType(TYPE_VPN)` | return `null`; otherwise disguise `NetworkInfo` `TYPE_VPN`→`TYPE_WIFI` |
+| Interface name / routes / DNS | `LinkProperties.{getInterfaceName,getRoutes,getDnsServers}` | null `mIfaceName`, filter `mRoutes`, recurse into stacked links |
+| Async push | `registerDefaultNetworkCallback()` / `registerNetworkCallback()` | suppress VPN-requested callbacks; stash recipient UID across dispatch (issue #70) |
+
+### 3E. Package visibility — "is the VPN-manager app installed?"
+
+lsposed-only, in `PackageVisibilityHooks.kt`, filtering `IPackageManagerBase`
+results for *observer* UIDs (`/data/system/vpnhide_observer_uids.txt`) against a
+hidden-package set (`/data/system/vpnhide_hidden_pkgs.txt`):
+
+- enumeration: `getInstalledPackages`, `getInstalledApplications`
+- resolution: `queryIntent{Activities,Services,Receivers,ContentProviders}`, `resolveIntent`, `resolveService`
+- direct lookup: `getPackageInfo`, `getApplicationInfo`, `getInstaller{PackageName,SourceInfo}`
+- UID mapping: `getPackageUid` (→ −1), `getPackagesForUid` (filtered)
+
+System callers (UID < 10000) are always exempt so the launcher/installer keep
+working.
+
+---
+
+## 4. Importance ranking
+
+Rough priority when triaging "which vector matters", based on what real
+detectors actually probe:
+
+1. **Interface enumeration + route dump (3A, 3B).** The first thing every native
+   detector checks. Must be airtight across libc *and* raw-syscall readers →
+   needs kmod for the bypass-proof guarantee, zygisk for kmod-less installs.
+2. **Framework network model (3D).** What pure-Java apps and most anti-fraud
+   SDKs use. lsposed-only; high value because it is the easy path for apps.
+3. **Package visibility (3E).** Stops "you have a VPN app installed" heuristics.
+   Independent of whether a VPN is currently up.
+4. **Socket/address procfs (3C).** Lower frequency; matters for thorough native
+   detectors and only when SELinux allows the read.
+5. **Single-lookup route, policy-rule edge cases (3B).** Rare; partially or
+   intentionally uncovered (see Gaps).
+
+---
+
+## 5. Known gaps & assumptions
+
+- **Raw-syscall native readers defeat zygisk.** Only kmod is bypass-proof.
+  Document any "covered" claim with the layer; a zygisk-only install is not
+  raw-syscall-proof.
+- **zygisk netlink filtering is recv-family-scoped.** It hooks `recvmsg`,
+  `recv`, `recvfrom`, `__recvfrom_chk`. A detector reading a netlink socket via
+  plain `read()`/`readv()` or `recvmmsg` would slip past. Not seen in the wild
+  yet; add hooks if it appears.
+- **kmod procfs gap:** no `if_inet6` / `tcp` / `tcp6` seq-file hooks (3C).
+- **Single-lookup route** (`rt_fill_info`) is intentionally unhooked — no stable
+  static-function ABI; low value under split tunnel. See
+  [ROADMAP.md](ROADMAP.md).
+- **Host-route logic is inert under Android `VpnService`** (`protect()` path,
+  3B). Kept for desktop-style VPNs.
+- **Server-side signals are out of scope** (egress IP, DNS, RTT). Split-tunnel
+  guidance is the mitigation, not code.
+- **VPN-preserving mode** (keep target traffic *inside* the tunnel while hidden)
+  is future work; today the physical-handle swap assumes split tunnel. See
+  [ROADMAP.md](ROADMAP.md), issue #130.
+
+---
+
+## 6. Where coverage is defined in code
+
+| Layer | Entry points |
+|---|---|
+| kmod | `kmod/vpnhide_kmod.c` (10 kretprobes); iface matcher `kmod/generated/iface_lists.h` |
+| zygisk | `zygisk/src/hooks.rs` (ioctl/getifaddrs/openat/recv*); `zygisk/src/filter.rs` (procfs + netlink filters) |
+| lsposed | `lsposed/app/.../HookEntry.kt`, `PackageVisibilityHooks.kt`; iface matcher `.../generated/IfaceLists.kt` |
+| iface match rules | single source of truth `data/interfaces.toml` → `scripts/codegen-interfaces.py` renders all four languages |
+
+The interface-name patterns (`tun`/`tap`/`wg`/`ppp`/`ipsec`/`xfrm`/`utun`/`l2tp`/`gre`,
+substring `vpn`, and the `if<digits>` renamed-tunnel form from issue #86) are
+generated identically for all layers from `data/interfaces.toml`.

--- a/docs/detection-vectors.md
+++ b/docs/detection-vectors.md
@@ -57,9 +57,24 @@ Key consequences:
   (`ConnectivityManager`, `LinkProperties`, capabilities, callbacks) and
   **package visibility**. Native layers cannot synthesize a coherent
   `NetworkCapabilities` parcel; framework layers cannot touch `getifaddrs`.
-- The layers are **complementary, not redundant**. The recommended install is
-  all three; each closes vectors the others structurally cannot. Where only one
-  layer covers a vector, that is called out below.
+- **kmod and zygisk are two implementations of the *same* native layer — you
+  install one, not both.** They cover essentially the same native vectors
+  (interface enumeration, routes, procfs, netlink); the choice is a tradeoff,
+  not an addition:
+    - **kmod** is preferred — bypass-proof and out-of-process (zero footprint in
+      the app), but needs a supported GKI kernel with `CONFIG_KPROBES`.
+    - **zygisk** is the fallback for kernels kmod doesn't support — works on any
+      arm64 kernel, but only catches libc-routed calls (a raw `svc #0` slips
+      past) and runs inside the app process (visible to aggressive anti-tamper).
+  Running both at once is redundant, not additive (both would filter the same
+  data for the same target). The small deltas between them — e.g. zygisk also
+  filters `/proc/net/{if_inet6,tcp,tcp6}`, kmod also handles `RTM_GETRULE` and
+  the server host-route — are noted in the matrix; neither delta is a reason to
+  stack them.
+- So a complete install is **two roles**: the native layer (kmod *or* zygisk)
+  **plus** lsposed for the Java vectors, with SELinux as an unreliable platform
+  backstop underneath. Where only one layer covers a vector, that is called out
+  below.
 
 > **SELinux is a free but unreliable backstop.** On a Pixel 4a / Android 13,
 > `untrusted_app` is already *denied* `read` on `/proc/net/route` and `search`

--- a/docs/state.md
+++ b/docs/state.md
@@ -258,7 +258,7 @@ Not owned by us, but consulted for diagnostics or wiring.
 | `/data/misc/<vector-uuid>/prefs/<pkg>/` | Vector LSPosed | Redirected SharedPreferences — see § 5 |
 | `/proc/sys/kernel/random/boot_id` | Linux kernel | Compared everywhere with stored `boot_id` fields to detect "is this record from the current boot?" |
 | `/proc/version`, `/proc/modules`, `/proc/config.gz` | Linux kernel | Read by `kmod/module/post-fs-data.sh` for kernel diagnostics |
-| `/proc/net/{route,ipv6_route,if_inet6,tcp,tcp6,udp,udp6,dev,fib_trie}` | Linux kernel | Read by `lsposed/native/src/` diagnostics + filtered by Zygisk hooks (`zygisk/src/hooks.rs`) — a memfd substitute is returned when a target app `openat`'s these |
+| `/proc/net/{route,ipv6_route,if_inet6,tcp,tcp6,udp,udp6,dev,fib_trie}` | Linux kernel | Read by `lsposed/native/src/` diagnostics + filtered by Zygisk hooks (`zygisk/src/hooks.rs`) — a memfd substitute is returned when a target app `openat`'s these. Which of these are filtered by which layer is the **coverage** question, mapped in [detection-vectors.md](detection-vectors.md) |
 | `/sys/class/net/`, `/sys/class/net/<iface>/operstate` | Linux kernel | `isVpnActiveBlocking` (`ShellUtils.kt:96`) iterates interfaces and checks operstate to detect "VPN is up right now" |
 
 ---


### PR DESCRIPTION
Consolidates "which app probe is hidden by which component" into one authoritative document, and corrects the README coverage table — it marked the netlink path as SELinux-blocked and predated the issue #86 fix, both of which our on-device work disproved.

The new `docs/detection-vectors.md` is the technical source of truth (layers, per-vector matrix, gaps); the README table stays as the user-facing summary and now links to it.

- Add `docs/detection-vectors.md`: threat model, the kmod/zygisk/lsposed/SELinux enforcement layers, a per-vector coverage matrix (interface enumeration, route table, socket procfs, framework Java APIs, package visibility), an importance ranking, known gaps/assumptions, and where each layer is defined in code
- Fix `README.md` / `README.en.md` coverage table: netlink `RTM_GETLINK`/`RTM_GETADDR`/`RTM_GETROUTE` are not SELinux-restricted; `RTM_GETROUTE` is now covered by kmod and zygisk; correct `RTM_GETADDR`, `/proc/net/ipv6_route`, and `/proc/net/tcp` cells; rewrite the conclusion to explain the netlink path and per-device SELinux variance
- Emphasize that SELinux policy differs across devices, ROMs, and Android versions, so the layers never rely on it
- Cross-link the new doc from `CLAUDE.md`, `docs/ROADMAP.md`, and `docs/state.md`