### PR TITLE
Bump dev tooling and CI toolchain versions

### DIFF
--- a/.github/docker/ci/Dockerfile
+++ b/.github/docker/ci/Dockerfile
@@ -51,7 +51,7 @@ RUN mkdir -p "${ANDROID_HOME}/cmdline-tools" && \
 ENV RUSTUP_HOME=/usr/local/rustup \
     CARGO_HOME=/usr/local/cargo \
     PATH=/usr/local/cargo/bin:$PATH \
-    RUST_VERSION=1.95.0 \
+    RUST_VERSION=1.96.0 \
     CARGO_NDK_VERSION=4.1.2
 
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | \
@@ -62,7 +62,7 @@ RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | \
     chmod -R a+w /usr/local/rustup /usr/local/cargo
 
 # ── Android NDK (for zygisk) ─────────────────────────────────────────
-ENV ANDROID_NDK_VERSION=r28b
+ENV ANDROID_NDK_VERSION=r28c
 ENV ANDROID_NDK_HOME=/opt/android-ndk
 # Gobley's cargo plugin reads ANDROID_NDK_ROOT (not _HOME) to find the NDK
 # when looking up the toolchain library directory for Android Rust targets.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ permissions:
   packages: read
 
 env:
-  RUFF_VERSION: "0.15.18"
+  RUFF_VERSION: "0.15.20"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
@@ -65,7 +65,7 @@ jobs:
       # zygisk + lsposed jobs — when those run on the same Cargo.lock the
       # restore-keys fallback shares warm artifacts across jobs.
       - name: Cache cargo
-        uses: actions/cache@v5
+        uses: actions/cache@v6
         with:
           path: |
             /usr/local/cargo/registry
@@ -267,7 +267,7 @@ jobs:
         run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
 
       - name: Cache cargo
-        uses: actions/cache@v5
+        uses: actions/cache@v6
         with:
           path: |
             /usr/local/cargo/registry
@@ -307,7 +307,7 @@ jobs:
         run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
 
       - name: Cache cargo
-        uses: actions/cache@v5
+        uses: actions/cache@v6
         with:
           path: |
             /usr/local/cargo/registry

--- a/lsposed/build.gradle.kts
+++ b/lsposed/build.gradle.kts
@@ -14,7 +14,7 @@ plugins {
 // run locally with `./gradlew cpdCheck`, report at build/reports/cpd/. For a
 // genuinely-unavoidable clone, refactor it or raise minimumTokenCount.
 cpd {
-    toolVersion = "7.8.0"
+    toolVersion = "7.25.0"
     language = "kotlin"
     // Tune up if too noisy / down to catch smaller clones. ~100 tokens ≈ a
     // small duplicated function.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@
 # header), so ruff is a dev/CI tool here, never a runtime dependency.
 
 [tool.ruff]
-required-version = "==0.15.18"
+required-version = "==0.15.20"
 target-version = "py312"  # CI image (Ubuntu 24.04) ships Python 3.12
 line-length = 100
 extend-exclude = [


### PR DESCRIPTION
Routine dependency refresh. I audited every manifest in the repo (Cargo, Gradle version catalog, Gradle wrapper, the CI Dockerfile, pyproject, and the workflow action pins) against the upstream registries. The Rust runtime deps (libc, log, android_logger, cmake, cargo-ndk) and the Android deps (AGP, Kotlin, Compose BOM, activity/core/datastore, detekt, material-kolor, squircle, etc.) were already on their latest stable releases, and the deliberately-pinned pre-release pins (material3 alpha, the Gobley AGP-9 fork) are unchanged. So this PR only moves dev tooling and the CI image.

- PMD CPD `toolVersion` 7.8.0 → 7.25.0 — `cpdCheck` still builds clean with no new clones flagged
- ruff 0.15.18 → 0.15.20 — bumped in both `pyproject.toml` (`required-version`) and the CI `RUFF_VERSION` env so they stay in sync; `ruff format --check` and `ruff check` pass
- CI image rustc 1.95.0 → 1.96.0 (MSRV stays 1.85)
- CI image NDK r28b → r28c — aligns the baked-in NDK with the Gradle `ndkVersion = "28.2.13676358"` that was already pinned, removing a mismatch
- `actions/cache` v5 → v6

## Testing
- `ruff@0.15.20 format --check` + `check` — clean
- `./gradlew cpdCheck` with PMD 7.25.0 — BUILD SUCCESSFUL
- rustc/NDK/cache changes are CI-image/workflow-only and are exercised by the CI image rebuild + the normal build/clippy/test jobs