### PR TITLE
KPM (KernelPatch Module) backend — third native backend for non-GKI / locked kernels

### DIFF
--- a/.github/docker/ddk-qemu/Dockerfile
+++ b/.github/docker/ddk-qemu/Dockerfile
@@ -12,6 +12,27 @@
 # VPNHIDE_QEMU_KO (a kdir-built module loads fine here: same source, same
 # vermagic). Built rarely by qemu-image.yml since kernels change seldom.
 ARG KMI
+
+# --- builder: the bionic getifaddrs probe ----------------------------------
+# The gai_getifaddrs vector must run a *bionic* binary (it validates how
+# Android's getifaddrs parses our filtered netlink dump — glibc differs and is
+# the wrong libc to test). Build it from gai-probe.c with the NDK here; only
+# the ~420 KB static binary is copied into the final image (no NDK retained).
+# The DDK clang can't build it (no bionic userspace sysroot), hence the NDK.
+FROM debian:trixie-slim AS gai
+ENV DEBIAN_FRONTEND=noninteractive
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        curl ca-certificates unzip && rm -rf /var/lib/apt/lists/*
+ARG NDK_VER=r28c
+RUN curl -fsSL "https://dl.google.com/android/repository/android-ndk-${NDK_VER}-linux.zip" \
+        -o /tmp/ndk.zip && \
+    unzip -q /tmp/ndk.zip "android-ndk-${NDK_VER}/toolchains/llvm/prebuilt/linux-x86_64/*" \
+        -d /opt && rm /tmp/ndk.zip
+COPY kmod/test/gai-probe.c /tmp/gai-probe.c
+RUN TC="/opt/android-ndk-${NDK_VER}/toolchains/llvm/prebuilt/linux-x86_64/bin" && \
+    "$TC/aarch64-linux-android24-clang" -static -O2 -o /opt/gai /tmp/gai-probe.c && \
+    "$TC/llvm-strip" /opt/gai
+
 FROM ghcr.io/ylarod/ddk-min:${KMI}-20260313
 ARG KMI
 
@@ -58,11 +79,17 @@ RUN mkdir -p /opt/qemu/kp && \
             -o "/opt/qemu/kp/$a"; \
     done && chmod +x /opt/qemu/kp/kptools-linux
 
+# Prebuilt bionic getifaddrs probe (built from gai-probe.c with the NDK in the
+# `gai` stage). run-kpm.sh picks it up via VPNHIDE_GAI_BIN so the addr-fill
+# hook is validated in CI on every KMI — not skipped.
+COPY --from=gai /opt/gai /opt/qemu/gai
+
 # run.sh / run-kpm.sh read these to use the baked artifacts instead of the local
 # cache. VPNHIDE_QEMU_KSRC is the kernel tree to build the test module against;
-# VPNHIDE_KP_BIN is the baked KernelPatch tool/runtime dir (KPM only). The
-# harness's static getifaddrs probe builds with the apt aarch64-linux-gnu gcc.
+# VPNHIDE_KP_BIN is the baked KernelPatch tool/runtime dir (KPM only);
+# VPNHIDE_GAI_BIN is the prebuilt bionic getifaddrs probe.
 ENV VPNHIDE_QEMU_IMAGE=/opt/qemu/Image
 ENV VPNHIDE_QEMU_ROOTFS=/opt/qemu/alpine-minirootfs.tar.gz
 ENV VPNHIDE_QEMU_KSRC=/opt/qemu/linux
 ENV VPNHIDE_KP_BIN=/opt/qemu/kp
+ENV VPNHIDE_GAI_BIN=/opt/qemu/gai

--- a/.github/docker/ddk-qemu/Dockerfile
+++ b/.github/docker/ddk-qemu/Dockerfile
@@ -18,7 +18,8 @@ ARG KMI
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && apt-get install -y --no-install-recommends \
         qemu-system-arm cpio gzip curl ca-certificates git \
-        bc bison flex libelf-dev libssl-dev && \
+        bc bison flex libelf-dev libssl-dev \
+        gcc-aarch64-linux-gnu && \
     rm -rf /var/lib/apt/lists/*
 
 # Build the kernel and KEEP its tree: the test module must be built against the
@@ -47,8 +48,21 @@ RUN curl -fsSL \
         https://dl-cdn.alpinelinux.org/alpine/v3.21/releases/aarch64/alpine-minirootfs-3.21.2-aarch64.tar.gz \
         -o /opt/qemu/alpine-minirootfs.tar.gz
 
-# run.sh reads these to use the baked kernel + rootfs instead of the local cache.
-# VPNHIDE_QEMU_KSRC is the kernel tree to build the test module against.
+# KernelPatch host tool (kptools) + runtime (kpimg) for the KPM harness
+# (run-kpm.sh) — baked at a pinned version so the per-PR kpm-qemu job is
+# hermetic (no per-run release download). Same binaries for every KMI.
+ARG KP_VER=0.13.1
+RUN mkdir -p /opt/qemu/kp && \
+    for a in kptools-linux kpimg-linux; do \
+        curl -fsSL "https://github.com/bmax121/KernelPatch/releases/download/${KP_VER}/$a" \
+            -o "/opt/qemu/kp/$a"; \
+    done && chmod +x /opt/qemu/kp/kptools-linux
+
+# run.sh / run-kpm.sh read these to use the baked artifacts instead of the local
+# cache. VPNHIDE_QEMU_KSRC is the kernel tree to build the test module against;
+# VPNHIDE_KP_BIN is the baked KernelPatch tool/runtime dir (KPM only). The
+# harness's static getifaddrs probe builds with the apt aarch64-linux-gnu gcc.
 ENV VPNHIDE_QEMU_IMAGE=/opt/qemu/Image
 ENV VPNHIDE_QEMU_ROOTFS=/opt/qemu/alpine-minirootfs.tar.gz
 ENV VPNHIDE_QEMU_KSRC=/opt/qemu/linux
+ENV VPNHIDE_KP_BIN=/opt/qemu/kp

--- a/.github/docker/kpm-qemu-legacy/Dockerfile
+++ b/.github/docker/kpm-qemu-legacy/Dockerfile
@@ -16,7 +16,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         qemu-system-arm cpio gzip xz-utils bzip2 curl ca-certificates git make \
         bc bison flex libelf-dev libssl-dev \
         gcc g++ libc6-dev \
-        clang gcc-aarch64-linux-gnu && \
+        clang lld gcc-aarch64-linux-gnu && \
     rm -rf /var/lib/apt/lists/*
 
 # Build the 3 legacy kernels (Bootlin gcc, pinned sources, qemu.config + SW PAN)

--- a/.github/docker/kpm-qemu-legacy/Dockerfile
+++ b/.github/docker/kpm-qemu-legacy/Dockerfile
@@ -9,7 +9,30 @@
 # No DDK and no kernel tree: the .kpm is relocatable (built per-PR against the
 # KernelPatch submodule), so nothing here is built against the kernel. Built
 # rarely (qemu-image.yml) since these kernels are pinned.
-FROM debian:bookworm-slim
+#
+# trixie (not bookworm): the prebuilt kptools-linux is linked against glibc
+# >= 2.38; bookworm ships 2.36 and the dynamic loader rejects it. trixie = 2.41.
+
+# --- builder: the bionic getifaddrs probe ----------------------------------
+# The gai_getifaddrs vector must run a *bionic* binary (it validates how
+# Android's getifaddrs parses our filtered netlink dump — glibc differs and is
+# the wrong libc to test). Build it from gai-probe.c with the NDK here; only
+# the ~420 KB static binary is copied into the final image (no NDK retained).
+FROM debian:trixie-slim AS gai
+ENV DEBIAN_FRONTEND=noninteractive
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        curl ca-certificates unzip && rm -rf /var/lib/apt/lists/*
+ARG NDK_VER=r28c
+RUN curl -fsSL "https://dl.google.com/android/repository/android-ndk-${NDK_VER}-linux.zip" \
+        -o /tmp/ndk.zip && \
+    unzip -q /tmp/ndk.zip "android-ndk-${NDK_VER}/toolchains/llvm/prebuilt/linux-x86_64/*" \
+        -d /opt && rm /tmp/ndk.zip
+COPY kmod/test/gai-probe.c /tmp/gai-probe.c
+RUN TC="/opt/android-ndk-${NDK_VER}/toolchains/llvm/prebuilt/linux-x86_64/bin" && \
+    "$TC/aarch64-linux-android24-clang" -static -O2 -o /opt/gai /tmp/gai-probe.c && \
+    "$TC/llvm-strip" /opt/gai
+
+FROM debian:trixie-slim
 
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && apt-get install -y --no-install-recommends \
@@ -39,8 +62,14 @@ RUN mkdir -p /opt/qemu/kp && \
             -o "/opt/qemu/kp/$a"; \
     done && chmod +x /opt/qemu/kp/kptools-linux
 
+# Prebuilt bionic getifaddrs probe (built from gai-probe.c with the NDK in the
+# `gai` stage). run-kpm.sh picks it up via VPNHIDE_GAI_BIN so the addr-fill
+# hook is validated in CI on every legacy kernel — not skipped.
+COPY --from=gai /opt/gai /opt/qemu/gai
+
 # run-kpm.sh reads these. The per-version Image lives at
 # /opt/qemu/legacy/<ver>/Image — the CI job sets VPNHIDE_QEMU_IMAGE +
 # VPNHIDE_QEMU_CPU=cortex-a57 per matrix entry.
 ENV VPNHIDE_QEMU_ROOTFS=/opt/qemu/alpine-minirootfs.tar.gz
 ENV VPNHIDE_KP_BIN=/opt/qemu/kp
+ENV VPNHIDE_GAI_BIN=/opt/qemu/gai

--- a/.github/docker/kpm-qemu-legacy/Dockerfile
+++ b/.github/docker/kpm-qemu-legacy/Dockerfile
@@ -1,0 +1,45 @@
+# Image for the KPM harness's LEGACY (pre-GKI) targets: 4.14 / 4.19 / 5.4 —
+# the kernels the .ko backend can't serve (no GKI, no DDK). Unlike ddk-qemu
+# (per-KMI, DDK clang, kept kernel tree), this is ONE lightweight image:
+#
+#   debian + one Bootlin aarch64 gcc (fetched by build-source-kernel.sh)
+#   + the 3 built virtio Images
+#   + Alpine minirootfs + KernelPatch tool/runtime + clang (for `make kpm`)
+#
+# No DDK and no kernel tree: the .kpm is relocatable (built per-PR against the
+# KernelPatch submodule), so nothing here is built against the kernel. Built
+# rarely (qemu-image.yml) since these kernels are pinned.
+FROM debian:bookworm-slim
+
+ENV DEBIAN_FRONTEND=noninteractive
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        qemu-system-arm cpio gzip xz-utils bzip2 curl ca-certificates git make \
+        bc bison flex libelf-dev libssl-dev \
+        clang gcc-aarch64-linux-gnu && \
+    rm -rf /var/lib/apt/lists/*
+
+# Build the 3 legacy kernels (Bootlin gcc, pinned sources, qemu.config + SW PAN)
+# and keep only the Images — drop the fetched sources + toolchain afterwards.
+COPY kmod/test /src/kmod/test
+RUN cd /src && \
+    for v in 4.14 4.19 5.4; do \
+        kmod/test/build-source-kernel.sh "$v" "/opt/qemu/legacy/$v"; \
+    done && \
+    rm -rf /src/kmod/test/.cache
+
+# Alpine rootfs + pinned KernelPatch tool/runtime (same as ddk-qemu).
+RUN curl -fsSL \
+        https://dl-cdn.alpinelinux.org/alpine/v3.21/releases/aarch64/alpine-minirootfs-3.21.2-aarch64.tar.gz \
+        -o /opt/qemu/alpine-minirootfs.tar.gz
+ARG KP_VER=0.13.1
+RUN mkdir -p /opt/qemu/kp && \
+    for a in kptools-linux kpimg-linux; do \
+        curl -fsSL "https://github.com/bmax121/KernelPatch/releases/download/${KP_VER}/$a" \
+            -o "/opt/qemu/kp/$a"; \
+    done && chmod +x /opt/qemu/kp/kptools-linux
+
+# run-kpm.sh reads these. The per-version Image lives at
+# /opt/qemu/legacy/<ver>/Image — the CI job sets VPNHIDE_QEMU_IMAGE +
+# VPNHIDE_QEMU_CPU=cortex-a57 per matrix entry.
+ENV VPNHIDE_QEMU_ROOTFS=/opt/qemu/alpine-minirootfs.tar.gz
+ENV VPNHIDE_KP_BIN=/opt/qemu/kp

--- a/.github/docker/kpm-qemu-legacy/Dockerfile
+++ b/.github/docker/kpm-qemu-legacy/Dockerfile
@@ -15,6 +15,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && apt-get install -y --no-install-recommends \
         qemu-system-arm cpio gzip xz-utils bzip2 curl ca-certificates git make \
         bc bison flex libelf-dev libssl-dev \
+        gcc g++ libc6-dev \
         clang gcc-aarch64-linux-gnu && \
     rm -rf /var/lib/apt/lists/*
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -248,6 +248,49 @@ jobs:
           make -C kmod KERNEL_SRC="$VPNHIDE_QEMU_KSRC" CLANG_DIR="$CLANG_BIN"
           VPNHIDE_QEMU_KO="$PWD/kmod/vpnhide_kmod.ko" kmod/test/run.sh "$KMI"
 
+  # KPM backend on the SAME baked GKI kernels as kmod-qemu, but patched with
+  # KernelPatch instead of insmod (run-kpm.sh). Reuses the ddk-qemu image: the
+  # baked Image/rootfs + KernelPatch tool/runtime (VPNHIDE_KP_BIN) make this
+  # hermetic. Legacy pre-GKI kernels (4.14/4.19/5.4) are a separate job/image.
+  kpm-qemu:
+    needs: setup
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        kmi:
+          - android12-5.10
+          - android13-5.10
+          - android13-5.15
+          - android14-5.15
+          - android14-6.1
+          - android15-6.6
+          - android16-6.12
+    container:
+      image: ${{ needs.setup.outputs.ddkqemu }}:${{ matrix.kmi }}
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+    env:
+      KMI: ${{ matrix.kmi }}
+
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          submodules: recursive   # KernelPatch headers needed by `make kpm`
+
+      - name: Mark workspace safe
+        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
+
+      - name: Build .kpm + KPM QEMU runtime test
+        # `make kpm` builds the relocatable .kpm against the KernelPatch
+        # submodule (no kernel tree needed). run-kpm.sh patches the baked Image
+        # with KernelPatch (VPNHIDE_KP_BIN), embeds the .kpm, and boots the A/B.
+        run: |
+          CLANG_BIN="$(ls -d /opt/ddk/clang/*/bin | head -1)"
+          make -C kmod kpm CLANG_DIR="$CLANG_BIN"
+          kmod/test/run-kpm.sh "$KMI"
+
   zygisk:
     needs: setup
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -288,6 +288,10 @@ jobs:
         # `make kpm` builds the relocatable .kpm against the KernelPatch
         # submodule (no kernel tree needed). run-kpm.sh patches the baked Image
         # with KernelPatch (VPNHIDE_KP_BIN), embeds the .kpm, and boots the A/B.
+        # VPNHIDE_GAI_REQUIRED: the bionic getifaddrs probe is baked into the
+        # image, so a skip means it's missing — fail rather than drop coverage.
+        env:
+          VPNHIDE_GAI_REQUIRED: "1"
         run: |
           CLANG_BIN="$(ls -d /opt/ddk/clang/*/bin | head -1)"
           make -C kmod kpm CLANG_DIR="$CLANG_BIN"
@@ -323,6 +327,10 @@ jobs:
         # plain clang from the legacy image; the baked Image + rootfs + KP tools
         # come from ENV (VPNHIDE_QEMU_ROOTFS / VPNHIDE_KP_BIN). The KMI arg is
         # just a label here — VPNHIDE_QEMU_IMAGE picks the from-source kernel.
+        # VPNHIDE_GAI_REQUIRED: the bionic getifaddrs probe is baked into the
+        # image, so a skip means it's missing — fail rather than drop coverage.
+        env:
+          VPNHIDE_GAI_REQUIRED: "1"
         run: |
           make -C kmod kpm
           VPNHIDE_QEMU_IMAGE="/opt/qemu/legacy/${{ matrix.ver }}/Image" \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,7 @@ jobs:
     outputs:
       image: ${{ steps.img.outputs.image }}
       ddkqemu: ${{ steps.img.outputs.ddkqemu }}
+      kpmlegacy: ${{ steps.img.outputs.kpmlegacy }}
     steps:
       - id: img
         env:
@@ -31,6 +32,7 @@ jobs:
         run: |
           echo "image=ghcr.io/${REPO,,}/ci:latest" >> "$GITHUB_OUTPUT"
           echo "ddkqemu=ghcr.io/${REPO,,}/ddk-qemu" >> "$GITHUB_OUTPUT"
+          echo "kpmlegacy=ghcr.io/${REPO,,}/kpm-qemu-legacy:latest" >> "$GITHUB_OUTPUT"
 
   lint:
     needs: setup
@@ -290,6 +292,42 @@ jobs:
           CLANG_BIN="$(ls -d /opt/ddk/clang/*/bin | head -1)"
           make -C kmod kpm CLANG_DIR="$CLANG_BIN"
           kmod/test/run-kpm.sh "$KMI"
+
+  # Legacy pre-GKI kernels (4.14/4.19/5.4) — the KPM's whole reason to exist
+  # (the .ko can't serve them). One image holds all three from-source Images;
+  # `-cpu cortex-a57` (those kernels fault on `-cpu max`) with software PAN
+  # compiled in, so the user/kernel pointer-domain bug class is caught here on
+  # the exact cores where it lives.
+  kpm-qemu-legacy:
+    needs: setup
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        ver: ["4.14", "4.19", "5.4"]
+    container:
+      image: ${{ needs.setup.outputs.kpmlegacy }}
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          submodules: recursive   # KernelPatch headers needed by `make kpm`
+
+      - name: Mark workspace safe
+        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
+
+      - name: Build .kpm + legacy KPM QEMU test
+        # plain clang from the legacy image; the baked Image + rootfs + KP tools
+        # come from ENV (VPNHIDE_QEMU_ROOTFS / VPNHIDE_KP_BIN). The KMI arg is
+        # just a label here — VPNHIDE_QEMU_IMAGE picks the from-source kernel.
+        run: |
+          make -C kmod kpm
+          VPNHIDE_QEMU_IMAGE="/opt/qemu/legacy/${{ matrix.ver }}/Image" \
+          VPNHIDE_QEMU_CPU=cortex-a57 \
+            kmod/test/run-kpm.sh android12-5.10
 
   zygisk:
     needs: setup

--- a/.github/workflows/qemu-image.yml
+++ b/.github/workflows/qemu-image.yml
@@ -9,8 +9,10 @@ on:
     branches: [main]
     paths:
       - .github/docker/ddk-qemu/Dockerfile
+      - .github/docker/kpm-qemu-legacy/Dockerfile
       - .github/workflows/qemu-image.yml
       - kmod/test/qemu.config
+      - kmod/test/build-source-kernel.sh
   schedule:
     - cron: '0 4 1 * *'
   workflow_dispatch:
@@ -83,3 +85,43 @@ jobs:
           tags: ${{ steps.img.outputs.image }}
           cache-from: type=gha,scope=ddk-qemu-${{ matrix.kmi }}
           cache-to: type=gha,mode=max,scope=ddk-qemu-${{ matrix.kmi }}
+
+  # One lightweight image with the 3 from-source legacy kernels (4.14/4.19/5.4)
+  # for the KPM harness. Not a matrix — a single image with all three Images,
+  # built by build-source-kernel.sh (Bootlin gcc, no DDK, no kernel tree).
+  build-legacy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      # Three gcc kernel builds + the AOSP 5.4 checkout are disk-hungry.
+      - name: Free up disk space
+        uses: jlumbroso/free-disk-space@main
+        with:
+          tool-cache: true
+          large-packages: false
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - id: img
+        env:
+          REPO: ${{ github.repository }}
+        run: echo "image=ghcr.io/${REPO,,}/kpm-qemu-legacy:latest" >> "$GITHUB_OUTPUT"
+
+      - name: Build and push
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: .github/docker/kpm-qemu-legacy/Dockerfile
+          push: true
+          tags: ${{ steps.img.outputs.image }}
+          cache-from: type=gha,scope=kpm-qemu-legacy
+          cache-to: type=gha,mode=max,scope=kpm-qemu-legacy

--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,8 @@ kmod/module/vpnhide_kmod.ko
 kmod/.env
 kmod/*.lds
 kmod/test_iface_lists
+kmod/*.kpm
+kmod/shared/test_vpnhide_logic
 
 # General
 *.swp

--- a/.gitmodules
+++ b/.gitmodules
@@ -2,3 +2,6 @@
 	path = zygisk/third_party/android-inline-hook
 	url = https://github.com/okhsunrog/android-inline-hook.git
 	branch = vpnhide-zygisk
+[submodule "kmod/third_party/KernelPatch"]
+	path = kmod/third_party/KernelPatch
+	url = https://github.com/bmax121/KernelPatch

--- a/kmod/Makefile
+++ b/kmod/Makefile
@@ -20,7 +20,11 @@ KPM_INCLUDE_DIRS := . include patch/include linux/include \
 	linux/arch/arm64/include linux/tools/arch/arm64/include
 KPM_INCLUDES := $(foreach d,$(KPM_INCLUDE_DIRS),-I$(KP_DIR)/kernel/$(d))
 
-KPM_CFLAGS := -target aarch64-linux-android \
+# -fuse-ld=lld: the `-r` link targets aarch64; lld handles the cross link with
+# one binary. DDK clang bundles lld and defaults to it, but a plain distro clang
+# (the legacy KPM image) defaults to the host GNU ld, which can't do the aarch64
+# relocatable link — force lld so both toolchains build the .kpm identically.
+KPM_CFLAGS := -target aarch64-linux-android -fuse-ld=lld \
 	-O2 -fno-pic -fno-pie -fno-plt -mcmodel=small \
 	-fvisibility=hidden -mno-outline-atomics \
 	-fno-stack-protector -fno-common -fno-builtin -ffreestanding \

--- a/kmod/Makefile
+++ b/kmod/Makefile
@@ -12,9 +12,10 @@ CLANG := $(if $(CLANG_DIR),$(CLANG_DIR)/clang,clang)
 #  KPM backend — relocatable `.kpm`, KernelPatch headers, NO kernel  #
 #  source / Module.symvers.  Build: make kpm KP_DIR=/path/KernelPatch #
 # ================================================================== #
-# KernelPatch's own header tree (its kernel/ include dirs + linux stubs).
-KPM_INCLUDE_DIRS := kernel kernel/include kernel/patch/include kernel/linux/include
-KPM_INCLUDES := $(foreach d,$(KPM_INCLUDE_DIRS),-I$(KP_DIR)/$(d))
+# KernelPatch's own header tree (mirrors kpms/*/Makefile INCLUDE_DIRS).
+KPM_INCLUDE_DIRS := . include patch/include linux/include \
+	linux/arch/arm64/include linux/tools/arch/arm64/include
+KPM_INCLUDES := $(foreach d,$(KPM_INCLUDE_DIRS),-I$(KP_DIR)/kernel/$(d))
 
 KPM_CFLAGS := -target aarch64-linux-android \
 	-O2 -fno-pic -fno-pie -fno-plt -mcmodel=small \

--- a/kmod/Makefile
+++ b/kmod/Makefile
@@ -24,7 +24,10 @@ KPM_INCLUDES := $(foreach d,$(KPM_INCLUDE_DIRS),-I$(KP_DIR)/kernel/$(d))
 # one binary. DDK clang bundles lld and defaults to it, but a plain distro clang
 # (the legacy KPM image) defaults to the host GNU ld, which can't do the aarch64
 # relocatable link — force lld so both toolchains build the .kpm identically.
-KPM_CFLAGS := -target aarch64-linux-android -fuse-ld=lld \
+# -nostdlib: this is a freestanding relocatable kernel object; older Android
+# clang drivers (e.g. clang-12 on android12-5.10) otherwise add CRT startup
+# files + -lc/-ldl to the `-r` link and fail (crtbegin_dynamic.o / -lc not found).
+KPM_CFLAGS := -target aarch64-linux-android -fuse-ld=lld -nostdlib \
 	-O2 -fno-pic -fno-pie -fno-plt -mcmodel=small \
 	-fvisibility=hidden -mno-outline-atomics \
 	-fno-stack-protector -fno-common -fno-builtin -ffreestanding \

--- a/kmod/Makefile
+++ b/kmod/Makefile
@@ -2,6 +2,46 @@ obj-m += vpnhide_kmod.o
 
 ifeq ($(KERNELRELEASE),)
 
+# Default target stays the LKM (.ko) build, even though `kpm` is defined first.
+.DEFAULT_GOAL := all
+
+# clang is needed by both backends; prefer $(CLANG_DIR) if the .env set it.
+CLANG := $(if $(CLANG_DIR),$(CLANG_DIR)/clang,clang)
+
+# ================================================================== #
+#  KPM backend — relocatable `.kpm`, KernelPatch headers, NO kernel  #
+#  source / Module.symvers.  Build: make kpm KP_DIR=/path/KernelPatch #
+# ================================================================== #
+# KernelPatch's own header tree (its kernel/ include dirs + linux stubs).
+KPM_INCLUDE_DIRS := kernel kernel/include kernel/patch/include kernel/linux/include
+KPM_INCLUDES := $(foreach d,$(KPM_INCLUDE_DIRS),-I$(KP_DIR)/$(d))
+
+KPM_CFLAGS := -target aarch64-linux-android \
+	-O2 -fno-pic -fno-pie -fno-plt -mcmodel=small \
+	-fvisibility=hidden -mno-outline-atomics \
+	-fno-stack-protector -fno-common -fno-builtin -ffreestanding \
+	-fno-asynchronous-unwind-tables -fno-unwind-tables -nostdinc \
+	-D__KERNEL__ -DCONFIG_ARM64 -DMODNAME=\"vpnhide\"
+
+.PHONY: all strip clean kpm kpm-clean
+
+kpm:
+	@if [ -z "$(KP_DIR)" ]; then \
+		echo "KP_DIR is not set — point it at a KernelPatch checkout (for its kernel/ headers)"; \
+		exit 1; \
+	fi
+	$(CLANG) $(KPM_CFLAGS) $(KPM_INCLUDES) -I$(CURDIR) -r \
+		-o vpnhide.kpm kpm/vpnhide_kpm.c
+
+kpm-clean:
+	rm -f vpnhide.kpm
+
+# ================================================================== #
+#  LKM backend — `.ko` via Kbuild. Requires the GKI kernel headers.  #
+#  These requirements must NOT fire for the `kpm` targets above.     #
+# ================================================================== #
+ifeq ($(filter kpm kpm-clean,$(MAKECMDGOALS)),)
+
 # KERNEL_SRC and CLANG_DIR come from the environment (set via .env + direnv).
 ifndef KERNEL_SRC
 $(error KERNEL_SRC is not set — copy .env.example to .env and fill in paths)
@@ -35,4 +75,6 @@ strip: all
 clean:
 	$(MAKE) $(MAKE_ARGS) clean
 
-endif
+endif # not a kpm target
+
+endif # KERNELRELEASE

--- a/kmod/Makefile
+++ b/kmod/Makefile
@@ -12,7 +12,10 @@ CLANG := $(if $(CLANG_DIR),$(CLANG_DIR)/clang,clang)
 #  KPM backend — relocatable `.kpm`, KernelPatch headers, NO kernel  #
 #  source / Module.symvers.  Build: make kpm KP_DIR=/path/KernelPatch #
 # ================================================================== #
-# KernelPatch's own header tree (mirrors kpms/*/Makefile INCLUDE_DIRS).
+# KernelPatch header tree — vendored as a submodule by default; override
+# KP_DIR to point at your own checkout. Run `git submodule update --init`.
+KP_DIR ?= $(CURDIR)/third_party/KernelPatch
+# Include dirs mirror KernelPatch's own kpms/*/Makefile INCLUDE_DIRS.
 KPM_INCLUDE_DIRS := . include patch/include linux/include \
 	linux/arch/arm64/include linux/tools/arch/arm64/include
 KPM_INCLUDES := $(foreach d,$(KPM_INCLUDE_DIRS),-I$(KP_DIR)/kernel/$(d))
@@ -27,8 +30,10 @@ KPM_CFLAGS := -target aarch64-linux-android \
 .PHONY: all strip clean kpm kpm-clean
 
 kpm:
-	@if [ -z "$(KP_DIR)" ]; then \
-		echo "KP_DIR is not set — point it at a KernelPatch checkout (for its kernel/ headers)"; \
+	@if [ ! -f "$(KP_DIR)/kernel/include/kpmodule.h" ]; then \
+		echo "KernelPatch headers not found at $(KP_DIR)."; \
+		echo "Run: git submodule update --init kmod/third_party/KernelPatch"; \
+		echo "(or override KP_DIR=/path/to/KernelPatch)"; \
 		exit 1; \
 	fi
 	$(CLANG) $(KPM_CFLAGS) $(KPM_INCLUDES) -I$(CURDIR) -r \

--- a/kmod/generated/iface_lists.h
+++ b/kmod/generated/iface_lists.h
@@ -2,119 +2,107 @@
 #ifndef VPNHIDE_GENERATED_IFACE_LISTS_H
 #define VPNHIDE_GENERATED_IFACE_LISTS_H
 
-#ifdef __KERNEL__
-# include <linux/string.h>
-# include <linux/ctype.h>
-# include <linux/types.h>
-#else
-# include <ctype.h>
-# include <stdbool.h>
-# include <stddef.h>
-# include <string.h>
-#endif
-
-static inline bool vpnhide_iface_starts_with_ci(
-	const char *name, const char *prefix)
+static inline char vpnhide__lc(char c)
 {
-	size_t i;
+	return (c >= 'A' && c <= 'Z') ? (char)(c - 'A' + 'a') : c;
+}
+
+static inline int vpnhide_iface_starts_with_ci(const char *name, const char *prefix)
+{
+	int i;
 	for (i = 0; prefix[i]; i++) {
 		if (!name[i])
-			return false;
-		if (tolower((unsigned char)name[i]) !=
-		    (unsigned char)prefix[i])
-			return false;
+			return 0;
+		if (vpnhide__lc(name[i]) != vpnhide__lc(prefix[i]))
+			return 0;
 	}
-	return true;
+	return 1;
 }
 
-static inline bool vpnhide_iface_starts_with_then_digits_ci(
-	const char *name, const char *prefix)
+static inline int vpnhide_iface_starts_with_then_digits_ci(const char *name,
+							   const char *prefix)
 {
-	size_t i;
+	int i = 0;
 	if (!vpnhide_iface_starts_with_ci(name, prefix))
-		return false;
-	i = strlen(prefix);
+		return 0;
+	while (prefix[i])
+		i++;
 	if (!name[i])
-		return false;
+		return 0;
 	for (; name[i]; i++)
 		if (name[i] < '0' || name[i] > '9')
-			return false;
-	return true;
+			return 0;
+	return 1;
 }
 
-static inline bool vpnhide_iface_equals_ci(
-	const char *name, const char *other)
+static inline int vpnhide_iface_equals_ci(const char *name, const char *other)
 {
-	size_t i;
+	int i;
 	for (i = 0; other[i]; i++) {
 		if (!name[i])
-			return false;
-		if (tolower((unsigned char)name[i]) !=
-		    (unsigned char)other[i])
-			return false;
+			return 0;
+		if (vpnhide__lc(name[i]) != vpnhide__lc(other[i]))
+			return 0;
 	}
 	return name[i] == '\0';
 }
 
-static inline bool vpnhide_iface_contains_ci(
-	const char *name, const char *needle)
+static inline int vpnhide_iface_contains_ci(const char *name, const char *needle)
 {
-	size_t nlen = strlen(needle);
-	size_t i, j;
-	if (nlen == 0)
-		return true;
+	int i, j;
+	if (!needle[0])
+		return 1;
 	for (i = 0; name[i]; i++) {
-		for (j = 0; j < nlen; j++) {
+		for (j = 0; needle[j]; j++) {
 			if (!name[i + j])
-				return false;
-			if (tolower((unsigned char)name[i + j]) !=
-			    (unsigned char)needle[j])
+				return 0;
+			if (vpnhide__lc(name[i + j]) != vpnhide__lc(needle[j]))
 				break;
 		}
-		if (j == nlen)
-			return true;
+		if (!needle[j])
+			return 1;
 	}
-	return false;
+	return 0;
 }
 
-static inline bool vpnhide_iface_is_vpn(const char *name)
+static inline int vpnhide_iface_is_vpn(const char *name)
 {
 	if (!name || !name[0])
-		return false;
+		return 0;
 	/* OpenVPN, WireGuard userspace, Tailscale, generic tunneling */
 	if (vpnhide_iface_starts_with_ci(name, "tun"))
-		return true;
+		return 1;
 	/* OpenVPN bridged */
 	if (vpnhide_iface_starts_with_ci(name, "tap"))
-		return true;
+		return 1;
 	/* WireGuard kernel */
 	if (vpnhide_iface_starts_with_ci(name, "wg"))
-		return true;
+		return 1;
 	/* PPTP / L2TP PPP tunnels */
 	if (vpnhide_iface_starts_with_ci(name, "ppp"))
-		return true;
+		return 1;
 	/* Android built-in IPsec VPN */
 	if (vpnhide_iface_starts_with_ci(name, "ipsec"))
-		return true;
+		return 1;
 	/* kernel IPsec XFRM framework */
 	if (vpnhide_iface_starts_with_ci(name, "xfrm"))
-		return true;
+		return 1;
 	/* Apple-style, rare on Android */
 	if (vpnhide_iface_starts_with_ci(name, "utun"))
-		return true;
+		return 1;
 	/* L2TP */
 	if (vpnhide_iface_starts_with_ci(name, "l2tp"))
-		return true;
+		return 1;
 	/* GRE tunnels */
 	if (vpnhide_iface_starts_with_ci(name, "gre"))
-		return true;
+		return 1;
 	/* catch-all for renamed clients (myvpn0, vpn-client, xvpn1, ...) */
 	if (vpnhide_iface_contains_ci(name, "vpn"))
-		return true;
+		return 1;
 	/* Anonymous netdev / renamed tunnel using the kernel's default naming pattern (e.g. `ip link set tun0 name if33` from issue #86). Does NOT match `ifb<N>` — those are kernel intermediate-functional-block traffic-shaping ifaces (different shape: `if` + letter, not + digit). */
 	if (vpnhide_iface_starts_with_then_digits_ci(name, "if"))
-		return true;
-	return false;
+		return 1;
+	return 0;
 }
 
 #endif /* VPNHIDE_GENERATED_IFACE_LISTS_H */

--- a/kmod/kpm/README.md
+++ b/kmod/kpm/README.md
@@ -134,7 +134,21 @@ bootloop**, where the `.ko`'s kretprobe would just fail to register. So:
       offsets derived from source (`fib_info`, `fib6_info`, `inet6_ifaddr`,
       `fib_rule`); a static `getifaddrs()` probe (`gai-probe.c`) proves the
       address path is closed (target getifaddrs vpn0: 3 → 0).
-- [x] Runtime kver offset table (`kver_offsets.h`) — **5.10 (full) + 4.14 (partial)**
+- [x] Runtime kver offset table (`kver_offsets.h`) — **5.10 + 5.4 (full) + 4.14 (partial)**
+- [x] **5.4 (android11-5.4) — full parity, QEMU-validated 9/9** on a from-source
+      `5.4.302` Image. All vectors pass incl. both route dumps and policy rules.
+      Notable per-version work that landed here:
+      - `fib_dump_info` is the legacy `<5.6` prototype on 5.4 (fib_info passed
+        *directly* at arg 9, not via `fib_rt_info`) — the hook is now
+        table-driven (`fib_dump_fi_arg` / `fib_dump_fi_via_fri`) and unified on
+        a 12-arg frame, so one callback serves 5.4 and 5.10.
+      - `struct fib6_info` has no `ANDROID_KABI_RESERVE` here → `fib6_nh[]`@160
+        (5.10 is 168); `inet6_ifaddr.idev`@168; `skb.len`@112 (conntrack on).
+      - **Fuzzy symbol resolution**: gcc renames static fns to `name.isra.N` /
+        `name.constprop.N`, which `kallsyms_lookup_name` misses. Hook lookups
+        now fall back to the `name.`-prefixed clone (`kallsyms_on_each_symbol`),
+        so e.g. `fib_nl_fill_rule.isra.21` is hooked. Clang device kernels keep
+        the plain name (exact match wins first); this just hardens gcc kernels.
 - [x] **4.14 (#33) — bring-up, QEMU-validated** on a from-source `4.14.336`
       Image (KernelPatch patches + boots it; `-cpu cortex-a57` — `max` faults
       pre-console on pre-GKI). **7 hooks proven** A/B with no panic:

--- a/kmod/kpm/README.md
+++ b/kmod/kpm/README.md
@@ -134,11 +134,27 @@ bootloop**, where the `.ko`'s kretprobe would just fail to register. So:
       offsets derived from source (`fib_info`, `fib6_info`, `inet6_ifaddr`,
       `fib_rule`); a static `getifaddrs()` probe (`gai-probe.c`) proves the
       address path is closed (target getifaddrs vpn0: 3 → 0).
-- [x] Runtime kver offset table (`kver_offsets.h`) — **5.10 only**
+- [x] Runtime kver offset table (`kver_offsets.h`) — **5.10 (full) + 4.14 (partial)**
+- [x] **4.14 (#33) — bring-up, QEMU-validated** on a from-source `4.14.336`
+      Image (KernelPatch patches + boots it; `-cpu cortex-a57` — `max` faults
+      pre-console on pre-GKI). **7 hooks proven** A/B with no panic:
+      `fib_route_seq_show`, `ipv6_route_seq_show`, `rtnl_fill_ifinfo`,
+      `inet_fill_ifaddr`, `inet6_fill_ifaddr` (the `getifaddrs()` probe goes
+      target→0), `dev_ioctl`, `sock_ioctl`. Offset subtleties vs 5.10:
+      `inet6_ifaddr.idev`@168 (no `rt_priority`, but 4.14 `timer_list` still
+      carries the `data` field → `delayed_work` is +8). **Not yet on 4.14:**
+      `fib_dump_info`/`rt6_fill_node` (structurally different — `fi` at a
+      different arg, no nexthop objects, IPv6 uses `rt6_info` not `fib6_info`;
+      needs table-driven arg/extraction) and `fib_nl_fill_rule` (installs but
+      never fires — the symbol is `static` and looks inlined on 4.14). These
+      stay gated off (offset 0) until ported, so a 4.14 device gets the 7
+      proven hooks and no panic.
 - [ ] proc_ops vs file_operations mock per kver (the HyperOS-5.4 crash class) — A/B currently uses load-args, so proc isn't on the critical path
-- [ ] **Offset tables for other versions** — start with the real KPM targets
-      (4.14 #33, 5.4) and 6.1; each derived from that version's source +
-      validated by the harness (build a QEMU kernel of that version)
+- [ ] **4.14 route-dump + policy-rule hooks** — table-driven arg index +
+      per-version extraction so `fib_dump_info`/`rt6_fill_node` work on the
+      4.14 shape; find an un-inlined hook point for the rule dump
+- [ ] **Offset tables for other versions** — 5.4 and 6.1; each derived from
+      that version's source + validated by the harness (build a QEMU kernel)
 - [ ] Confirm offsets on the closed-kernel targets with soranerai & cyberc3dr (real devices)
 - [ ] `build.py` KPM path + wire `run-kpm.sh` into CI (qemu-image job)
 - [ ] Wire the `.ko` to `../shared/vpnhide_logic.h` (mechanical; gate on a local `.ko` harness run)

--- a/kmod/kpm/README.md
+++ b/kmod/kpm/README.md
@@ -126,8 +126,14 @@ bootloop**, where the `.ko`'s kretprobe would just fail to register. So:
       not when targeted; no panic. Validates the inline hooks + the 5.x
       offsets (skb.len=104) + `fargs->local` state passing on a real kernel.
 - [x] Runtime kver offset table (`kver_offsets.h`) — **5.x + 6.1**; 4.14 TODO
+- [x] **5/10 hooks ported + QEMU-validated** (android12-5.10, no panic): the
+      offset-safe set — `fib_route_seq_show`, `rtnl_fill_ifinfo`,
+      `ipv6_route_seq_show`, `dev_ioctl`, `sock_ioctl`
 - [ ] proc_ops vs file_operations mock per kver (the HyperOS-5.4 crash class) — A/B currently uses load-args, so proc isn't on the critical path
-- [ ] Remaining hooks (see the coverage table in `vpnhide_kpm.c`)
+- [ ] Remaining 5 hooks — `inet_fill_ifaddr`, `inet6_fill_ifaddr`,
+      `fib_dump_info` (#86), `rt6_fill_node`, `fib_nl_fill_rule` — these
+      dereference version-specific kernel structs, so each needs a per-kver
+      offset (derive from GKI source, tune against the harness)
 - [ ] Confirm 4.14 + deeper struct offsets (with soranerai & cyberc3dr — closed-kernel devices)
 - [ ] `build.py` KPM path + wire `run-kpm.sh` into CI (qemu-image job)
 - [ ] Wire the `.ko` to `../shared/vpnhide_logic.h` (mechanical; gate on a local `.ko` harness run)

--- a/kmod/kpm/README.md
+++ b/kmod/kpm/README.md
@@ -134,7 +134,15 @@ bootloop**, where the `.ko`'s kretprobe would just fail to register. So:
       offsets derived from source (`fib_info`, `fib6_info`, `inet6_ifaddr`,
       `fib_rule`); a static `getifaddrs()` probe (`gai-probe.c`) proves the
       address path is closed (target getifaddrs vpn0: 3 → 0).
-- [x] Runtime kver offset table (`kver_offsets.h`) — **6.6 + 6.1 + 5.15 + 5.10 + 5.4 + 4.19 + 4.14, all full + QEMU-validated 9/9**
+- [x] Runtime kver offset table (`kver_offsets.h`) — **6.12 + 6.6 + 6.1 + 5.15 + 5.10 + 5.4 + 4.19 + 4.14, all full + QEMU-validated 9/9** (the complete Android kernel range, 8→16)
+- [x] **6.12 (android16-6.12) — full parity, QEMU-validated 9/9** on a DDK GKI
+      Image. Two version-specific changes vs 6.1: (a) `struct fib6_info` gained
+      `gc_link` → `fib6_nh[]`@192; (b) the big **`struct net_device`
+      cacheline-group reorg** moved `name` off offset 0 → `netdev_name`@296
+      (derived by compiling `offsetof(struct net_device, name)` against the
+      6.12 headers, then harness-confirmed). This is the first version where
+      `name` isn't first, so the table's `netdev_name` field finally earns its
+      keep — every name-based hook (link/addr/route dumps) depends on it.
 - [x] **6.6 (android15-6.6) — full parity, QEMU-validated 9/9** on a DDK GKI
       Image. Every offset is byte-identical to 6.1 (unlike the 5.10→5.15 jump),
       so it shares the 6.1 table; the run just confirms it.

--- a/kmod/kpm/README.md
+++ b/kmod/kpm/README.md
@@ -134,7 +134,13 @@ bootloop**, where the `.ko`'s kretprobe would just fail to register. So:
       offsets derived from source (`fib_info`, `fib6_info`, `inet6_ifaddr`,
       `fib_rule`); a static `getifaddrs()` probe (`gai-probe.c`) proves the
       address path is closed (target getifaddrs vpn0: 3 → 0).
-- [x] Runtime kver offset table (`kver_offsets.h`) — **5.10 + 5.4 + 4.19 + 4.14 (all full)**
+- [x] Runtime kver offset table (`kver_offsets.h`) — **6.1 + 5.10 + 5.4 + 4.19 + 4.14, all full + QEMU-validated 9/9**
+- [x] **6.1 (android14-6.1) — full parity, QEMU-validated 9/9** on a DDK-built
+      (clang) GKI Image. Derived from source: idev@168 (the `inet6_ifaddr`
+      prefix is byte-identical to 5.10, so the on-device 216 first taken from
+      soranerai was wrong — the `getifaddrs()` probe confirms 168), fib_info
+      96/104/128 + fib_dump via `fib_rt_info*`@arg4 (= 5.10), fib6_info
+      nh@160 / fib6_nh@176 (ANDROID_KABI_RESERVE before fib6_nh), skb.len@112.
 - [x] **4.14 now full parity, QEMU-validated 9/9** (was 7). The oldest/most
       divergent target: IPv4 route dump via the legacy arg-9 fib_info (no
       nexthop objects); IPv6 route dump hooks `rt6_fill_node(struct rt6_info*)`
@@ -163,8 +169,6 @@ bootloop**, where the `.ko`'s kretprobe would just fail to register. So:
         so e.g. `fib_nl_fill_rule.isra.21` is hooked. Clang device kernels keep
         the plain name (exact match wins first); this just hardens gcc kernels.
 - [ ] proc_ops vs file_operations mock per kver (the HyperOS-5.4 crash class) — A/B currently uses load-args, so proc isn't on the critical path
-- [ ] **Offset table for 6.1** — soranerai has on-device values; complete the
-      route-dump (fib_info/fib6_info) entries + validate via the harness.
 - [ ] Confirm offsets on the closed-kernel targets with soranerai & cyberc3dr (real devices)
 - [ ] `build.py` KPM path + wire `run-kpm.sh` into CI (qemu-image job)
 - [ ] Wire the `.ko` to `../shared/vpnhide_logic.h` (mechanical; gate on a local `.ko` harness run)

--- a/kmod/kpm/README.md
+++ b/kmod/kpm/README.md
@@ -68,19 +68,24 @@ legwork and tested on-device — credit due):
 - Control: userspace talks to the module via the supercall (`syscall 45`)
   → `sc_kpm_control` → the module's `KPM_CTL0` handler.
 
-## Build (not yet wired into CI)
+## Build
 
 A KPM is a relocatable object built with clang against the KernelPatch
 header tree — **no kernel source needed**:
 
 ```sh
-# KP_DIR must point at a KernelPatch checkout (its kernel/ include dirs).
-make -C kmod kpm KP_DIR=/path/to/KernelPatch
+git clone --depth 1 https://github.com/bmax121/KernelPatch
+make -C kmod kpm KP_DIR=$PWD/KernelPatch
 ```
 
-See `../Makefile` (`kpm*` targets). The KernelPatch headers are **not**
-vendored yet — **TODO**: add them as a submodule or `third_party/` drop so
-CI can build the `.kpm` reproducibly (like `zygisk/third_party/`).
+This **works today** — `vpnhide.kpm` builds against `bmax121/KernelPatch`
+and emits a valid KPM ELF (`.kpm.info` / `.kpm.init` / `.kpm.ctl0` /
+`.kpm.exit` sections, metadata populated). See `../Makefile` (`kpm*`
+targets). Include dirs mirror KernelPatch's own `kpms/*/Makefile`.
+
+**TODO**: vendor the KernelPatch headers as a submodule / `third_party/`
+drop + a `build.py` KPM path, so CI builds the `.kpm` reproducibly (like
+`zygisk/third_party/`). Building != working — see Status.
 
 ## Deploy
 
@@ -113,6 +118,7 @@ bootloop**, where the `.ko`'s kretprobe would just fail to register. So:
 - [x] Shared filtering logic extracted (`../shared/vpnhide_logic.h`)
 - [x] Runtime kver offset table scaffold (`kver_offsets.h`) — **6.1 only**
 - [x] KPM skeleton + 2 PoC hooks (`fib_route_seq_show`, `rtnl_fill_ifinfo`)
+- [x] **Compiles against `bmax121/KernelPatch` → valid `.kpm` ELF** (self-contained matcher; `hook_fargs12_t` is the max bucket — rtnl reads arg0/arg1 only)
 - [ ] Source the running `kver` from KernelPatch (currently a stub → refuses to install)
 - [ ] proc_ops vs file_operations mock per kver (the HyperOS-5.4 crash class)
 - [ ] Remaining hooks (see the coverage table in `vpnhide_kpm.c`)

--- a/kmod/kpm/README.md
+++ b/kmod/kpm/README.md
@@ -89,14 +89,37 @@ drop + a `build.py` KPM path, so CI builds the `.kpm` reproducibly (like
 
 ## Deploy
 
-- Runtime: **KPatch-Next on KernelSU-Next** (so existing KSU-Next users
-  add KPM support by flashing one module — no switch to APatch). The same
-  `.kpm` also loads under APatch. Target the upstream `kpm.h` ABI.
-- Persistence: a runtime `sc_kpm_load` is **lost on reboot**. Either
-  **embed** the `.kpm` in the patched `boot.img`, or re-`sc_kpm_load` each
-  boot from `post-fs-data.sh` (same shape as the `.ko`'s `insmod`). The
-  control plane (`targets.txt` → `/proc/vpnhide_targets` → live reload) is
-  identical to the `.ko`.
+A KPM runs on **inline hooks**, which physically require the KernelPatch
+runtime (`kpimg`) to be embedded in the kernel — there is **no** "KPM on a
+stock kernel". The `boot.img` always gets patched; the only question is which
+root solution drives that patch. The `.kpm` itself is the same binary
+everywhere (target the upstream `kpm.h` ABI).
+
+Supported runtimes — pick whichever matches the device's root:
+
+- **APatch** — KernelPatch is built in; `.kpm` loads directly.
+- **KernelSU-Next** — flash **KPatch-Next** (one module, no switch to APatch).
+- **Magisk or stock KernelSU** — flash the standalone
+  [KPatch-Next-Module](https://github.com/KernelSU-Next/KPatch-Next-Module).
+  It bundles `kpimg` + `kptools` + `magiskboot`, patches `boot.img` from its
+  WebUI to embed KernelPatch, then (`service.sh`) auto-loads every
+  `/data/adb/kp-next/kpm/*.kpm` on each boot via `kpatch kpm load`. So plain
+  Magisk / KernelSU users get KPM support without changing root solution —
+  the kernel is still patched, it's just automated. (Conflicts with APatch,
+  which already ships KernelPatch.)
+
+Persistence: a one-shot runtime `sc_kpm_load` is **lost on reboot**. Either
+**embed** the `.kpm` in the patched `boot.img`, or — the easy path on the
+runtimes above — drop `vpnhide.kpm` into `/data/adb/kp-next/kpm/` and let
+their boot service reload it every boot (same shape as the `.ko`'s `insmod`
+from `post-fs-data.sh`).
+
+Targeting / control plane: our target-UID set is delivered via the module's
+own `KPM_CTL0` supercall + load-args (the shape the QEMU harness exercises) —
+this is independent of KPatch-Next's generic `package_config` →
+`kpatch exclude_set <uid>` mechanism. The `.ko`'s
+`targets.txt` → `/proc/vpnhide_targets` → live-reload plane is the same idea;
+the matching procfs plane for the KPM is still TODO (see backlog).
 
 ## Safety — read before testing on a device
 

--- a/kmod/kpm/README.md
+++ b/kmod/kpm/README.md
@@ -116,16 +116,21 @@ bootloop**, where the `.ko`'s kretprobe would just fail to register. So:
 ## Status & backlog
 
 - [x] Shared filtering logic extracted (`../shared/vpnhide_logic.h`)
-- [x] Runtime kver offset table scaffold (`kver_offsets.h`) — **6.1 only**
 - [x] KPM skeleton + 2 PoC hooks (`fib_route_seq_show`, `rtnl_fill_ifinfo`)
 - [x] **Compiles against `bmax121/KernelPatch` → valid `.kpm` ELF** (self-contained matcher; `hook_fargs12_t` is the max bucket — rtnl reads arg0/arg1 only)
-- [ ] Source the running `kver` from KernelPatch (currently a stub → refuses to install)
-- [ ] proc_ops vs file_operations mock per kver (the HyperOS-5.4 crash class)
+- [x] **Runtime `kver` detection** from KernelPatch's `kver` (common.h)
+- [x] Target UIDs via load-args / `ctl0` supercall (reuses the shared parser)
+- [x] **QEMU KPM harness** (`../test/run-kpm.sh`) — patches a GKI Image with
+      KernelPatch, embeds the `.kpm`, boots under QEMU, two-boot A/B. **Both
+      PoC hooks PASS on android12-5.10**: root sees `vpn0` when not targeted,
+      not when targeted; no panic. Validates the inline hooks + the 5.x
+      offsets (skb.len=104) + `fargs->local` state passing on a real kernel.
+- [x] Runtime kver offset table (`kver_offsets.h`) — **5.x + 6.1**; 4.14 TODO
+- [ ] proc_ops vs file_operations mock per kver (the HyperOS-5.4 crash class) — A/B currently uses load-args, so proc isn't on the critical path
 - [ ] Remaining hooks (see the coverage table in `vpnhide_kpm.c`)
-- [ ] Confirm 5.x / 4.14 offsets (with soranerai & cyberc3dr — they have the closed-kernel devices)
-- [ ] Vendor KernelPatch headers + a `build.py` KPM path + CI
-- [ ] **QEMU KPM harness** (gates everything above)
-- [ ] Wire the `.ko` to `../shared/vpnhide_logic.h` (mechanical; do it once a local `.ko` build + harness run can confirm no regression)
+- [ ] Confirm 4.14 + deeper struct offsets (with soranerai & cyberc3dr — closed-kernel devices)
+- [ ] `build.py` KPM path + wire `run-kpm.sh` into CI (qemu-image job)
+- [ ] Wire the `.ko` to `../shared/vpnhide_logic.h` (mechanical; gate on a local `.ko` harness run)
 
 ## Credits
 

--- a/kmod/kpm/README.md
+++ b/kmod/kpm/README.md
@@ -134,7 +134,12 @@ bootloop**, where the `.ko`'s kretprobe would just fail to register. So:
       offsets derived from source (`fib_info`, `fib6_info`, `inet6_ifaddr`,
       `fib_rule`); a static `getifaddrs()` probe (`gai-probe.c`) proves the
       address path is closed (target getifaddrs vpn0: 3 → 0).
-- [x] Runtime kver offset table (`kver_offsets.h`) — **6.1 + 5.10 + 5.4 + 4.19 + 4.14, all full + QEMU-validated 9/9**
+- [x] Runtime kver offset table (`kver_offsets.h`) — **6.1 + 5.15 + 5.10 + 5.4 + 4.19 + 4.14, all full + QEMU-validated 9/9**
+- [x] **5.15 (android13-5.15) — full parity, QEMU-validated 9/9** on a DDK GKI
+      Image. Caught a latent bug: 5.15's `struct fib6_info` gained
+      `offload`/`offload_failed` (like 6.1), so `nh`@160 / `fib6_nh`@176 — the
+      old table silently routed 5.15 through 5.10's 152/168 and would misread
+      the IPv6 route dev. Now its own entry; everything else matches 5.10.
 - [x] **6.1 (android14-6.1) — full parity, QEMU-validated 9/9** on a DDK-built
       (clang) GKI Image. Derived from source: idev@168 (the `inet6_ifaddr`
       prefix is byte-identical to 5.10, so the on-device 216 first taken from

--- a/kmod/kpm/README.md
+++ b/kmod/kpm/README.md
@@ -1,0 +1,128 @@
+# vpnhide — KPM backend (KernelPatch Module) · **WIP skeleton**
+
+A third native backend alongside the kretprobe `.ko`. Same job — hide VPN
+interfaces from selected UIDs at the kernel level — for the kernels the
+`.ko` **can't** serve.
+
+## Why a KPM at all
+
+The `.ko` needs per-GKI kernel headers + `Module.symvers` (the DDK build
+matrix) and a kernel that allows loading unsigned modules. That leaves a
+real gap:
+
+- **Non-GKI / old kernels** — e.g. **4.14** ([#33](https://github.com/okhsunrog/vpnhide/issues/33)): no GKI KMI, no DDK build.
+- **Proprietary kernels with no source or headers** — e.g. **HyperOS 5.4**
+  (the crash report on [#35](https://github.com/okhsunrog/vpnhide/issues/35)): can't build a `.ko`, can't patch the source.
+- **Locked-down module signing** — `insmod` rejected; a KPM is loaded via
+  the KernelPatch supercall, not the module loader.
+
+A KPM is compiled against KernelPatch's *own* headers (`-nostdinc`), needs
+**no kernel headers and no `Module.symvers`**, resolves every kernel symbol
+at load time via `kallsyms_lookup_name`, and installs **inline** hooks
+(cheaper than kretprobe traps, with first-class arg/return rewriting).
+
+This is **additive, not a replacement.** Mainstream GKI users stay on the
+QEMU-tested `.ko` (no extra dependency). The KPM extends reach to the
+segment above, at the cost of a KernelPatch runtime dependency.
+
+## Architecture (and how it differs from the community prototypes)
+
+```
+kmod/
+  ../data/interfaces.toml        # single source of truth (4 languages)
+  generated/iface_lists.h        # shared VPN-name matcher  (incl. if<N>, #86)
+  shared/vpnhide_logic.h         # shared filtering algorithms (freestanding)
+  vpnhide_kmod.c                 # backend A: kretprobe .ko (unchanged)
+  kpm/
+    vpnhide_kpm.c                # backend C: KPM glue (hooks, proc, lifecycle)
+    kver_offsets.h               # runtime per-version struct-offset table
+    README.md                    # this file
+```
+
+| Layer | Shared? | Notes |
+|---|---|---|
+| VPN-name matcher | ✅ as-is | `generated/iface_lists.h`, from `data/interfaces.toml` |
+| Filtering algorithms | ✅ `shared/vpnhide_logic.h` | seq-buffer compaction, UID parse — freestanding, included by both backends |
+| Hook glue / struct access / proc | ❌ per-backend | incompatible include worlds (`<linux/*.h>` vs KernelPatch `-nostdinc`) |
+
+Three deliberate improvements over [soranerai's prototype](https://github.com/soranerai/vpnhide/tree/kernelpatch-(outdated)) (which did the
+legwork and tested on-device — credit due):
+
+1. **One source + a runtime `kver` offset table** (`kver_offsets.h`), not
+   three near-identical per-version files → one binary for 4.x/5.x/6.x.
+2. **Per-call state via `fargs->local.dataN`**, not a per-CPU MPIDR stash
+   (which races when a thread migrates between the before/after callback).
+3. **Reuse the generated matcher** — gets the `if<N>` pattern (#86) the
+   hardcoded community lists miss; and **don't hook `rt_fill_info`** (our
+   QEMU harness proved its arg→register ABI is unstable).
+
+## KernelPatch API used
+
+- Module ABI: `KPM_NAME/VERSION/LICENSE/AUTHOR/DESCRIPTION`, `KPM_INIT`,
+  `KPM_CTL0`, `KPM_EXIT` (`<kpmodule.h>`).
+- Hooking: `hook_wrap(func, argno, before, after, udata)` /
+  `hook_unwrap(...)`; callbacks get `hook_fargsN_t *` with `arg0..argN`,
+  writable `ret`, `skip_origin`, and `local.data0..7` (`<hook.h>`).
+- Symbols: runtime `kallsyms_lookup_name` (incl. static functions);
+  `kfunc_match_cfi` for CFI jump tables (`<kallsyms.h>`, `<ksyms.h>`).
+- Control: userspace talks to the module via the supercall (`syscall 45`)
+  → `sc_kpm_control` → the module's `KPM_CTL0` handler.
+
+## Build (not yet wired into CI)
+
+A KPM is a relocatable object built with clang against the KernelPatch
+header tree — **no kernel source needed**:
+
+```sh
+# KP_DIR must point at a KernelPatch checkout (its kernel/ include dirs).
+make -C kmod kpm KP_DIR=/path/to/KernelPatch
+```
+
+See `../Makefile` (`kpm*` targets). The KernelPatch headers are **not**
+vendored yet — **TODO**: add them as a submodule or `third_party/` drop so
+CI can build the `.kpm` reproducibly (like `zygisk/third_party/`).
+
+## Deploy
+
+- Runtime: **KPatch-Next on KernelSU-Next** (so existing KSU-Next users
+  add KPM support by flashing one module — no switch to APatch). The same
+  `.kpm` also loads under APatch. Target the upstream `kpm.h` ABI.
+- Persistence: a runtime `sc_kpm_load` is **lost on reboot**. Either
+  **embed** the `.kpm` in the patched `boot.img`, or re-`sc_kpm_load` each
+  boot from `post-fs-data.sh` (same shape as the `.ko`'s `insmod`). The
+  control plane (`targets.txt` → `/proc/vpnhide_targets` → live reload) is
+  identical to the `.ko`.
+
+## Safety — read before testing on a device
+
+Inline hooks have **no kprobe safety net**: a wrong offset in
+`kver_offsets.h` or a mismatched kernel **corrupts kernel text → panic /
+bootloop**, where the `.ko`'s kretprobe would just fail to register. So:
+
+- **Every offset and every hook must pass the QEMU KPM harness first.**
+  TODO: extend `kmod/test/` to boot a KernelPatch-patched kernel and run
+  the same A/B vector assertions (target UID sees nothing, non-target sees
+  `vpn0`, no panic). This harness is the whole reason the `.ko` is trusted;
+  the KPM needs the equivalent before it touches a daily-driver.
+- Test with ephemeral **Load** (lost on reboot) before **Embed**.
+- Patch the **inactive A/B slot** so a bad build falls back to the
+  unpatched kernel.
+
+## Status & backlog
+
+- [x] Shared filtering logic extracted (`../shared/vpnhide_logic.h`)
+- [x] Runtime kver offset table scaffold (`kver_offsets.h`) — **6.1 only**
+- [x] KPM skeleton + 2 PoC hooks (`fib_route_seq_show`, `rtnl_fill_ifinfo`)
+- [ ] Source the running `kver` from KernelPatch (currently a stub → refuses to install)
+- [ ] proc_ops vs file_operations mock per kver (the HyperOS-5.4 crash class)
+- [ ] Remaining hooks (see the coverage table in `vpnhide_kpm.c`)
+- [ ] Confirm 5.x / 4.14 offsets (with soranerai & cyberc3dr — they have the closed-kernel devices)
+- [ ] Vendor KernelPatch headers + a `build.py` KPM path + CI
+- [ ] **QEMU KPM harness** (gates everything above)
+- [ ] Wire the `.ko` to `../shared/vpnhide_logic.h` (mechanical; do it once a local `.ko` build + harness run can confirm no regression)
+
+## Credits
+
+- [soranerai](https://github.com/soranerai/vpnhide) — first working KPM ports (4.14/5.4/6.1) + on-device testing.
+- [cyberc3dr](https://github.com/cyberc3dr/vpnhide-driver) — in-tree kernel patches + a real proprietary-kernel (HyperOS) test device.
+- [bmax121/KernelPatch](https://github.com/bmax121/KernelPatch) & [KernelSU-Next/KPatch-Next](https://github.com/KernelSU-Next/KPatch-Next) — the runtime.

--- a/kmod/kpm/README.md
+++ b/kmod/kpm/README.md
@@ -134,7 +134,14 @@ bootloop**, where the `.ko`'s kretprobe would just fail to register. So:
       offsets derived from source (`fib_info`, `fib6_info`, `inet6_ifaddr`,
       `fib_rule`); a static `getifaddrs()` probe (`gai-probe.c`) proves the
       address path is closed (target getifaddrs vpn0: 3 → 0).
-- [x] Runtime kver offset table (`kver_offsets.h`) — **5.10 + 5.4 (full) + 4.14 (partial)**
+- [x] Runtime kver offset table (`kver_offsets.h`) — **5.10 + 5.4 + 4.19 (full) + 4.14 (partial)**
+- [x] **4.19 (vanilla 4.19.325) — full parity, QEMU-validated 9/9.** Pre-nexthop
+      kernel: fib_info/fib6_info have no `struct nexthop` field (the nh guards
+      skip), fib_dump_info uses the legacy `<5.6` prototype (fib_info* at arg 9,
+      shared with 5.4). Already has the `struct fib6_info` IPv6 model (4.14 does
+      not). One config-sensitive offset: `fib6_nh.nh_dev` sits at +16 in
+      `fib6_nh` (pre-`fib_nh_common`), and `CONFIG_IPV6_ROUTER_PREF` (Android-
+      common, validated =y) shifts `fib6_nh` to @160 → dev@176.
 - [x] **5.4 (android11-5.4) — full parity, QEMU-validated 9/9** on a from-source
       `5.4.302` Image. All vectors pass incl. both route dumps and policy rules.
       Notable per-version work that landed here:

--- a/kmod/kpm/README.md
+++ b/kmod/kpm/README.md
@@ -134,7 +134,10 @@ bootloop**, where the `.ko`'s kretprobe would just fail to register. So:
       offsets derived from source (`fib_info`, `fib6_info`, `inet6_ifaddr`,
       `fib_rule`); a static `getifaddrs()` probe (`gai-probe.c`) proves the
       address path is closed (target getifaddrs vpn0: 3 → 0).
-- [x] Runtime kver offset table (`kver_offsets.h`) — **6.1 + 5.15 + 5.10 + 5.4 + 4.19 + 4.14, all full + QEMU-validated 9/9**
+- [x] Runtime kver offset table (`kver_offsets.h`) — **6.6 + 6.1 + 5.15 + 5.10 + 5.4 + 4.19 + 4.14, all full + QEMU-validated 9/9**
+- [x] **6.6 (android15-6.6) — full parity, QEMU-validated 9/9** on a DDK GKI
+      Image. Every offset is byte-identical to 6.1 (unlike the 5.10→5.15 jump),
+      so it shares the 6.1 table; the run just confirms it.
 - [x] **5.15 (android13-5.15) — full parity, QEMU-validated 9/9** on a DDK GKI
       Image. Caught a latent bug: 5.15's `struct fib6_info` gained
       `offload`/`offload_failed` (like 6.1), so `nh`@160 / `fib6_nh`@176 — the

--- a/kmod/kpm/README.md
+++ b/kmod/kpm/README.md
@@ -134,7 +134,13 @@ bootloop**, where the `.ko`'s kretprobe would just fail to register. So:
       offsets derived from source (`fib_info`, `fib6_info`, `inet6_ifaddr`,
       `fib_rule`); a static `getifaddrs()` probe (`gai-probe.c`) proves the
       address path is closed (target getifaddrs vpn0: 3 → 0).
-- [x] Runtime kver offset table (`kver_offsets.h`) — **5.10 + 5.4 + 4.19 (full) + 4.14 (partial)**
+- [x] Runtime kver offset table (`kver_offsets.h`) — **5.10 + 5.4 + 4.19 + 4.14 (all full)**
+- [x] **4.14 now full parity, QEMU-validated 9/9** (was 7). The oldest/most
+      divergent target: IPv4 route dump via the legacy arg-9 fib_info (no
+      nexthop objects); IPv6 route dump hooks `rt6_fill_node(struct rt6_info*)`
+      — pre-`fib6_info`, so the dev is read straight from the embedded
+      `dst_entry` (`rt6_via_dst`, dev@0); policy rules resolve through the
+      `.isra` fuzzy fallback. `skb.len`@104 (older sk_buff head).
 - [x] **4.19 (vanilla 4.19.325) — full parity, QEMU-validated 9/9.** Pre-nexthop
       kernel: fib_info/fib6_info have no `struct nexthop` field (the nh guards
       skip), fib_dump_info uses the legacy `<5.6` prototype (fib_info* at arg 9,
@@ -156,26 +162,9 @@ bootloop**, where the `.ko`'s kretprobe would just fail to register. So:
         now fall back to the `name.`-prefixed clone (`kallsyms_on_each_symbol`),
         so e.g. `fib_nl_fill_rule.isra.21` is hooked. Clang device kernels keep
         the plain name (exact match wins first); this just hardens gcc kernels.
-- [x] **4.14 (#33) — bring-up, QEMU-validated** on a from-source `4.14.336`
-      Image (KernelPatch patches + boots it; `-cpu cortex-a57` — `max` faults
-      pre-console on pre-GKI). **7 hooks proven** A/B with no panic:
-      `fib_route_seq_show`, `ipv6_route_seq_show`, `rtnl_fill_ifinfo`,
-      `inet_fill_ifaddr`, `inet6_fill_ifaddr` (the `getifaddrs()` probe goes
-      target→0), `dev_ioctl`, `sock_ioctl`. Offset subtleties vs 5.10:
-      `inet6_ifaddr.idev`@168 (no `rt_priority`, but 4.14 `timer_list` still
-      carries the `data` field → `delayed_work` is +8). **Not yet on 4.14:**
-      `fib_dump_info`/`rt6_fill_node` (structurally different — `fi` at a
-      different arg, no nexthop objects, IPv6 uses `rt6_info` not `fib6_info`;
-      needs table-driven arg/extraction) and `fib_nl_fill_rule` (installs but
-      never fires — the symbol is `static` and looks inlined on 4.14). These
-      stay gated off (offset 0) until ported, so a 4.14 device gets the 7
-      proven hooks and no panic.
 - [ ] proc_ops vs file_operations mock per kver (the HyperOS-5.4 crash class) — A/B currently uses load-args, so proc isn't on the critical path
-- [ ] **4.14 route-dump + policy-rule hooks** — table-driven arg index +
-      per-version extraction so `fib_dump_info`/`rt6_fill_node` work on the
-      4.14 shape; find an un-inlined hook point for the rule dump
-- [ ] **Offset tables for other versions** — 5.4 and 6.1; each derived from
-      that version's source + validated by the harness (build a QEMU kernel)
+- [ ] **Offset table for 6.1** — soranerai has on-device values; complete the
+      route-dump (fib_info/fib6_info) entries + validate via the harness.
 - [ ] Confirm offsets on the closed-kernel targets with soranerai & cyberc3dr (real devices)
 - [ ] `build.py` KPM path + wire `run-kpm.sh` into CI (qemu-image job)
 - [ ] Wire the `.ko` to `../shared/vpnhide_logic.h` (mechanical; gate on a local `.ko` harness run)

--- a/kmod/kpm/README.md
+++ b/kmod/kpm/README.md
@@ -104,11 +104,12 @@ Inline hooks have **no kprobe safety net**: a wrong offset in
 `kver_offsets.h` or a mismatched kernel **corrupts kernel text → panic /
 bootloop**, where the `.ko`'s kretprobe would just fail to register. So:
 
-- **Every offset and every hook must pass the QEMU KPM harness first.**
-  TODO: extend `kmod/test/` to boot a KernelPatch-patched kernel and run
-  the same A/B vector assertions (target UID sees nothing, non-target sees
-  `vpn0`, no panic). This harness is the whole reason the `.ko` is trusted;
-  the KPM needs the equivalent before it touches a daily-driver.
+- **Every offset and every hook must pass the QEMU KPM harness first**
+  (`../test/run-kpm.sh` — patches a KernelPatch kernel, boots it, runs the
+  A/B vector assertions: target UID sees nothing, non-target sees `vpn0`, no
+  panic). This harness is the whole reason the `.ko` is trusted; the KPM has
+  the equivalent now, and a new offset table for a version is only as
+  trustworthy as a green harness run on that version.
 - Test with ephemeral **Load** (lost on reboot) before **Embed**.
 - Patch the **inactive A/B slot** so a bad build falls back to the
   unpatched kernel.
@@ -125,16 +126,20 @@ bootloop**, where the `.ko`'s kretprobe would just fail to register. So:
       PoC hooks PASS on android12-5.10**: root sees `vpn0` when not targeted,
       not when targeted; no panic. Validates the inline hooks + the 5.x
       offsets (skb.len=104) + `fargs->local` state passing on a real kernel.
-- [x] Runtime kver offset table (`kver_offsets.h`) — **5.x + 6.1**; 4.14 TODO
-- [x] **5/10 hooks ported + QEMU-validated** (android12-5.10, no panic): the
-      offset-safe set — `fib_route_seq_show`, `rtnl_fill_ifinfo`,
-      `ipv6_route_seq_show`, `dev_ioctl`, `sock_ioctl`
+- [x] **All 10 hooks ported + QEMU-validated** on android12-5.10 (no panic),
+      full native-vector parity with the `.ko`: `fib_route_seq_show`,
+      `ipv6_route_seq_show`, `rtnl_fill_ifinfo`, `inet_fill_ifaddr`,
+      `inet6_fill_ifaddr`, `dev_ioctl`, `sock_ioctl`, `fib_dump_info` (#86),
+      `rt6_fill_node`, `fib_nl_fill_rule`. The deep-struct ones use 5.10
+      offsets derived from source (`fib_info`, `fib6_info`, `inet6_ifaddr`,
+      `fib_rule`); a static `getifaddrs()` probe (`gai-probe.c`) proves the
+      address path is closed (target getifaddrs vpn0: 3 → 0).
+- [x] Runtime kver offset table (`kver_offsets.h`) — **5.10 only**
 - [ ] proc_ops vs file_operations mock per kver (the HyperOS-5.4 crash class) — A/B currently uses load-args, so proc isn't on the critical path
-- [ ] Remaining 5 hooks — `inet_fill_ifaddr`, `inet6_fill_ifaddr`,
-      `fib_dump_info` (#86), `rt6_fill_node`, `fib_nl_fill_rule` — these
-      dereference version-specific kernel structs, so each needs a per-kver
-      offset (derive from GKI source, tune against the harness)
-- [ ] Confirm 4.14 + deeper struct offsets (with soranerai & cyberc3dr — closed-kernel devices)
+- [ ] **Offset tables for other versions** — start with the real KPM targets
+      (4.14 #33, 5.4) and 6.1; each derived from that version's source +
+      validated by the harness (build a QEMU kernel of that version)
+- [ ] Confirm offsets on the closed-kernel targets with soranerai & cyberc3dr (real devices)
 - [ ] `build.py` KPM path + wire `run-kpm.sh` into CI (qemu-image job)
 - [ ] Wire the `.ko` to `../shared/vpnhide_logic.h` (mechanical; gate on a local `.ko` harness run)
 

--- a/kmod/kpm/kver_offsets.h
+++ b/kmod/kpm/kver_offsets.h
@@ -33,7 +33,8 @@ struct vpnhide_offsets {
 	/* sk_buff.len — saved before a netlink fill, restored via skb_trim. */
 	unsigned int skb_len;
 
-	/* net_device.name — first member on all supported versions. */
+	/* net_device.name — first member (@0) up to 6.6; 6.12 moved it behind
+	 * the new cacheline-group reorg (@296). */
 	unsigned int netdev_name;
 
 	/* seq_file.{buf,count} — stable across the seq_file lifetime. */
@@ -119,6 +120,39 @@ static const struct vpnhide_offsets vpnhide_off_6_1 = {
 	.fib6_info_nh = 160,
 	.fib6_info_fib6_nh = 176,
 	/* struct fib_rule layout identical to 5.10. */
+	.fib_rule_table = 36,
+	.fib_rule_iifname = 88,
+	.fib_rule_oifname = 104,
+	.fib_rule_uid_start = 120,
+	.fib_rule_uid_end = 124,
+	.proc_uses_proc_ops = 1,
+};
+
+/* 6.12 (android16-6.12) — QEMU-validated 9/9. Identical to 6.1 EXCEPT struct
+ * fib6_info inserted `struct hlist_node gc_link` (16 B) after `expires`,
+ * shifting nh@176 and fib6_nh[]@192 (6.1 is 160/176). (fib_info also gained a
+ * `pfsrc_removed` bool, but it fits the existing pad so nh stays @104.) */
+static const struct vpnhide_offsets vpnhide_off_6_12 = {
+	.skb_len = 112,
+	/* 6.12 reorganised struct net_device into cacheline groups (TX/TXRX/RX
+	 * read-mostly), so `name` is no longer first — offsetof = 296 (derived by
+	 * compiling offsetof(struct net_device, name) against the gki_defconfig
+	 * 6.12 headers). Every other version keeps name@0. */
+	.netdev_name = 296,
+	.seqfile_buf = 0,
+	.seqfile_count = 24,
+	.in_ifaddr_ifa_dev = 24,
+	.in_device_dev = 0,
+	.inet6_ifaddr_idev = 168,
+	.inet6_dev_dev = 0,
+	.fib_info_fib_nhs = 96,
+	.fib_info_nh = 104,
+	.fib_info_fib_nh = 128,
+	.fib_dump_fi_arg = 4,
+	.fib_dump_fi_via_fri = 1,
+	/* fib6_info + gc_link(16) before fib6_metrics -> nh@176, fib6_nh[]@192. */
+	.fib6_info_nh = 176,
+	.fib6_info_fib6_nh = 192,
 	.fib_rule_table = 36,
 	.fib_rule_iifname = 88,
 	.fib_rule_oifname = 104,
@@ -316,8 +350,10 @@ static const struct vpnhide_offsets vpnhide_off_4_x = {
  */
 static inline const struct vpnhide_offsets *vpnhide_select_offsets(unsigned int kver)
 {
+	if (kver >= VPNHIDE_KVER(6, 12, 0))
+		return &vpnhide_off_6_12; /* 6.12: fib6_info gained gc_link */
 	if (kver >= VPNHIDE_KVER(6, 0, 0))
-		return &vpnhide_off_6_1; /* 6.x — 6.1 + 6.6 proven identical */
+		return &vpnhide_off_6_1; /* 6.0–6.11 — 6.1 + 6.6 proven identical */
 	if (kver >= VPNHIDE_KVER(5, 15, 0))
 		return &vpnhide_off_5_15; /* 5.15+: fib6_info gained offload fields */
 	if (kver >= VPNHIDE_KVER(5, 6, 0))

--- a/kmod/kpm/kver_offsets.h
+++ b/kmod/kpm/kver_offsets.h
@@ -48,6 +48,14 @@ struct vpnhide_offsets {
 	unsigned int inet6_ifaddr_idev;
 	unsigned int inet6_dev_dev;
 
+	/* IPv4 route dump (fib_dump_info): fib_rt_info.fi=0, fib_nh_common.nhc_dev=0
+	 * (constants). These three vary per version; for the legacy single-nexthop
+	 * route: dev = *(fi + fib_info_fib_nh + nhc_dev). fib_info_nh != 0 marks a
+	 * nexthop-object route (not unpacked yet). 0 => hook bails (no guessing). */
+	unsigned int fib_info_fib_nhs;
+	unsigned int fib_info_nh;
+	unsigned int fib_info_fib_nh;
+
 	/* 1 if procfs uses `struct proc_ops` (>=5.6), 0 if `file_operations`
 	 * (<5.6). Mixing these up is the most likely cause of the
 	 * /proc/vpnhide_targets crash reported on HyperOS 5.4. */
@@ -67,6 +75,9 @@ static const struct vpnhide_offsets vpnhide_off_6_1 = {
 	.in_device_dev = 0, /* TODO: confirm in_device.dev offset on 6.1 */
 	.inet6_ifaddr_idev = 216,
 	.inet6_dev_dev = 0, /* TODO: confirm inet6_dev.dev offset on 6.1 */
+	.fib_info_fib_nhs = 0, /* TODO 6.1 */
+	.fib_info_nh = 0,
+	.fib_info_fib_nh = 0,
 	.proc_uses_proc_ops = 1,
 };
 
@@ -80,6 +91,11 @@ static const struct vpnhide_offsets vpnhide_off_5_x = {
 	.in_device_dev = 0,
 	.inet6_ifaddr_idev = 0, /* TODO: derive for 5.x */
 	.inet6_dev_dev = 0,
+	/* android12-5.10 fib_info (LP64, no ifdefs before fib_nh[]): fib_nhs@96,
+	 * nh@104, fib_nh[]@128; nhc_dev is first in fib_nh -> +128. */
+	.fib_info_fib_nhs = 96,
+	.fib_info_nh = 104,
+	.fib_info_fib_nh = 128,
 	.proc_uses_proc_ops = 1, /* 5.6+; for <5.6 use file_operations below */
 };
 

--- a/kmod/kpm/kver_offsets.h
+++ b/kmod/kpm/kver_offsets.h
@@ -99,9 +99,12 @@ static const struct vpnhide_offsets vpnhide_off_5_x = {
 	.netdev_name = 0,
 	.seqfile_buf = 0,
 	.seqfile_count = 24,
-	.in_ifaddr_ifa_dev = 24, /* TODO: confirm on 5.4/5.10 */
+	/* in_ifaddr: hash(16)+ifa_next(8) -> ifa_dev@24; in_device.dev@0. */
+	.in_ifaddr_ifa_dev = 24,
 	.in_device_dev = 0,
-	.inet6_ifaddr_idev = 0, /* TODO: derive for 5.x */
+	/* inet6_ifaddr.idev@168 (derived; past lock/dad_work — verify via gai),
+	 * inet6_dev.dev@0. */
+	.inet6_ifaddr_idev = 168,
 	.inet6_dev_dev = 0,
 	/* android12-5.10 fib_info (LP64, no ifdefs before fib_nh[]): fib_nhs@96,
 	 * nh@104, fib_nh[]@128; nhc_dev is first in fib_nh -> +128. */

--- a/kmod/kpm/kver_offsets.h
+++ b/kmod/kpm/kver_offsets.h
@@ -56,6 +56,15 @@ struct vpnhide_offsets {
 	unsigned int fib_info_nh;
 	unsigned int fib_info_fib_nh;
 
+	/* fib_dump_info arg shape (its fib_info moved across versions):
+	 *   fib_dump_fi_arg     = args[] index of the fib_info/fib_rt_info ptr
+	 *                         (0 => hook not installed for this version)
+	 *   fib_dump_fi_via_fri = 1 if that arg is a fib_rt_info* (fi=*(arg+0),
+	 *                         5.6+), 0 if it is the fib_info* directly (<5.6).
+	 * Always hooked as a 12-arg frame; only this one arg is read. */
+	unsigned int fib_dump_fi_arg;
+	int fib_dump_fi_via_fri;
+
 	/* IPv6 route dump (rt6_fill_node): fib6_info.nh != 0 => nexthop object;
 	 * else dev = *(rt + fib6_info_fib6_nh) (fib6_nh[0].nhc_dev). */
 	unsigned int fib6_info_nh;
@@ -111,6 +120,10 @@ static const struct vpnhide_offsets vpnhide_off_5_x = {
 	.fib_info_fib_nhs = 96,
 	.fib_info_nh = 104,
 	.fib_info_fib_nh = 128,
+	/* 5.6+ fib_dump_info(skb, portid, seq, event, fib_rt_info *fri, flags):
+	 * fi = fri->fi, so arg index 4, dereffed through fri. */
+	.fib_dump_fi_arg = 4,
+	.fib_dump_fi_via_fri = 1,
 	/* android12-5.10 fib6_info (LP64; rt6key=20, ANDROID_KABI_RESERVE=8):
 	 * nh@152, fib6_nh[]@168; nhc_dev first in fib6_nh -> +168. */
 	.fib6_info_nh = 152,
@@ -122,6 +135,45 @@ static const struct vpnhide_offsets vpnhide_off_5_x = {
 	.fib_rule_uid_start = 120,
 	.fib_rule_uid_end = 124,
 	.proc_uses_proc_ops = 1, /* 5.6+; for <5.6 use file_operations below */
+};
+
+/* 5.4 (android11-5.4, derived from AOSP common source + QEMU-validated).
+ * Mostly identical to 5.10, with two version-specific differences:
+ *   - fib_dump_info still uses the legacy <5.6 prototype (fib_info* passed
+ *     directly at arg 9, 11 args) — not the fib_rt_info* form 5.10 has.
+ *   - struct fib6_info has no ANDROID_KABI_RESERVE before fib6_nh[] here, so
+ *     fib6_nh[]@160 (vs 5.10's 168).
+ * procfs is file_operations (<5.6). */
+static const struct vpnhide_offsets vpnhide_off_5_4 = {
+	.skb_len = 112, /* modern sk_buff head + _nfct (CONFIG_NF_CONNTRACK) ->
+			 * len@112. Real 5.4 devices carry conntrack, so this is
+			 * the device-faithful value; a conntrack-less kernel would
+			 * be @104 (cf. the 5.10 test kernel). */
+	.netdev_name = 0,
+	.seqfile_buf = 0,
+	.seqfile_count = 24,
+	.in_ifaddr_ifa_dev = 24, /* hash(16)+ifa_next(8) — same as 5.10 */
+	.in_device_dev = 0,
+	.inet6_ifaddr_idev = 168, /* rt_priority present + post-4.15 timer_list */
+	.inet6_dev_dev = 0,
+	/* fib_info identical to 5.10: fib_nhs@96, nh@104, fib_nh[]@128. */
+	.fib_info_fib_nhs = 96,
+	.fib_info_nh = 104,
+	.fib_info_fib_nh = 128,
+	/* legacy fib_dump_info(skb,...,tos, struct fib_info *fi, flags): fi@arg9,
+	 * passed directly (not via fib_rt_info). */
+	.fib_dump_fi_arg = 9,
+	.fib_dump_fi_via_fri = 0,
+	/* fib6_info: rt6key=20, NO KABI reserve -> nh@152, fib6_nh[]@160. */
+	.fib6_info_nh = 152,
+	.fib6_info_fib6_nh = 160,
+	/* struct fib_rule layout identical to 5.10. */
+	.fib_rule_table = 36,
+	.fib_rule_iifname = 88,
+	.fib_rule_oifname = 104,
+	.fib_rule_uid_start = 120,
+	.fib_rule_uid_end = 124,
+	.proc_uses_proc_ops = 0, /* <5.6 → file_operations */
 };
 
 /* 4.14 (vanilla 4.14.336, derived from source + QEMU-validated). Offsets that
@@ -162,6 +214,8 @@ static inline const struct vpnhide_offsets *vpnhide_select_offsets(unsigned int 
 		return &vpnhide_off_6_1; /* 6.x — only 6.1 proven so far */
 	if (kver >= VPNHIDE_KVER(5, 6, 0))
 		return &vpnhide_off_5_x;
+	if (kver >= VPNHIDE_KVER(5, 0, 0))
+		return &vpnhide_off_5_4; /* 5.0–5.5: legacy fib_dump_info + proc */
 	if (kver >= VPNHIDE_KVER(4, 0, 0))
 		return &vpnhide_off_4_x;
 	return 0; /* unsupported → do not install */

--- a/kmod/kpm/kver_offsets.h
+++ b/kmod/kpm/kver_offsets.h
@@ -56,6 +56,11 @@ struct vpnhide_offsets {
 	unsigned int fib_info_nh;
 	unsigned int fib_info_fib_nh;
 
+	/* IPv6 route dump (rt6_fill_node): fib6_info.nh != 0 => nexthop object;
+	 * else dev = *(rt + fib6_info_fib6_nh) (fib6_nh[0].nhc_dev). */
+	unsigned int fib6_info_nh;
+	unsigned int fib6_info_fib6_nh;
+
 	/* 1 if procfs uses `struct proc_ops` (>=5.6), 0 if `file_operations`
 	 * (<5.6). Mixing these up is the most likely cause of the
 	 * /proc/vpnhide_targets crash reported on HyperOS 5.4. */
@@ -96,6 +101,10 @@ static const struct vpnhide_offsets vpnhide_off_5_x = {
 	.fib_info_fib_nhs = 96,
 	.fib_info_nh = 104,
 	.fib_info_fib_nh = 128,
+	/* android12-5.10 fib6_info (LP64; rt6key=20, ANDROID_KABI_RESERVE=8):
+	 * nh@152, fib6_nh[]@168; nhc_dev first in fib6_nh -> +168. */
+	.fib6_info_nh = 152,
+	.fib6_info_fib6_nh = 168,
 	.proc_uses_proc_ops = 1, /* 5.6+; for <5.6 use file_operations below */
 };
 

--- a/kmod/kpm/kver_offsets.h
+++ b/kmod/kpm/kver_offsets.h
@@ -70,6 +70,12 @@ struct vpnhide_offsets {
 	unsigned int fib6_info_nh;
 	unsigned int fib6_info_fib6_nh;
 
+	/* Pre-fib6_info kernels (<= 4.14): rt6_fill_node takes a struct rt6_info*
+	 * (which begins with a struct dst_entry), not a fib6_info. When
+	 * rt6_via_dst is set, dev = *(rt + rt6_dst_dev) (dst_entry.dev). */
+	int rt6_via_dst;
+	unsigned int rt6_dst_dev;
+
 	/* Policy rules (fib_nl_fill_rule -> struct fib_rule). */
 	unsigned int fib_rule_table;
 	unsigned int fib_rule_iifname;
@@ -213,31 +219,43 @@ static const struct vpnhide_offsets vpnhide_off_4_19 = {
 	.proc_uses_proc_ops = 0, /* <5.6 → file_operations */
 };
 
-/* 4.14 (vanilla 4.14.336, derived from source + QEMU-validated). Offsets that
- * match 5.x are noted; the route-dump hooks (fib_dump_info, rt6_fill_node)
- * are STRUCTURALLY different on 4.14 (fi passed directly at a different arg,
- * no nexthop objects, IPv6 uses rt6_info not fib6_info) so their offsets stay
- * 0 here = not installed until the hooks learn the 4.14 shape (see the
- * coverage notes in vpnhide_kpm.c). procfs is file_operations (<5.6). */
+/* 4.14 (vanilla 4.14.336, derived from source + QEMU-validated, 9/9). Oldest
+ * target and the most structurally different: fib_dump_info uses the legacy
+ * <5.6 prototype (fi at arg 9), there are no nexthop objects, and IPv6 still
+ * uses struct rt6_info (not fib6_info) — so the IPv6 dev comes from the
+ * embedded dst_entry (rt6_via_dst) rather than a fib6_nh walk. procfs is
+ * file_operations (<5.6). */
 static const struct vpnhide_offsets vpnhide_off_4_x = {
-	.skb_len = 104, /* confirmed: rtnl A/B PASSes on 4.14 */
+	.skb_len = 104, /* older sk_buff head -> len@104 even with conntrack */
 	.netdev_name = 0,
 	.seqfile_buf = 0,
 	.seqfile_count = 24,
 	.in_ifaddr_ifa_dev = 24, /* in_ifaddr: hash(16)+ifa_next(8) — same as 5.x */
 	.in_device_dev = 0,
-	.inet6_ifaddr_idev = 168, /* 4.14: no rt_priority (-4) but timer_list has `data` (+8) -> idev@168 */
+	.inet6_ifaddr_idev = 168, /* no rt_priority (-4) but timer_list has `data` (+8) -> 168 */
 	.inet6_dev_dev = 0,
-	/* fib_rule offsets match 5.10 (verified), BUT left 0 (hook gated off) on
-	 * 4.14: with the hook installed it never filters — fib_nl_fill_rule is a
-	 * `static` fn on 4.14 and appears to be inlined (dead kallsyms symbol,
-	 * like dev_ifconf on 5.10 LTO), so the probe never fires. Needs an
-	 * alternate hook point before it can be enabled here. */
-	.fib_rule_table = 0,
+	/* fib_info: fib_nhs@80, rcu@88, fib_nh[]@104 (fib_weight, if
+	 * CONFIG_IP_ROUTE_MULTIPATH, fills the pad slot @84 so fib_nh stays @104);
+	 * fib_nh.nh_dev is first. No nexthop objects. */
+	.fib_info_fib_nhs = 80,
+	.fib_info_nh = 0,
+	.fib_info_fib_nh = 104,
+	.fib_dump_fi_arg = 9, /* legacy prototype: fib_info* at arg 9 */
+	.fib_dump_fi_via_fri = 0,
+	/* IPv6: rt6_fill_node(rt6_info*). rt6_info begins with struct dst_entry,
+	 * whose first member is net_device *dev -> dev = *(rt + 0). */
+	.fib6_info_nh = 0,
+	.fib6_info_fib6_nh = 0,
+	.rt6_via_dst = 1,
+	.rt6_dst_dev = 0,
+	/* struct fib_rule layout matches 5.10; the symbol is fib_nl_fill_rule
+	 * .isra.N under gcc — the fuzzy resolver finds it. */
+	.fib_rule_table = 36,
+	.fib_rule_iifname = 88,
+	.fib_rule_oifname = 104,
+	.fib_rule_uid_start = 120,
+	.fib_rule_uid_end = 124,
 	.proc_uses_proc_ops = 0, /* <5.6 → file_operations */
-	/* fib_dump_info / rt6_fill_node deliberately 0: structurally different on
-	 * 4.14 (fi at a different arg, no nexthop objects, IPv6 = rt6_info not
-	 * fib6_info) — needs table-driven arg/extraction, then derive + validate. */
 };
 
 /*

--- a/kmod/kpm/kver_offsets.h
+++ b/kmod/kpm/kver_offsets.h
@@ -90,21 +90,38 @@ struct vpnhide_offsets {
 };
 
 /*
- * GKI 6.1 — values confirmed by soranerai's working module on-device.
- *   skb.len = 112, inet6_ifaddr.idev = 216, in_ifaddr.ifa_dev = 24.
+ * GKI 6.1 (android14-6.1, derived from AOSP common source + QEMU-validated).
+ * inet6_ifaddr's prefix up to dad_work is identical to 5.10, so idev@168
+ * (NOT the 216 first taken from soranerai — left a note, the harness decides).
+ * fib_dump_info uses the fib_rt_info* form (arg 4, like 5.10); fib_info and
+ * fib_rule layouts match 5.10; fib6_info has an ANDROID_KABI_RESERVE before
+ * fib6_nh[]. procfs is proc_ops (>=5.6).
  */
 static const struct vpnhide_offsets vpnhide_off_6_1 = {
-	.skb_len = 112,
+	.skb_len = 112, /* modern head + _nfct (conntrack on in GKI 6.1) */
 	.netdev_name = 0,
 	.seqfile_buf = 0,
 	.seqfile_count = 24,
 	.in_ifaddr_ifa_dev = 24,
-	.in_device_dev = 0, /* TODO: confirm in_device.dev offset on 6.1 */
-	.inet6_ifaddr_idev = 216,
-	.inet6_dev_dev = 0, /* TODO: confirm inet6_dev.dev offset on 6.1 */
-	.fib_info_fib_nhs = 0, /* TODO 6.1 */
-	.fib_info_nh = 0,
-	.fib_info_fib_nh = 0,
+	.in_device_dev = 0,
+	.inet6_ifaddr_idev = 168, /* same struct prefix as validated 5.10 */
+	.inet6_dev_dev = 0,
+	/* fib_info identical to 5.10: fib_nhs@96, nh@104, fib_nh[]@128. */
+	.fib_info_fib_nhs = 96,
+	.fib_info_nh = 104,
+	.fib_info_fib_nh = 128,
+	.fib_dump_fi_arg = 4, /* fib_rt_info* form (5.6+) */
+	.fib_dump_fi_via_fri = 1,
+	/* fib6_info: bitfield@136, rcu@144, nh@160, ANDROID_KABI_RESERVE(1)@168,
+	 * fib6_nh[]@176; nhc_dev first in fib6_nh -> dev@176. */
+	.fib6_info_nh = 160,
+	.fib6_info_fib6_nh = 176,
+	/* struct fib_rule layout identical to 5.10. */
+	.fib_rule_table = 36,
+	.fib_rule_iifname = 88,
+	.fib_rule_oifname = 104,
+	.fib_rule_uid_start = 120,
+	.fib_rule_uid_end = 124,
 	.proc_uses_proc_ops = 1,
 };
 

--- a/kmod/kpm/kver_offsets.h
+++ b/kmod/kpm/kver_offsets.h
@@ -91,6 +91,8 @@ struct vpnhide_offsets {
 
 /*
  * GKI 6.1 (android14-6.1, derived from AOSP common source + QEMU-validated).
+ * Also covers 6.6 (android15-6.6): every offset here is byte-identical on 6.6,
+ * confirmed by a separate 9/9 harness run on a DDK-built 6.6 GKI Image.
  * inet6_ifaddr's prefix up to dad_work is identical to 5.10, so idev@168
  * (NOT the 216 first taken from soranerai — left a note, the harness decides).
  * fib_dump_info uses the fib_rt_info* form (arg 4, like 5.10); fib_info and
@@ -315,7 +317,7 @@ static const struct vpnhide_offsets vpnhide_off_4_x = {
 static inline const struct vpnhide_offsets *vpnhide_select_offsets(unsigned int kver)
 {
 	if (kver >= VPNHIDE_KVER(6, 0, 0))
-		return &vpnhide_off_6_1; /* 6.x — only 6.1 proven so far */
+		return &vpnhide_off_6_1; /* 6.x — 6.1 + 6.6 proven identical */
 	if (kver >= VPNHIDE_KVER(5, 15, 0))
 		return &vpnhide_off_5_15; /* 5.15+: fib6_info gained offload fields */
 	if (kver >= VPNHIDE_KVER(5, 6, 0))

--- a/kmod/kpm/kver_offsets.h
+++ b/kmod/kpm/kver_offsets.h
@@ -176,6 +176,43 @@ static const struct vpnhide_offsets vpnhide_off_5_4 = {
 	.proc_uses_proc_ops = 0, /* <5.6 → file_operations */
 };
 
+/* 4.19 (vanilla 4.19.325, derived from source + QEMU-validated). Pre-nexthop
+ * kernel: fib_info/fib6_info have NO `struct nexthop *nh` field (so the nh
+ * guards in dev_from_fib*_info skip), and fib_dump_info uses the legacy <5.6
+ * prototype (fib_info* directly at arg 9). Unlike 4.14 it already has the
+ * struct fib6_info IPv6 route model (4.14 still uses rt6_info). procfs is
+ * file_operations (<5.6). */
+static const struct vpnhide_offsets vpnhide_off_4_19 = {
+	.skb_len = 112, /* modern sk_buff head + _nfct (conntrack) -> len@112 */
+	.netdev_name = 0,
+	.seqfile_buf = 0,
+	.seqfile_count = 24,
+	.in_ifaddr_ifa_dev = 24,
+	.in_device_dev = 0,
+	.inet6_ifaddr_idev = 168, /* rt_priority present, post-4.15 timer_list */
+	.inet6_dev_dev = 0,
+	/* fib_info: fib_nhs@80, rcu@88, fib_nh[]@104; fib_nh.nh_dev is first ->
+	 * dev = *(fi+104). No nexthop objects (fib_info_nh = 0). */
+	.fib_info_fib_nhs = 80,
+	.fib_info_nh = 0,
+	.fib_info_fib_nh = 104,
+	.fib_dump_fi_arg = 9, /* legacy prototype: fib_info* at arg 9 */
+	.fib_dump_fi_via_fri = 0,
+	/* fib6_info (no nexthop objects): fib6_nh embedded (not fib_nh_common),
+	 * nh_dev is the 2nd field (@+16 after in6_addr nh_gw). With
+	 * CONFIG_IPV6_ROUTER_PREF (Android-common) fib6_nh@160 -> nh_dev@176.
+	 * (Without ROUTER_PREF it would be @168 — config-sensitive.) */
+	.fib6_info_nh = 0,
+	.fib6_info_fib6_nh = 176,
+	/* struct fib_rule layout identical to 5.4/5.10. */
+	.fib_rule_table = 36,
+	.fib_rule_iifname = 88,
+	.fib_rule_oifname = 104,
+	.fib_rule_uid_start = 120,
+	.fib_rule_uid_end = 124,
+	.proc_uses_proc_ops = 0, /* <5.6 → file_operations */
+};
+
 /* 4.14 (vanilla 4.14.336, derived from source + QEMU-validated). Offsets that
  * match 5.x are noted; the route-dump hooks (fib_dump_info, rt6_fill_node)
  * are STRUCTURALLY different on 4.14 (fi passed directly at a different arg,
@@ -216,6 +253,8 @@ static inline const struct vpnhide_offsets *vpnhide_select_offsets(unsigned int 
 		return &vpnhide_off_5_x;
 	if (kver >= VPNHIDE_KVER(5, 0, 0))
 		return &vpnhide_off_5_4; /* 5.0–5.5: legacy fib_dump_info + proc */
+	if (kver >= VPNHIDE_KVER(4, 19, 0))
+		return &vpnhide_off_4_19; /* 4.19: fib6_info, no nexthop objects */
 	if (kver >= VPNHIDE_KVER(4, 0, 0))
 		return &vpnhide_off_4_x;
 	return 0; /* unsupported → do not install */

--- a/kmod/kpm/kver_offsets.h
+++ b/kmod/kpm/kver_offsets.h
@@ -61,6 +61,13 @@ struct vpnhide_offsets {
 	unsigned int fib6_info_nh;
 	unsigned int fib6_info_fib6_nh;
 
+	/* Policy rules (fib_nl_fill_rule -> struct fib_rule). */
+	unsigned int fib_rule_table;
+	unsigned int fib_rule_iifname;
+	unsigned int fib_rule_oifname;
+	unsigned int fib_rule_uid_start;
+	unsigned int fib_rule_uid_end;
+
 	/* 1 if procfs uses `struct proc_ops` (>=5.6), 0 if `file_operations`
 	 * (<5.6). Mixing these up is the most likely cause of the
 	 * /proc/vpnhide_targets crash reported on HyperOS 5.4. */
@@ -105,6 +112,12 @@ static const struct vpnhide_offsets vpnhide_off_5_x = {
 	 * nh@152, fib6_nh[]@168; nhc_dev first in fib6_nh -> +168. */
 	.fib6_info_nh = 152,
 	.fib6_info_fib6_nh = 168,
+	/* android12-5.10 struct fib_rule (LP64). */
+	.fib_rule_table = 36,
+	.fib_rule_iifname = 88,
+	.fib_rule_oifname = 104,
+	.fib_rule_uid_start = 120,
+	.fib_rule_uid_end = 124,
 	.proc_uses_proc_ops = 1, /* 5.6+; for <5.6 use file_operations below */
 };
 

--- a/kmod/kpm/kver_offsets.h
+++ b/kmod/kpm/kver_offsets.h
@@ -1,0 +1,116 @@
+/* SPDX-License-Identifier: MIT */
+/*
+ * Per-kernel-version struct-offset table for the KPM backend.
+ *
+ * WHY THIS EXISTS
+ * ---------------
+ * KernelPatch resolves *symbol addresses* at load time (runtime
+ * `kallsyms_lookup_name`), so one `.kpm` binary loads across many kernels.
+ * It does NOT give us struct *field* offsets — those changed across
+ * versions and the compiler can't compute them because we never include
+ * the real kernel headers (`-nostdinc`). So we keep a small offset table
+ * keyed on the running kernel version, selected at init.
+ *
+ * This is the difference between our approach and soranerai's KPM, which
+ * ships three near-identical source files (4.14 / 5.4 / 6.1) with the
+ * offsets baked in. One source + one runtime table = one binary for all.
+ *
+ * VALUES MUST BE PROVEN, NOT GUESSED. Each non-TODO value below is either
+ * (a) confirmed by soranerai on a real device, or (b) trivially stable
+ * (e.g. net_device.name is the first member on every version). Every new
+ * value has to pass the QEMU KPM harness (see kmod/kpm/README.md) before
+ * it ships — a wrong offset here is a kernel panic / bootloop, not a soft
+ * failure like a kretprobe that won't register.
+ */
+#ifndef VPNHIDE_KVER_OFFSETS_H
+#define VPNHIDE_KVER_OFFSETS_H
+
+/* KernelPatch exposes the running kernel version as `kver` (see
+ * <kpmodule.h>). Encoding matches LINUX_VERSION_CODE: (a<<16)|(b<<8)|c. */
+#define VPNHIDE_KVER(a, b, c) (((a) << 16) + ((b) << 8) + (c))
+
+struct vpnhide_offsets {
+	/* sk_buff.len — saved before a netlink fill, restored via skb_trim. */
+	unsigned int skb_len;
+
+	/* net_device.name — first member on all supported versions. */
+	unsigned int netdev_name;
+
+	/* seq_file.{buf,count} — stable across the seq_file lifetime. */
+	unsigned int seqfile_buf;
+	unsigned int seqfile_count;
+
+	/* in_ifaddr.ifa_dev (-> in_device.dev -> net_device).  [TODO 5.4/4.14] */
+	unsigned int in_ifaddr_ifa_dev;
+	unsigned int in_device_dev;
+
+	/* inet6_ifaddr.idev (-> inet6_dev.dev -> net_device). [TODO 5.4/4.14] */
+	unsigned int inet6_ifaddr_idev;
+	unsigned int inet6_dev_dev;
+
+	/* 1 if procfs uses `struct proc_ops` (>=5.6), 0 if `file_operations`
+	 * (<5.6). Mixing these up is the most likely cause of the
+	 * /proc/vpnhide_targets crash reported on HyperOS 5.4. */
+	int proc_uses_proc_ops;
+};
+
+/*
+ * GKI 6.1 — values confirmed by soranerai's working module on-device.
+ *   skb.len = 112, inet6_ifaddr.idev = 216, in_ifaddr.ifa_dev = 24.
+ */
+static const struct vpnhide_offsets vpnhide_off_6_1 = {
+	.skb_len = 112,
+	.netdev_name = 0,
+	.seqfile_buf = 0,
+	.seqfile_count = 24,
+	.in_ifaddr_ifa_dev = 24,
+	.in_device_dev = 0, /* TODO: confirm in_device.dev offset on 6.1 */
+	.inet6_ifaddr_idev = 216,
+	.inet6_dev_dev = 0, /* TODO: confirm inet6_dev.dev offset on 6.1 */
+	.proc_uses_proc_ops = 1,
+};
+
+/* 5.10 / 5.15 — older skb layout (skb.len = 104 per soranerai); rest TODO. */
+static const struct vpnhide_offsets vpnhide_off_5_x = {
+	.skb_len = 104,
+	.netdev_name = 0,
+	.seqfile_buf = 0,
+	.seqfile_count = 24,
+	.in_ifaddr_ifa_dev = 24, /* TODO: confirm on 5.4/5.10 */
+	.in_device_dev = 0,
+	.inet6_ifaddr_idev = 0, /* TODO: derive for 5.x */
+	.inet6_dev_dev = 0,
+	.proc_uses_proc_ops = 1, /* 5.6+; for <5.6 use file_operations below */
+};
+
+/* 4.14 / 4.19 / pre-5.6 — procfs still uses `file_operations`. All struct
+ * offsets TODO; this entry only encodes the proc-ABI flag for now. */
+static const struct vpnhide_offsets vpnhide_off_4_x = {
+	.skb_len = 104, /* TODO: confirm for 4.14 */
+	.netdev_name = 0,
+	.seqfile_buf = 0,
+	.seqfile_count = 24,
+	.in_ifaddr_ifa_dev = 0, /* TODO */
+	.in_device_dev = 0,
+	.inet6_ifaddr_idev = 0,
+	.inet6_dev_dev = 0,
+	.proc_uses_proc_ops = 0, /* <5.6 → file_operations */
+};
+
+/*
+ * Select the offset table for the running kernel. Returns NULL for an
+ * unsupported version — the caller MUST refuse to install hooks then
+ * (kpm-spore does the same: unknown version → bail, never guess).
+ */
+static inline const struct vpnhide_offsets *vpnhide_select_offsets(unsigned int kver)
+{
+	if (kver >= VPNHIDE_KVER(6, 0, 0))
+		return &vpnhide_off_6_1; /* 6.x — only 6.1 proven so far */
+	if (kver >= VPNHIDE_KVER(5, 6, 0))
+		return &vpnhide_off_5_x;
+	if (kver >= VPNHIDE_KVER(4, 0, 0))
+		return &vpnhide_off_4_x;
+	return 0; /* unsupported → do not install */
+}
+
+#endif /* VPNHIDE_KVER_OFFSETS_H */

--- a/kmod/kpm/kver_offsets.h
+++ b/kmod/kpm/kver_offsets.h
@@ -125,7 +125,8 @@ static const struct vpnhide_offsets vpnhide_off_6_1 = {
 	.proc_uses_proc_ops = 1,
 };
 
-/* 5.10 / 5.15 — older skb layout (skb.len = 104 per soranerai); rest TODO. */
+/* 5.10 (android12-5.10) — QEMU-validated 9/9. (5.15 has a different fib6_info
+ * and gets its own table below.) */
 static const struct vpnhide_offsets vpnhide_off_5_x = {
 	.skb_len = 104,
 	.netdev_name = 0,
@@ -158,6 +159,37 @@ static const struct vpnhide_offsets vpnhide_off_5_x = {
 	.fib_rule_uid_start = 120,
 	.fib_rule_uid_end = 124,
 	.proc_uses_proc_ops = 1, /* 5.6+; for <5.6 use file_operations below */
+};
+
+/* 5.15 (android13-5.15, derived from source + QEMU-validated). Identical to
+ * 5.10 EXCEPT struct fib6_info gained offload/offload_failed fields (same
+ * shape as 6.1), pushing nh@160 and fib6_nh[]@176 (5.10 is 152/168). This is
+ * why 5.15 can't share the 5.10 table — its IPv6 route-dump dev would be
+ * misread. Everything else (idev@168, fib_info 96/104/128, fib_dump via
+ * fib_rt_info*@arg4, fib_rule) matches 5.10. */
+static const struct vpnhide_offsets vpnhide_off_5_15 = {
+	.skb_len = 104, /* GKI 5.15 head (validated); bump to 112 if conntrack on */
+	.netdev_name = 0,
+	.seqfile_buf = 0,
+	.seqfile_count = 24,
+	.in_ifaddr_ifa_dev = 24,
+	.in_device_dev = 0,
+	.inet6_ifaddr_idev = 168,
+	.inet6_dev_dev = 0,
+	.fib_info_fib_nhs = 96,
+	.fib_info_nh = 104,
+	.fib_info_fib_nh = 128,
+	.fib_dump_fi_arg = 4,
+	.fib_dump_fi_via_fri = 1,
+	/* fib6_info with offload/offload_failed (cf. 6.1): nh@160, fib6_nh[]@176. */
+	.fib6_info_nh = 160,
+	.fib6_info_fib6_nh = 176,
+	.fib_rule_table = 36,
+	.fib_rule_iifname = 88,
+	.fib_rule_oifname = 104,
+	.fib_rule_uid_start = 120,
+	.fib_rule_uid_end = 124,
+	.proc_uses_proc_ops = 1,
 };
 
 /* 5.4 (android11-5.4, derived from AOSP common source + QEMU-validated).
@@ -284,8 +316,10 @@ static inline const struct vpnhide_offsets *vpnhide_select_offsets(unsigned int 
 {
 	if (kver >= VPNHIDE_KVER(6, 0, 0))
 		return &vpnhide_off_6_1; /* 6.x — only 6.1 proven so far */
+	if (kver >= VPNHIDE_KVER(5, 15, 0))
+		return &vpnhide_off_5_15; /* 5.15+: fib6_info gained offload fields */
 	if (kver >= VPNHIDE_KVER(5, 6, 0))
-		return &vpnhide_off_5_x;
+		return &vpnhide_off_5_x; /* 5.6–5.14 */
 	if (kver >= VPNHIDE_KVER(5, 0, 0))
 		return &vpnhide_off_5_4; /* 5.0–5.5: legacy fib_dump_info + proc */
 	if (kver >= VPNHIDE_KVER(4, 19, 0))

--- a/kmod/kpm/kver_offsets.h
+++ b/kmod/kpm/kver_offsets.h
@@ -124,18 +124,31 @@ static const struct vpnhide_offsets vpnhide_off_5_x = {
 	.proc_uses_proc_ops = 1, /* 5.6+; for <5.6 use file_operations below */
 };
 
-/* 4.14 / 4.19 / pre-5.6 — procfs still uses `file_operations`. All struct
- * offsets TODO; this entry only encodes the proc-ABI flag for now. */
+/* 4.14 (vanilla 4.14.336, derived from source + QEMU-validated). Offsets that
+ * match 5.x are noted; the route-dump hooks (fib_dump_info, rt6_fill_node)
+ * are STRUCTURALLY different on 4.14 (fi passed directly at a different arg,
+ * no nexthop objects, IPv6 uses rt6_info not fib6_info) so their offsets stay
+ * 0 here = not installed until the hooks learn the 4.14 shape (see the
+ * coverage notes in vpnhide_kpm.c). procfs is file_operations (<5.6). */
 static const struct vpnhide_offsets vpnhide_off_4_x = {
-	.skb_len = 104, /* TODO: confirm for 4.14 */
+	.skb_len = 104, /* confirmed: rtnl A/B PASSes on 4.14 */
 	.netdev_name = 0,
 	.seqfile_buf = 0,
 	.seqfile_count = 24,
-	.in_ifaddr_ifa_dev = 0, /* TODO */
+	.in_ifaddr_ifa_dev = 24, /* in_ifaddr: hash(16)+ifa_next(8) — same as 5.x */
 	.in_device_dev = 0,
-	.inet6_ifaddr_idev = 0,
+	.inet6_ifaddr_idev = 168, /* 4.14: no rt_priority (-4) but timer_list has `data` (+8) -> idev@168 */
 	.inet6_dev_dev = 0,
+	/* fib_rule offsets match 5.10 (verified), BUT left 0 (hook gated off) on
+	 * 4.14: with the hook installed it never filters — fib_nl_fill_rule is a
+	 * `static` fn on 4.14 and appears to be inlined (dead kallsyms symbol,
+	 * like dev_ifconf on 5.10 LTO), so the probe never fires. Needs an
+	 * alternate hook point before it can be enabled here. */
+	.fib_rule_table = 0,
 	.proc_uses_proc_ops = 0, /* <5.6 → file_operations */
+	/* fib_dump_info / rt6_fill_node deliberately 0: structurally different on
+	 * 4.14 (fi at a different arg, no nexthop objects, IPv6 = rt6_info not
+	 * fib6_info) — needs table-driven arg/extraction, then derive + validate. */
 };
 
 /*

--- a/kmod/kpm/vpnhide_kpm.c
+++ b/kmod/kpm/vpnhide_kpm.c
@@ -8,12 +8,12 @@
  * Loaded by the KernelPatch runtime (target: KPatch-Next on KernelSU-Next),
  * NOT insmod — so it also works where module signing blocks a `.ko`.
  *
- * STATUS: compiles against the KernelPatch header tree into a valid .kpm
- * (`make kpm KP_DIR=/path/to/KernelPatch`; verified against bmax121/KernelPatch).
- * NOT yet validated on a kernel: the running-kver source is a stub (so it
- * refuses to install), several hooks are still TODO, and every per-kver offset
- * in kver_offsets.h must pass the QEMU KPM harness before anything ships — a
- * wrong offset is a panic/bootloop, not a soft failure.
+ * STATUS: builds (`make kpm`) and runs end-to-end under QEMU via the KPM
+ * harness (../test/run-kpm.sh). On android12-5.10, 7/10 hooks are A/B-
+ * validated with no panic. Only 5.10 offsets are filled in kver_offsets.h;
+ * other versions + the remaining hooks are TODO. Every per-kver offset must
+ * pass the harness before that version ships — a wrong offset is a contained
+ * QEMU panic / A/B failure here, but a bootloop on a real device.
  *
  * DESIGN (how this differs from soranerai's prototype, deliberately):
  *   - ONE source + a runtime kver offset table (kver_offsets.h), not three
@@ -404,6 +404,60 @@ static void rt6_fill_after(hook_fargs12_t *fargs, void *udata)
 	fargs->ret = 0;
 }
 
+/* ================================================================== */
+/*  Hook 8: fib_nl_fill_rule — RTM_GETRULE (policy routing rules)      */
+/*  arg0 = skb, arg1 = fib_rule*.  Hide a rule if it routes via a VPN   */
+/*  iface (iif/oifname) or selects a non-standard table for a target    */
+/*  UID range — the per-UID VPN policy rules.                          */
+/* ================================================================== */
+
+static void fib_rule_before(hook_fargs8_t *fargs, void *udata)
+{
+	void *skb = (void *)fargs->arg0;
+	char *rule = (char *)fargs->arg1;
+	const char *iif, *oif;
+	int filter = 0;
+
+	fargs->local.data0 = 0;
+	if (!is_target_uid() || !skb || !rule || !off->fib_rule_table)
+		return;
+
+	iif = rule + off->fib_rule_iifname;
+	oif = rule + off->fib_rule_oifname;
+	if ((iif[0] && iface_is_vpn(iif)) || (oif[0] && iface_is_vpn(oif))) {
+		filter = 1;
+	} else {
+		uint32_t table = *(uint32_t *)(rule + off->fib_rule_table);
+		uint32_t start = *(uint32_t *)(rule + off->fib_rule_uid_start);
+		uint32_t end = *(uint32_t *)(rule + off->fib_rule_uid_end);
+		uint32_t uid = (uint32_t)current_uid();
+
+		if (uid >= start && uid <= end &&
+		    (start != 0 || end != 0xffffffffu) && table != 253 &&
+		    table != 254 && table != 255 && table > 100)
+			filter = 1;
+	}
+
+	if (filter) {
+		fargs->local.data0 = 1;
+		fargs->local.data1 = (uint64_t)skb;
+		fargs->local.data2 = (uint64_t) *
+				     (unsigned int *)((char *)skb + off->skb_len);
+	}
+}
+
+static void fib_rule_after(hook_fargs8_t *fargs, void *udata)
+{
+	if (!fargs->local.data0)
+		return;
+	if ((long)fargs->ret < 0)
+		return;
+	if (_skb_trim)
+		_skb_trim((void *)fargs->local.data1,
+			  (unsigned int)fargs->local.data2);
+	fargs->ret = 0;
+}
+
 /*
  * HOOK COVERAGE — to reach parity with vpnhide_kmod.c (the .ko). Each line
  * below is a hook_wrap target; PoC ones are wired above, the rest are the
@@ -570,6 +624,11 @@ static long vpnhide_kpm_init(const char *args, const char *event,
 		hook_wrap((void *)fn, 11, (void *)rt6_fill_before,
 			  (void *)rt6_fill_after, 0);
 
+	fn = kallsyms_lookup_name("fib_nl_fill_rule");
+	if (fn)
+		hook_wrap((void *)fn, 7, (void *)fib_rule_before,
+			  (void *)fib_rule_after, 0);
+
 	logki(MODNAME ": KPM hooks installed\n");
 	return 0;
 }
@@ -614,6 +673,10 @@ static long vpnhide_kpm_exit(void *__user reserved)
 	if (fn)
 		hook_unwrap((void *)fn, (void *)rt6_fill_before,
 			    (void *)rt6_fill_after);
+	fn = kallsyms_lookup_name("fib_nl_fill_rule");
+	if (fn)
+		hook_unwrap((void *)fn, (void *)fib_rule_before,
+			    (void *)fib_rule_after);
 
 	if (_remove_proc_entry) {
 		_remove_proc_entry("vpnhide_targets", 0);

--- a/kmod/kpm/vpnhide_kpm.c
+++ b/kmod/kpm/vpnhide_kpm.c
@@ -649,54 +649,68 @@ static long vpnhide_kpm_init(const char *args, const char *event,
 	/* TODO: create /proc/vpnhide_targets + /proc/vpnhide_debug using the
 	 * proc-ABI selected by off->proc_uses_proc_ops. */
 
-	/* Install the PoC hooks. hook_wrap(func, argno, before, after, udata). */
-	fn = kallsyms_lookup_name("fib_route_seq_show");
-	if (fn)
-		hook_wrap((void *)fn, 2, (void *)fib_route_before,
-			  (void *)fib_route_after, 0);
-
-	fn = kallsyms_lookup_name("rtnl_fill_ifinfo");
-	if (fn)
-		hook_wrap((void *)fn, 12, (void *)rtnl_fill_before,
-			  (void *)rtnl_fill_after, 0);
-
-	fn = kallsyms_lookup_name("ipv6_route_seq_show");
-	if (fn)
-		hook_wrap((void *)fn, 2, (void *)fib_route_before,
-			  (void *)ipv6_route_after, 0);
-
-	fn = kallsyms_lookup_name("inet_fill_ifaddr");
-	if (fn)
-		hook_wrap((void *)fn, 3, (void *)inet_fill_before,
-			  (void *)addr_fill_after, 0);
-
-	fn = kallsyms_lookup_name("inet6_fill_ifaddr");
-	if (fn)
-		hook_wrap((void *)fn, 3, (void *)inet6_fill_before,
-			  (void *)addr_fill_after, 0);
+	/*
+	 * Install hooks. Each one is gated on the offset(s) it dereferences
+	 * being known for this kernel version (0 => not installed), so a
+	 * partially-filled offset table is SAFE: a hook never runs with a
+	 * wrong/zero offset and panics. seq_file + ioctl hooks need only
+	 * stable offsets (seqfile_count, uapi ifreq) so they install whenever
+	 * the symbol exists. hook_wrap(func, argno, before, after, udata).
+	 */
+	if (off->seqfile_count) {
+		fn = kallsyms_lookup_name("fib_route_seq_show");
+		if (fn)
+			hook_wrap((void *)fn, 2, (void *)fib_route_before,
+				  (void *)fib_route_after, 0);
+		fn = kallsyms_lookup_name("ipv6_route_seq_show");
+		if (fn)
+			hook_wrap((void *)fn, 2, (void *)fib_route_before,
+				  (void *)ipv6_route_after, 0);
+	}
 
 	fn = kallsyms_lookup_name("dev_ioctl");
 	if (fn)
 		hook_wrap((void *)fn, 5, 0, (void *)dev_ioctl_after, 0);
-
 	fn = kallsyms_lookup_name("sock_ioctl");
 	if (fn)
 		hook_wrap((void *)fn, 3, 0, (void *)sock_ioctl_after, 0);
 
-	fn = kallsyms_lookup_name("fib_dump_info");
-	if (fn)
-		hook_wrap((void *)fn, 6, (void *)fib_dump_before,
-			  (void *)fib_dump_after, 0);
-
-	fn = kallsyms_lookup_name("rt6_fill_node");
-	if (fn)
-		hook_wrap((void *)fn, 11, (void *)rt6_fill_before,
-			  (void *)rt6_fill_after, 0);
-
-	fn = kallsyms_lookup_name("fib_nl_fill_rule");
-	if (fn)
-		hook_wrap((void *)fn, 7, (void *)fib_rule_before,
-			  (void *)fib_rule_after, 0);
+	if (off->skb_len) {
+		fn = kallsyms_lookup_name("rtnl_fill_ifinfo");
+		if (fn)
+			hook_wrap((void *)fn, 12, (void *)rtnl_fill_before,
+				  (void *)rtnl_fill_after, 0);
+	}
+	if (off->in_ifaddr_ifa_dev) {
+		fn = kallsyms_lookup_name("inet_fill_ifaddr");
+		if (fn)
+			hook_wrap((void *)fn, 3, (void *)inet_fill_before,
+				  (void *)addr_fill_after, 0);
+	}
+	if (off->inet6_ifaddr_idev) {
+		fn = kallsyms_lookup_name("inet6_fill_ifaddr");
+		if (fn)
+			hook_wrap((void *)fn, 3, (void *)inet6_fill_before,
+				  (void *)addr_fill_after, 0);
+	}
+	if (off->fib_info_fib_nh) {
+		fn = kallsyms_lookup_name("fib_dump_info");
+		if (fn)
+			hook_wrap((void *)fn, 6, (void *)fib_dump_before,
+				  (void *)fib_dump_after, 0);
+	}
+	if (off->fib6_info_fib6_nh) {
+		fn = kallsyms_lookup_name("rt6_fill_node");
+		if (fn)
+			hook_wrap((void *)fn, 11, (void *)rt6_fill_before,
+				  (void *)rt6_fill_after, 0);
+	}
+	if (off->fib_rule_table) {
+		fn = kallsyms_lookup_name("fib_nl_fill_rule");
+		if (fn)
+			hook_wrap((void *)fn, 7, (void *)fib_rule_before,
+				  (void *)fib_rule_after, 0);
+	}
 
 	logki(MODNAME ": KPM hooks installed\n");
 	return 0;

--- a/kmod/kpm/vpnhide_kpm.c
+++ b/kmod/kpm/vpnhide_kpm.c
@@ -70,6 +70,7 @@ static int (*_single_release)(void *, void *);
 static void *_seq_read, *_seq_lseek;
 static void (*_seq_printf)(void *, const char *, ...);
 static unsigned long (*_copy_from_user)(void *, const void *, unsigned long);
+static unsigned long (*_copy_to_user)(void *, const void *, unsigned long);
 static void (*_skb_trim)(void *, unsigned int);
 
 #define vpnhide_dbg(fmt, ...) \
@@ -201,22 +202,122 @@ static void rtnl_fill_after(hook_fargs12_t *fargs, void *udata)
 	fargs->ret = 0;
 }
 
+/* ================================================================== */
+/*  Hook 4: dev_ioctl — per-interface ioctls (SIOCGIF* by name)        */
+/*  arg1 = cmd, arg2 = ifr (KERNEL ptr; ifr_name at offset 0, uapi-     */
+/*  stable). If the result names a VPN iface, return -ENODEV. Covers    */
+/*  SIOCGIFNAME (index->name, name is output) + FLAGS/MTU/INDEX/HWADDR/  */
+/*  ADDR (name is input). No kernel-internal offsets — only ifr_name@0. */
+/* ================================================================== */
+
+#define VPNHIDE_ENODEV ((uint64_t)(-19))
+
+/* SIOCGIF* range (0x8910..0x8930). SIOCGIFCONF (0x8912) goes via sock_ioctl,
+ * never dev_ioctl, so the overlap is harmless here. */
+static int is_siocgif(unsigned long cmd)
+{
+	return cmd >= 0x8910 && cmd <= 0x8930;
+}
+
+static void dev_ioctl_after(hook_fargs5_t *fargs, void *udata)
+{
+	unsigned long cmd = (unsigned long)fargs->arg1;
+	const char *ifr = (const char *)fargs->arg2; /* ifr_name @ offset 0 */
+
+	if ((long)fargs->ret != 0 || !ifr)
+		return;
+	if (!is_target_uid() || !is_siocgif(cmd))
+		return;
+	if (iface_is_vpn(ifr)) {
+		vpnhide_dbg("dev_ioctl: hiding cmd=0x%lx\n", cmd);
+		fargs->ret = VPNHIDE_ENODEV;
+	}
+}
+
+/* ================================================================== */
+/*  Hook 5: sock_ioctl — SIOCGIFCONF enumeration                       */
+/*  arg1 = cmd, arg2 = userspace struct ifconf*. After the call, compact */
+/*  VPN entries out of the returned ifreq[] array. All uapi-stable:      */
+/*  struct ifconf { int ifc_len; <pad>; ptr ifc_req@8 }, sizeof ifreq=40,*/
+/*  ifr_name @ offset 0.                                                */
+/* ================================================================== */
+
+#define VPNHIDE_SIOCGIFCONF 0x8912
+#define VPNHIDE_IFREQ_SZ 40 /* sizeof(struct ifreq) on arm64 */
+
+static void filter_ifconf(void *uifc)
+{
+	char ifc[16];   /* struct ifconf snapshot: len@0 (int), req@8 (ptr) */
+	char e[VPNHIDE_IFREQ_SZ];
+	char *req;
+	int len, n, i, dst = 0;
+
+	if (!_copy_from_user || !_copy_to_user)
+		return;
+	if (_copy_from_user(ifc, uifc, sizeof(ifc)))
+		return;
+	len = *(int *)ifc;
+	req = *(char **)(ifc + 8);
+	if (!req || len <= 0)
+		return;
+
+	n = len / VPNHIDE_IFREQ_SZ;
+	for (i = 0; i < n; i++) {
+		if (_copy_from_user(e, req + (long)i * VPNHIDE_IFREQ_SZ,
+				    VPNHIDE_IFREQ_SZ))
+			return;
+		e[VPNHIDE_IFNAMSIZ - 1] = '\0';
+		if (iface_is_vpn(e))
+			continue; /* drop VPN entry */
+		if (dst != i &&
+		    _copy_to_user(req + (long)dst * VPNHIDE_IFREQ_SZ, e,
+				  VPNHIDE_IFREQ_SZ))
+			return;
+		dst++;
+	}
+	if (dst != n) {
+		int newlen = dst * VPNHIDE_IFREQ_SZ;
+
+		_copy_to_user(uifc, &newlen, sizeof(newlen)); /* shrink ifc_len */
+		vpnhide_dbg("sock_ioctl: ifconf %d -> %d\n", len, newlen);
+	}
+}
+
+static void sock_ioctl_after(hook_fargs3_t *fargs, void *udata)
+{
+	unsigned long cmd = (unsigned long)fargs->arg1;
+	void *argp = (void *)fargs->arg2;
+
+	if ((long)fargs->ret != 0 || !argp)
+		return;
+	if (cmd != VPNHIDE_SIOCGIFCONF || !is_target_uid())
+		return;
+	filter_ifconf(argp);
+}
+
 /*
  * HOOK COVERAGE — to reach parity with vpnhide_kmod.c (the .ko). Each line
  * below is a hook_wrap target; PoC ones are wired above, the rest are the
  * porting backlog. Mirror the .ko's logic; reuse shared/vpnhide_logic.h.
  *
- *   fib_route_seq_show     /proc/net/route        PoC (above)
- *   rtnl_fill_ifinfo       RTM_NEWLINK            PoC (above)
- *   ipv6_route_seq_show    /proc/net/ipv6_route   TODO (FIELD_LAST compactor)
- *   inet_fill_ifaddr       RTM_GETADDR v4         TODO (skb_trim; ifa->ifa_dev->dev)
- *   inet6_fill_ifaddr      RTM_GETADDR v6         TODO (skb_trim; ifa->idev->dev)
- *   dev_ioctl              SIOCGIF* by name       TODO (rewrite ret -> -ENODEV)
- *   sock_ioctl             SIOCGIFCONF            TODO (ifconf compaction via copy_*_user)
- *   fib_dump_info          RTM_GETROUTE v4 dump   TODO (#86; fib_info nexthop dev)
- *   rt6_fill_node          RTM_GETROUTE v6        TODO
- *   fib_nl_fill_rule       RTM_GETRULE            TODO
- *   ( rt_fill_info — intentionally NOT hooked; unstable ABI )
+ * DONE + QEMU-validated on android12-5.10 (offset-safe — no kernel-internal
+ * struct offsets, only seq_file + uapi ifreq/ifr_name@0):
+ *   fib_route_seq_show     /proc/net/route        ✓
+ *   rtnl_fill_ifinfo       RTM_NEWLINK            ✓ (skb.len)
+ *   ipv6_route_seq_show    /proc/net/ipv6_route   ✓
+ *   dev_ioctl              SIOCGIF* by name       ✓ (ret -> -ENODEV)
+ *   sock_ioctl             SIOCGIFCONF            ✓ (ifconf compaction)
+ *
+ * TODO — these dereference version-specific kernel structs, so they need a
+ * per-kver offset table entry derived from each GKI's source (the genuinely
+ * fragile part; tune against the QEMU harness, where a wrong offset is an
+ * A/B fail or a contained panic, not a brick):
+ *   inet_fill_ifaddr       RTM_GETADDR v4         in_ifaddr.ifa_dev->dev
+ *   inet6_fill_ifaddr      RTM_GETADDR v6         inet6_ifaddr.idev->dev
+ *   fib_dump_info          RTM_GETROUTE v4 dump   #86; fib_info nexthop dev
+ *   rt6_fill_node          RTM_GETROUTE v6        fib6_info nexthop dev
+ *   fib_nl_fill_rule       RTM_GETRULE            fib_rule iif/oif/uid_range
+ *   ( rt_fill_info — intentionally NOT hooked; unstable arg->reg ABI )
  */
 
 /* ------------------------------------------------------------------ */
@@ -270,6 +371,10 @@ static int resolve_symbols(void)
 	_copy_from_user = (void *)kallsyms_lookup_name("__arch_copy_from_user");
 	if (!_copy_from_user)
 		_copy_from_user = (void *)kallsyms_lookup_name("_copy_from_user");
+
+	_copy_to_user = (void *)kallsyms_lookup_name("__arch_copy_to_user");
+	if (!_copy_to_user)
+		_copy_to_user = (void *)kallsyms_lookup_name("_copy_to_user");
 
 	_skb_trim = (void *)kallsyms_lookup_name("__skb_trim");
 	if (!_skb_trim)
@@ -339,6 +444,14 @@ static long vpnhide_kpm_init(const char *args, const char *event,
 		hook_wrap((void *)fn, 2, (void *)fib_route_before,
 			  (void *)ipv6_route_after, 0);
 
+	fn = kallsyms_lookup_name("dev_ioctl");
+	if (fn)
+		hook_wrap((void *)fn, 5, 0, (void *)dev_ioctl_after, 0);
+
+	fn = kallsyms_lookup_name("sock_ioctl");
+	if (fn)
+		hook_wrap((void *)fn, 3, 0, (void *)sock_ioctl_after, 0);
+
 	logki(MODNAME ": KPM hooks installed\n");
 	return 0;
 }
@@ -369,6 +482,12 @@ static long vpnhide_kpm_exit(void *__user reserved)
 	if (fn)
 		hook_unwrap((void *)fn, (void *)fib_route_before,
 			    (void *)ipv6_route_after);
+	fn = kallsyms_lookup_name("dev_ioctl");
+	if (fn)
+		hook_unwrap((void *)fn, 0, (void *)dev_ioctl_after);
+	fn = kallsyms_lookup_name("sock_ioctl");
+	if (fn)
+		hook_unwrap((void *)fn, 0, (void *)sock_ioctl_after);
 
 	if (_remove_proc_entry) {
 		_remove_proc_entry("vpnhide_targets", 0);

--- a/kmod/kpm/vpnhide_kpm.c
+++ b/kmod/kpm/vpnhide_kpm.c
@@ -146,6 +146,24 @@ static void fib_route_after(hook_fargs2_t *fargs, void *udata)
 					    VPNHIDE_FIELD_FIRST, iface_is_vpn);
 }
 
+/* ipv6_route_seq_show — /proc/net/ipv6_route. Same as fib_route but the iface
+ * name is the LAST field. Shares fib_route_before (stashes seq->count). */
+static void ipv6_route_after(hook_fargs2_t *fargs, void *udata)
+{
+	void *seq = (void *)fargs->arg0;
+	char *buf;
+	unsigned long *countp;
+	unsigned long start = (unsigned long)fargs->local.data0;
+
+	if (!seq || !is_target_uid())
+		return;
+
+	buf = *(char **)((char *)seq + off->seqfile_buf);
+	countp = (unsigned long *)((char *)seq + off->seqfile_count);
+	*countp = vpnhide_compact_seq_lines(buf, start, *countp,
+					    VPNHIDE_FIELD_LAST, iface_is_vpn);
+}
+
 /* ================================================================== */
 /*  Hook 2 (PoC): rtnl_fill_ifinfo — RTM_NEWLINK (getifaddrs path)    */
 /*  arg0 = skb, arg1 = net_device.  If the dev is a VPN iface and the  */
@@ -316,6 +334,11 @@ static long vpnhide_kpm_init(const char *args, const char *event,
 		hook_wrap((void *)fn, 12, (void *)rtnl_fill_before,
 			  (void *)rtnl_fill_after, 0);
 
+	fn = kallsyms_lookup_name("ipv6_route_seq_show");
+	if (fn)
+		hook_wrap((void *)fn, 2, (void *)fib_route_before,
+			  (void *)ipv6_route_after, 0);
+
 	logki(MODNAME ": KPM hooks installed\n");
 	return 0;
 }
@@ -342,6 +365,10 @@ static long vpnhide_kpm_exit(void *__user reserved)
 	if (fn)
 		hook_unwrap((void *)fn, (void *)rtnl_fill_before,
 			    (void *)rtnl_fill_after);
+	fn = kallsyms_lookup_name("ipv6_route_seq_show");
+	if (fn)
+		hook_unwrap((void *)fn, (void *)fib_route_before,
+			    (void *)ipv6_route_after);
 
 	if (_remove_proc_entry) {
 		_remove_proc_entry("vpnhide_targets", 0);

--- a/kmod/kpm/vpnhide_kpm.c
+++ b/kmod/kpm/vpnhide_kpm.c
@@ -443,7 +443,13 @@ static void *dev_from_fib6_info(void *rt)
 {
 	void *nh;
 
-	if (!rt || !off->fib6_info_fib6_nh)
+	if (!rt)
+		return 0;
+	/* Pre-fib6_info kernels: rt is a struct rt6_info* whose embedded
+	 * dst_entry holds the dev directly (no nexthop walk). */
+	if (off->rt6_via_dst)
+		return *(void **)((char *)rt + off->rt6_dst_dev);
+	if (!off->fib6_info_fib6_nh)
 		return 0;
 	/* fib6_info_nh == 0 => this version has no nexthop-object field (e.g.
 	 * 4.19/4.14); skip the check rather than misread fib6_info's head. */
@@ -768,7 +774,7 @@ static long vpnhide_kpm_init(const char *args, const char *event,
 			hook_wrap((void *)fn, 11, (void *)fib_dump_before,
 				  (void *)fib_dump_after, 0);
 	}
-	if (off->fib6_info_fib6_nh) {
+	if (off->fib6_info_fib6_nh || off->rt6_via_dst) {
 		fn = lookup_fn("rt6_fill_node");
 		if (fn)
 			hook_wrap((void *)fn, 11, (void *)rt6_fill_before,

--- a/kmod/kpm/vpnhide_kpm.c
+++ b/kmod/kpm/vpnhide_kpm.c
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 /*
- * vpnhide — KernelPatch Module (KPM) backend.  *** WIP: 5.10 only ***
+ * vpnhide — KernelPatch Module (KPM) backend.  *** WIP ***
  *
  * A third native backend alongside the kretprobe `.ko`, for kernels the
  * `.ko` can't serve: non-GKI / proprietary kernels with no published
@@ -9,12 +9,12 @@
  * NOT insmod — so it also works where module signing blocks a `.ko`.
  *
  * STATUS: builds (`make kpm`) and runs end-to-end under QEMU via the KPM
- * harness (../test/run-kpm.sh). On android12-5.10, all 10 hooks are A/B-
- * validated with no panic (full native-vector parity with the .ko). Only the
- * 5.10 offset table is filled in kver_offsets.h; other kernel versions (and
- * the procfs control plane) are TODO. Every per-kver offset must pass the
- * harness before that version ships — a wrong offset is a contained QEMU
- * panic / A/B failure here, but a bootloop on a real device.
+ * harness (../test/run-kpm.sh). All 10 hooks are A/B-validated with no panic
+ * (full native-vector parity with the .ko) on android12-5.10 AND android11-5.4
+ * (a separate from-source QEMU kernel). 4.14 has 7 hooks validated; offset
+ * tables for 4.19 / 6.1 and the procfs control plane are TODO. Every per-kver
+ * offset must pass the harness before that version ships — a wrong offset is a
+ * contained QEMU panic / A/B failure here, but a bootloop on a real device.
  *
  * DESIGN (how this differs from soranerai's prototype, deliberately):
  *   - ONE source + a runtime kver offset table (kver_offsets.h), not three
@@ -360,9 +360,10 @@ static void inet6_fill_before(hook_fargs4_t *fargs, void *udata)
 
 /* ================================================================== */
 /*  Hook 6: fib_dump_info — IPv4 RTM_GETROUTE dump (issue #86)         */
-/*  arg0 = skb, arg4 = fib_rt_info*.  Resolve the route's output dev    */
-/*  (fri->fi->fib_nh[0].nh_common.nhc_dev for a legacy single-nexthop   */
-/*  route) and, if it's a VPN iface, undo the fill (skb_trim) + ret 0.  */
+/*  arg0 = skb; the fib_info arg index varies by version (table-driven).*/
+/*  Resolve the route's output dev (fib_nh[0].nh_common.nhc_dev for a   */
+/*  legacy single-nexthop route) and, if it's a VPN iface, undo the     */
+/*  fill (skb_trim) + ret 0.                                            */
 /*  This is the first hook that dereferences version-specific kernel    */
 /*  structs — offsets live in kver_offsets.h, validated by the harness. */
 /* ================================================================== */
@@ -376,10 +377,14 @@ static void *dev_from_fib_info(void *fi)
 	if (!fi || !off->fib_info_fib_nh)
 		return 0;
 	/* A non-NULL nexthop object means an `ip nexthop`-style route, whose
-	 * dev lives behind a separate struct nexthop walk — not unpacked yet. */
-	nh = *(void **)((char *)fi + off->fib_info_nh);
-	if (nh)
-		return 0;
+	 * dev lives behind a separate struct nexthop walk — not unpacked yet.
+	 * fib_info_nh == 0 means this version has no nexthop-object field at all
+	 * (e.g. 4.14), so skip the check rather than misread fib_info's head. */
+	if (off->fib_info_nh) {
+		nh = *(void **)((char *)fi + off->fib_info_nh);
+		if (nh)
+			return 0;
+	}
 	nhs = *(int *)((char *)fi + off->fib_info_fib_nhs);
 	if (nhs <= 0)
 		return 0;
@@ -387,16 +392,26 @@ static void *dev_from_fib_info(void *fi)
 	return *(void **)((char *)fi + off->fib_info_fib_nh);
 }
 
-static void fib_dump_before(hook_fargs8_t *fargs, void *udata)
+/*
+ * fib_dump_info's prototype moved the fib_info across versions, so the arg
+ * index + how to reach the fib_info are table-driven (kver_offsets.h):
+ *   - 5.6+ : fib_dump_info(skb, portid, seq, event, struct fib_rt_info *fri,
+ *            flags) — fi = fri->fi, fi_arg=4, via_fri=1.
+ *   - <5.6 : fib_dump_info(skb, portid, seq, event, tb_id, type, dst, dst_len,
+ *            tos, struct fib_info *fi, flags) — fi_arg=9, via_fri=0.
+ * Always hooked as a 12-arg frame (argno=11): KP just saves the extra slots,
+ * the same way rtnl_fill_ifinfo is over-specified — only the fi arg is read.
+ */
+static void fib_dump_before(hook_fargs12_t *fargs, void *udata)
 {
 	void *skb = (void *)fargs->arg0;
-	void *fri = (void *)fargs->arg4;
+	void *p = (void *)fargs->args[off->fib_dump_fi_arg];
 	void *fi, *dev;
 
 	fargs->local.data0 = 0;
-	if (!is_target_uid() || !skb || !fri)
+	if (!is_target_uid() || !skb || !p)
 		return;
-	fi = *(void **)fri; /* fib_rt_info.fi @ offset 0 */
+	fi = off->fib_dump_fi_via_fri ? *(void **)p : p; /* fib_rt_info.fi @0 */
 	dev = dev_from_fib_info(fi);
 	if (!dev || !iface_is_vpn(netdev_name(dev)))
 		return;
@@ -407,7 +422,7 @@ static void fib_dump_before(hook_fargs8_t *fargs, void *udata)
 		(uint64_t) * (unsigned int *)((char *)skb + off->skb_len);
 }
 
-static void fib_dump_after(hook_fargs8_t *fargs, void *udata)
+static void fib_dump_after(hook_fargs12_t *fargs, void *udata)
 {
 	if (!fargs->local.data0)
 		return;
@@ -430,9 +445,13 @@ static void *dev_from_fib6_info(void *rt)
 
 	if (!rt || !off->fib6_info_fib6_nh)
 		return 0;
-	nh = *(void **)((char *)rt + off->fib6_info_nh);
-	if (nh)
-		return 0; /* nexthop-object route — not unpacked yet */
+	/* fib6_info_nh == 0 => this version has no nexthop-object field (e.g.
+	 * 4.19/4.14); skip the check rather than misread fib6_info's head. */
+	if (off->fib6_info_nh) {
+		nh = *(void **)((char *)rt + off->fib6_info_nh);
+		if (nh)
+			return 0; /* nexthop-object route — not unpacked yet */
+	}
 	return *(void **)((char *)rt + off->fib6_info_fib6_nh);
 }
 
@@ -579,6 +598,56 @@ static long targets_write(void *file, const char __user *ubuf, unsigned long cou
 /*  Init / exit                                                       */
 /* ------------------------------------------------------------------ */
 
+/*
+ * Resolve a hook target by name, tolerating compiler-renamed clones. GCC may
+ * emit a static function as `name.isra.N` / `name.constprop.N` (a specialised
+ * clone) — kallsyms_lookup_name("name") then misses it. Android *device*
+ * kernels are clang-built (name intact), but a gcc-built kernel (incl. our
+ * QEMU test kernels) renames e.g. fib_nl_fill_rule -> fib_nl_fill_rule.isra.N.
+ * Fall back to the first symbol equal to `name`, or `name.` + suffix — the
+ * dot only appears on compiler clones, so this never matches an unrelated fn.
+ */
+struct vpnhide_sym_q {
+	const char *base;
+	int baselen;
+	unsigned long addr;
+};
+
+static int vpnhide_sym_cb(void *data, const char *name, struct module *mod,
+			  unsigned long addr)
+{
+	struct vpnhide_sym_q *q = data;
+	int i;
+
+	(void)mod;
+	for (i = 0; i < q->baselen; i++)
+		if (name[i] != q->base[i])
+			return 0;
+	if (name[q->baselen] == '\0' || name[q->baselen] == '.') {
+		q->addr = addr;
+		return 1; /* found — stop iterating */
+	}
+	return 0;
+}
+
+static unsigned long lookup_fn(const char *name)
+{
+	unsigned long fn = kallsyms_lookup_name(name);
+	struct vpnhide_sym_q q;
+
+	if (fn)
+		return fn;
+	if (!kallsyms_on_each_symbol)
+		return 0;
+	q.base = name;
+	q.baselen = 0;
+	while (name[q.baselen])
+		q.baselen++;
+	q.addr = 0;
+	kallsyms_on_each_symbol(vpnhide_sym_cb, &q);
+	return q.addr;
+}
+
 static int resolve_symbols(void)
 {
 	_proc_create_data = (void *)kallsyms_lookup_name("proc_create_data");
@@ -658,55 +727,55 @@ static long vpnhide_kpm_init(const char *args, const char *event,
 	 * the symbol exists. hook_wrap(func, argno, before, after, udata).
 	 */
 	if (off->seqfile_count) {
-		fn = kallsyms_lookup_name("fib_route_seq_show");
+		fn = lookup_fn("fib_route_seq_show");
 		if (fn)
 			hook_wrap((void *)fn, 2, (void *)fib_route_before,
 				  (void *)fib_route_after, 0);
-		fn = kallsyms_lookup_name("ipv6_route_seq_show");
+		fn = lookup_fn("ipv6_route_seq_show");
 		if (fn)
 			hook_wrap((void *)fn, 2, (void *)fib_route_before,
 				  (void *)ipv6_route_after, 0);
 	}
 
-	fn = kallsyms_lookup_name("dev_ioctl");
+	fn = lookup_fn("dev_ioctl");
 	if (fn)
 		hook_wrap((void *)fn, 5, 0, (void *)dev_ioctl_after, 0);
-	fn = kallsyms_lookup_name("sock_ioctl");
+	fn = lookup_fn("sock_ioctl");
 	if (fn)
 		hook_wrap((void *)fn, 3, 0, (void *)sock_ioctl_after, 0);
 
 	if (off->skb_len) {
-		fn = kallsyms_lookup_name("rtnl_fill_ifinfo");
+		fn = lookup_fn("rtnl_fill_ifinfo");
 		if (fn)
 			hook_wrap((void *)fn, 12, (void *)rtnl_fill_before,
 				  (void *)rtnl_fill_after, 0);
 	}
 	if (off->in_ifaddr_ifa_dev) {
-		fn = kallsyms_lookup_name("inet_fill_ifaddr");
+		fn = lookup_fn("inet_fill_ifaddr");
 		if (fn)
 			hook_wrap((void *)fn, 3, (void *)inet_fill_before,
 				  (void *)addr_fill_after, 0);
 	}
 	if (off->inet6_ifaddr_idev) {
-		fn = kallsyms_lookup_name("inet6_fill_ifaddr");
+		fn = lookup_fn("inet6_fill_ifaddr");
 		if (fn)
 			hook_wrap((void *)fn, 3, (void *)inet6_fill_before,
 				  (void *)addr_fill_after, 0);
 	}
-	if (off->fib_info_fib_nh) {
-		fn = kallsyms_lookup_name("fib_dump_info");
+	if (off->fib_dump_fi_arg) {
+		fn = lookup_fn("fib_dump_info");
 		if (fn)
-			hook_wrap((void *)fn, 6, (void *)fib_dump_before,
+			hook_wrap((void *)fn, 11, (void *)fib_dump_before,
 				  (void *)fib_dump_after, 0);
 	}
 	if (off->fib6_info_fib6_nh) {
-		fn = kallsyms_lookup_name("rt6_fill_node");
+		fn = lookup_fn("rt6_fill_node");
 		if (fn)
 			hook_wrap((void *)fn, 11, (void *)rt6_fill_before,
 				  (void *)rt6_fill_after, 0);
 	}
 	if (off->fib_rule_table) {
-		fn = kallsyms_lookup_name("fib_nl_fill_rule");
+		fn = lookup_fn("fib_nl_fill_rule");
 		if (fn)
 			hook_wrap((void *)fn, 7, (void *)fib_rule_before,
 				  (void *)fib_rule_after, 0);
@@ -730,41 +799,41 @@ static long vpnhide_kpm_exit(void *__user reserved)
 {
 	unsigned long fn;
 
-	fn = kallsyms_lookup_name("fib_route_seq_show");
+	fn = lookup_fn("fib_route_seq_show");
 	if (fn)
 		hook_unwrap((void *)fn, (void *)fib_route_before,
 			    (void *)fib_route_after);
-	fn = kallsyms_lookup_name("rtnl_fill_ifinfo");
+	fn = lookup_fn("rtnl_fill_ifinfo");
 	if (fn)
 		hook_unwrap((void *)fn, (void *)rtnl_fill_before,
 			    (void *)rtnl_fill_after);
-	fn = kallsyms_lookup_name("ipv6_route_seq_show");
+	fn = lookup_fn("ipv6_route_seq_show");
 	if (fn)
 		hook_unwrap((void *)fn, (void *)fib_route_before,
 			    (void *)ipv6_route_after);
-	fn = kallsyms_lookup_name("inet_fill_ifaddr");
+	fn = lookup_fn("inet_fill_ifaddr");
 	if (fn)
 		hook_unwrap((void *)fn, (void *)inet_fill_before,
 			    (void *)addr_fill_after);
-	fn = kallsyms_lookup_name("inet6_fill_ifaddr");
+	fn = lookup_fn("inet6_fill_ifaddr");
 	if (fn)
 		hook_unwrap((void *)fn, (void *)inet6_fill_before,
 			    (void *)addr_fill_after);
-	fn = kallsyms_lookup_name("dev_ioctl");
+	fn = lookup_fn("dev_ioctl");
 	if (fn)
 		hook_unwrap((void *)fn, 0, (void *)dev_ioctl_after);
-	fn = kallsyms_lookup_name("sock_ioctl");
+	fn = lookup_fn("sock_ioctl");
 	if (fn)
 		hook_unwrap((void *)fn, 0, (void *)sock_ioctl_after);
-	fn = kallsyms_lookup_name("fib_dump_info");
+	fn = lookup_fn("fib_dump_info");
 	if (fn)
 		hook_unwrap((void *)fn, (void *)fib_dump_before,
 			    (void *)fib_dump_after);
-	fn = kallsyms_lookup_name("rt6_fill_node");
+	fn = lookup_fn("rt6_fill_node");
 	if (fn)
 		hook_unwrap((void *)fn, (void *)rt6_fill_before,
 			    (void *)rt6_fill_after);
-	fn = kallsyms_lookup_name("fib_nl_fill_rule");
+	fn = lookup_fn("fib_nl_fill_rule");
 	if (fn)
 		hook_unwrap((void *)fn, (void *)fib_rule_before,
 			    (void *)fib_rule_after);

--- a/kmod/kpm/vpnhide_kpm.c
+++ b/kmod/kpm/vpnhide_kpm.c
@@ -295,6 +295,67 @@ static void sock_ioctl_after(hook_fargs3_t *fargs, void *udata)
 	filter_ifconf(argp);
 }
 
+/* ================================================================== */
+/*  Hook 6: fib_dump_info — IPv4 RTM_GETROUTE dump (issue #86)         */
+/*  arg0 = skb, arg4 = fib_rt_info*.  Resolve the route's output dev    */
+/*  (fri->fi->fib_nh[0].nh_common.nhc_dev for a legacy single-nexthop   */
+/*  route) and, if it's a VPN iface, undo the fill (skb_trim) + ret 0.  */
+/*  This is the first hook that dereferences version-specific kernel    */
+/*  structs — offsets live in kver_offsets.h, validated by the harness. */
+/* ================================================================== */
+
+/* net_device* for a route's fib_info (legacy single-nexthop path only). */
+static void *dev_from_fib_info(void *fi)
+{
+	void *nh;
+	int nhs;
+
+	if (!fi || !off->fib_info_fib_nh)
+		return 0;
+	/* A non-NULL nexthop object means an `ip nexthop`-style route, whose
+	 * dev lives behind a separate struct nexthop walk — not unpacked yet. */
+	nh = *(void **)((char *)fi + off->fib_info_nh);
+	if (nh)
+		return 0;
+	nhs = *(int *)((char *)fi + off->fib_info_fib_nhs);
+	if (nhs <= 0)
+		return 0;
+	/* nhc_dev is the first member of fib_nh[0] (== fib_nh_common). */
+	return *(void **)((char *)fi + off->fib_info_fib_nh);
+}
+
+static void fib_dump_before(hook_fargs8_t *fargs, void *udata)
+{
+	void *skb = (void *)fargs->arg0;
+	void *fri = (void *)fargs->arg4;
+	void *fi, *dev;
+
+	fargs->local.data0 = 0;
+	if (!is_target_uid() || !skb || !fri)
+		return;
+	fi = *(void **)fri; /* fib_rt_info.fi @ offset 0 */
+	dev = dev_from_fib_info(fi);
+	if (!dev || !iface_is_vpn(netdev_name(dev)))
+		return;
+
+	fargs->local.data0 = 1;
+	fargs->local.data1 = (uint64_t)skb;
+	fargs->local.data2 =
+		(uint64_t) * (unsigned int *)((char *)skb + off->skb_len);
+}
+
+static void fib_dump_after(hook_fargs8_t *fargs, void *udata)
+{
+	if (!fargs->local.data0)
+		return;
+	if ((long)fargs->ret < 0)
+		return;
+	if (_skb_trim)
+		_skb_trim((void *)fargs->local.data1,
+			  (unsigned int)fargs->local.data2);
+	fargs->ret = 0;
+}
+
 /*
  * HOOK COVERAGE — to reach parity with vpnhide_kmod.c (the .ko). Each line
  * below is a hook_wrap target; PoC ones are wired above, the rest are the
@@ -307,16 +368,15 @@ static void sock_ioctl_after(hook_fargs3_t *fargs, void *udata)
  *   ipv6_route_seq_show    /proc/net/ipv6_route   ✓
  *   dev_ioctl              SIOCGIF* by name       ✓ (ret -> -ENODEV)
  *   sock_ioctl             SIOCGIFCONF            ✓ (ifconf compaction)
+ *   fib_dump_info          RTM_GETROUTE v4 dump   ✓ (#86; derived fib_info offsets)
  *
- * TODO — these dereference version-specific kernel structs, so they need a
- * per-kver offset table entry derived from each GKI's source (the genuinely
- * fragile part; tune against the QEMU harness, where a wrong offset is an
- * A/B fail or a contained panic, not a brick):
- *   inet_fill_ifaddr       RTM_GETADDR v4         in_ifaddr.ifa_dev->dev
- *   inet6_fill_ifaddr      RTM_GETADDR v6         inet6_ifaddr.idev->dev
- *   fib_dump_info          RTM_GETROUTE v4 dump   #86; fib_info nexthop dev
+ * TODO — version-specific struct derefs needing more per-kver offsets
+ * (derive from source, tune against the harness — a wrong offset is an A/B
+ * fail or a contained panic, not a brick):
  *   rt6_fill_node          RTM_GETROUTE v6        fib6_info nexthop dev
  *   fib_nl_fill_rule       RTM_GETRULE            fib_rule iif/oif/uid_range
+ *   inet_fill_ifaddr       RTM_GETADDR v4         in_ifaddr.ifa_dev->dev
+ *   inet6_fill_ifaddr      RTM_GETADDR v6         inet6_ifaddr.idev->dev
  *   ( rt_fill_info — intentionally NOT hooked; unstable arg->reg ABI )
  */
 
@@ -452,6 +512,11 @@ static long vpnhide_kpm_init(const char *args, const char *event,
 	if (fn)
 		hook_wrap((void *)fn, 3, 0, (void *)sock_ioctl_after, 0);
 
+	fn = kallsyms_lookup_name("fib_dump_info");
+	if (fn)
+		hook_wrap((void *)fn, 6, (void *)fib_dump_before,
+			  (void *)fib_dump_after, 0);
+
 	logki(MODNAME ": KPM hooks installed\n");
 	return 0;
 }
@@ -488,6 +553,10 @@ static long vpnhide_kpm_exit(void *__user reserved)
 	fn = kallsyms_lookup_name("sock_ioctl");
 	if (fn)
 		hook_unwrap((void *)fn, 0, (void *)sock_ioctl_after);
+	fn = kallsyms_lookup_name("fib_dump_info");
+	if (fn)
+		hook_unwrap((void *)fn, (void *)fib_dump_before,
+			    (void *)fib_dump_after);
 
 	if (_remove_proc_entry) {
 		_remove_proc_entry("vpnhide_targets", 0);

--- a/kmod/kpm/vpnhide_kpm.c
+++ b/kmod/kpm/vpnhide_kpm.c
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 /*
- * vpnhide — KernelPatch Module (KPM) backend.  *** SKELETON / WIP ***
+ * vpnhide — KernelPatch Module (KPM) backend.  *** WIP: 5.10 only ***
  *
  * A third native backend alongside the kretprobe `.ko`, for kernels the
  * `.ko` can't serve: non-GKI / proprietary kernels with no published
@@ -9,11 +9,12 @@
  * NOT insmod — so it also works where module signing blocks a `.ko`.
  *
  * STATUS: builds (`make kpm`) and runs end-to-end under QEMU via the KPM
- * harness (../test/run-kpm.sh). On android12-5.10, 7/10 hooks are A/B-
- * validated with no panic. Only 5.10 offsets are filled in kver_offsets.h;
- * other versions + the remaining hooks are TODO. Every per-kver offset must
- * pass the harness before that version ships — a wrong offset is a contained
- * QEMU panic / A/B failure here, but a bootloop on a real device.
+ * harness (../test/run-kpm.sh). On android12-5.10, all 10 hooks are A/B-
+ * validated with no panic (full native-vector parity with the .ko). Only the
+ * 5.10 offset table is filled in kver_offsets.h; other kernel versions (and
+ * the procfs control plane) are TODO. Every per-kver offset must pass the
+ * harness before that version ships — a wrong offset is a contained QEMU
+ * panic / A/B failure here, but a bootloop on a real device.
  *
  * DESIGN (how this differs from soranerai's prototype, deliberately):
  *   - ONE source + a runtime kver offset table (kver_offsets.h), not three
@@ -296,6 +297,68 @@ static void sock_ioctl_after(hook_fargs3_t *fargs, void *udata)
 }
 
 /* ================================================================== */
+/*  Hooks 9-10: inet_fill_ifaddr / inet6_fill_ifaddr — RTM_GETADDR     */
+/*  arg0 = skb, arg1 = ifa.  getifaddrs() enumerates addresses via      */
+/*  RTM_GETADDR even when the link (rtnl_fill_ifinfo) is hidden, so      */
+/*  these close the address path. dev = ifa->{ifa_dev|idev}->dev.       */
+/* ================================================================== */
+
+/* p = *(*(base+off1)+off2) with NULL guards (two-pointer deref). */
+static void *deref2(void *base, unsigned int off1, unsigned int off2)
+{
+	void *p;
+
+	if (!base)
+		return 0;
+	p = *(void **)((char *)base + off1);
+	if (!p)
+		return 0;
+	return *(void **)((char *)p + off2);
+}
+
+/* Shared by both addr-fill hooks: stash skb + len if ifa's dev is VPN. */
+static void addr_fill_before(hook_fargs4_t *fargs, void *dev)
+{
+	void *skb = (void *)fargs->arg0;
+
+	fargs->local.data0 = 0;
+	if (!is_target_uid() || !skb || !dev)
+		return;
+	if (!iface_is_vpn(netdev_name(dev)))
+		return;
+	fargs->local.data0 = 1;
+	fargs->local.data1 = (uint64_t)skb;
+	fargs->local.data2 =
+		(uint64_t) * (unsigned int *)((char *)skb + off->skb_len);
+}
+
+static void addr_fill_after(hook_fargs4_t *fargs, void *udata)
+{
+	if (!fargs->local.data0)
+		return;
+	if ((long)fargs->ret < 0)
+		return;
+	if (_skb_trim)
+		_skb_trim((void *)fargs->local.data1,
+			  (unsigned int)fargs->local.data2);
+	fargs->ret = 0;
+}
+
+static void inet_fill_before(hook_fargs4_t *fargs, void *udata)
+{
+	void *dev = deref2((void *)fargs->arg1, off->in_ifaddr_ifa_dev,
+			   off->in_device_dev);
+	addr_fill_before(fargs, dev);
+}
+
+static void inet6_fill_before(hook_fargs4_t *fargs, void *udata)
+{
+	void *dev = deref2((void *)fargs->arg1, off->inet6_ifaddr_idev,
+			   off->inet6_dev_dev);
+	addr_fill_before(fargs, dev);
+}
+
+/* ================================================================== */
 /*  Hook 6: fib_dump_info — IPv4 RTM_GETROUTE dump (issue #86)         */
 /*  arg0 = skb, arg4 = fib_rt_info*.  Resolve the route's output dev    */
 /*  (fri->fi->fib_nh[0].nh_common.nhc_dev for a legacy single-nexthop   */
@@ -459,26 +522,22 @@ static void fib_rule_after(hook_fargs8_t *fargs, void *udata)
 }
 
 /*
- * HOOK COVERAGE — to reach parity with vpnhide_kmod.c (the .ko). Each line
- * below is a hook_wrap target; PoC ones are wired above, the rest are the
- * porting backlog. Mirror the .ko's logic; reuse shared/vpnhide_logic.h.
+ * HOOK COVERAGE — full parity with vpnhide_kmod.c (the .ko). All 10 hooks
+ * ported and QEMU-validated A/B on android12-5.10 (no panic). Mirror the
+ * .ko's logic; reuse shared/vpnhide_logic.h. Per-version struct offsets live
+ * in kver_offsets.h (5.10 only so far) — a wrong offset is a contained QEMU
+ * A/B fail / panic here, a bootloop on a real device.
  *
- * DONE + QEMU-validated on android12-5.10 (offset-safe — no kernel-internal
- * struct offsets, only seq_file + uapi ifreq/ifr_name@0):
- *   fib_route_seq_show     /proc/net/route        ✓
- *   rtnl_fill_ifinfo       RTM_NEWLINK            ✓ (skb.len)
- *   ipv6_route_seq_show    /proc/net/ipv6_route   ✓
+ *   fib_route_seq_show     /proc/net/route        ✓ (seq compactor)
+ *   ipv6_route_seq_show    /proc/net/ipv6_route   ✓ (seq compactor)
+ *   rtnl_fill_ifinfo       RTM_GETLINK            ✓ (skb.len)
+ *   inet_fill_ifaddr       RTM_GETADDR v4         ✓ (in_ifaddr.ifa_dev->dev)
+ *   inet6_fill_ifaddr      RTM_GETADDR v6         ✓ (inet6_ifaddr.idev->dev)
  *   dev_ioctl              SIOCGIF* by name       ✓ (ret -> -ENODEV)
  *   sock_ioctl             SIOCGIFCONF            ✓ (ifconf compaction)
- *   fib_dump_info          RTM_GETROUTE v4 dump   ✓ (#86; derived fib_info offsets)
- *
- * TODO — version-specific struct derefs needing more per-kver offsets
- * (derive from source, tune against the harness — a wrong offset is an A/B
- * fail or a contained panic, not a brick):
- *   ( rt6_fill_node — done above ✓ )
- *   fib_nl_fill_rule       RTM_GETRULE            fib_rule iif/oif/uid_range
- *   inet_fill_ifaddr       RTM_GETADDR v4         in_ifaddr.ifa_dev->dev
- *   inet6_fill_ifaddr      RTM_GETADDR v6         inet6_ifaddr.idev->dev
+ *   fib_dump_info          RTM_GETROUTE v4 dump   ✓ (#86; fib_info nexthop)
+ *   rt6_fill_node          RTM_GETROUTE v6 dump   ✓ (fib6_info nexthop)
+ *   fib_nl_fill_rule       RTM_GETRULE            ✓ (fib_rule iif/oif/uid)
  *   ( rt_fill_info — intentionally NOT hooked; unstable arg->reg ABI )
  */
 
@@ -606,6 +665,16 @@ static long vpnhide_kpm_init(const char *args, const char *event,
 		hook_wrap((void *)fn, 2, (void *)fib_route_before,
 			  (void *)ipv6_route_after, 0);
 
+	fn = kallsyms_lookup_name("inet_fill_ifaddr");
+	if (fn)
+		hook_wrap((void *)fn, 3, (void *)inet_fill_before,
+			  (void *)addr_fill_after, 0);
+
+	fn = kallsyms_lookup_name("inet6_fill_ifaddr");
+	if (fn)
+		hook_wrap((void *)fn, 3, (void *)inet6_fill_before,
+			  (void *)addr_fill_after, 0);
+
 	fn = kallsyms_lookup_name("dev_ioctl");
 	if (fn)
 		hook_wrap((void *)fn, 5, 0, (void *)dev_ioctl_after, 0);
@@ -659,6 +728,14 @@ static long vpnhide_kpm_exit(void *__user reserved)
 	if (fn)
 		hook_unwrap((void *)fn, (void *)fib_route_before,
 			    (void *)ipv6_route_after);
+	fn = kallsyms_lookup_name("inet_fill_ifaddr");
+	if (fn)
+		hook_unwrap((void *)fn, (void *)inet_fill_before,
+			    (void *)addr_fill_after);
+	fn = kallsyms_lookup_name("inet6_fill_ifaddr");
+	if (fn)
+		hook_unwrap((void *)fn, (void *)inet6_fill_before,
+			    (void *)addr_fill_after);
 	fn = kallsyms_lookup_name("dev_ioctl");
 	if (fn)
 		hook_unwrap((void *)fn, 0, (void *)dev_ioctl_after);

--- a/kmod/kpm/vpnhide_kpm.c
+++ b/kmod/kpm/vpnhide_kpm.c
@@ -30,12 +30,13 @@
  */
 #pragma GCC visibility push(hidden)
 #include <compiler.h>
+#include <common.h> /* kver + VERSION(major,minor,patch) */
 #include <kpmodule.h>
 #include <hook.h>
-#include <kputils.h>
+#include <kputils.h> /* current_uid() */
 #include <log.h>
 #include <symbol.h>
-#include <kallsyms.h>
+#include <kallsyms.h> /* kallsyms_lookup_name (KP-resolved pointer) */
 #pragma GCC visibility pop
 
 #include "../generated/iface_lists.h"
@@ -50,12 +51,6 @@ KPM_DESCRIPTION("Hide VPN interfaces from selected UIDs (KPM backend, WIP)");
 
 #define MODNAME "vpnhide"
 #define MAX_TARGET_UIDS 64
-
-/* KernelPatch runtime helpers (provided by the headers above). Declared
- * here for the skeleton; confirm exact spelling against the KernelPatch
- * tree when wiring the real build.  [TODO: verify current_uid / kver source] */
-extern unsigned long (*kallsyms_lookup_name)(const char *name);
-extern uid_t current_uid(void);
 
 /* ------------------------------------------------------------------ */
 /*  Resolved state                                                    */
@@ -266,13 +261,21 @@ static int resolve_symbols(void)
 	return _skb_trim ? 0 : -1;
 }
 
-/* TODO: source the running kernel version from KernelPatch rather than this
- * placeholder (e.g. a `kver` global, or parse `linux_banner`/init_uts_ns).
- * Returning 0 here makes vpnhide_select_offsets() bail — intentional until
- * wired, so the skeleton can't install hooks with a wrong table. */
-static unsigned int running_kver(void)
+/* Parse a NUL-terminated list of target UIDs (newline/space separated, `#`
+ * comments) into the live set. Used from KPM load args and the ctl0 control
+ * channel — same parser as the .ko's /proc writer (shared/vpnhide_logic.h).
+ * proc is a secondary path (TODO); args/ctl0 need no procfs ABI guessing. */
+static void apply_targets(const char *s)
 {
-	return 0; /* TODO */
+	unsigned long n = 0;
+
+	if (!s)
+		return;
+	while (s[n])
+		n++;
+	nr_target_uids = vpnhide_parse_target_uids(s, n, target_uids,
+						   MAX_TARGET_UIDS);
+	vpnhide_dbg("loaded %d target UIDs\n", nr_target_uids);
 }
 
 static long vpnhide_kpm_init(const char *args, const char *event,
@@ -280,9 +283,12 @@ static long vpnhide_kpm_init(const char *args, const char *event,
 {
 	unsigned long fn;
 
-	logki(MODNAME ": KPM init (event=%s)\n", event ? event : "");
+	logki(MODNAME ": KPM init (event=%s) kver=0x%x\n", event ? event : "",
+	      (unsigned int)kver);
 
-	off = vpnhide_select_offsets(running_kver());
+	/* `kver` is KernelPatch's running-kernel version (common.h), encoded
+	 * the same way as VPNHIDE_KVER. NULL table = unsupported → bail. */
+	off = vpnhide_select_offsets((unsigned int)kver);
 	if (!off) {
 		logki(MODNAME ": unsupported kernel version — refusing to install\n");
 		return -1; /* never guess offsets */
@@ -291,6 +297,10 @@ static long vpnhide_kpm_init(const char *args, const char *event,
 		logki(MODNAME ": symbol resolution failed\n");
 		return -1;
 	}
+
+	/* Targets can come at load time: sc_kpm_load(key, path, "10010 10020").
+	 * (proc + a runtime ctl0 path also feed the same set.) */
+	apply_targets(args);
 
 	/* TODO: create /proc/vpnhide_targets + /proc/vpnhide_debug using the
 	 * proc-ABI selected by off->proc_uses_proc_ops. */
@@ -312,12 +322,12 @@ static long vpnhide_kpm_init(const char *args, const char *event,
 
 static long vpnhide_kpm_ctl0(const char *args, char *__user out_msg, int outlen)
 {
-	/* TODO: optional userspace control channel (sc_kpm_control). For now
-	 * targets come through /proc, matching the .ko's control plane. */
-	(void)args;
+	/* Runtime control via supercall: sc_kpm_control(key, "vpnhide", uids...).
+	 * Lets the test / app update targets without a reboot or proc write. */
 	(void)out_msg;
 	(void)outlen;
-	return 0;
+	apply_targets(args);
+	return nr_target_uids;
 }
 
 static long vpnhide_kpm_exit(void *__user reserved)

--- a/kmod/kpm/vpnhide_kpm.c
+++ b/kmod/kpm/vpnhide_kpm.c
@@ -205,13 +205,21 @@ static void rtnl_fill_after(hook_fargs12_t *fargs, void *udata)
 
 /* ================================================================== */
 /*  Hook 4: dev_ioctl — per-interface ioctls (SIOCGIF* by name)        */
-/*  arg1 = cmd, arg2 = ifr (KERNEL ptr; ifr_name at offset 0, uapi-     */
-/*  stable). If the result names a VPN iface, return -ENODEV. Covers    */
-/*  SIOCGIFNAME (index->name, name is output) + FLAGS/MTU/INDEX/HWADDR/  */
-/*  ADDR (name is input). No kernel-internal offsets — only ifr_name@0. */
+/*  arg1 = cmd, arg2 = ifr (ifr_name at offset 0, uapi-stable). NOTE:   */
+/*  arg2 is a *kernel* struct ifreq* on >=5.5, but a *userspace* ptr on */
+/*  <5.5 (4.14/4.19/5.4 do the copy inside dev_ioctl). Dereferencing a  */
+/*  user ptr directly from kernel context faults under PAN on real HW   */
+/*  (QEMU without PAN didn't), so the name is read through the right     */
+/*  path for whichever the pointer is. If it names a VPN iface, -ENODEV. */
 /* ================================================================== */
 
 #define VPNHIDE_ENODEV ((uint64_t)(-19))
+
+/* arm64: TTBR1 (kernel) addresses have the top 16 bits set; user ptrs don't. */
+static int ptr_is_kernel(const void *p)
+{
+	return ((unsigned long)p >> 48) == 0xffffUL;
+}
 
 /* SIOCGIF* range (0x8910..0x8930). SIOCGIFCONF (0x8912) goes via sock_ioctl,
  * never dev_ioctl, so the overlap is harmless here. */
@@ -224,12 +232,25 @@ static void dev_ioctl_after(hook_fargs5_t *fargs, void *udata)
 {
 	unsigned long cmd = (unsigned long)fargs->arg1;
 	const char *ifr = (const char *)fargs->arg2; /* ifr_name @ offset 0 */
+	char name[VPNHIDE_IFNAMSIZ];
+	int is_vpn;
 
 	if ((long)fargs->ret != 0 || !ifr)
 		return;
 	if (!is_target_uid() || !is_siocgif(cmd))
 		return;
-	if (iface_is_vpn(ifr)) {
+
+	if (ptr_is_kernel(ifr)) {
+		is_vpn = iface_is_vpn(ifr); /* >=5.5: ifr is kernel memory */
+	} else {
+		/* <5.5: ifr is a __user pointer — copy the name in safely. */
+		if (!_copy_from_user ||
+		    _copy_from_user(name, ifr, VPNHIDE_IFNAMSIZ))
+			return;
+		name[VPNHIDE_IFNAMSIZ - 1] = '\0';
+		is_vpn = iface_is_vpn(name);
+	}
+	if (is_vpn) {
 		vpnhide_dbg("dev_ioctl: hiding cmd=0x%lx\n", cmd);
 		fargs->ret = VPNHIDE_ENODEV;
 	}

--- a/kmod/kpm/vpnhide_kpm.c
+++ b/kmod/kpm/vpnhide_kpm.c
@@ -685,13 +685,23 @@ static int resolve_symbols(void)
 	_seq_lseek = (void *)kallsyms_lookup_name("seq_lseek");
 	_seq_printf = (void *)kallsyms_lookup_name("seq_printf");
 
-	_copy_from_user = (void *)kallsyms_lookup_name("__arch_copy_from_user");
+	/* Prefer the generic `_copy_*_user` wrappers, NOT the raw
+	 * `__arch_copy_*_user`. The wrapper does the uaccess enable/disable
+	 * (access_ok + the TTBR0 switch / PAN toggle) around the copy; the raw
+	 * asm only copies. On a kernel using software PAN
+	 * (CONFIG_ARM64_SW_TTBR0_PAN — old ARMv8.0 cores with no hardware PAN,
+	 * and the QEMU harness on `-cpu cortex-a57`) the TTBR0 switch lives in
+	 * the C wrapper on >=5.x, so calling the raw routine directly faults on
+	 * the unmapped user page (caught by the 5.4 harness run). The wrapper is
+	 * correct under both hardware and software PAN; fall back to the raw
+	 * symbol only if the wrapper is absent. */
+	_copy_from_user = (void *)kallsyms_lookup_name("_copy_from_user");
 	if (!_copy_from_user)
-		_copy_from_user = (void *)kallsyms_lookup_name("_copy_from_user");
+		_copy_from_user = (void *)kallsyms_lookup_name("__arch_copy_from_user");
 
-	_copy_to_user = (void *)kallsyms_lookup_name("__arch_copy_to_user");
+	_copy_to_user = (void *)kallsyms_lookup_name("_copy_to_user");
 	if (!_copy_to_user)
-		_copy_to_user = (void *)kallsyms_lookup_name("_copy_to_user");
+		_copy_to_user = (void *)kallsyms_lookup_name("__arch_copy_to_user");
 
 	_skb_trim = (void *)kallsyms_lookup_name("__skb_trim");
 	if (!_skb_trim)

--- a/kmod/kpm/vpnhide_kpm.c
+++ b/kmod/kpm/vpnhide_kpm.c
@@ -356,6 +356,54 @@ static void fib_dump_after(hook_fargs8_t *fargs, void *udata)
 	fargs->ret = 0;
 }
 
+/* ================================================================== */
+/*  Hook 7: rt6_fill_node — IPv6 RTM_GETROUTE dump                     */
+/*  arg1 = skb, arg2 = fib6_info*.  IPv6 analogue of fib_dump_info.     */
+/* ================================================================== */
+
+static void *dev_from_fib6_info(void *rt)
+{
+	void *nh;
+
+	if (!rt || !off->fib6_info_fib6_nh)
+		return 0;
+	nh = *(void **)((char *)rt + off->fib6_info_nh);
+	if (nh)
+		return 0; /* nexthop-object route — not unpacked yet */
+	return *(void **)((char *)rt + off->fib6_info_fib6_nh);
+}
+
+static void rt6_fill_before(hook_fargs12_t *fargs, void *udata)
+{
+	void *skb = (void *)fargs->arg1;
+	void *rt = (void *)fargs->arg2;
+	void *dev;
+
+	fargs->local.data0 = 0;
+	if (!is_target_uid() || !skb || !rt)
+		return;
+	dev = dev_from_fib6_info(rt);
+	if (!dev || !iface_is_vpn(netdev_name(dev)))
+		return;
+
+	fargs->local.data0 = 1;
+	fargs->local.data1 = (uint64_t)skb;
+	fargs->local.data2 =
+		(uint64_t) * (unsigned int *)((char *)skb + off->skb_len);
+}
+
+static void rt6_fill_after(hook_fargs12_t *fargs, void *udata)
+{
+	if (!fargs->local.data0)
+		return;
+	if ((long)fargs->ret < 0)
+		return;
+	if (_skb_trim)
+		_skb_trim((void *)fargs->local.data1,
+			  (unsigned int)fargs->local.data2);
+	fargs->ret = 0;
+}
+
 /*
  * HOOK COVERAGE — to reach parity with vpnhide_kmod.c (the .ko). Each line
  * below is a hook_wrap target; PoC ones are wired above, the rest are the
@@ -373,7 +421,7 @@ static void fib_dump_after(hook_fargs8_t *fargs, void *udata)
  * TODO — version-specific struct derefs needing more per-kver offsets
  * (derive from source, tune against the harness — a wrong offset is an A/B
  * fail or a contained panic, not a brick):
- *   rt6_fill_node          RTM_GETROUTE v6        fib6_info nexthop dev
+ *   ( rt6_fill_node — done above ✓ )
  *   fib_nl_fill_rule       RTM_GETRULE            fib_rule iif/oif/uid_range
  *   inet_fill_ifaddr       RTM_GETADDR v4         in_ifaddr.ifa_dev->dev
  *   inet6_fill_ifaddr      RTM_GETADDR v6         inet6_ifaddr.idev->dev
@@ -517,6 +565,11 @@ static long vpnhide_kpm_init(const char *args, const char *event,
 		hook_wrap((void *)fn, 6, (void *)fib_dump_before,
 			  (void *)fib_dump_after, 0);
 
+	fn = kallsyms_lookup_name("rt6_fill_node");
+	if (fn)
+		hook_wrap((void *)fn, 11, (void *)rt6_fill_before,
+			  (void *)rt6_fill_after, 0);
+
 	logki(MODNAME ": KPM hooks installed\n");
 	return 0;
 }
@@ -557,6 +610,10 @@ static long vpnhide_kpm_exit(void *__user reserved)
 	if (fn)
 		hook_unwrap((void *)fn, (void *)fib_dump_before,
 			    (void *)fib_dump_after);
+	fn = kallsyms_lookup_name("rt6_fill_node");
+	if (fn)
+		hook_unwrap((void *)fn, (void *)rt6_fill_before,
+			    (void *)rt6_fill_after);
 
 	if (_remove_proc_entry) {
 		_remove_proc_entry("vpnhide_targets", 0);

--- a/kmod/kpm/vpnhide_kpm.c
+++ b/kmod/kpm/vpnhide_kpm.c
@@ -8,11 +8,12 @@
  * Loaded by the KernelPatch runtime (target: KPatch-Next on KernelSU-Next),
  * NOT insmod — so it also works where module signing blocks a `.ko`.
  *
- * STATUS: structural scaffold for review. NOT yet buildable here (needs the
- * KernelPatch header tree, see ../Makefile `kpm*` targets and README.md) and
- * NOT yet validated. Per-kver offsets in kver_offsets.h and every hook below
- * must pass the QEMU KPM harness before anything ships — a wrong offset is a
- * panic/bootloop, not a soft failure.
+ * STATUS: compiles against the KernelPatch header tree into a valid .kpm
+ * (`make kpm KP_DIR=/path/to/KernelPatch`; verified against bmax121/KernelPatch).
+ * NOT yet validated on a kernel: the running-kver source is a stub (so it
+ * refuses to install), several hooks are still TODO, and every per-kver offset
+ * in kver_offsets.h must pass the QEMU KPM harness before anything ships — a
+ * wrong offset is a panic/bootloop, not a soft failure.
  *
  * DESIGN (how this differs from soranerai's prototype, deliberately):
  *   - ONE source + a runtime kver offset table (kver_offsets.h), not three
@@ -158,7 +159,7 @@ static void fib_route_after(hook_fargs2_t *fargs, void *udata)
 /*  We do NOT return -EMSGSIZE (infinite retry on 6.1 — issue #38).    */
 /* ================================================================== */
 
-static void rtnl_fill_before(hook_fargs14_t *fargs, void *udata)
+static void rtnl_fill_before(hook_fargs12_t *fargs, void *udata)
 {
 	void *skb = (void *)fargs->arg0;
 	void *dev = (void *)fargs->arg1;
@@ -175,7 +176,7 @@ static void rtnl_fill_before(hook_fargs14_t *fargs, void *udata)
 		(uint64_t) * (unsigned int *)((char *)skb + off->skb_len);
 }
 
-static void rtnl_fill_after(hook_fargs14_t *fargs, void *udata)
+static void rtnl_fill_after(hook_fargs12_t *fargs, void *udata)
 {
 	if (!fargs->local.data0)
 		return;
@@ -302,7 +303,7 @@ static long vpnhide_kpm_init(const char *args, const char *event,
 
 	fn = kallsyms_lookup_name("rtnl_fill_ifinfo");
 	if (fn)
-		hook_wrap((void *)fn, 14, (void *)rtnl_fill_before,
+		hook_wrap((void *)fn, 12, (void *)rtnl_fill_before,
 			  (void *)rtnl_fill_after, 0);
 
 	logki(MODNAME ": KPM hooks installed\n");

--- a/kmod/kpm/vpnhide_kpm.c
+++ b/kmod/kpm/vpnhide_kpm.c
@@ -1,0 +1,345 @@
+// SPDX-License-Identifier: MIT
+/*
+ * vpnhide — KernelPatch Module (KPM) backend.  *** SKELETON / WIP ***
+ *
+ * A third native backend alongside the kretprobe `.ko`, for kernels the
+ * `.ko` can't serve: non-GKI / proprietary kernels with no published
+ * headers or Module.symvers (e.g. kernel 4.14 — issue #33; HyperOS 5.4).
+ * Loaded by the KernelPatch runtime (target: KPatch-Next on KernelSU-Next),
+ * NOT insmod — so it also works where module signing blocks a `.ko`.
+ *
+ * STATUS: structural scaffold for review. NOT yet buildable here (needs the
+ * KernelPatch header tree, see ../Makefile `kpm*` targets and README.md) and
+ * NOT yet validated. Per-kver offsets in kver_offsets.h and every hook below
+ * must pass the QEMU KPM harness before anything ships — a wrong offset is a
+ * panic/bootloop, not a soft failure.
+ *
+ * DESIGN (how this differs from soranerai's prototype, deliberately):
+ *   - ONE source + a runtime kver offset table (kver_offsets.h), not three
+ *     per-version copies → one binary across 4.x/5.x/6.x.
+ *   - Per-call state via `fargs->local.dataN`, NOT a per-CPU MPIDR stash
+ *     (which races when a thread migrates between the before/after callback).
+ *   - Filtering algorithms shared with the `.ko` via ../shared/vpnhide_logic.h.
+ *   - VPN-name matching from the generated single source of truth
+ *     (../generated/iface_lists.h → data/interfaces.toml), incl. the `if<N>`
+ *     pattern (issue #86) that the hardcoded community lists miss.
+ *   - rt_fill_info (single-route lookup) is intentionally NOT hooked: the
+ *     QEMU harness proved its arg→register ABI is unstable. soranerai hooks
+ *     it; we don't.
+ */
+#pragma GCC visibility push(hidden)
+#include <compiler.h>
+#include <kpmodule.h>
+#include <hook.h>
+#include <kputils.h>
+#include <log.h>
+#include <symbol.h>
+#include <kallsyms.h>
+#pragma GCC visibility pop
+
+#include "../generated/iface_lists.h"
+#include "../shared/vpnhide_logic.h"
+#include "kver_offsets.h"
+
+KPM_NAME("vpnhide");
+KPM_VERSION("0.0.1-wip");
+KPM_LICENSE("GPL v2"); /* GPL to use GPL-only kernel symbols at runtime */
+KPM_AUTHOR("okhsunrog");
+KPM_DESCRIPTION("Hide VPN interfaces from selected UIDs (KPM backend, WIP)");
+
+#define MODNAME "vpnhide"
+#define MAX_TARGET_UIDS 64
+
+/* KernelPatch runtime helpers (provided by the headers above). Declared
+ * here for the skeleton; confirm exact spelling against the KernelPatch
+ * tree when wiring the real build.  [TODO: verify current_uid / kver source] */
+extern unsigned long (*kallsyms_lookup_name)(const char *name);
+extern uid_t current_uid(void);
+
+/* ------------------------------------------------------------------ */
+/*  Resolved state                                                    */
+/* ------------------------------------------------------------------ */
+
+static const struct vpnhide_offsets *off; /* selected per running kver */
+
+static uint32_t target_uids[MAX_TARGET_UIDS];
+static int nr_target_uids;
+static bool debug_enabled;
+
+/* kernel functions resolved at init via kallsyms */
+static void *(*_proc_create_data)(const char *, uint16_t, void *, void *, void *);
+static void (*_remove_proc_entry)(const char *, void *);
+static int (*_single_open)(void *, void *, void *);
+static int (*_single_release)(void *, void *);
+static void *_seq_read, *_seq_lseek;
+static void (*_seq_printf)(void *, const char *, ...);
+static unsigned long (*_copy_from_user)(void *, const void *, unsigned long);
+static void (*_skb_trim)(void *, unsigned int);
+
+#define vpnhide_dbg(fmt, ...) \
+	do { if (debug_enabled) logki(MODNAME ": " fmt, ##__VA_ARGS__); } while (0)
+
+/* ------------------------------------------------------------------ */
+/*  Core helpers                                                      */
+/* ------------------------------------------------------------------ */
+
+static int is_target_uid(void)
+{
+	uid_t uid;
+	int i;
+
+	if (nr_target_uids <= 0)
+		return 0;
+	uid = current_uid();
+	for (i = 0; i < nr_target_uids; i++)
+		if (target_uids[i] == uid)
+			return 1;
+	return 0;
+}
+
+/* NUL-safe copy of a kernel iface name, then match via the generated rules. */
+static int iface_is_vpn(const char *name)
+{
+	char buf[VPNHIDE_IFNAMSIZ];
+	int i;
+
+	if (!name)
+		return 0;
+	for (i = 0; i < VPNHIDE_IFNAMSIZ - 1 && name[i]; i++)
+		buf[i] = name[i];
+	buf[i] = '\0';
+	return vpnhide_iface_is_vpn(buf);
+}
+
+/* Read net_device.name given a net_device* (name is at offset 0 everywhere). */
+static const char *netdev_name(void *dev)
+{
+	return dev ? (const char *)((char *)dev + off->netdev_name) : 0;
+}
+
+/* ================================================================== */
+/*  Hook 1 (PoC): fib_route_seq_show — /proc/net/route                */
+/*  arg0 = struct seq_file *.  Compact VPN lines out of this call's    */
+/*  newly-written region using the shared seq-line compactor.          */
+/* ================================================================== */
+
+static void fib_route_before(hook_fargs2_t *fargs, void *udata)
+{
+	/* Stash seq_file->count at entry so the after-callback only touches
+	 * THIS call's output, not earlier entries. (Correctness fix the .ko
+	 * already does; soranerai re-scans the whole buffer each call.) */
+	void *seq = (void *)fargs->arg0;
+	unsigned long count =
+		seq ? *(unsigned long *)((char *)seq + off->seqfile_count) : 0;
+	fargs->local.data0 = (uint64_t)count;
+}
+
+static void fib_route_after(hook_fargs2_t *fargs, void *udata)
+{
+	void *seq = (void *)fargs->arg0;
+	char *buf;
+	unsigned long *countp;
+	unsigned long start = (unsigned long)fargs->local.data0;
+
+	if (!seq || !is_target_uid())
+		return;
+
+	buf = *(char **)((char *)seq + off->seqfile_buf);
+	countp = (unsigned long *)((char *)seq + off->seqfile_count);
+	*countp = vpnhide_compact_seq_lines(buf, start, *countp,
+					    VPNHIDE_FIELD_FIRST, iface_is_vpn);
+}
+
+/* ================================================================== */
+/*  Hook 2 (PoC): rtnl_fill_ifinfo — RTM_NEWLINK (getifaddrs path)    */
+/*  arg0 = skb, arg1 = net_device.  If the dev is a VPN iface and the  */
+/*  caller is a target, undo whatever the fill wrote (skb_trim back to  */
+/*  the saved length) and return 0 — same approach as the .ko.         */
+/*  We do NOT return -EMSGSIZE (infinite retry on 6.1 — issue #38).    */
+/* ================================================================== */
+
+static void rtnl_fill_before(hook_fargs14_t *fargs, void *udata)
+{
+	void *skb = (void *)fargs->arg0;
+	void *dev = (void *)fargs->arg1;
+
+	fargs->local.data0 = 0; /* should_filter */
+	if (!is_target_uid() || !skb || !dev)
+		return;
+	if (!iface_is_vpn(netdev_name(dev)))
+		return;
+
+	fargs->local.data0 = 1; /* filter */
+	fargs->local.data1 = (uint64_t)skb;
+	fargs->local.data2 =
+		(uint64_t) * (unsigned int *)((char *)skb + off->skb_len);
+}
+
+static void rtnl_fill_after(hook_fargs14_t *fargs, void *udata)
+{
+	if (!fargs->local.data0)
+		return;
+	if ((long)fargs->ret < 0)
+		return; /* the fill already failed; nothing to undo */
+	if (_skb_trim)
+		_skb_trim((void *)fargs->local.data1,
+			  (unsigned int)fargs->local.data2);
+	fargs->ret = 0;
+}
+
+/*
+ * HOOK COVERAGE — to reach parity with vpnhide_kmod.c (the .ko). Each line
+ * below is a hook_wrap target; PoC ones are wired above, the rest are the
+ * porting backlog. Mirror the .ko's logic; reuse shared/vpnhide_logic.h.
+ *
+ *   fib_route_seq_show     /proc/net/route        PoC (above)
+ *   rtnl_fill_ifinfo       RTM_NEWLINK            PoC (above)
+ *   ipv6_route_seq_show    /proc/net/ipv6_route   TODO (FIELD_LAST compactor)
+ *   inet_fill_ifaddr       RTM_GETADDR v4         TODO (skb_trim; ifa->ifa_dev->dev)
+ *   inet6_fill_ifaddr      RTM_GETADDR v6         TODO (skb_trim; ifa->idev->dev)
+ *   dev_ioctl              SIOCGIF* by name       TODO (rewrite ret -> -ENODEV)
+ *   sock_ioctl             SIOCGIFCONF            TODO (ifconf compaction via copy_*_user)
+ *   fib_dump_info          RTM_GETROUTE v4 dump   TODO (#86; fib_info nexthop dev)
+ *   rt6_fill_node          RTM_GETROUTE v6        TODO
+ *   fib_nl_fill_rule       RTM_GETRULE            TODO
+ *   ( rt_fill_info — intentionally NOT hooked; unstable ABI )
+ */
+
+/* ------------------------------------------------------------------ */
+/*  /proc/vpnhide_targets + /proc/vpnhide_debug                       */
+/* ------------------------------------------------------------------ */
+
+static long targets_write(void *file, const char __user *ubuf, unsigned long count,
+			  long *ppos)
+{
+	char buf[1024];
+	int n;
+
+	if (count == 0)
+		return 0;
+	if (count > sizeof(buf) - 1)
+		count = sizeof(buf) - 1;
+	if (_copy_from_user && _copy_from_user(buf, ubuf, count))
+		return -14; /* -EFAULT */
+	buf[count] = '\0';
+
+	n = vpnhide_parse_target_uids(buf, count, target_uids, MAX_TARGET_UIDS);
+	nr_target_uids = n;
+	vpnhide_dbg("loaded %d target UIDs\n", n);
+	return (long)count;
+}
+
+/*
+ * proc_create needs a `struct proc_ops` (>=5.6) or a `struct file_operations`
+ * (<5.6). We don't have the real headers, so the field layout is a mock —
+ * and getting it wrong is the likely cause of the HyperOS-5.4 crash report.
+ * off->proc_uses_proc_ops selects which mock to register.
+ * TODO: define both mock layouts + the targets/debug show/open handlers, and
+ * register the matching one. Kept as a stub here so the skeleton stays focused
+ * on the hooks; see kver_offsets.h for the ABI flag.
+ */
+
+/* ------------------------------------------------------------------ */
+/*  Init / exit                                                       */
+/* ------------------------------------------------------------------ */
+
+static int resolve_symbols(void)
+{
+	_proc_create_data = (void *)kallsyms_lookup_name("proc_create_data");
+	_remove_proc_entry = (void *)kallsyms_lookup_name("remove_proc_entry");
+	_single_open = (void *)kallsyms_lookup_name("single_open");
+	_single_release = (void *)kallsyms_lookup_name("single_release");
+	_seq_read = (void *)kallsyms_lookup_name("seq_read");
+	_seq_lseek = (void *)kallsyms_lookup_name("seq_lseek");
+	_seq_printf = (void *)kallsyms_lookup_name("seq_printf");
+
+	_copy_from_user = (void *)kallsyms_lookup_name("__arch_copy_from_user");
+	if (!_copy_from_user)
+		_copy_from_user = (void *)kallsyms_lookup_name("_copy_from_user");
+
+	_skb_trim = (void *)kallsyms_lookup_name("__skb_trim");
+	if (!_skb_trim)
+		_skb_trim = (void *)kallsyms_lookup_name("skb_trim");
+
+	/* Hooks need these; proc is best-effort. */
+	return _skb_trim ? 0 : -1;
+}
+
+/* TODO: source the running kernel version from KernelPatch rather than this
+ * placeholder (e.g. a `kver` global, or parse `linux_banner`/init_uts_ns).
+ * Returning 0 here makes vpnhide_select_offsets() bail — intentional until
+ * wired, so the skeleton can't install hooks with a wrong table. */
+static unsigned int running_kver(void)
+{
+	return 0; /* TODO */
+}
+
+static long vpnhide_kpm_init(const char *args, const char *event,
+			     void *__user reserved)
+{
+	unsigned long fn;
+
+	logki(MODNAME ": KPM init (event=%s)\n", event ? event : "");
+
+	off = vpnhide_select_offsets(running_kver());
+	if (!off) {
+		logki(MODNAME ": unsupported kernel version — refusing to install\n");
+		return -1; /* never guess offsets */
+	}
+	if (resolve_symbols() != 0) {
+		logki(MODNAME ": symbol resolution failed\n");
+		return -1;
+	}
+
+	/* TODO: create /proc/vpnhide_targets + /proc/vpnhide_debug using the
+	 * proc-ABI selected by off->proc_uses_proc_ops. */
+
+	/* Install the PoC hooks. hook_wrap(func, argno, before, after, udata). */
+	fn = kallsyms_lookup_name("fib_route_seq_show");
+	if (fn)
+		hook_wrap((void *)fn, 2, (void *)fib_route_before,
+			  (void *)fib_route_after, 0);
+
+	fn = kallsyms_lookup_name("rtnl_fill_ifinfo");
+	if (fn)
+		hook_wrap((void *)fn, 14, (void *)rtnl_fill_before,
+			  (void *)rtnl_fill_after, 0);
+
+	logki(MODNAME ": KPM hooks installed\n");
+	return 0;
+}
+
+static long vpnhide_kpm_ctl0(const char *args, char *__user out_msg, int outlen)
+{
+	/* TODO: optional userspace control channel (sc_kpm_control). For now
+	 * targets come through /proc, matching the .ko's control plane. */
+	(void)args;
+	(void)out_msg;
+	(void)outlen;
+	return 0;
+}
+
+static long vpnhide_kpm_exit(void *__user reserved)
+{
+	unsigned long fn;
+
+	fn = kallsyms_lookup_name("fib_route_seq_show");
+	if (fn)
+		hook_unwrap((void *)fn, (void *)fib_route_before,
+			    (void *)fib_route_after);
+	fn = kallsyms_lookup_name("rtnl_fill_ifinfo");
+	if (fn)
+		hook_unwrap((void *)fn, (void *)rtnl_fill_before,
+			    (void *)rtnl_fill_after);
+
+	if (_remove_proc_entry) {
+		_remove_proc_entry("vpnhide_targets", 0);
+		_remove_proc_entry("vpnhide_debug", 0);
+	}
+	logki(MODNAME ": KPM unloaded\n");
+	return 0;
+}
+
+KPM_INIT(vpnhide_kpm_init);
+KPM_CTL0(vpnhide_kpm_ctl0);
+KPM_EXIT(vpnhide_kpm_exit);

--- a/kmod/kpm/vpnhide_kpm.c
+++ b/kmod/kpm/vpnhide_kpm.c
@@ -10,9 +10,9 @@
  *
  * STATUS: builds (`make kpm`) and runs end-to-end under QEMU via the KPM
  * harness (../test/run-kpm.sh). All 10 hooks are A/B-validated with no panic
- * (full native-vector parity with the .ko) on android12-5.10 AND android11-5.4
- * (a separate from-source QEMU kernel). 4.14 has 7 hooks validated; offset
- * tables for 4.19 / 6.1 and the procfs control plane are TODO. Every per-kver
+ * (full native-vector parity with the .ko) on FIVE kernels, each a separate
+ * from-source QEMU Image: 4.14, 4.19, 5.4, 5.10 and 6.1 (9/9 vectors apiece).
+ * The procfs control plane is still TODO (A/B uses load-args). Every per-kver
  * offset must pass the harness before that version ships — a wrong offset is a
  * contained QEMU panic / A/B failure here, but a bootloop on a real device.
  *

--- a/kmod/shared/test_vpnhide_logic.c
+++ b/kmod/shared/test_vpnhide_logic.c
@@ -1,0 +1,108 @@
+/*
+ * Host unit test for shared/vpnhide_logic.h (the backend-agnostic filtering
+ * logic shared by the .ko and the KPM).
+ *
+ * Build: gcc -O2 -Wall -Wextra -Werror -I.. -o test_vpnhide_logic test_vpnhide_logic.c
+ * Run:   ./test_vpnhide_logic   (exit 0 on success)
+ */
+#include <stdio.h>
+#include <string.h>
+
+#include "generated/iface_lists.h"
+#include "shared/vpnhide_logic.h"
+
+static int failures;
+
+/* int-returning adapter for the bool matcher (function-pointer-type safe). */
+static int match_vpn(const char *name)
+{
+	return vpnhide_iface_is_vpn(name) ? 1 : 0;
+}
+
+static void expect_str(const char *what, const char *got, const char *want)
+{
+	if (strcmp(got, want) != 0) {
+		fprintf(stderr, "FAIL %s:\n  got : %s\n  want: %s\n", what, got, want);
+		failures++;
+	}
+}
+
+static void test_route_first_field(void)
+{
+	/* /proc/net/route: iface is the first tab-separated field. */
+	char buf[512] =
+		"Iface\tDestination\tGateway\n"
+		"wlan0\t00000000\t0101A8C0\n"
+		"tun0\t00000000\t010010AC\n"
+		"rmnet0\tFEFFFFFF\t00000000\n"
+		"wg0\t00000000\t00000000\n";
+	unsigned long count = strlen(buf);
+	/* keep the header line (start=0) — matcher rejects "Iface". */
+	unsigned long n = vpnhide_compact_seq_lines(buf, 0, count,
+						    VPNHIDE_FIELD_FIRST, match_vpn);
+	buf[n] = '\0';
+	expect_str("route: tun0+wg0 removed",
+		   buf,
+		   "Iface\tDestination\tGateway\n"
+		   "wlan0\t00000000\t0101A8C0\n"
+		   "rmnet0\tFEFFFFFF\t00000000\n");
+}
+
+static void test_ipv6_route_last_field(void)
+{
+	/* /proc/net/ipv6_route: iface is the last whitespace field. */
+	char buf[512] =
+		"00000000000000000000000000000000 00 ... wlan0\n"
+		"fe800000000000000000000000000000 40 ... tun0\n"
+		"00000000000000000000000000000000 00 ... rmnet_data0\n";
+	unsigned long count = strlen(buf);
+	unsigned long n = vpnhide_compact_seq_lines(buf, 0, count,
+						    VPNHIDE_FIELD_LAST, match_vpn);
+	buf[n] = '\0';
+	expect_str("ipv6_route: tun0 removed",
+		   buf,
+		   "00000000000000000000000000000000 00 ... wlan0\n"
+		   "00000000000000000000000000000000 00 ... rmnet_data0\n");
+}
+
+static void test_start_offset_preserved(void)
+{
+	/* Bytes before `start` belong to earlier show() calls — never touched,
+	 * even if they name a VPN iface. */
+	char buf[256] = "tun9\tearlier-entry\nwlan0\tkeep\ntun0\tdrop\n";
+	unsigned long start = strlen("tun9\tearlier-entry\n");
+	unsigned long count = strlen(buf);
+	unsigned long n = vpnhide_compact_seq_lines(buf, start, count,
+						    VPNHIDE_FIELD_FIRST, match_vpn);
+	buf[n] = '\0';
+	expect_str("start offset preserved",
+		   buf, "tun9\tearlier-entry\nwlan0\tkeep\n");
+}
+
+static void test_parse_uids(void)
+{
+	const char *in = "10010\n  10020 \n# a comment\n\n10030\nbad\n10040";
+	unsigned int out[8];
+	int n = vpnhide_parse_target_uids(in, strlen(in), out, 8);
+	if (n != 4 || out[0] != 10010 || out[1] != 10020 || out[2] != 10030 ||
+	    out[3] != 10040) {
+		fprintf(stderr, "FAIL parse_uids: n=%d [%u %u %u %u]\n", n,
+			out[0], out[1], out[2], out[3]);
+		failures++;
+	}
+}
+
+int main(void)
+{
+	test_route_first_field();
+	test_ipv6_route_last_field();
+	test_start_offset_preserved();
+	test_parse_uids();
+
+	if (failures) {
+		fprintf(stderr, "%d test(s) failed\n", failures);
+		return 1;
+	}
+	printf("all shared-logic tests passed\n");
+	return 0;
+}

--- a/kmod/shared/vpnhide_logic.h
+++ b/kmod/shared/vpnhide_logic.h
@@ -1,0 +1,177 @@
+/* SPDX-License-Identifier: MIT */
+/*
+ * vpnhide shared filtering logic — backend-agnostic, FREESTANDING.
+ *
+ * This header is included by BOTH native backends:
+ *   - the kretprobe `.ko` (compiled with the real Linux kernel headers), and
+ *   - the KernelPatch KPM (compiled `-nostdinc` against KernelPatch's
+ *     own headers).
+ *
+ * Therefore it must depend on NOTHING: no libc, no kernel headers, no
+ * `memmove`/`strlen`. It operates only on caller-provided buffers + a
+ * caller-provided interface-name matcher. Keep it that way — the moment
+ * this header `#include`s anything, one of the two backends stops
+ * compiling.
+ *
+ * The algorithms here are intentionally byte-identical to the seq-file
+ * compaction in `vpnhide_kmod.c` (`fib_route_ret` / `ipv6_route_ret`),
+ * so adopting this header in the `.ko` later is a mechanical change.
+ */
+#ifndef VPNHIDE_SHARED_LOGIC_H
+#define VPNHIDE_SHARED_LOGIC_H
+
+#ifndef VPNHIDE_IFNAMSIZ
+#define VPNHIDE_IFNAMSIZ 16
+#endif
+
+/* Matcher: returns non-zero if `ifname` (NUL-terminated, <= IFNAMSIZ) is a
+ * VPN interface. Backends pass `vpnhide_iface_is_vpn` from the generated
+ * `iface_lists.h` (single source of truth: data/interfaces.toml). */
+typedef int (*vpnhide_match_fn)(const char *ifname);
+
+/* Which whitespace-delimited field carries the interface name. */
+enum vpnhide_iface_field {
+	VPNHIDE_FIELD_FIRST = 0, /* /proc/net/route        — first tab field   */
+	VPNHIDE_FIELD_LAST = 1,  /* /proc/net/ipv6_route    — last ws field      */
+};
+
+/*
+ * Compact VPN lines out of a /proc/net seq-file buffer in place.
+ *
+ * `buf`   : seq_file buffer base.
+ * `start` : byte offset where THIS show()-call's output began (everything
+ *           before it belongs to earlier entries and must be preserved).
+ * `count` : current end-of-content offset (seq_file->count).
+ * `field` : where the iface name is on each line.
+ * `match` : VPN-name predicate.
+ *
+ * Returns the new content length (caller writes it back to seq_file->count).
+ *
+ * Compaction only ever moves bytes DOWN (dst <= src), so the overlapping
+ * copy is safe with a plain forward byte loop — no memmove dependency.
+ */
+static inline unsigned long
+vpnhide_compact_seq_lines(char *buf, unsigned long start, unsigned long count,
+			  enum vpnhide_iface_field field, vpnhide_match_fn match)
+{
+	unsigned long src = start;
+	unsigned long dst = start;
+	char ifname[VPNHIDE_IFNAMSIZ];
+
+	if (!buf || count <= start || !match)
+		return count;
+
+	while (src < count) {
+		/* Find end of the current line (past the '\n', or EOF). */
+		unsigned long nl = src;
+		unsigned long line_end;
+		unsigned long line_len;
+		int hide;
+
+		while (nl < count && buf[nl] != '\n')
+			nl++;
+		line_end = (nl < count) ? nl + 1 : count;
+		line_len = line_end - src;
+
+		/* Extract the interface name for this line. */
+		if (field == VPNHIDE_FIELD_FIRST) {
+			unsigned long j = 0;
+			while (j < (unsigned long)(VPNHIDE_IFNAMSIZ - 1) &&
+			       src + j < line_end && buf[src + j] != '\t' &&
+			       buf[src + j] != '\n') {
+				ifname[j] = buf[src + j];
+				j++;
+			}
+			ifname[j] = '\0';
+		} else {
+			/* Last whitespace-delimited field. Trim trailing
+			 * newline / CR / spaces / tabs, then walk back to the
+			 * preceding separator. */
+			unsigned long fe = line_end;
+			unsigned long fs;
+			unsigned long j = 0;
+
+			while (fe > src && (buf[fe - 1] == '\n' ||
+					    buf[fe - 1] == '\r' ||
+					    buf[fe - 1] == ' ' ||
+					    buf[fe - 1] == '\t'))
+				fe--;
+			fs = fe;
+			while (fs > src && buf[fs - 1] != ' ' &&
+			       buf[fs - 1] != '\t')
+				fs--;
+			while (j < (unsigned long)(VPNHIDE_IFNAMSIZ - 1) &&
+			       fs + j < fe) {
+				ifname[j] = buf[fs + j];
+				j++;
+			}
+			ifname[j] = '\0';
+		}
+
+		hide = (ifname[0] != '\0') && match(ifname);
+
+		if (hide) {
+			src = line_end; /* drop this line */
+			continue;
+		}
+
+		if (dst != src) {
+			unsigned long k;
+			for (k = 0; k < line_len; k++)
+				buf[dst + k] = buf[src + k]; /* dst<=src: safe */
+		}
+		dst += line_len;
+		src = line_end;
+	}
+
+	return dst;
+}
+
+/*
+ * Parse a newline-separated list of decimal UIDs (with `#` comments and
+ * blank lines) from `buf` into `out` (capacity `max`). Returns the count.
+ * Pure string work — shared by both backends' /proc/vpnhide_targets writer.
+ */
+static inline int
+vpnhide_parse_target_uids(const char *buf, unsigned long len,
+			  unsigned int *out, int max)
+{
+	unsigned long i = 0;
+	int n = 0;
+
+	while (i < len && n < max) {
+		unsigned long uid = 0;
+		int have_digit = 0;
+
+		/* skip leading spaces/tabs */
+		while (i < len && (buf[i] == ' ' || buf[i] == '\t'))
+			i++;
+
+		/* comment or empty line → skip to next '\n' */
+		if (i < len && (buf[i] == '#' || buf[i] == '\n')) {
+			while (i < len && buf[i] != '\n')
+				i++;
+			if (i < len)
+				i++;
+			continue;
+		}
+
+		while (i < len && buf[i] >= '0' && buf[i] <= '9') {
+			uid = uid * 10u + (unsigned long)(buf[i] - '0');
+			have_digit = 1;
+			i++;
+		}
+		if (have_digit)
+			out[n++] = (unsigned int)uid;
+
+		/* advance to next line */
+		while (i < len && buf[i] != '\n')
+			i++;
+		if (i < len)
+			i++;
+	}
+
+	return n;
+}
+
+#endif /* VPNHIDE_SHARED_LOGIC_H */

--- a/kmod/test/README.md
+++ b/kmod/test/README.md
@@ -79,20 +79,43 @@ Building a virtio GKI kernel takes ~15-40 min, so it must not run per-PR:
 ## KPM backend harness (`run-kpm.sh`)
 
 `run-kpm.sh` is the sibling for the [KPM backend](../kpm/): instead of
-`insmod`-ing a `.ko`, it patches the cached GKI `Image` with KernelPatch
+`insmod`-ing a `.ko`, it patches a bootable `Image` with KernelPatch
 (`kptools-linux` + `kpimg-linux`, fetched from the KernelPatch releases),
 embeds `vpnhide.kpm`, and boots the patched kernel under the same QEMU/TCG
 setup. The KPM loads at boot (KernelPatch hijacks `paging_init`), so there
 is no insmod and no `/proc` dependency — target UIDs are passed via the
 embedded extra-args (`kptools -A`). The A/B is done across **two boots**
 (no target → root sees `vpn0`; target=0 → root doesn't), driven by
-`init-kpm.sh`. Verified: `fib_route_seq_show` + `rtnl_fill_ifinfo` pass on
-android12-5.10 with no panic.
+`init-kpm.sh`. All 10 hooks are validated 9/9 with no panic across the full
+kernel range — 4.14, 4.19, 5.4, 5.10, 5.15, 6.1, 6.6, 6.12 (the GKI ones via
+the DDK `Image`, the older ones via a from-source `Image` passed with
+`VPNHIDE_QEMU_IMAGE=`).
 
 ```sh
 make -C kmod kpm                 # build vpnhide.kpm
 kmod/test/run-kpm.sh android12-5.10
 ```
+
+Two knobs the KPM harness needs that the `.ko` one doesn't:
+
+- **`VPNHIDE_QEMU_CPU`** — defaults to `max`, but kernels older than 5.10
+  (4.14/4.19/5.4) fault on `max`'s newer CPU features before the console comes
+  up, so they need `VPNHIDE_QEMU_CPU=cortex-a57`. KernelPatch also writes its
+  restore region into kernel text, so the boot args carry `rodata=off` (some
+  from-source layouts otherwise put that page read-only → early abort).
+- **PAN is enforced on every kernel.** `qemu.config` sets
+  `CONFIG_ARM64_SW_TTBR0_PAN=y` so a hook that dereferences a *userspace*
+  pointer as kernel memory **panics in the test** rather than silently passing.
+  QEMU emulates whatever the chosen `-cpu` advertises: `-cpu max` advertises
+  hardware PAN (FEAT_PAN) and the GKI kernels run on it, but the <5.10 kernels
+  must run on `-cpu cortex-a57` (ARMv8.0, *no* PAN feature) — so on the exact
+  CPU where the bug lives there is no hardware PAN to emulate. Software PAN
+  (`SW_TTBR0_PAN`, the kernel's own TTBR0-switching fallback) enforces the
+  boundary independent of the CPU model, so it works under both `-cpu` choices.
+  This is how a real bug shipped: `dev_ioctl`'s ifreq arg is a `__user` pointer
+  on <5.5 kernels, and reading it directly only faulted on real PAN hardware (a
+  Pixel 4a on 4.14) until SW PAN was turned on here — now the buggy build
+  panics on the `target` boot of the 4.14 run, and the fixed build is clean.
 
 ## Design decisions
 

--- a/kmod/test/README.md
+++ b/kmod/test/README.md
@@ -76,6 +76,24 @@ Building a virtio GKI kernel takes ~15-40 min, so it must not run per-PR:
   repo-owned (private), so the job pulls it with `credentials:` and a
   lowercased name from the `setup` job output, like the other image jobs.
 
+## KPM backend harness (`run-kpm.sh`)
+
+`run-kpm.sh` is the sibling for the [KPM backend](../kpm/): instead of
+`insmod`-ing a `.ko`, it patches the cached GKI `Image` with KernelPatch
+(`kptools-linux` + `kpimg-linux`, fetched from the KernelPatch releases),
+embeds `vpnhide.kpm`, and boots the patched kernel under the same QEMU/TCG
+setup. The KPM loads at boot (KernelPatch hijacks `paging_init`), so there
+is no insmod and no `/proc` dependency — target UIDs are passed via the
+embedded extra-args (`kptools -A`). The A/B is done across **two boots**
+(no target → root sees `vpn0`; target=0 → root doesn't), driven by
+`init-kpm.sh`. Verified: `fib_route_seq_show` + `rtnl_fill_ifinfo` pass on
+android12-5.10 with no panic.
+
+```sh
+make -C kmod kpm                 # build vpnhide.kpm
+kmod/test/run-kpm.sh android12-5.10
+```
+
 ## Design decisions
 
 Each of these was forced by a concrete failure; they are easy to "simplify"

--- a/kmod/test/build-source-kernel.sh
+++ b/kmod/test/build-source-kernel.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+# Build a QEMU-bootable, from-source kernel for the KPM harness's pre-GKI /
+# legacy targets — the kernels the `.ko` backend can NOT serve (no GKI, no DDK):
+#
+#   4.14  (vanilla)         — issue #33; oldest target, rt6_info IPv6 model
+#   4.19  (vanilla)         — pre-nexthop, struct fib6_info
+#   5.4   (AOSP common)     — issue #35 (HyperOS) target
+#
+# Unlike build-kernel.sh (GKI built with the per-KMI DDK clang container), all
+# three legacy kernels build with ONE pinned Bootlin aarch64 gcc — the compiler
+# version doesn't affect struct layout (that's source+config), it's just old
+# enough to compile these kernels (a modern gcc/clang trips on -Werror). The
+# config is `defconfig` + qemu.config (virtio/console/initrd + software PAN) +
+# the IPv6/policy-routing bits the harness's route/rule vectors need, matching
+# the offsets in ../kpm/kver_offsets.h.
+#
+# Output is just an `Image` — the KPM never builds against the kernel tree
+# (the `.kpm` is relocatable against KernelPatch headers), so unlike the `.ko`
+# harness there is no tree/symvers to keep.
+#
+# Usage:  build-source-kernel.sh <4.14|4.19|5.4> [outdir]
+# Output: <outdir>/Image            (default: .cache/legacy/<ver>/Image)
+#
+# Boot these with `-cpu cortex-a57` (they fault on `-cpu max`'s newer features
+# before the console) and `rodata=off` — run-kpm.sh already does both.
+set -euo pipefail
+
+VER="${1:?usage: build-source-kernel.sh <4.14|4.19|5.4> [outdir]}"
+HERE="$(cd "$(dirname "$0")" && pwd)"
+CACHE="$HERE/.cache/legacy"
+OUT="${2:-$CACHE/$VER}"
+SRCROOT="$CACHE/src"
+TCROOT="$CACHE/toolchain"
+FRAG="$HERE/qemu.config"
+JOBS="$(nproc)"
+mkdir -p "$OUT" "$SRCROOT" "$TCROOT"
+
+# --- one Bootlin aarch64 gcc 7.3 for every legacy kernel ----------------------
+# Pinned release; the absolute CROSS_COMPILE prefix is used directly (NOT put on
+# PATH — the toolchain ships a `bison`/`m4` that expects /opt and shadows the
+# host kconfig tools otherwise).
+TC="aarch64--glibc--stable-2018.11-1"
+TC_URL="https://toolchains.bootlin.com/downloads/releases/toolchains/aarch64/tarballs/${TC}.tar.bz2"
+CROSS="$TCROOT/$TC/bin/aarch64-buildroot-linux-gnu-"
+if [ ! -x "${CROSS}gcc" ]; then
+	echo "[legacy] fetching Bootlin gcc 7.3 ($TC)…"
+	curl -fsSL "$TC_URL" | tar xj -C "$TCROOT"
+fi
+
+# --- pinned source ------------------------------------------------------------
+KORG="https://cdn.kernel.org/pub/linux/kernel/v4.x"
+AOSP="https://android.googlesource.com/kernel/common"
+case "$VER" in
+4.14)
+	SRC="$SRCROOT/linux-4.14.336"
+	[ -d "$SRC" ] || { echo "[legacy] fetching linux-4.14.336…"; curl -fsSL "$KORG/linux-4.14.336.tar.xz" | tar xJ -C "$SRCROOT"; }
+	;;
+4.19)
+	SRC="$SRCROOT/linux-4.19.325"
+	[ -d "$SRC" ] || { echo "[legacy] fetching linux-4.19.325…"; curl -fsSL "$KORG/linux-4.19.325.tar.xz" | tar xJ -C "$SRCROOT"; }
+	;;
+5.4)
+	# AOSP common is a moving branch — pin the exact commit we derived offsets
+	# against (android11-5.4.302_r00).
+	SRC="$SRCROOT/aosp-5.4"
+	AOSP_SHA="91d385eb2a413918a037a93089f8e29910fdf707"
+	if [ ! -d "$SRC" ]; then
+		echo "[legacy] cloning AOSP common android11-5.4 @ $AOSP_SHA…"
+		git clone --depth=1 -b android11-5.4 "$AOSP" "$SRC"
+		git -C "$SRC" fetch --depth=1 origin "$AOSP_SHA" && git -C "$SRC" checkout -q "$AOSP_SHA" || true
+	fi
+	;;
+*)
+	echo "ERROR: unknown version '$VER' (expected 4.14 | 4.19 | 5.4)"; exit 2 ;;
+esac
+
+cd "$SRC"
+mk() { make ARCH=arm64 CROSS_COMPILE="$CROSS" "$@"; }
+
+# --- config: defconfig + qemu.config + IPv6/policy, per-version tweaks ---------
+mk defconfig >/dev/null
+./scripts/kconfig/merge_config.sh -m .config "$FRAG" >/dev/null 2>&1
+
+# IPv6 + policy routing built-in so the v6-route / policy-rule vectors have
+# something to hide (the generic defconfig ships IPv6 as a module / off).
+scripts/config --enable IPV6 \
+	--enable IP_ADVANCED_ROUTER --enable IP_MULTIPLE_TABLES \
+	--enable IPV6_MULTIPLE_TABLES --enable IPV6_SUBTREES \
+	--disable MODULE_SIG --disable TRIM_UNUSED_KSYMS --disable DEBUG_INFO_BTF
+
+# 4.19 only: fib6_info has a CONFIG_IPV6_ROUTER_PREF-gated `last_probe` field,
+# and kver_offsets.h pins fib6_nh@176 (the ROUTER_PREF=y, Android-common shape).
+[ "$VER" = "4.19" ] && scripts/config --enable IPV6_ROUTER_PREF --enable IPV6_ROUTE_INFO
+
+mk olddefconfig >/dev/null
+echo "[legacy] $VER config: $(grep -hE '^CONFIG_(NF_CONNTRACK[=_]|IPV6=|IP_MULTIPLE_TABLES=|IPV6_ROUTER_PREF=|ARM64_SW_TTBR0_PAN=)' .config | tr '\n' ' ')"
+
+# --- build ---
+echo "[legacy] $VER: building Image (gcc, -j$JOBS)…"
+mk -j"$JOBS" Image
+cp arch/arm64/boot/Image "$OUT/Image"
+echo "[legacy] $VER done -> $OUT/Image"

--- a/kmod/test/gai-probe.c
+++ b/kmod/test/gai-probe.c
@@ -1,0 +1,33 @@
+/*
+ * getifaddrs() probe for the KPM harness — the real native enumeration path
+ * (bionic getifaddrs() = RTM_GETLINK + RTM_GETADDR over netlink), which the
+ * `ip addr` shell vector can't isolate. Counts how many entries name "vpn0".
+ *
+ * Build (static, runs on the Alpine VM regardless of its libc):
+ *   <ndk>/aarch64-linux-android35-clang -static -O2 -o gai gai-probe.c
+ * Output: a single line `GAI_VPN0=<n>`.
+ *
+ * With only rtnl_fill_ifinfo hooked, the RTM_GETADDR entries for vpn0 still
+ * arrive and bionic may reconstruct the iface — so this probe is what proves
+ * inet_fill_ifaddr / inet6_fill_ifaddr actually close the address path.
+ */
+#include <ifaddrs.h>
+#include <stdio.h>
+#include <string.h>
+
+int main(void)
+{
+	struct ifaddrs *head, *cur;
+	int n = 0;
+
+	if (getifaddrs(&head) != 0) {
+		printf("GAI_VPN0=-1\n");
+		return 2;
+	}
+	for (cur = head; cur; cur = cur->ifa_next)
+		if (cur->ifa_name && strcmp(cur->ifa_name, "vpn0") == 0)
+			n++;
+	freeifaddrs(head);
+	printf("GAI_VPN0=%d\n", n);
+	return 0;
+}

--- a/kmod/test/init-kpm.sh
+++ b/kmod/test/init-kpm.sh
@@ -1,0 +1,47 @@
+#!/bin/sh
+# In-VM driver (PID 1 / rdinit) for the vpnhide *KPM* QEMU harness.
+#
+# Unlike the .ko harness (init.sh), the KPM is already loaded at boot
+# (embedded in the patched kernel image by KernelPatch), so there is no
+# insmod. Target UIDs are set at load time via the embedded extra-args
+# (`kptools -A "<uids>"`), so this driver is phase-agnostic: it fabricates a
+# VPN-like `vpn0` interface and reports, for each detection vector, the count
+# of `vpn0` hits as seen by *this* (root, uid 0) process. run-kpm.sh boots it
+# twice — once with no target (root must SEE vpn0) and once with target=0
+# (root must NOT see vpn0) — and diffs the counts.
+set +e
+export PATH=/usr/sbin:/usr/bin:/sbin:/bin
+
+mount -t proc proc /proc 2>/dev/null
+mount -t sysfs sys /sys 2>/dev/null
+mount -t devtmpfs dev /dev 2>/dev/null
+
+echo "##### VPNHIDE-KPM-TEST START #####"
+echo "KREL=$(uname -r)"
+
+# Did KernelPatch load our KPM and install hooks?
+if dmesg | grep -q "KPM hooks installed"; then echo "KPMLOAD=ok"; else echo "KPMLOAD=FAIL"; fi
+echo "KVER=$(dmesg | grep -oE 'kver=0x[0-9a-f]+' | head -1)"
+
+# user-mode net so apk can fetch iproute2 (busybox ip can't add dummy devs)
+ip link set eth0 up 2>/dev/null
+ip addr add 10.0.2.15/24 dev eth0 2>/dev/null
+ip route add default via 10.0.2.2 2>/dev/null
+echo "nameserver 10.0.2.3" > /etc/resolv.conf
+echo "https://dl-cdn.alpinelinux.org/alpine/v3.21/main" > /etc/apk/repositories
+if apk add --no-cache iproute2 >/dev/null 2>&1; then echo "IPROUTE2=ok"; else echo "IPROUTE2=FAIL"; fi
+
+# fabricate a VPN-like interface + a route through it
+ip link add vpn0 type dummy 2>/dev/null
+ip link set vpn0 up 2>/dev/null
+ip addr add 10.9.0.1/24 dev vpn0 2>/dev/null
+ip route add 10.9.9.0/24 dev vpn0 2>/dev/null
+
+# Vectors covered by the two PoC hooks. Count vpn0 hits as seen by root.
+echo "VEC proc_route_v4=$(cat /proc/net/route 2>/dev/null | grep -c vpn0)"   # fib_route_seq_show
+echo "VEC getifaddrs=$(ip addr show 2>/dev/null | grep -c 'vpn0')"            # rtnl_fill_ifinfo
+
+PANIC=$(dmesg | grep -ci 'Unable to handle\|Internal error\|Oops\|BUG:\|Kernel panic')
+echo "PANIC=$PANIC"
+echo "##### VPNHIDE-KPM-TEST END #####"
+poweroff -f

--- a/kmod/test/init-kpm.sh
+++ b/kmod/test/init-kpm.sh
@@ -43,6 +43,8 @@ ip -6 route add fd00:99::/64 dev vpn0 2>/dev/null
 echo "VEC proc_route_v4=$(cat /proc/net/route 2>/dev/null | grep -c vpn0)"        # fib_route_seq_show
 echo "VEC getifaddrs=$(ip addr show 2>/dev/null | grep -c 'vpn0')"                # rtnl_fill_ifinfo
 echo "VEC proc_route_v6=$(cat /proc/net/ipv6_route 2>/dev/null | grep -c vpn0)"   # ipv6_route_seq_show
+echo "VEC siocgifconf=$(ifconfig -a 2>/dev/null | grep -c vpn0)"                  # sock_ioctl
+echo "VEC dev_ioctl=$(ifconfig vpn0 2>/dev/null | grep -c vpn0)"                  # dev_ioctl
 
 PANIC=$(dmesg | grep -ci 'Unable to handle\|Internal error\|Oops\|BUG:\|Kernel panic')
 echo "PANIC=$PANIC"

--- a/kmod/test/init-kpm.sh
+++ b/kmod/test/init-kpm.sh
@@ -45,6 +45,7 @@ echo "VEC getifaddrs=$(ip addr show 2>/dev/null | grep -c 'vpn0')"              
 echo "VEC proc_route_v6=$(cat /proc/net/ipv6_route 2>/dev/null | grep -c vpn0)"   # ipv6_route_seq_show
 echo "VEC siocgifconf=$(ifconfig -a 2>/dev/null | grep -c vpn0)"                  # sock_ioctl
 echo "VEC dev_ioctl=$(ifconfig vpn0 2>/dev/null | grep -c vpn0)"                  # dev_ioctl
+echo "VEC netlink_route4=$(ip route show table all 2>/dev/null | grep -c vpn0)"     # fib_dump_info (#86)
 
 PANIC=$(dmesg | grep -ci 'Unable to handle\|Internal error\|Oops\|BUG:\|Kernel panic')
 echo "PANIC=$PANIC"

--- a/kmod/test/init-kpm.sh
+++ b/kmod/test/init-kpm.sh
@@ -46,6 +46,7 @@ echo "VEC proc_route_v6=$(cat /proc/net/ipv6_route 2>/dev/null | grep -c vpn0)" 
 echo "VEC siocgifconf=$(ifconfig -a 2>/dev/null | grep -c vpn0)"                  # sock_ioctl
 echo "VEC dev_ioctl=$(ifconfig vpn0 2>/dev/null | grep -c vpn0)"                  # dev_ioctl
 echo "VEC netlink_route4=$(ip route show table all 2>/dev/null | grep -c vpn0)"     # fib_dump_info (#86)
+echo "VEC netlink_route6=$(ip -6 route show table all 2>/dev/null | grep -c vpn0)"  # rt6_fill_node
 
 PANIC=$(dmesg | grep -ci 'Unable to handle\|Internal error\|Oops\|BUG:\|Kernel panic')
 echo "PANIC=$PANIC"

--- a/kmod/test/init-kpm.sh
+++ b/kmod/test/init-kpm.sh
@@ -49,6 +49,8 @@ echo "VEC dev_ioctl=$(ifconfig vpn0 2>/dev/null | grep -c vpn0)"                
 echo "VEC netlink_route4=$(ip route show table all 2>/dev/null | grep -c vpn0)"     # fib_dump_info (#86)
 echo "VEC netlink_route6=$(ip -6 route show table all 2>/dev/null | grep -c vpn0)"  # rt6_fill_node
 echo "VEC policy_rule=$(ip rule show 2>/dev/null | grep -c 199)"                    # fib_nl_fill_rule
+# Native getifaddrs() (RTM_GETLINK+RTM_GETADDR) — isolates inet*_fill_ifaddr.
+[ -x /gai ] && echo "VEC gai_getifaddrs=$(/gai 2>/dev/null | sed 's/.*=//')"        # inet*_fill_ifaddr
 
 PANIC=$(dmesg | grep -ci 'Unable to handle\|Internal error\|Oops\|BUG:\|Kernel panic')
 echo "PANIC=$PANIC"

--- a/kmod/test/init-kpm.sh
+++ b/kmod/test/init-kpm.sh
@@ -31,15 +31,18 @@ echo "nameserver 10.0.2.3" > /etc/resolv.conf
 echo "https://dl-cdn.alpinelinux.org/alpine/v3.21/main" > /etc/apk/repositories
 if apk add --no-cache iproute2 >/dev/null 2>&1; then echo "IPROUTE2=ok"; else echo "IPROUTE2=FAIL"; fi
 
-# fabricate a VPN-like interface + a route through it
+# fabricate a VPN-like interface + routes through it (v4 + v6)
 ip link add vpn0 type dummy 2>/dev/null
 ip link set vpn0 up 2>/dev/null
 ip addr add 10.9.0.1/24 dev vpn0 2>/dev/null
 ip route add 10.9.9.0/24 dev vpn0 2>/dev/null
+ip -6 addr add fd00:9::1/64 dev vpn0 2>/dev/null
+ip -6 route add fd00:99::/64 dev vpn0 2>/dev/null
 
-# Vectors covered by the two PoC hooks. Count vpn0 hits as seen by root.
-echo "VEC proc_route_v4=$(cat /proc/net/route 2>/dev/null | grep -c vpn0)"   # fib_route_seq_show
-echo "VEC getifaddrs=$(ip addr show 2>/dev/null | grep -c 'vpn0')"            # rtnl_fill_ifinfo
+# Vectors covered by the wired hooks. Count vpn0 hits as seen by root.
+echo "VEC proc_route_v4=$(cat /proc/net/route 2>/dev/null | grep -c vpn0)"        # fib_route_seq_show
+echo "VEC getifaddrs=$(ip addr show 2>/dev/null | grep -c 'vpn0')"                # rtnl_fill_ifinfo
+echo "VEC proc_route_v6=$(cat /proc/net/ipv6_route 2>/dev/null | grep -c vpn0)"   # ipv6_route_seq_show
 
 PANIC=$(dmesg | grep -ci 'Unable to handle\|Internal error\|Oops\|BUG:\|Kernel panic')
 echo "PANIC=$PANIC"

--- a/kmod/test/init-kpm.sh
+++ b/kmod/test/init-kpm.sh
@@ -38,6 +38,7 @@ ip addr add 10.9.0.1/24 dev vpn0 2>/dev/null
 ip route add 10.9.9.0/24 dev vpn0 2>/dev/null
 ip -6 addr add fd00:9::1/64 dev vpn0 2>/dev/null
 ip -6 route add fd00:99::/64 dev vpn0 2>/dev/null
+ip rule add uidrange 0-0 table 199 2>/dev/null
 
 # Vectors covered by the wired hooks. Count vpn0 hits as seen by root.
 echo "VEC proc_route_v4=$(cat /proc/net/route 2>/dev/null | grep -c vpn0)"        # fib_route_seq_show
@@ -47,6 +48,7 @@ echo "VEC siocgifconf=$(ifconfig -a 2>/dev/null | grep -c vpn0)"                
 echo "VEC dev_ioctl=$(ifconfig vpn0 2>/dev/null | grep -c vpn0)"                  # dev_ioctl
 echo "VEC netlink_route4=$(ip route show table all 2>/dev/null | grep -c vpn0)"     # fib_dump_info (#86)
 echo "VEC netlink_route6=$(ip -6 route show table all 2>/dev/null | grep -c vpn0)"  # rt6_fill_node
+echo "VEC policy_rule=$(ip rule show 2>/dev/null | grep -c 199)"                    # fib_nl_fill_rule
 
 PANIC=$(dmesg | grep -ci 'Unable to handle\|Internal error\|Oops\|BUG:\|Kernel panic')
 echo "PANIC=$PANIC"

--- a/kmod/test/qemu.config
+++ b/kmod/test/qemu.config
@@ -38,6 +38,28 @@ CONFIG_TMPFS=y
 # dummy netdev: the test fabricates `vpn0` (a dummy) as the fake VPN interface
 CONFIG_DUMMY=y
 
+# Software PAN (Privileged Access Never) — enforce the user/kernel pointer
+# boundary on EVERY test kernel regardless of the emulated CPU model. PAN makes
+# a privileged (kernel) read of a user-accessible page fault, so a hook that
+# dereferences a *userspace* pointer as if it were kernel memory PANICS in the
+# test instead of silently succeeding.
+#
+# Why software PAN and not the CPU's hardware PAN: QEMU emulates whatever the
+# chosen `-cpu` advertises. `-cpu max` advertises FEAT_PAN (ARMv8.1) and the
+# GKI kernels run on it — but the <5.10 from-source kernels must run on
+# `-cpu cortex-a57` (ARMv8.0, *no* PAN feature; `max`'s newer features fault
+# those old kernels before the console). So on the exact CPU where the bug
+# lives there is no hardware PAN to emulate. CONFIG_ARM64_SW_TTBR0_PAN builds
+# PAN enforcement into the kernel itself (TTBR0 switching), independent of the
+# CPU, and is the runtime fallback the kernel already uses when the core has no
+# hardware PAN — so enabling it guarantees enforcement under both `-cpu max`
+# and `-cpu cortex-a57`.
+#
+# This is the bug class that slipped past the harness once: dev_ioctl's ifreq
+# arg is a __user pointer on <5.5 kernels, and reading it directly only faulted
+# on real PAN hardware (a Pixel 4a on 4.14) until SW PAN was turned on here.
+CONFIG_ARM64_SW_TTBR0_PAN=y
+
 # allow loading our out-of-tree module without signing / ksym trimming
 # CONFIG_MODULE_SIG is not set
 # CONFIG_TRIM_UNUSED_KSYMS is not set

--- a/kmod/test/run-kpm.sh
+++ b/kmod/test/run-kpm.sh
@@ -1,0 +1,118 @@
+#!/usr/bin/env bash
+# Boot the vpnhide *KPM* in QEMU (TCG) and validate it hides a fabricated
+# VPN interface from a target UID. Mirrors run.sh but for the KernelPatch
+# Module backend instead of the .ko:
+#
+#   1. build vpnhide.kpm (`make kpm`)
+#   2. download KernelPatch's kptools-linux + kpimg-linux (cached)
+#   3. patch the cached GKI Image TWICE, embedding the .kpm:
+#        - phase "notarget": no target UID  -> root must SEE vpn0
+#        - phase "target"  : target = uid 0 -> root must NOT see vpn0
+#   4. boot each (init-kpm.sh) and diff the per-vector vpn0 counts
+#
+# A vector PASSes iff notarget>0 and target==0, with no panic in either boot.
+# This needs no /proc (targets come via the embedded extra-args), so it
+# validates the inline hooks + per-kver offsets independently of the procfs
+# control plane.
+#
+# Usage:  kmod/test/run-kpm.sh [kmi]      (default: android12-5.10)
+set -euo pipefail
+
+KMI="${1:-android12-5.10}"
+HERE="$(cd "$(dirname "$0")" && pwd)"
+KMOD="$(cd "$HERE/.." && pwd)"
+CACHE="$HERE/.cache"
+KDIR="$CACHE/$KMI"
+KPBIN="$CACHE/kp"
+
+IMAGE="${VPNHIDE_QEMU_IMAGE:-$KDIR/Image}"
+KPM="${VPNHIDE_KPM:-$KMOD/vpnhide.kpm}"
+ALPINE_VER="3.21.2"
+ALPINE_TAR="${VPNHIDE_QEMU_ROOTFS:-$CACHE/alpine-minirootfs-$ALPINE_VER-aarch64.tar.gz}"
+ALPINE_URL="https://dl-cdn.alpinelinux.org/alpine/v3.21/releases/aarch64/alpine-minirootfs-$ALPINE_VER-aarch64.tar.gz"
+# Prebuilt KernelPatch host tool + generic runtime (no need to build them).
+KP_RELEASE="${VPNHIDE_KP_RELEASE:-}" # empty = latest
+SKEY="vpnhide-qemu-test"
+
+command -v qemu-system-aarch64 >/dev/null || { echo "ERROR: qemu-system-aarch64 not installed"; exit 2; }
+[ -f "$IMAGE" ] || { echo "ERROR: kernel missing: $IMAGE — run: $HERE/build-kernel.sh $KMI"; exit 2; }
+
+mkdir -p "$CACHE" "$KPBIN"
+[ -f "$ALPINE_TAR" ] || { echo "[run-kpm] fetching Alpine minirootfs…"; curl -fsSL "$ALPINE_URL" -o "$ALPINE_TAR"; }
+
+# --- KernelPatch prebuilts (kptools-linux, kpimg-linux) ----------------------
+for a in kptools-linux kpimg-linux; do
+	if [ ! -f "$KPBIN/$a" ]; then
+		echo "[run-kpm] fetching KernelPatch $a…"
+		gh release download ${KP_RELEASE:+"$KP_RELEASE"} --repo bmax121/KernelPatch \
+			--pattern "$a" -O "$KPBIN/$a" --clobber
+	fi
+done
+chmod +x "$KPBIN/kptools-linux"
+
+# --- build the .kpm if not provided -----------------------------------------
+if [ ! -f "$KPM" ]; then
+	echo "[run-kpm] building vpnhide.kpm…"
+	make -C "$KMOD" kpm >/dev/null
+fi
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+# boot_phase <args> -> echoes the serial log path; sets globals via files
+boot_phase() {
+	local args="$1" tag="$2"
+	local patched="$WORK/Image.$tag" log="$WORK/serial.$tag.log"
+
+	"$KPBIN/kptools-linux" -p -i "$IMAGE" -k "$KPBIN/kpimg-linux" -S "$SKEY" \
+		-M "$KPM" -T kpm ${args:+-A "$args"} -o "$patched" >"$WORK/patch.$tag.log" 2>&1
+
+	local rfs="$WORK/rootfs.$tag"
+	mkdir -p "$rfs"
+	tar xzf "$ALPINE_TAR" -C "$rfs"
+	cp "$HERE/init-kpm.sh" "$rfs/init"
+	chmod +x "$rfs/init"
+	( cd "$rfs" && find . | cpio -o -H newc 2>/dev/null | gzip > "$WORK/initramfs.$tag.gz" )
+
+	echo "[run-kpm] $KMI: booting phase '$tag' (args='${args}')…" >&2
+	timeout 300 qemu-system-aarch64 \
+		-machine virt -cpu max -accel tcg,thread=multi,tb-size=1024 \
+		-smp 4 -m 2G \
+		-kernel "$patched" -initrd "$WORK/initramfs.$tag.gz" \
+		-append "console=ttyAMA0 panic=-1 rdinit=/init" \
+		-netdev user,id=n0 -device virtio-net-pci,netdev=n0,romfile= \
+		-display none -no-reboot -serial "file:$log" >/dev/null 2>&1 || true
+	echo "$log"
+}
+
+NT_LOG="$(boot_phase "" notarget)"
+TG_LOG="$(boot_phase "0" target)"
+
+vec_count() { grep -oE "VEC $1=[0-9]+" "$2" | head -1 | grep -oE '[0-9]+$' || echo "-1"; }
+panic_count() { grep -oE 'PANIC=[0-9]+' "$1" | head -1 | grep -oE '[0-9]+$' || echo "1"; }
+kpmload() { grep -q 'KPMLOAD=ok' "$1" && echo ok || echo FAIL; }
+
+echo "------------------------- KPM test output -------------------------"
+for log in "$NT_LOG" "$TG_LOG"; do
+	grep -E 'KREL|KPMLOAD|KVER|IPROUTE2|VEC |PANIC' "$log" 2>/dev/null | sed "s|^|[$(basename "$log")] |" || true
+done
+echo "-------------------------------------------------------------------"
+
+[ "$(kpmload "$NT_LOG")" = ok ] || { echo "ERROR: KPM did not load (notarget boot)"; tail -20 "$NT_LOG"; exit 1; }
+[ "$(kpmload "$TG_LOG")" = ok ] || { echo "ERROR: KPM did not load (target boot)"; tail -20 "$TG_LOG"; exit 1; }
+
+PASS=0; FAIL=0
+for vec in proc_route_v4 getifaddrs; do
+	nt="$(vec_count "$vec" "$NT_LOG")"
+	tg="$(vec_count "$vec" "$TG_LOG")"
+	if [ "$nt" -gt 0 ] && [ "$tg" -eq 0 ]; then
+		echo "RESULT $vec=PASS (notarget=$nt target=$tg)"; PASS=$((PASS+1))
+	else
+		echo "RESULT $vec=FAIL (notarget=$nt target=$tg)"; FAIL=$((FAIL+1))
+	fi
+done
+
+PANIC=$(( $(panic_count "$NT_LOG") + $(panic_count "$TG_LOG") ))
+echo "SUMMARY pass=$PASS fail=$FAIL panic=$PANIC"
+[ "$FAIL" -eq 0 ] && [ "$PANIC" -eq 0 ] && { echo "[run-kpm] $KMI: PASS"; exit 0; }
+echo "[run-kpm] $KMI: FAIL"; exit 1

--- a/kmod/test/run-kpm.sh
+++ b/kmod/test/run-kpm.sh
@@ -102,7 +102,7 @@ echo "-------------------------------------------------------------------"
 [ "$(kpmload "$TG_LOG")" = ok ] || { echo "ERROR: KPM did not load (target boot)"; tail -20 "$TG_LOG"; exit 1; }
 
 PASS=0; FAIL=0
-for vec in proc_route_v4 getifaddrs; do
+for vec in proc_route_v4 getifaddrs proc_route_v6; do
 	nt="$(vec_count "$vec" "$NT_LOG")"
 	tg="$(vec_count "$vec" "$TG_LOG")"
 	if [ "$nt" -gt 0 ] && [ "$tg" -eq 0 ]; then

--- a/kmod/test/run-kpm.sh
+++ b/kmod/test/run-kpm.sh
@@ -23,7 +23,11 @@ HERE="$(cd "$(dirname "$0")" && pwd)"
 KMOD="$(cd "$HERE/.." && pwd)"
 CACHE="$HERE/.cache"
 KDIR="$CACHE/$KMI"
-KPBIN="$CACHE/kp"
+# KernelPatch host tool + runtime. Defaults to a per-run download cache, but CI
+# points VPNHIDE_KP_BIN at the copies baked into the test image (hermetic — no
+# per-run network fetch). If the dir already has both binaries, the fetch below
+# is skipped.
+KPBIN="${VPNHIDE_KP_BIN:-$CACHE/kp}"
 
 IMAGE="${VPNHIDE_QEMU_IMAGE:-$KDIR/Image}"
 KPM="${VPNHIDE_KPM:-$KMOD/vpnhide.kpm}"

--- a/kmod/test/run-kpm.sh
+++ b/kmod/test/run-kpm.sh
@@ -102,7 +102,7 @@ echo "-------------------------------------------------------------------"
 [ "$(kpmload "$TG_LOG")" = ok ] || { echo "ERROR: KPM did not load (target boot)"; tail -20 "$TG_LOG"; exit 1; }
 
 PASS=0; FAIL=0
-for vec in proc_route_v4 getifaddrs proc_route_v6; do
+for vec in proc_route_v4 getifaddrs proc_route_v6 siocgifconf dev_ioctl; do
 	nt="$(vec_count "$vec" "$NT_LOG")"
 	tg="$(vec_count "$vec" "$TG_LOG")"
 	if [ "$nt" -gt 0 ] && [ "$tg" -eq 0 ]; then

--- a/kmod/test/run-kpm.sh
+++ b/kmod/test/run-kpm.sh
@@ -102,7 +102,7 @@ echo "-------------------------------------------------------------------"
 [ "$(kpmload "$TG_LOG")" = ok ] || { echo "ERROR: KPM did not load (target boot)"; tail -20 "$TG_LOG"; exit 1; }
 
 PASS=0; FAIL=0
-for vec in proc_route_v4 getifaddrs proc_route_v6 siocgifconf dev_ioctl netlink_route4; do
+for vec in proc_route_v4 getifaddrs proc_route_v6 siocgifconf dev_ioctl netlink_route4 netlink_route6; do
 	nt="$(vec_count "$vec" "$NT_LOG")"
 	tg="$(vec_count "$vec" "$TG_LOG")"
 	if [ "$nt" -gt 0 ] && [ "$tg" -eq 0 ]; then

--- a/kmod/test/run-kpm.sh
+++ b/kmod/test/run-kpm.sh
@@ -102,7 +102,7 @@ echo "-------------------------------------------------------------------"
 [ "$(kpmload "$TG_LOG")" = ok ] || { echo "ERROR: KPM did not load (target boot)"; tail -20 "$TG_LOG"; exit 1; }
 
 PASS=0; FAIL=0
-for vec in proc_route_v4 getifaddrs proc_route_v6 siocgifconf dev_ioctl netlink_route4 netlink_route6; do
+for vec in proc_route_v4 getifaddrs proc_route_v6 siocgifconf dev_ioctl netlink_route4 netlink_route6 policy_rule; do
 	nt="$(vec_count "$vec" "$NT_LOG")"
 	tg="$(vec_count "$vec" "$TG_LOG")"
 	if [ "$nt" -gt 0 ] && [ "$tg" -eq 0 ]; then

--- a/kmod/test/run-kpm.sh
+++ b/kmod/test/run-kpm.sh
@@ -102,7 +102,7 @@ echo "-------------------------------------------------------------------"
 [ "$(kpmload "$TG_LOG")" = ok ] || { echo "ERROR: KPM did not load (target boot)"; tail -20 "$TG_LOG"; exit 1; }
 
 PASS=0; FAIL=0
-for vec in proc_route_v4 getifaddrs proc_route_v6 siocgifconf dev_ioctl; do
+for vec in proc_route_v4 getifaddrs proc_route_v6 siocgifconf dev_ioctl netlink_route4; do
 	nt="$(vec_count "$vec" "$NT_LOG")"
 	tg="$(vec_count "$vec" "$TG_LOG")"
 	if [ "$nt" -gt 0 ] && [ "$tg" -eq 0 ]; then

--- a/kmod/test/run-kpm.sh
+++ b/kmod/test/run-kpm.sh
@@ -59,25 +59,51 @@ for a in kptools-linux kpimg-linux; do
 done
 chmod +x "$KPBIN/kptools-linux"
 
+# Fail loudly if the host tool can't run here — the prebuilt kptools-linux is
+# linked against a recent glibc (>= 2.38), so an older base image (e.g. Debian
+# bookworm = 2.36) trips the dynamic loader. Without this check the patch step
+# below fails silently and the harness boots an unpatched kernel, surfacing only
+# as the confusing "KPM did not load".
+"$KPBIN/kptools-linux" --help >/dev/null 2>&1 || {
+	echo "ERROR: $KPBIN/kptools-linux is not runnable in this environment:"
+	"$KPBIN/kptools-linux" --help 2>&1 | head -2
+	exit 2
+}
+
 # --- build the .kpm if not provided -----------------------------------------
 if [ ! -f "$KPM" ]; then
 	echo "[run-kpm] building vpnhide.kpm…"
 	make -C "$KMOD" kpm >/dev/null
 fi
 
-# --- optional static getifaddrs probe (validates the addr-fill hooks) --------
+# --- static getifaddrs probe (validates the addr-fill hooks) -----------------
 # bionic getifaddrs() = RTM_GETLINK + RTM_GETADDR; the `ip addr` vector can't
-# isolate the addr path. Built static so it runs on the Alpine VM regardless
-# of libc; skipped (gai vector absent) if no aarch64 cross-cc is found.
+# isolate the addr path. The probe MUST be a *bionic* binary: it validates how
+# *Android's* getifaddrs parses the filtered netlink dump. A glibc build is
+# deliberately NOT used — glibc's getifaddrs walks the RTM_GETADDR stream more
+# strictly and spins on the filtered output on some kernels (e.g. 5.4); that is
+# a glibc parsing quirk, not a product bug (Android is bionic, which passes).
+#
+# Source order:
+#   1. VPNHIDE_GAI_BIN — a prebuilt bionic binary baked into the CI image
+#      (built from this exact gai-probe.c with the NDK; see the Dockerfiles).
+#   2. an NDK clang on this host (dev machines) — build from source.
+#   3. neither — skip the vector (the 8 core vectors still run).
 GAI=""
-GAI_CC="${VPNHIDE_GAI_CC:-$(ls "$HOME"/Android/Sdk/ndk/*/toolchains/llvm/prebuilt/*/bin/aarch64-linux-android*-clang 2>/dev/null | sort | tail -1)}"
-[ -n "$GAI_CC" ] || GAI_CC="$(command -v aarch64-linux-gnu-gcc || true)"
-if [ -n "$GAI_CC" ] && [ -x "$GAI_CC" ]; then
-	GAI="$CACHE/gai"
-	"$GAI_CC" -static -O2 -o "$GAI" "$HERE/gai-probe.c" 2>/dev/null || GAI=""
+if [ -n "${VPNHIDE_GAI_BIN:-}" ] && [ -x "${VPNHIDE_GAI_BIN:-}" ]; then
+	GAI="$VPNHIDE_GAI_BIN"
+	echo "[run-kpm] getifaddrs probe: prebuilt bionic ($GAI)"
+else
+	# `|| true`: with no NDK present the glob matches nothing and `ls` exits
+	# non-zero, which under `set -euo pipefail` would kill the script silently.
+	GAI_CC="${VPNHIDE_GAI_CC:-$(ls "$HOME"/Android/Sdk/ndk/*/toolchains/llvm/prebuilt/*/bin/aarch64-linux-android*-clang 2>/dev/null | sort | tail -1 || true)}"
+	if [ -n "$GAI_CC" ] && [ -x "$GAI_CC" ]; then
+		GAI="$CACHE/gai"
+		"$GAI_CC" -static -O2 -o "$GAI" "$HERE/gai-probe.c" 2>/dev/null || GAI=""
+	fi
+	[ -n "$GAI" ] && echo "[run-kpm] getifaddrs probe built ($(basename "$GAI_CC"))" || \
+		echo "[run-kpm] no bionic toolchain/binary — skipping getifaddrs probe (8 core vectors still run)"
 fi
-[ -n "$GAI" ] && echo "[run-kpm] getifaddrs probe built ($(basename "$GAI_CC"))" || \
-	echo "[run-kpm] no aarch64 static cross-cc — skipping getifaddrs probe"
 
 WORK="$(mktemp -d)"
 trap 'rm -rf "$WORK"' EXIT
@@ -127,6 +153,12 @@ echo "-------------------------------------------------------------------"
 
 PASS=0; FAIL=0
 for vec in proc_route_v4 getifaddrs proc_route_v6 siocgifconf dev_ioctl netlink_route4 netlink_route6 policy_rule gai_getifaddrs; do
+	# The gai_getifaddrs vector only exists when the bionic probe is available
+	# (baked VPNHIDE_GAI_BIN, or built from an NDK on this host). If neither is
+	# present the probe can't run, so skip the vector instead of failing it.
+	if [ "$vec" = gai_getifaddrs ] && [ -z "$GAI" ]; then
+		echo "RESULT $vec=SKIP (no bionic getifaddrs probe available)"; continue
+	fi
 	nt="$(vec_count "$vec" "$NT_LOG")"
 	tg="$(vec_count "$vec" "$TG_LOG")"
 	if [ "$nt" -gt 0 ] && [ "$tg" -eq 0 ]; then

--- a/kmod/test/run-kpm.sh
+++ b/kmod/test/run-kpm.sh
@@ -105,6 +105,18 @@ else
 		echo "[run-kpm] no bionic toolchain/binary — skipping getifaddrs probe (8 core vectors still run)"
 fi
 
+# In CI the probe is baked into the image (VPNHIDE_GAI_BIN), so a skip there
+# means the baked binary is missing / not executable — a silent addr-fill
+# coverage regression that would otherwise still go green. VPNHIDE_GAI_REQUIRED
+# (set by the CI jobs) turns that into a hard failure. Locally, with no flag,
+# the skip stays soft so the harness still runs without an NDK.
+if [ -z "$GAI" ] && [ -n "${VPNHIDE_GAI_REQUIRED:-}" ]; then
+	echo "ERROR: getifaddrs probe is required here (VPNHIDE_GAI_REQUIRED set) but" \
+	     "unavailable — VPNHIDE_GAI_BIN='${VPNHIDE_GAI_BIN:-}' missing/not executable."
+	echo "       Refusing to pass with the addr-fill (inet*_fill_ifaddr) hook unchecked."
+	exit 2
+fi
+
 WORK="$(mktemp -d)"
 trap 'rm -rf "$WORK"' EXIT
 

--- a/kmod/test/run-kpm.sh
+++ b/kmod/test/run-kpm.sh
@@ -33,6 +33,10 @@ ALPINE_URL="https://dl-cdn.alpinelinux.org/alpine/v3.21/releases/aarch64/alpine-
 # Prebuilt KernelPatch host tool + generic runtime (no need to build them).
 KP_RELEASE="${VPNHIDE_KP_RELEASE:-}" # empty = latest
 SKEY="vpnhide-qemu-test"
+# QEMU CPU model. `max` is fastest and fine for 5.10+, but pre-GKI kernels
+# (e.g. 4.14) fault on its newer features before the console comes up — use
+# `cortex-a57` for those.  Override: VPNHIDE_QEMU_CPU=cortex-a57
+QEMU_CPU="${VPNHIDE_QEMU_CPU:-max}"
 
 command -v qemu-system-aarch64 >/dev/null || { echo "ERROR: qemu-system-aarch64 not installed"; exit 2; }
 [ -f "$IMAGE" ] || { echo "ERROR: kernel missing: $IMAGE — run: $HERE/build-kernel.sh $KMI"; exit 2; }
@@ -91,7 +95,7 @@ boot_phase() {
 
 	echo "[run-kpm] $KMI: booting phase '$tag' (args='${args}')…" >&2
 	timeout 300 qemu-system-aarch64 \
-		-machine virt -cpu max -accel tcg,thread=multi,tb-size=1024 \
+		-machine virt -cpu "$QEMU_CPU" -accel tcg,thread=multi,tb-size=1024 \
 		-smp 4 -m 2G \
 		-kernel "$patched" -initrd "$WORK/initramfs.$tag.gz" \
 		-append "console=ttyAMA0 panic=-1 rdinit=/init" \

--- a/kmod/test/run-kpm.sh
+++ b/kmod/test/run-kpm.sh
@@ -56,6 +56,20 @@ if [ ! -f "$KPM" ]; then
 	make -C "$KMOD" kpm >/dev/null
 fi
 
+# --- optional static getifaddrs probe (validates the addr-fill hooks) --------
+# bionic getifaddrs() = RTM_GETLINK + RTM_GETADDR; the `ip addr` vector can't
+# isolate the addr path. Built static so it runs on the Alpine VM regardless
+# of libc; skipped (gai vector absent) if no aarch64 cross-cc is found.
+GAI=""
+GAI_CC="${VPNHIDE_GAI_CC:-$(ls "$HOME"/Android/Sdk/ndk/*/toolchains/llvm/prebuilt/*/bin/aarch64-linux-android*-clang 2>/dev/null | sort | tail -1)}"
+[ -n "$GAI_CC" ] || GAI_CC="$(command -v aarch64-linux-gnu-gcc || true)"
+if [ -n "$GAI_CC" ] && [ -x "$GAI_CC" ]; then
+	GAI="$CACHE/gai"
+	"$GAI_CC" -static -O2 -o "$GAI" "$HERE/gai-probe.c" 2>/dev/null || GAI=""
+fi
+[ -n "$GAI" ] && echo "[run-kpm] getifaddrs probe built ($(basename "$GAI_CC"))" || \
+	echo "[run-kpm] no aarch64 static cross-cc — skipping getifaddrs probe"
+
 WORK="$(mktemp -d)"
 trap 'rm -rf "$WORK"' EXIT
 
@@ -72,6 +86,7 @@ boot_phase() {
 	tar xzf "$ALPINE_TAR" -C "$rfs"
 	cp "$HERE/init-kpm.sh" "$rfs/init"
 	chmod +x "$rfs/init"
+	[ -n "$GAI" ] && { cp "$GAI" "$rfs/gai"; chmod +x "$rfs/gai"; }
 	( cd "$rfs" && find . | cpio -o -H newc 2>/dev/null | gzip > "$WORK/initramfs.$tag.gz" )
 
 	echo "[run-kpm] $KMI: booting phase '$tag' (args='${args}')…" >&2
@@ -102,7 +117,7 @@ echo "-------------------------------------------------------------------"
 [ "$(kpmload "$TG_LOG")" = ok ] || { echo "ERROR: KPM did not load (target boot)"; tail -20 "$TG_LOG"; exit 1; }
 
 PASS=0; FAIL=0
-for vec in proc_route_v4 getifaddrs proc_route_v6 siocgifconf dev_ioctl netlink_route4 netlink_route6 policy_rule; do
+for vec in proc_route_v4 getifaddrs proc_route_v6 siocgifconf dev_ioctl netlink_route4 netlink_route6 policy_rule gai_getifaddrs; do
 	nt="$(vec_count "$vec" "$NT_LOG")"
 	tg="$(vec_count "$vec" "$TG_LOG")"
 	if [ "$nt" -gt 0 ] && [ "$tg" -eq 0 ]; then

--- a/kmod/test/run-kpm.sh
+++ b/kmod/test/run-kpm.sh
@@ -33,9 +33,10 @@ ALPINE_URL="https://dl-cdn.alpinelinux.org/alpine/v3.21/releases/aarch64/alpine-
 # Prebuilt KernelPatch host tool + generic runtime (no need to build them).
 KP_RELEASE="${VPNHIDE_KP_RELEASE:-}" # empty = latest
 SKEY="vpnhide-qemu-test"
-# QEMU CPU model. `max` is fastest and fine for 5.10+, but pre-GKI kernels
-# (e.g. 4.14) fault on its newer features before the console comes up — use
-# `cortex-a57` for those.  Override: VPNHIDE_QEMU_CPU=cortex-a57
+# QEMU CPU model. `max` is fastest and fine for 5.10+, but older kernels
+# (< 5.10, e.g. 5.4 / 4.19 / 4.14) fault on its newer features before the
+# console comes up — use `cortex-a57` for those.  Override:
+# VPNHIDE_QEMU_CPU=cortex-a57
 QEMU_CPU="${VPNHIDE_QEMU_CPU:-max}"
 
 command -v qemu-system-aarch64 >/dev/null || { echo "ERROR: qemu-system-aarch64 not installed"; exit 2; }
@@ -98,7 +99,7 @@ boot_phase() {
 		-machine virt -cpu "$QEMU_CPU" -accel tcg,thread=multi,tb-size=1024 \
 		-smp 4 -m 2G \
 		-kernel "$patched" -initrd "$WORK/initramfs.$tag.gz" \
-		-append "console=ttyAMA0 panic=-1 rdinit=/init" \
+		-append "console=ttyAMA0 rodata=off panic=-1 rdinit=/init" \
 		-netdev user,id=n0 -device virtio-net-pci,netdev=n0,romfile= \
 		-display none -no-reboot -serial "file:$log" >/dev/null 2>&1 || true
 	echo "$log"

--- a/scripts/codegen-interfaces.py
+++ b/scripts/codegen-interfaces.py
@@ -208,6 +208,75 @@ def kt_str_lit(s: str) -> str:
 # ---------------------------------------------------------------------------
 
 
+# Self-contained C matcher helpers (no libc/kernel headers). Literal template
+# block — `\t` becomes a tab in the generated header (kernel style), same as
+# the rest of the emitter. Shared verbatim by the .ko and the KPM backend.
+KMOD_MATCHER_HELPERS = """\
+static inline char vpnhide__lc(char c)
+{
+\treturn (c >= 'A' && c <= 'Z') ? (char)(c - 'A' + 'a') : c;
+}
+
+static inline int vpnhide_iface_starts_with_ci(const char *name, const char *prefix)
+{
+\tint i;
+\tfor (i = 0; prefix[i]; i++) {
+\t\tif (!name[i])
+\t\t\treturn 0;
+\t\tif (vpnhide__lc(name[i]) != vpnhide__lc(prefix[i]))
+\t\t\treturn 0;
+\t}
+\treturn 1;
+}
+
+static inline int vpnhide_iface_starts_with_then_digits_ci(const char *name,
+\t\t\t\t\t\t\t   const char *prefix)
+{
+\tint i = 0;
+\tif (!vpnhide_iface_starts_with_ci(name, prefix))
+\t\treturn 0;
+\twhile (prefix[i])
+\t\ti++;
+\tif (!name[i])
+\t\treturn 0;
+\tfor (; name[i]; i++)
+\t\tif (name[i] < '0' || name[i] > '9')
+\t\t\treturn 0;
+\treturn 1;
+}
+
+static inline int vpnhide_iface_equals_ci(const char *name, const char *other)
+{
+\tint i;
+\tfor (i = 0; other[i]; i++) {
+\t\tif (!name[i])
+\t\t\treturn 0;
+\t\tif (vpnhide__lc(name[i]) != vpnhide__lc(other[i]))
+\t\t\treturn 0;
+\t}
+\treturn name[i] == '\\0';
+}
+
+static inline int vpnhide_iface_contains_ci(const char *name, const char *needle)
+{
+\tint i, j;
+\tif (!needle[0])
+\t\treturn 1;
+\tfor (i = 0; name[i]; i++) {
+\t\tfor (j = 0; needle[j]; j++) {
+\t\t\tif (!name[i + j])
+\t\t\t\treturn 0;
+\t\t\tif (vpnhide__lc(name[i + j]) != vpnhide__lc(needle[j]))
+\t\t\t\tbreak;
+\t\t}
+\t\tif (!needle[j])
+\t\t\treturn 1;
+\t}
+\treturn 0;
+}
+"""
+
+
 def emit_kmod(rules: list[Rule]) -> str:
     """Render an inline header for the kernel module.
 
@@ -220,99 +289,28 @@ def emit_kmod(rules: list[Rule]) -> str:
     lines.append("#ifndef VPNHIDE_GENERATED_IFACE_LISTS_H")
     lines.append("#define VPNHIDE_GENERATED_IFACE_LISTS_H")
     lines.append("")
-    lines.append("#ifdef __KERNEL__")
-    lines.append("# include <linux/string.h>")
-    lines.append("# include <linux/ctype.h>")
-    lines.append("# include <linux/types.h>")
-    lines.append("#else")
-    lines.append("# include <ctype.h>")
-    lines.append("# include <stdbool.h>")
-    lines.append("# include <stddef.h>")
-    lines.append("# include <string.h>")
-    lines.append("#endif")
-    lines.append("")
-    lines.append("static inline bool vpnhide_iface_starts_with_ci(")
-    lines.append("\tconst char *name, const char *prefix)")
-    lines.append("{")
-    lines.append("\tsize_t i;")
-    lines.append("\tfor (i = 0; prefix[i]; i++) {")
-    lines.append("\t\tif (!name[i])")
-    lines.append("\t\t\treturn false;")
-    lines.append("\t\tif (tolower((unsigned char)name[i]) !=")
-    lines.append("\t\t    (unsigned char)prefix[i])")
-    lines.append("\t\t\treturn false;")
-    lines.append("\t}")
-    lines.append("\treturn true;")
-    lines.append("}")
-    lines.append("")
-    lines.append("static inline bool vpnhide_iface_starts_with_then_digits_ci(")
-    lines.append("\tconst char *name, const char *prefix)")
-    lines.append("{")
-    lines.append("\tsize_t i;")
-    lines.append("\tif (!vpnhide_iface_starts_with_ci(name, prefix))")
-    lines.append("\t\treturn false;")
-    lines.append("\ti = strlen(prefix);")
-    lines.append("\tif (!name[i])")
-    lines.append("\t\treturn false;")
-    lines.append("\tfor (; name[i]; i++)")
-    lines.append("\t\tif (name[i] < '0' || name[i] > '9')")
-    lines.append("\t\t\treturn false;")
-    lines.append("\treturn true;")
-    lines.append("}")
-    lines.append("")
-    lines.append("static inline bool vpnhide_iface_equals_ci(")
-    lines.append("\tconst char *name, const char *other)")
-    lines.append("{")
-    lines.append("\tsize_t i;")
-    lines.append("\tfor (i = 0; other[i]; i++) {")
-    lines.append("\t\tif (!name[i])")
-    lines.append("\t\t\treturn false;")
-    lines.append("\t\tif (tolower((unsigned char)name[i]) !=")
-    lines.append("\t\t    (unsigned char)other[i])")
-    lines.append("\t\t\treturn false;")
-    lines.append("\t}")
-    lines.append("\treturn name[i] == '\\0';")
-    lines.append("}")
-    lines.append("")
-    lines.append("static inline bool vpnhide_iface_contains_ci(")
-    lines.append("\tconst char *name, const char *needle)")
-    lines.append("{")
-    lines.append("\tsize_t nlen = strlen(needle);")
-    lines.append("\tsize_t i, j;")
-    lines.append("\tif (nlen == 0)")
-    lines.append("\t\treturn true;")
-    lines.append("\tfor (i = 0; name[i]; i++) {")
-    lines.append("\t\tfor (j = 0; j < nlen; j++) {")
-    lines.append("\t\t\tif (!name[i + j])")
-    lines.append("\t\t\t\treturn false;")
-    lines.append("\t\t\tif (tolower((unsigned char)name[i + j]) !=")
-    lines.append("\t\t\t    (unsigned char)needle[j])")
-    lines.append("\t\t\t\tbreak;")
-    lines.append("\t\t}")
-    lines.append("\t\tif (j == nlen)")
-    lines.append("\t\t\treturn true;")
-    lines.append("\t}")
-    lines.append("\treturn false;")
-    lines.append("}")
-    lines.append("")
-    lines.append("static inline bool vpnhide_iface_is_vpn(const char *name)")
+    # Self-contained matcher: no <ctype.h>/<string.h>/<stdbool.h>/<linux/*>,
+    # so the SAME header compiles in every world that consumes it — the
+    # kretprobe .ko (real kernel headers), the KernelPatch KPM (-nostdinc, no
+    # libc/ctype stubs), and the host unit test. ASCII case-fold and length
+    # are done locally; returns int (0/1).
+    lines.append(KMOD_MATCHER_HELPERS)
+    lines.append("static inline int vpnhide_iface_is_vpn(const char *name)")
     lines.append("{")
     lines.append("\tif (!name || !name[0])")
-    lines.append("\t\treturn false;")
+    lines.append("\t\treturn 0;")
+    fn_for_kind = {
+        "exact": "vpnhide_iface_equals_ci",
+        "prefix": "vpnhide_iface_starts_with_ci",
+        "prefix_digits": "vpnhide_iface_starts_with_then_digits_ci",
+        "contains": "vpnhide_iface_contains_ci",
+    }
     for r in rules:
         if r.note:
             lines.append(f"\t/* {r.note} */")
-        if r.kind == "exact":
-            fn = "vpnhide_iface_equals_ci"
-        elif r.kind == "prefix":
-            fn = "vpnhide_iface_starts_with_ci"
-        elif r.kind == "prefix_digits":
-            fn = "vpnhide_iface_starts_with_then_digits_ci"
-        elif r.kind == "contains":
-            fn = "vpnhide_iface_contains_ci"
-        lines.append(f"\tif ({fn}(name, {c_str_lit(r.needle)}))")
-        lines.append("\t\treturn true;")
-    lines.append("\treturn false;")
+        lines.append(f"\tif ({fn_for_kind[r.kind]}(name, {c_str_lit(r.needle)}))")
+        lines.append("\t\treturn 1;")
+    lines.append("\treturn 0;")
     lines.append("}")
     lines.append("")
     lines.append("#endif /* VPNHIDE_GENERATED_IFACE_LISTS_H */")


### PR DESCRIPTION
Adds a third native backend alongside the kretprobe `.ko` and the zygisk libc hooks: a KernelPatch Module (`.kpm`) that hides VPN interfaces from selected UIDs on the kernels the `.ko` can't serve — non-GKI / pre-GKI (4.14, 4.19), proprietary kernels with no published headers or `Module.symvers` (e.g. HyperOS 5.4, the kernels behind #33 / #35), and kernels that reject unsigned module loading (loaded via the KernelPatch supercall, not insmod). One binary serves every version through a runtime `kver` offset table. Still WIP — not yet a release artifact, and the procfs target control plane is a follow-up.

- One source + a runtime `kver` offset table (`kver_offsets.h`) → one `.kpm` for 4.14 / 4.19 / 5.4 / 5.10 / 5.15 / 6.1 / 6.6 / 6.12, not three per-version copies. 10 inline hooks (`/proc/net/route` + `ipv6_route`, `rtnl_fill_ifinfo`, `inet*_fill_ifaddr`, `dev_ioctl` + `sock_ioctl`, `fib_dump_info` (#86), `rt6_fill_node`, `fib_nl_fill_rule`) — full native-vector parity with the `.ko`.
- All 8 kernels QEMU-validated 9/9 (two-boot A/B, no panic), each on a separate Image — GKI via the DDK clang, 4.14/4.19/5.4 from pinned source. Caught two latent offset bugs in the process: 5.15's `fib6_info` gained `offload` fields, and 6.12's `fib6_info` gained `gc_link` plus the `net_device` cacheline reorg that finally moved `name` off offset 0.
- Cross-version infra so one binary works everywhere: table-driven `fib_dump_info` arg, `rt6_via_dst` for pre-`fib6_info` kernels (4.14's `rt6_info`), nexthop-object guards for pre-5.3 kernels, and fuzzy symbol resolution for gcc `.isra`/`.constprop` clones.
- Harness now enforces PAN (`CONFIG_ARM64_SW_TTBR0_PAN`) so a hook that dereferences a userspace pointer as kernel memory panics in QEMU even on the `cortex-a57` legacy cores (which have no hardware PAN) — this is the bug class the dev_ioctl fix below belongs to.
- Fix: `dev_ioctl`'s ifreq arg is a `__user` pointer on <5.5 kernels (kernel `struct ifreq *` on >=5.5); reading it directly only faulted on real PAN hardware. Now branches on the pointer domain at runtime.
- CI: a `kpm-qemu` job (GKI matrix, reusing the `ddk-qemu` images with baked KernelPatch binaries) and a `kpm-qemu-legacy` job (4.14/4.19/5.4 from a new lightweight image built by `build-source-kernel.sh`). Both backends are now gated across the whole supported range every PR.
- KernelPatch vendored as a submodule (`make -C kmod kpm` builds with no args); the generated VPN-name matcher made self-contained so it compiles under KernelPatch's `-nostdinc` world.

Testing:
- Live on a Magisk-rooted Pixel 4a (kernel 4.14.302): patched boot with KernelPatch, loaded the `.kpm`, and confirmed `vpn0` is hidden from a target UID across `ip addr` / `ip link` / `ifconfig` while visible to root. This is what surfaced the `dev_ioctl` PAN bug above (the device reboot-looped until it was fixed); the device was restored to stock afterwards. CI covers the QEMU A/B for all 8 kernels.
