### PR TITLE
Migrate every backend to the shared control protocol

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,6 +22,8 @@ These short files cover everything specific to this repo. Skipping them leads to
 - [CONTRIBUTING.md](CONTRIBUTING.md) — PR process, commit conventions, changelog requirement
 - [docs/development.md](docs/development.md) — prereqs, per-module build quickstart, keystore setup, device install, CI lints
 - [docs/state.md](docs/state.md) — every persistent path / proc entry / iptables chain the project touches; who writes, who reads, lifetime
+- [docs/storage.md](docs/storage.md) — **target** storage & activation design: the single JSON canonical, the activator (Rust workspace, three bins) that derives the runtime wire, LSPosed self-read, the APatch superkey, SELinux layout. Read before touching how config is stored/loaded.
+- [docs/protocol.md](docs/protocol.md) — the frozen v1 control/stats **wire** between the app and the native backends (config/stats/status); the format every backend parser must agree on
 - [docs/detection-vectors.md](docs/detection-vectors.md) — what an app can probe to detect the VPN (or a hidden package), which component (kmod / zygisk / lsposed / SELinux) covers each vector, how it manifests. Read before adding or changing a hook.
 - [docs/changelog.md](docs/changelog.md) — changelog storage (`changelog.d/` fragments + history JSON), `./scripts/changelog.py` usage
 - [docs/releasing.md](docs/releasing.md) — `./scripts/release.py` usage, version-bump flow

--- a/changelog.d/changed-all-backends-now-speak-one-control-222a.md
+++ b/changelog.d/changed-all-backends-now-speak-one-control-222a.md
@@ -1,0 +1,9 @@
+_2026-06-28_
+
+## English
+
+All backends now speak one control protocol: the app, kmod, KPM, Zygisk and LSPosed exchange targets over a single versioned wire format. The kmod's two /proc nodes folded into one (/proc/vpnhide_ctl) and Zygisk now keys on UID like every other backend.
+
+## Русский
+
+Все бэкенды теперь говорят на одном управляющем протоколе: приложение, kmod, KPM, Zygisk и LSPosed обмениваются целями через единый версионированный формат. Два /proc-узла kmod объединены в один (/proc/vpnhide_ctl), а Zygisk теперь сопоставляет по UID, как и остальные бэкенды.

--- a/docs/detection-vectors.md
+++ b/docs/detection-vectors.md
@@ -41,7 +41,7 @@ Coverage comes from three vpnhide components plus the platform. They differ in
 
 | Layer | Where it runs | Selects targets by | Sees | Bypassable by raw syscalls? |
 |---|---|---|---|---|
-| **kmod** | Linux kernel (kretprobes) | **UID** (`/proc/vpnhide_targets`) | Everything below libc — the syscall/skb/seq_file source | **No** — filters at the source regardless of how userspace calls |
+| **kmod** | Linux kernel (kretprobes) | **UID** (`/proc/vpnhide_ctl`) | Everything below libc — the syscall/skb/seq_file source | **No** — filters at the source regardless of how userspace calls |
 | **zygisk** | target process, inline `libc` hooks (shadowhook) | **package** (`targets.txt`, per-fork) | Only calls routed through the hooked `libc` symbols | **Yes** — a direct `svc #0` / unhooked libc entry slips past |
 | **lsposed** | `system_server`, Binder hooks (Vector framework) | **UID** (`/data/system/vpnhide_uids.txt`) | Java/framework Binder results *before* serialization to the app | N/A — the data is built in another process; the app only gets the sanitized parcel |
 | **SELinux** | platform policy | domain (`untrusted_app`) | n/a — it *denies* access rather than filtering | n/a — a denial is a denial |

--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -15,6 +15,14 @@ folded into config; the `.ko` channel is one folded node `/proc/vpnhide_ctl`
 (write=config, read=status+stats); KPM uses the `kpm ctl0` supercall (§7).
 Threat model: an **unprivileged** app — root-level detection is out of scope.
 
+> **Storage & activation live in [storage.md](storage.md).** This document is the
+> frozen **wire** spec (the bytes exchanged at runtime). The layer above it — a
+> single JSON canonical on disk, the activator that derives this wire for the
+> native backends, LSPosed reading the JSON directly (it does **not** consume this
+> wire), and the APatch superkey — is specified there, and supersedes the
+> storage-related statements in §1.3–§1.4, §6, and §7.4 below. The wire format
+> (§4–§5) is unchanged.
+
 ---
 
 ## 1. Architecture
@@ -532,13 +540,16 @@ the su-management supercalls allow):
   KPM if the `.ko` is loaded, §1.5), `kpatch kpm load vpnhide.kpm`, then apply the
   persisted config snapshot via `kpatch kpm ctl0`. Fully automatic, no user
   interaction. This is what we recommend users run.
-- **APatch, `c02`, superkey-required.** A boot script has no superkey, so it
-  **cannot** load or configure the KPM. It only writes a status flag
-  (`awaiting_superkey`) and may post a one-shot user notification (e.g. via
-  `am broadcast` to the app). Activation happens **in the app**: the user enters
-  the superkey, the app runs `kpatch <key> kpm load` + `ctl0`. The superkey is
-  held **session-only in memory** (matching APatch's own re-prompt model); no
-  at-rest persistence in v1 (an opt-in Keystore/biometric store is deferred).
+- **APatch, `c02`, superkey-required.** **By default** a boot script has no
+  superkey, so it **cannot** load or configure the KPM: it writes a status flag
+  (`awaiting_superkey`) and activation happens **in the app** (the user enters the
+  superkey, the app runs `kpatch <key> kpm load` + `ctl0`), with the key held
+  session-only in memory. **Superseded by [storage.md](storage.md) §6:** an opt-in
+  flag persists the key root-only at `/data/adb/vpnhide/superkey` (DE storage,
+  boot-readable), which lets the boot activator configure APatch at boot too —
+  parity with keyless KPatch-Next. The persisted key is a plain file (the boot
+  binary can't reach Android Keystore) and is safe under this threat model
+  (root-only, never unprivileged-readable).
 
 This keeps the smooth, zero-interaction KPM story on the recommended Magisk/KSU +
 KPatch-Next combo, and contains all the superkey friction in the APatch branch,

--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -65,7 +65,7 @@ in transport and in which records they carry (profiles, §6).
 
 | Channel | Write transport | Read transport | Reader runs in |
 |---|---|---|---|
-| app ↔ `.ko` | `echo > /proc/vpnhide_targets` | `cat /proc/vpnhide_stats` (seq_file) | kernel |
+| app ↔ `.ko` | `echo > /proc/vpnhide_ctl` | `cat /proc/vpnhide_ctl` (seq_file) | kernel |
 | app ↔ KPM | supercall `ctl0` (`args`) | supercall `ctl0` (`out_msg`) | kernel |
 | app ↔ Zygisk | `targets.txt` via module dir-fd | n/a (stats via §7 if added) | Zygisk process (zygote-forked) |
 | app ↔ LSPosed | `/data/system/vpnhide_*` files | same files | `system_server` |

--- a/docs/state.md
+++ b/docs/state.md
@@ -1,5 +1,14 @@
 # Persistent state — every path the project touches
 
+> **Heads-up — storage redesign.** This catalogue describes the **current**
+> implementation (per-backend text files). The **target** storage & activation
+> architecture — one JSON canonical (`/data/system/vpnhide_config.json`) from
+> which an activator derives the runtime channels, LSPosed reading that JSON
+> directly, the four per-backend `targets.txt` + the `vpnhide_*` /data/system
+> files folding into the canonical, and the APatch superkey at
+> `/data/adb/vpnhide/superkey` — is specified in [storage.md](storage.md). Entries
+> below that it supersedes will be updated when that lands.
+
 Reference catalogue for everyone (humans, agents) trying to answer
 "where is this stored?" / "who reads X?" / "what survives a reboot?".
 

--- a/docs/state.md
+++ b/docs/state.md
@@ -27,16 +27,15 @@ persistent dirs of section 2.
 ### `/data/adb/modules/vpnhide_kmod/`
 - `module.prop` — module metadata + stamped `gkiVariant=` and `version=`. Read by app dashboard (`DashboardData.kt:382` `parseModuleProp`).
 - `post-fs-data.sh` — runs at boot, attempts `insmod vpnhide_kmod.ko`, writes diagnostics into the persistent dir.
-- `service.sh` — runs after boot, reads `targets.txt`, resolves UIDs, writes `/proc/vpnhide_targets`.
+- `service.sh` — runs after boot, reads `targets.txt`, resolves UIDs, emits a `vpnhide 1 config` snapshot to `/proc/vpnhide_ctl`.
 - `vpnhide_kmod.ko` — the kernel module binary itself.
 
 ### `/data/adb/modules/vpnhide_zygisk/`
 - `module.prop` — module metadata.
 - `customize.sh` — install-time hook; seeds persistent dir, migrates legacy targets.
-- `service.sh` — boot script; copies persistent `targets.txt` and `debug_logging` into module dir so the Zygisk loader's `get_module_dir()` fd sees them.
+- `service.sh` — boot script; resolves the persistent `targets.txt` package list → UIDs and writes a `vpnhide 1 config` snapshot here so the Zygisk loader's `get_module_dir()` fd sees it.
 - `zygisk/arm64-v8a.so` — Rust cdylib injected into every forked app by NeoZygisk.
-- `targets.txt` — **boot-time copy** of the canonical persistent file (`/data/adb/vpnhide_zygisk/targets.txt`). Loader reads via fd, not path. (`zygisk/module/service.sh`, `zygisk/src/lib.rs`)
-- `debug_logging` — `"0"` or `"1"`. **Boot-time copy** of `/data/adb/vpnhide_zygisk/debug_logging` (canonical). The app also writes both paths directly via su on every toggle, so the module-dir mirror stays current between reinstall and reboot. Read by zygisk module on init via the module dir fd.
+- `targets.txt` — a `vpnhide 1 config` snapshot (resolved UIDs + folded `debug`), re-emitted at boot from the canonical persistent package list (`/data/adb/vpnhide_zygisk/targets.txt`) and on Save by the app. The loader parses it via fd, not path. (`zygisk/module/service.sh`, `zygisk/src/lib.rs`) — debug is folded in now, so there is no separate `debug_logging` file.
 
 ### `/data/adb/modules/vpnhide_ports/`
 - `module.prop`.
@@ -68,8 +67,7 @@ was written this boot" vs. "stale from last boot".
 ### `/data/adb/vpnhide_zygisk/`
 | File | Format | Writer | Reader | Lifetime |
 |---|---|---|---|---|
-| `targets.txt` | one pkg per line | app via su; `zygisk/module/customize.sh` migrates from legacy in-module location | copied into module dir by `zygisk/module/service.sh` at boot | persistent |
-| `debug_logging` | single byte `"0"` or `"1"` | app via su (`DebugLoggingPrefs.kt::writeDebugFlagFiles`, part of the persistent toggle fan-out) | copied into module dir by `zygisk/module/service.sh` at boot, where the .so reads it via `get_module_dir()` fd | persistent |
+| `targets.txt` | one pkg per line (canonical package list; NOT the wire) | app via su; `zygisk/module/customize.sh` migrates from legacy in-module location | `zygisk/module/service.sh` at boot resolves it → UIDs → emits the module-dir config | persistent |
 
 ### `/data/adb/vpnhide_ports/`
 | File | Format | Writer | Reader | Lifetime |
@@ -99,11 +97,11 @@ enumerable + readable.
 
 | File | Format | Writer | Reader | Lifetime |
 |---|---|---|---|---|
-| `vpnhide_uids.txt` | one UID per line (integer) | `kmod/module/service.sh` and `zygisk/module/service.sh` resolve `targets.txt` → UIDs at boot; app via su after Save | LSPosed hook in system_server; `HookEntry.kt:174` first-call read + FileObserver (`HookEntry.kt:346`) for live reload | persistent (rewritten at boot + on save) |
+| `vpnhide_uids.txt` | a `vpnhide 1 config` snapshot (docs/protocol.md): header + `debug` + `target <uid> <mask>` lines | `kmod/module/service.sh` and `zygisk/module/service.sh` resolve `targets.txt` → UIDs and emit the config at boot; app via su (`ConfigChannels`) after Save / at startup reconcile | LSPosed hook in system_server; `SystemServerTargetUidCache` parses the config (`Protocol.parseConfig`) + FileObserver for live reload | persistent (rewritten at boot + on save) |
 | `vpnhide_hidden_pkgs.txt` | one pkg per line | app via su when user picks "Apps to hide from PackageManager" | `PackageVisibilityHooks.kt:124` + FileObserver | persistent |
 | `vpnhide_observer_uids.txt` | one UID per line | app via su | `PackageVisibilityHooks.kt:111` + FileObserver | persistent |
 | `vpnhide_hook_active` | `key=value`: `version`, `boot_id`, `timestamp`, `aosp_sdk`, optional `broken_fields` | `HookEntry.kt:312-339` `writeHookStatusFile` (in system_server) | app dashboard (`DashboardData.kt:805` reads via su); compares `boot_id` to detect stale records | per-boot |
-| `vpnhide_debug_logging` | single byte `"0"` or `"1"` | app via su (`DebugLoggingPrefs.kt::writeDebugFlagFiles`) | LSPosed hooks via `HookLog.reload` + FileObserver (`HookLog.kt:30-43`); `kmod/module/service.sh` re-seeds `/proc/vpnhide_debug` from this file at boot; surfaced as a Dashboard warning (`DashboardData.kt:991`) | persistent |
+| `vpnhide_debug_logging` | single byte `"0"` or `"1"` | app via su (`DebugLoggingPrefs.kt::writeDebugFlagFiles`) | LSPosed hooks via `HookLog.reload` + FileObserver (`HookLog.kt:30-43`); the boot scripts read it as the source for the `debug` line they fold into each config; surfaced as a Dashboard warning | persistent — the single canonical debug flag |
 
 **FileObservers** in `HookEntry.kt` and `PackageVisibilityHooks.kt`
 watch `/data/system/` for `CREATE | CLOSE_WRITE | MOVED_TO | MODIFY`
@@ -113,8 +111,10 @@ hooks **without any IPC or restart**.
 
 ### Debug-logging fan-out
 
-The "Debug logging" toggle in Diagnostics drives **four sinks** from
-one writer (`DebugLoggingPrefs.kt::applyDebugLoggingRuntime`):
+Debug is **folded into the control config** (the `debug` line, protocol §4.3),
+so the kmod and zygisk learn it from their config snapshot — there is no longer
+a per-backend debug node/file. One canonical persistent flag remains for the
+parts that can't take a config: `/data/system/vpnhide_debug_logging`.
 
 ```
 toggle ON/OFF
@@ -123,29 +123,18 @@ toggle ON/OFF
 applyDebugLoggingRuntime(enabled)
     ├─ VpnHideLog.enabled = enabled                          (1) app process — instant, in-memory
     └─ writeDebugFlagFiles (one batched su):
-         ├─ /data/system/vpnhide_debug_logging               (2) system_server — ~10ms via inotify FileObserver
-         ├─ /data/adb/vpnhide_zygisk/debug_logging           (3a) zygisk persistent — survives module reinstall
-         ├─ /data/adb/modules/vpnhide_zygisk/debug_logging   (3b) zygisk module-dir mirror — read by .so on next fork
-         └─ /proc/vpnhide_debug                              (4) kmod — instant if loaded, else no-op
+         ├─ /data/system/vpnhide_debug_logging               (2) the single canonical flag: system_server hook
+         │                                                       reads it live (HookLog inotify); boot scripts read
+         │                                                       it as the source for each config's `debug` line
+         └─ ConfigChannels.reconcileCommand(snapshot, enabled) re-emits the runtime config to
+              ├─ /proc/vpnhide_ctl                           (3) kmod — picks up the new flag on write, if loaded
+              └─ /data/adb/modules/vpnhide_zygisk/targets.txt (4) zygisk — folded into its config; takes effect on
+                                                                  the target app's next restart, as targets always have
 ```
 
-`/data/system/vpnhide_debug_logging` is the canonical persistent
-source-of-truth on disk for everything except zygisk; zygisk has its
-own canonical at `/data/adb/vpnhide_zygisk/debug_logging` because
-the .so reads via the module-dir fd, not via system_data_file path.
-
-Boot-time re-seeding makes the persistent toggle survive reboots
-without the app needing to open:
-
-- `kmod/module/service.sh` copies `/data/system/vpnhide_debug_logging`
-  → `/proc/vpnhide_debug` (in-kernel state lost on every boot).
-- `zygisk/module/service.sh` copies `/data/adb/vpnhide_zygisk/debug_logging`
-  → `/data/adb/modules/vpnhide_zygisk/debug_logging` (module-dir
-  mirror lost on every module reinstall).
-
-`MainActivity.onCreate` re-propagates from SharedPrefs to all four
-sinks at every app launch as a safety-net for "user reinstalled a
-module mid-session and didn't reboot before opening the app".
+Boot-time: each module's `service.sh` reads `/data/system/vpnhide_debug_logging`
+and folds it into the `debug` line of the config it emits, so the persistent
+toggle survives reboots without the app needing to open.
 
 Errors (`Log.e` / `HookLog.e` / Rust `error!`) always print
 regardless of the toggle — these fire at most once per process /
@@ -154,21 +143,22 @@ attach"-class problems happen.
 
 ---
 
-## 4. Kernel module ABI — `/proc/vpnhide_*`
+## 4. Kernel module ABI — `/proc/vpnhide_ctl`
 
 Created by `kmod/vpnhide_kmod.c` at module init via `proc_create()`,
-removed at module exit. Mode `0600`, root-only.
+removed at module exit. Mode `0600`, root-only. One folded control+stats
+node (protocol §OPEN-4) — it replaced the old `/proc/vpnhide_targets`
+(decimal UID list) + `/proc/vpnhide_debug` nodes.
 
 | Path | Format | Writer | Reader (kernel side) |
 |---|---|---|---|
-| `/proc/vpnhide_targets` | one UID per line; write replaces full set | root userspace: `kmod/module/service.sh` writes resolved UIDs at boot; LSPosed app via su after Save | `vpnhide_kmod.c` `targets_write` handler — caches UIDs in kernel memory, consulted by every kretprobe handler |
-| `/proc/vpnhide_debug` | `"1"` enables, `"0"` disables verbose `pr_info` from kretprobes | app via `DebugLoggingPrefs.kt::writeDebugFlagFiles` (part of the persistent toggle fan-out, see § 3); `kmod/module/service.sh` re-seeds at boot from `/data/system/vpnhide_debug_logging` | `READ_ONCE(debug_enabled)` in every probe handler |
+| `/proc/vpnhide_ctl` (write) | a `vpnhide 1 config` snapshot — `debug` line + `target <uid> <hookmask>` lines; write replaces full state, rejected-whole on a bad header | root userspace: `kmod/module/service.sh` emits the config at boot; the app via su (`ConfigChannels`) after Save / at startup reconcile | `vpnhide_kmod.c` `ctl_write` → shared `vpnhide_parse_config` — caches per-UID hook masks + the debug flag, consulted by every kretprobe handler (`hook_active`) |
+| `/proc/vpnhide_ctl` (read) | a self-documenting banner + `status` (backend/kver/installed-hook mask/error) + `stats` (counters TODO) | — | `ctl_show` via the shared `vpnhide_format_status`/`vpnhide_format_stats` |
 
-Both files are **per-boot, in-kernel state only**. Unloading the
-module (or rebooting) wipes the in-kernel state; service.sh re-seeds
-both at next boot — `/proc/vpnhide_targets` from
-`/data/adb/vpnhide_kmod/targets.txt`, and `/proc/vpnhide_debug` from
-`/data/system/vpnhide_debug_logging`.
+The state is **per-boot, in-kernel only**. Unloading the module (or
+rebooting) wipes it; service.sh re-emits the config at next boot from
+`/data/adb/vpnhide_kmod/targets.txt` (package names → resolved UIDs),
+folding the debug flag from `/data/system/vpnhide_debug_logging`.
 
 ---
 
@@ -275,12 +265,13 @@ post-fs-data.sh phase (root, before zygote):
 service.sh phase (root, after boot_completed-ish):
   kmod/module/service.sh
     → resolve /data/adb/vpnhide_kmod/targets.txt → UIDs
-    → write /proc/vpnhide_targets
-    → write /data/system/vpnhide_uids.txt
+    → emit `vpnhide 1 config` → /proc/vpnhide_ctl
+    → emit `vpnhide 1 config` → /data/system/vpnhide_uids.txt
   zygisk/module/service.sh
-    → cp /data/adb/vpnhide_zygisk/targets.txt → /data/adb/modules/vpnhide_zygisk/targets.txt
+    → resolve /data/adb/vpnhide_zygisk/targets.txt → UIDs
+      → emit `vpnhide 1 config` → /data/adb/modules/vpnhide_zygisk/targets.txt
     → resolve /data/adb/vpnhide_lsposed/targets.txt → UIDs
-    → append/merge into /data/system/vpnhide_uids.txt
+      → emit `vpnhide 1 config` → /data/system/vpnhide_uids.txt
   portshide/module/service.sh
     → wait for netd
     → /data/adb/modules/vpnhide_ports/vpnhide_ports_apply.sh
@@ -307,7 +298,7 @@ zygote forks an app (NeoZygisk):
 
 | Lifetime class | Examples |
 |---|---|
-| **In-kernel only (per-boot, volatile)** | `/proc/vpnhide_targets`, `/proc/vpnhide_debug`, iptables `vpnhide_out{,6}` chains |
+| **In-kernel only (per-boot, volatile)** | `/proc/vpnhide_ctl` (config + status/stats), iptables `vpnhide_out{,6}` chains |
 | **Per-boot** (overwritten each boot by service scripts) | `/data/adb/vpnhide_kmod/load_status`, `/data/adb/vpnhide_kmod/load_dmesg`, `/data/system/vpnhide_uids.txt`, `/data/system/vpnhide_hook_active` |
 | **Per-app-launch** (overwritten on each fork) | `<app-filesDir>/vpnhide_zygisk_active` |
 | **Persistent — survives reboot, module reinstall, app reinstall** | `/data/adb/vpnhide_*/targets.txt`, `/data/adb/vpnhide_ports/observers.txt`, `/data/system/vpnhide_hidden_pkgs.txt`, `/data/system/vpnhide_observer_uids.txt`, `/data/system/vpnhide_debug_logging` |

--- a/docs/storage.md
+++ b/docs/storage.md
@@ -1,0 +1,378 @@
+# vpnhide — storage & activation architecture
+
+How configuration is **stored**, who **reads** it, and how it is **activated** into
+each backend. This is the layer *above* the wire protocol: [protocol.md](protocol.md)
+defines the bytes exchanged with the kernel/native backends at runtime; this file
+defines the single on-disk source of truth those bytes are derived from.
+
+> **Status.** This is the **target** design. The current code (the control-protocol
+> migration, PR #164) is an interim step: it puts the text protocol on *every*
+> backend with per-backend text files. This document is where that converges —
+> one JSON canonical + an activator that derives the wire for the native
+> backends, with LSPosed reading the JSON directly. Sections below note where the
+> current code differs.
+
+---
+
+## 1. Two layers, one boundary
+
+Two formats, by role — not one format stretched over everything:
+
+- **On disk = JSON.** A single canonical "desired state" file. Package-keyed (so it
+  survives reinstalls), rich (roles, per-hook selection, debug, app settings),
+  trivially import/export-able. Read by the app (Kotlin) and the LSPosed hook
+  (Kotlin) and the activator (Rust).
+- **Runtime IPC = the text protocol** ([protocol.md](protocol.md), v1 frozen).
+  uid-keyed, hand-parsed, kernel-safe. The runtime wire for the **native**
+  backends only (kmod / KPM / Zygisk): config in, stats/status out.
+- **The bridge = the activator** (Rust). It projects the JSON onto the wire for
+  whichever native backend is installed.
+
+Why split: the kernel consumer (KPM, freestanding C) cannot parse JSON (see
+protocol.md §9), and the injected Zygisk `.so` should not carry a JSON parser into
+every app process. But the *storage* layer has no such constraint, and JSON buys
+one-file import/export and natural Kotlin/Rust structs. So JSON serves the high
+level (storage + the Java hook, where `org.json` is free), the text protocol serves
+the low level (kernel / injected native), and the activator translates between
+them. The "agent reads/writes raw over adb" property (protocol.md §2) is preserved:
+the live kernel state is still `cat /proc/vpnhide_ctl` text, and JSON is itself
+readable text.
+
+The number-keying difference is deliberate and bridged by the activator:
+
+| Layer | Keyed by | Why |
+|---|---|---|
+| Canonical JSON | **package name** | survives reinstall (UID rotates, package doesn't) |
+| Runtime protocol | **UID** | the kernel has no PackageManager |
+
+---
+
+## 2. The canonical config (the only file you manage)
+
+- **Path:** `/data/system/vpnhide_config.json`
+- **Perms / label:** `0640 root:system`, SELinux `system_data_file`.
+- **Writer:** the app, via `su` (atomic `tmp`+`rename`).
+- **Readers:** the app (`su`), the LSPosed hook (directly, from `system_server`),
+  the activator (root). **Not** readable by unprivileged apps or non-root `adb`
+  (see §7).
+- **Holds:** schema version, the global `debug` flag, per-package roles + (optional)
+  per-hook selection, and app settings. It does **not** hold stats, status, or the
+  APatch superkey (those are runtime/secret — §5, §6).
+- **Import / export = copy this one file.** It contains no device-specific secret,
+  so it is safe to back up / move / share. (This is *why* the superkey is **not**
+  stored here — §6.)
+
+Shape (illustrative):
+
+```json
+{
+  "version": 1,
+  "debug": false,
+  "apps": {
+    "com.example.bank":  { "java": true, "native": true,  "appHiding": false, "ports": false },
+    "org.example.proxy": { "java": true, "native": true,  "appHiding": true,  "ports": true }
+  },
+  "settings": {
+    "rememberSuperkey": false
+  }
+}
+```
+
+Per-hook granularity ("раздельное управление хуками"): the coarse `"native": true`
+is the common case (enable every native hook for the app). When the UI exposes
+per-hook control, `native` grows into an explicit hook list, e.g.
+`"native": ["fib_route_seq_show", "sock_ioctl"]`; the activator maps that to the
+protocol `hookmask` bits. An absent/`true` value means "all native hooks". The JSON
+is the *desired* selection; the wire carries the resolved `hookmask`.
+
+The `rememberSuperkey` boolean lives here (it is a preference, not a secret). The
+superkey itself does **not** (§6).
+
+---
+
+## 3. Java layer (LSPosed) — independent, self-reading
+
+The LSPosed backend is an **APK + a `system_server` hook**, not a Magisk module. Two
+consequences drive the design:
+
+1. **It has no `service.sh`** — nothing external should "populate" a file for it.
+2. **It must work standalone.** The native modules are optional and
+   mutually-exclusive plug-ins; the Java layer must be fully functional with *zero*
+   native modules installed. So it cannot depend on a native module's boot script to
+   configure it.
+
+The resolution: the **hook itself is the Java layer's boot mechanism** — LSPosed
+loads it into `system_server` on every boot. So it reads the canonical config
+**directly** and configures itself. No activator, no derived file.
+
+How it reads, carefully (this runs in the bootloop-critical `system_server`):
+
+- **Config in:** read `/data/system/vpnhide_config.json` directly (the hook is in
+  `system_server`, which *can* read `system_data_file`). `org.json` is built into
+  Android — no dependency. Re-read on `FileObserver` change. `debug` comes from the
+  same JSON (no separate debug file).
+- **UID resolution without re-entry:** the hook matches the *caller* by UID
+  (`Binder.getCallingUid()`), so it needs the target packages' UIDs. It resolves
+  them via **`/data/system/packages.list`** (the stable AOSP `pkg uid …` map) —
+  **not** via `PackageManager`, because the hook *is* hooking PackageManager and a
+  PM call could re-enter its own hooks (recursion → deadlock → bootloop). Reading
+  `packages.list` is a plain file read, hook-free.
+- **Multi-profile for free:** match `callingUid % 100000 ∈ targetAppIds`. Any
+  profile's instance of a target app matches, with no per-profile enumeration.
+- **Status out:** the hook writes `/data/system/vpnhide_hook_active`
+  (`version`/`boot_id`/`broken_fields`) so the dashboard knows the Java layer is
+  alive and healthy. (Config-in and status-out are different files / opposite
+  directions — `system_server` can't expose a `/proc`-style node, so it can't
+  multiplex both on one channel the way the kmod node does.)
+- **Stats:** deferred (§5).
+
+> Current code (#164) differs: LSPosed reads a *derived protocol config*
+> (`vpnhide_uids.txt`) that the native boot scripts populate. That is exactly the
+> native-dependency this target design removes.
+
+---
+
+## 4. Native layer (kmod / KPM / Zygisk) + the activator
+
+The native backends are **mutually exclusive** — exactly one is installed (the app
+warns/errors and asks the user to remove the extra otherwise). So the activator
+never writes "all three": it writes the **one** channel of the one installed native
+backend.
+
+### 4.1 The activator — a Rust workspace, three thin bins
+
+The projection is *identical* for all three native backends (take the `native`-role
+packages → resolve to UIDs → emit a `vpnhide 1 config` snapshot); only the
+**delivery sink** differs. So: one shared core, three thin per-target front-ends.
+
+```
+crates/
+  protocol/                 # lib, NO serde — the wire (parse/format). Shared by
+                            #   the Zygisk .so AND the activator. Today's
+                            #   zygisk/src/protocol.rs, promoted to a shared crate.
+  zygisk/                   # cdylib — the injected .so. deps: protocol (+ shadowhook).
+                            #   Lean: no serde, no JSON in every app process.
+  activator/
+    src/lib.rs              # shared core: JSON schema (serde), pkg→uid resolution
+                            #   (`pm`), project_native(json) -> String
+    src/bin/kmod.rs         #   project_native(json) → write("/proc/vpnhide_ctl")
+    src/bin/kpm.rs          #   project_native(json) → `kpatch [key] kpm ctl0`
+    src/bin/zygisk.rs       #   project_native(json) → write_atomic(module_dir file)
+```
+
+- **Why a workspace, not feature-flags or one crate with `src/bin/`+cdylib:**
+  `cdylib` and `bin` are different crate-types; feature-flags don't select artifact
+  type. A single crate that is *both* a cdylib and a bin risks pulling `serde` into
+  the injected `.so`. The workspace keeps the `.so`'s dependency tree lean (protocol
+  only) while the activator (a normal executable) freely uses `serde`. The three
+  **activators are executables**, so they fit `src/bin/` perfectly over a shared
+  `src/lib.rs`.
+- **Each native module ships only its own activator bin** (kmod module → `kmod`,
+  KPM module → `kpm`, Zygisk module → `zygisk`). Each does exactly its one channel,
+  no detection, no runtime branching.
+- **When it runs:** at boot from that module's `service.sh`, and on Save from the
+  app (`su <path>/activator`). It reads the canonical, resolves, writes its channel.
+
+### 4.2 The three channels
+
+| Backend | Channel | Kind | Note |
+|---|---|---|---|
+| kmod | `/proc/vpnhide_ctl` | proc node | write = config (kernel parses to memory); read = status+stats |
+| KPM | `kpatch kpm ctl0` | supercall | no file; config in via arg, stats/status out via `out_msg` |
+| Zygisk | file in its module dir | file | the `.so` reads it via the `get_module_dir()` fd |
+
+Why Zygisk needs a file in its module dir even though there is one canonical: the
+`.so`'s **only** privileged read handle per fork is the module-dir fd Zygisk hands
+it (§7). This is a *mechanism* constraint, not a format one — the activator simply
+derives the protocol config there. (Note: the protocol text — not JSON — keeps the
+injected `.so` free of a JSON parser, and carries the per-hook `hookmask` + `debug`
++ the future stats the way a flat package list never could.)
+
+---
+
+## 5. Stats & status — and what "hooks" means
+
+### 5.1 `config` hookmask vs `status` hooks — two different axes
+
+A common confusion (they are *not* the same):
+
+- **`config`: `target <uid> <hookmask>`** — per-UID, what you *want*: which hooks are
+  enabled for that app. This is the flexible per-target control.
+- **`status`: `hooks <mask>`** — per-backend, what is *actually installed*: did all
+  the backend's hooks register this boot? It is capability/health, not per-target.
+  Lets the app show "requested vs active" and detect a partial install
+  (`error = partial_hooks`). So `hooks 0x3ff` in a status read means "all 10 kernel
+  hooks are installed in this backend", **not** "this target's hooks".
+
+### 5.2 Config and stats don't collide
+
+They are **opposite directions of one channel**, distinguished by the `kind`
+header — not interleaved in one stored blob. Write feeds config (into memory); read
+emits status+stats (from separate counters). Example on the kmod node:
+
+```sh
+# write config (kind=config) — kernel parses into targets[]+debug, nothing echoed
+# printf 'vpnhide 1 config\ndebug 0\ntarget 0x27fa 0x3ff\n' > /proc/vpnhide_ctl
+
+# read status+stats (kind=status, kind=stats) — never returns the config you wrote
+# cat /proc/vpnhide_ctl
+# vpnhide v1 — a WRITE replaces ENTIRE state; this read is status+stats
+vpnhide 1 status
+backend 0x0
+kver 0x6019d
+hooks 0x3ff
+error 0x0
+vpnhide 1 stats
+0x27fa 0x0:0x5 0x3:0xc 0x9:0x1
+```
+
+`ctl_write` touches `targets[]`; `ctl_show` serialises counters — different structs,
+different syscalls, own locks. For file channels (Zygisk) the config-in file is
+single-writer / atomic-replace, and stats are never written back into it.
+
+### 5.3 Stats scope
+
+- **kmod / KPM: yes** — counters live in one place (kernel memory), so a pull-read is
+  natural. (Format wired; per-(uid,hook) counters are a TODO.)
+- **Zygisk: deferred.** Its counters would live **per app process** with no shared
+  aggregation point. A unix socket is out — it violates protocol.md §2 (pull-only,
+  no per-hit push) and needs a collector process (a rejected resident root daemon,
+  §1.1). Shared memory is the pull-compatible direction, but there is no clean way
+  to share *writable* memory across all injected app-domain processes without a
+  daemon (the module-dir file isn't writable by `untrusted_app` under SELinux; a
+  zygote-inherited memfd must be created in the zygote, where our code does not run).
+  So Zygisk emits **status only**; per-hook stats are a future problem, not a
+  blocker for this design.
+- **LSPosed: deferred** (it *could* aggregate in `system_server`'s single process,
+  but not now). Status via `vpnhide_hook_active`.
+
+---
+
+## 6. APatch SuperKey
+
+KernelPatch's control entry is a **syscall** (the supercall), and syscalls are not
+UID-gated — *any* process could invoke it. The **superkey** is the capability token
+that authenticates "may control the kernel patch". So it defends against the same
+**unprivileged** adversary this project already cares about: without it, a non-root
+app could `ctl0` our config or grant itself root. (KPatch-Next `d05` under
+Magisk/KSU is **keyless**; this whole section is **APatch-only**.)
+
+- **Default:** session-only, re-prompt each session (APatch's own model).
+- **Optional flag `rememberSuperkey`** (in the canonical `settings`): persist it so
+  it loads automatically — convenient for users who prefer it, and for development
+  (no manual entry each time).
+- **When the flag is on**, the key is stored at:
+  - **Path:** `/data/adb/vpnhide/superkey`, `0600 root`.
+  - **Why there, not elsewhere:**
+    - **Not in the canonical JSON** — that is the export file; the key would leak on
+      export, and it is device-specific (useless on another device) anyway.
+    - **Not in CE app-private** (`/data/data/<pkg>`, credential-encrypted) — that is
+      locked until the user unlocks the device, so a **boot** script (which runs
+      *before* first unlock) can't read it.
+    - **`/data/adb` is DE-accessible** (device-encrypted, decrypted at boot — Magisk
+      reads modules from there pre-unlock), and root-only. So the boot activator
+      (root) **can** read it before unlock.
+- **What it unlocks: APatch boot activation.** With the key on disk, the `kpm`
+  activator reads it at boot and runs `kpatch <key> kpm ctl0` — so APatch reaches
+  **parity with keyless KPatch-Next** (protection active after a reboot, no app
+  open needed). Without the flag, APatch is configured only after the user opens the
+  app and enters the key (KPM boot stays unconfigured until then).
+- **Plain file, not Keystore.** The boot activator is a Rust binary, not an Android
+  app, so it cannot call Android Keystore (a framework/binder API). Keystore-wrapping
+  could protect the *app-time* use only, not the boot path. So the boot-usable copy
+  is a plain file; FBE DE-encryption protects it at rest on a powered-off device.
+- **Threat-model fit:** readable by **root only** (trusted in this project's model),
+  never by unprivileged apps or non-root `adb` (§7). `argv` exposure of the key when
+  invoking `kpatch <key> …` is fine — modern `/proc` (`hidepid`) blocks unprivileged
+  apps from reading another process's `cmdline`; only root sees it. So no separate
+  "key off argv" helper (protocol.md §7.3) is needed for this model.
+
+---
+
+## 7. SELinux & visibility — who can read what
+
+Threat model: an **unprivileged** app; we do **not** hide from root. The whole layout
+falls out of one fact — three reader contexts with different reach:
+
+| Reader | Context | Can reach |
+|---|---|---|
+| app | `su` (root) | anything |
+| activator / boot scripts | root | anything |
+| LSPosed hook | `system_server` domain, **no root** | `system_data_file` only — **not** `/data/adb` |
+| Zygisk `.so` | per-fork, module-dir **fd** only | only what that fd points at |
+
+Consequences:
+
+- **Canonical → `/data/system`** (`system_data_file`, `0640 root:system`): app(su) +
+  activator(root) + LSPosed(`system_server`) all read it; unprivileged apps and
+  non-root `adb` get EACCES. (The one place `system_server` can read.)
+- **Superkey → `/data/adb`** (`0600 root`, DE): root-only and boot-readable.
+- **Zygisk → a copy in its module dir**: because its only privileged handle is the
+  module-dir fd. A direct `open()` of the canonical from the zygote domain would need
+  a fragile `sepolicy.rule`; a companion would be a rejected daemon. So: a cheap
+  derived copy, written by the activator.
+
+Visibility of the two sensitive files, concretely:
+
+| Reader | `/data/system/vpnhide_config.json` (0640 root:system) | `/data/adb/vpnhide/superkey` (0600 root) |
+|---|---|---|
+| unprivileged app | no | no |
+| root app | yes | yes |
+| `adb shell` (no root) | **no** (DAC + SELinux) | **no** |
+| `adb` with root (userdebug) | yes | yes |
+| `system_server` | yes (group `system`) | no |
+
+So `adb` without root reads **neither**; both are root-only beyond that — which is
+exactly the threat model.
+
+---
+
+## 8. File inventory (target)
+
+What you actually manage shrinks to **one** file; everything else is generated or
+optional.
+
+| File | Role | Lifetime |
+|---|---|---|
+| `/data/system/vpnhide_config.json` | **the** canonical config (managed, exported) | persistent |
+| `/proc/vpnhide_ctl` | kmod runtime channel (node, not a file) | per-boot, in-kernel |
+| `kpatch kpm ctl0` | KPM runtime channel (supercall, no file) | per-boot, in-kernel |
+| `/data/adb/modules/vpnhide_zygisk/<cfg>` | Zygisk runtime channel (derived copy) | regenerated |
+| `/data/system/vpnhide_hook_active` | LSPosed status (hook → dashboard) | per-boot |
+| `/data/adb/vpnhide/superkey` | APatch superkey (optional, flag-gated) | persistent, root-only |
+
+Removed vs. the pre-redesign layout:
+
+- the four per-backend `targets.txt` lists → folded into the **one** canonical;
+- `vpnhide_debug_logging` → **gone** (debug is a field in the canonical);
+- `vpnhide_uids.txt` / `vpnhide_hidden_pkgs.txt` / `vpnhide_observer_uids.txt` →
+  **gone** (LSPosed reads the canonical + `packages.list` and derives them in-process).
+
+---
+
+## 9. Migration
+
+On first run after the upgrade, if `/data/system/vpnhide_config.json` is absent, the
+app builds it **once** from whatever old per-backend text files exist (package
+lists, observers, hidden, debug flag), writes the canonical, then runs the
+activator. After that the old files are unused (and can be removed). The canonical is
+the single source from then on.
+
+---
+
+## 10. Relationship to [protocol.md](protocol.md)
+
+protocol.md remains the frozen **v1 wire** specification, and is still the runtime
+IPC for the native backends. This document supersedes its statements about the
+*storage/activation layer*, specifically:
+
+- **LSPosed does not consume the wire** — it reads the canonical JSON directly
+  (§3). protocol.md's "LSPosed parses its config profile from its file" / the
+  LSPosed rows in its channel + profile tables are superseded here.
+- **APatch boot is configurable** when the superkey is persisted (§6) — protocol.md
+  §7.4's "a boot script has no superkey, so it cannot configure" describes only the
+  no-persistence default.
+- **The app does not hand-build per-channel configs** — the activator does
+  (§4). The serialiser is the Rust `protocol` crate, shared with the Zygisk `.so`.
+
+The wire format itself (protocol.md §4–§5) is unchanged.

--- a/kmod/BUILDING.md
+++ b/kmod/BUILDING.md
@@ -58,7 +58,7 @@ Verify after reboot:
 ```bash
 adb shell "su -c 'lsmod | grep vpnhide'"
 adb shell "su -c 'dmesg | grep vpnhide'"
-adb shell "su -c 'cat /proc/vpnhide_targets'"
+adb shell "su -c 'cat /proc/vpnhide_ctl'"
 ```
 
 ## Troubleshooting
@@ -67,7 +67,7 @@ adb shell "su -c 'cat /proc/vpnhide_targets'"
 
 **`insmod: File exists`** — module already loaded. `rmmod vpnhide_kmod` first.
 
-**kretprobe not firing** — check `dmesg | grep vpnhide` for registration messages and `/proc/vpnhide_targets` for correct UIDs. Target app UIDs change on reinstall — re-resolve via the VPN Hide app.
+**kretprobe not firing** — check `dmesg | grep vpnhide` for registration messages and `/proc/vpnhide_ctl` for correct UIDs. Target app UIDs change on reinstall — re-resolve via the VPN Hide app.
 
 **`./kmod/build.py` says "neither podman nor docker found"** — install one (`dnf install podman` / `apt install docker.io`), or build natively against a local kernel source via `--kdir`.
 

--- a/kmod/README.md
+++ b/kmod/README.md
@@ -20,7 +20,7 @@ Zero footprint in the target app's process -- no modified function prologues, no
 | `rt6_fill_node` | Trims IPv6 VPN route entries from netlink route replies via `skb_trim` | IPv6 RTM_GETROUTE dumps/lookups |
 | `fib_nl_fill_rule` | Trims target-UID policy rules and VPN interface rules from netlink rule dumps via `skb_trim` | RTM_GETRULE policy routing dumps |
 
-All filtering is **per-UID**: only processes whose UID appears in `/proc/vpnhide_targets` see the filtered view. Everyone else (system services, VPN client, NFC subsystem) sees the real data.
+All filtering is **per-UID**: only processes whose UID is a `target` in the config written to `/proc/vpnhide_ctl` see the filtered view. Everyone else (system services, VPN client, NFC subsystem) sees the real data.
 
 ## Why kernel-level?
 
@@ -50,25 +50,25 @@ See [BUILDING.md](BUILDING.md) for the full guide (DDK Docker build, kernel sour
 
 On boot:
 - `post-fs-data.sh` runs `insmod` to load the kernel module
-- `service.sh` resolves package names from `targets.txt` to UIDs via `pm list packages -U` and writes them to `/proc/vpnhide_targets`
+- `service.sh` resolves package names from `targets.txt` to UIDs via `pm list packages -U` and emits a `vpnhide 1 config` snapshot (docs/protocol.md) to `/proc/vpnhide_ctl`
 
 ### Target management
 
-**VPN Hide app (recommended):** open the VPN Hide app (the [lsposed](../lsposed/) APK). It lists all installed apps with icons, search, and checkboxes. Saves targets for both kmod and zygisk, resolves UIDs, and writes to `/proc/vpnhide_targets` immediately. Works on both KernelSU and Magisk.
+**VPN Hide app (recommended):** open the VPN Hide app (the [lsposed](../lsposed/) APK). It lists all installed apps with icons, search, and checkboxes. Saves targets for every backend, resolves UIDs, and writes the config to `/proc/vpnhide_ctl` immediately. Works on both KernelSU and Magisk.
 
 **Shell:**
 ```bash
-# Write package names to the persistent config
+# Write package names to the persistent config (re-resolved at boot)
 adb shell su -c 'echo "com.example.targetapp" > /data/adb/vpnhide_kmod/targets.txt'
 
-# Or write UIDs directly to the kernel module
-adb shell su -c 'echo 10423 > /proc/vpnhide_targets'
+# Or push a control-config snapshot straight to the kernel (docs/protocol.md):
+# header + folded debug flag + one target line per UID (0x3ff = all hooks).
+adb shell su -c 'printf "vpnhide 1 config\ndebug 0\ntarget 0x28b7 0x3ff\n" > /proc/vpnhide_ctl'
 ```
 
-The app writes to **three places** simultaneously:
-1. `targets.txt` -- persistent package names (survives module updates)
-2. `/proc/vpnhide_targets` -- resolved UIDs for the kernel module (live, no reboot)
-3. `/data/system/vpnhide_uids.txt` -- resolved UIDs for the [lsposed](../lsposed/) module's system_server hooks (live reload via inotify)
+The app writes to **two layers** simultaneously:
+1. `targets.txt` -- persistent package names (survives module updates, re-resolved at boot)
+2. the runtime config channels -- a `vpnhide 1 config` snapshot of resolved UIDs: `/proc/vpnhide_ctl` for the kernel module (live, no reboot) and `/data/system/vpnhide_uids.txt` for the [lsposed](../lsposed/) module's system_server hooks (live reload via inotify)
 
 ## Combined use with system_server hooks
 

--- a/kmod/kpm/README.md
+++ b/kmod/kpm/README.md
@@ -118,7 +118,7 @@ Targeting / control plane: our target-UID set is delivered via the module's
 own `KPM_CTL0` supercall + load-args (the shape the QEMU harness exercises) —
 this is independent of KPatch-Next's generic `package_config` →
 `kpatch exclude_set <uid>` mechanism. The `.ko`'s
-`targets.txt` → `/proc/vpnhide_targets` → live-reload plane is the same idea;
+`targets.txt` → `/proc/vpnhide_ctl` → live-reload plane is the same idea;
 the matching procfs plane for the KPM is still TODO (see backlog).
 
 ## Safety — read before testing on a device

--- a/kmod/kpm/module/service.sh
+++ b/kmod/kpm/module/service.sh
@@ -9,9 +9,15 @@
 # config is applied by the app, not here (post-fs-data.sh set awaiting_superkey).
 
 KPM_TARGETS="/data/adb/vpnhide_kpm/targets.txt"
-KPM_DEBUG_LOGGING="/data/adb/vpnhide_kpm/debug_logging"
 LSPOSED_TARGETS="/data/adb/vpnhide_lsposed/targets.txt"
 SS_UIDS_FILE="/data/system/vpnhide_uids.txt"
+# Canonical persistent debug-logging flag (the one the app writes); folded into
+# the `debug` line of every config we emit (§4.3), same as the .ko/zygisk
+# scripts. Absent ⇒ off. The KPM has no separate debug file.
+SS_DEBUG_LOGGING="/data/system/vpnhide_debug_logging"
+
+DBG="$(cat "$SS_DEBUG_LOGGING" 2>/dev/null)"
+[ "$DBG" = 1 ] || DBG=0
 
 # Full kernel-owned hook mask (data/hooks.toml: ids 0..9). Per-hook control is
 # an app feature; the boot path enables all hooks for each target.
@@ -80,10 +86,7 @@ ${expanded}"; fi
 build_config() {
     local uid_list="$1"
     printf 'vpnhide 1 config\n'
-    if [ -f "$KPM_DEBUG_LOGGING" ]; then
-        d="$(tr -dc '01' < "$KPM_DEBUG_LOGGING" 2>/dev/null | cut -c1)"
-        [ -n "$d" ] && printf 'debug %s\n' "$d"
-    fi
+    printf 'debug %s\n' "$DBG"
     [ -z "$uid_list" ] && return
     echo "$uid_list" | while IFS= read -r uid; do
         [ -z "$uid" ] && continue
@@ -113,15 +116,10 @@ fi
 mkdir -p /data/adb/vpnhide_lsposed 2>/dev/null
 if [ -f "$LSPOSED_TARGETS" ]; then
     LSPOSED_UIDS="$(resolve_uids "$LSPOSED_TARGETS")"
-    if [ -n "$LSPOSED_UIDS" ]; then
-        echo "$LSPOSED_UIDS" > "$SS_UIDS_FILE"
-        count="$(echo "$LSPOSED_UIDS" | wc -l)"
-        log -t vpnhide "lsposed: wrote $count UIDs to $SS_UIDS_FILE"
-    else
-        echo > "$SS_UIDS_FILE"
-        log -t vpnhide "lsposed: no UIDs resolved"
-    fi
+    printf '%s\n' "$(build_config "$LSPOSED_UIDS")" > "$SS_UIDS_FILE"
     chmod 640 "$SS_UIDS_FILE"
     chown root:system "$SS_UIDS_FILE"
     chcon u:object_r:system_data_file:s0 "$SS_UIDS_FILE" 2>/dev/null
+    count="$(printf '%s\n' "$LSPOSED_UIDS" | grep -c .)"
+    log -t vpnhide "lsposed: wrote config for $count UIDs to $SS_UIDS_FILE"
 fi

--- a/kmod/kpm/vpnhide_kpm.c
+++ b/kmod/kpm/vpnhide_kpm.c
@@ -955,10 +955,8 @@ static long vpnhide_kpm_exit(void *__user reserved)
 		hook_unwrap((void *)fn, (void *)fib_rule_before,
 			    (void *)fib_rule_after);
 
-	if (_remove_proc_entry) {
-		_remove_proc_entry("vpnhide_targets", 0);
-		_remove_proc_entry("vpnhide_debug", 0);
-	}
+	/* No /proc node to remove: the KPM's control channel is the ctl0
+	 * supercall, not procfs (the optional mirror was never created). */
 	logki(MODNAME ": KPM unloaded\n");
 	return 0;
 }

--- a/kmod/module/service.sh
+++ b/kmod/module/service.sh
@@ -1,16 +1,37 @@
 #!/system/bin/sh
-# Resolves package names → UIDs for kmod and lsposed at boot.
-# kmod targets → /proc/vpnhide_targets
-# lsposed targets → /data/system/vpnhide_uids.txt
+# Resolves package names → UIDs at boot and writes a `vpnhide 1 config` snapshot
+# (docs/protocol.md) to each runtime channel — the same wire every backend
+# speaks. kmod config → /proc/vpnhide_ctl, lsposed config → vpnhide_uids.txt.
 
 KMOD_TARGETS="/data/adb/vpnhide_kmod/targets.txt"
 LSPOSED_TARGETS="/data/adb/vpnhide_lsposed/targets.txt"
-PROC_TARGETS="/proc/vpnhide_targets"
+PROC_CTL="/proc/vpnhide_ctl"
 SS_UIDS_FILE="/data/system/vpnhide_uids.txt"
+# Canonical persistent debug-logging flag; folded into the `debug` line of every
+# config we emit (§4.3). Absent ⇒ off (stealth-first default).
+SS_DEBUG_LOGGING="/data/system/vpnhide_debug_logging"
+
+DBG="$(cat "$SS_DEBUG_LOGGING" 2>/dev/null)"
+[ "$DBG" = 1 ] || DBG=0
+
+# Emit a `vpnhide 1 config` snapshot to stdout for a newline-separated UID list:
+# the header, the folded debug flag, and one `target <uid> 0x3ff` line per UID
+# (0x3ff = the full kernel hook mask). The whole snapshot must reach a backend
+# in ONE write (the /proc node parses per write), so callers capture this in a
+# variable and write it with a single redirect.
+emit_config() {
+    _uids="$1"
+    printf 'vpnhide 1 config\n'
+    printf 'debug %s\n' "$DBG"
+    [ -n "$_uids" ] && printf '%s\n' "$_uids" | while IFS= read -r u; do
+        [ -z "$u" ] && continue
+        printf 'target 0x%x 0x3ff\n' "$u"
+    done
+}
 
 # Wait for the proc entry (kernel module must be loaded)
 for i in 1 2 3 4 5 6 7 8 9 10; do
-    [ -f "$PROC_TARGETS" ] && break
+    [ -e "$PROC_CTL" ] && break
     sleep 1
 done
 
@@ -28,8 +49,8 @@ for i in $(seq 1 60); do
     sleep 1
 done
 
-if [ ! -f "$PROC_TARGETS" ]; then
-    log -t vpnhide "kernel module not loaded, skipping kmod UID resolution"
+if [ ! -e "$PROC_CTL" ]; then
+    log -t vpnhide "kernel module not loaded, skipping kmod config"
 fi
 
 # Migration: if lsposed targets don't exist yet, seed from kmod targets
@@ -76,19 +97,16 @@ ${expanded}"; fi
     [ -n "$uids" ] && echo "$uids"
 }
 
-# Resolve kmod targets → /proc/vpnhide_targets
-if [ -f "$PROC_TARGETS" ] && [ -f "$KMOD_TARGETS" ]; then
+# Resolve kmod targets → config snapshot → /proc/vpnhide_ctl (one write).
+if [ -e "$PROC_CTL" ] && [ -f "$KMOD_TARGETS" ]; then
     KMOD_UIDS="$(resolve_uids "$KMOD_TARGETS")"
-    if [ -n "$KMOD_UIDS" ]; then
-        echo "$KMOD_UIDS" > "$PROC_TARGETS"
-        count="$(echo "$KMOD_UIDS" | wc -l)"
-        log -t vpnhide "kmod: loaded $count target UIDs"
-    else
-        log -t vpnhide "kmod: no UIDs resolved"
-    fi
+    KMOD_CFG="$(emit_config "$KMOD_UIDS")"
+    printf '%s\n' "$KMOD_CFG" > "$PROC_CTL"
+    count="$(printf '%s\n' "$KMOD_UIDS" | grep -c .)"
+    log -t vpnhide "kmod: applied config for $count target UIDs (debug=$DBG)"
 fi
 
-# Resolve lsposed targets → /data/system/vpnhide_uids.txt
+# Resolve lsposed targets → config snapshot → /data/system/vpnhide_uids.txt
 # Create persist dir if needed (for first-time installs)
 mkdir -p /data/adb/vpnhide_lsposed 2>/dev/null
 # Mode 0640 + group=system: system_server (UID 1000, in group `system`)
@@ -97,19 +115,12 @@ mkdir -p /data/adb/vpnhide_lsposed 2>/dev/null
 # 0775 traversable by untrusted, so any o+r file is enumerable + readable.
 if [ -f "$LSPOSED_TARGETS" ]; then
     LSPOSED_UIDS="$(resolve_uids "$LSPOSED_TARGETS")"
-    if [ -n "$LSPOSED_UIDS" ]; then
-        echo "$LSPOSED_UIDS" > "$SS_UIDS_FILE"
-        chmod 640 "$SS_UIDS_FILE"
-        chown root:system "$SS_UIDS_FILE"
-        chcon u:object_r:system_data_file:s0 "$SS_UIDS_FILE" 2>/dev/null
-        count="$(echo "$LSPOSED_UIDS" | wc -l)"
-        log -t vpnhide "lsposed: wrote $count UIDs to $SS_UIDS_FILE"
-    else
-        echo > "$SS_UIDS_FILE"
-        chmod 640 "$SS_UIDS_FILE"
-        chown root:system "$SS_UIDS_FILE"
-        log -t vpnhide "lsposed: no UIDs resolved"
-    fi
+    printf '%s\n' "$(emit_config "$LSPOSED_UIDS")" > "$SS_UIDS_FILE"
+    chmod 640 "$SS_UIDS_FILE"
+    chown root:system "$SS_UIDS_FILE"
+    chcon u:object_r:system_data_file:s0 "$SS_UIDS_FILE" 2>/dev/null
+    count="$(printf '%s\n' "$LSPOSED_UIDS" | grep -c .)"
+    log -t vpnhide "lsposed: wrote config for $count UIDs to $SS_UIDS_FILE"
 fi
 
 # Migrate pre-PR files written by older versions with mode 0644: any
@@ -125,14 +136,7 @@ for f in "$SS_UIDS_FILE" \
     fi
 done
 
-# Re-seed /proc/vpnhide_debug from the persistent toggle flag the app
-# maintains. /proc/vpnhide_debug is per-boot in-kernel state — without
-# this re-seed, a user with "Debug logging" turned ON would silently
-# get OFF after every reboot until they re-opened the app (which is
-# what triggers the in-app re-propagation in MainActivity.onCreate).
-# Same model as targets.txt → /proc/vpnhide_targets above: persistent
-# file is canonical, /proc gets reseeded each boot.
-SS_DEBUG_LOGGING="/data/system/vpnhide_debug_logging"
-if [ -e /proc/vpnhide_debug ] && [ -f "$SS_DEBUG_LOGGING" ]; then
-    cat "$SS_DEBUG_LOGGING" > /proc/vpnhide_debug 2>/dev/null
-fi
+# The kmod debug flag is no longer a separate /proc node — it is the `debug`
+# line of the config snapshot written to /proc/vpnhide_ctl above (folded per
+# docs/protocol.md §4.3), sourced from $SS_DEBUG_LOGGING at the top of this
+# script. So there is nothing extra to re-seed here.

--- a/kmod/module/service.sh
+++ b/kmod/module/service.sh
@@ -68,7 +68,7 @@ ALL_PACKAGES="$(pm list packages -U --user all 2>/dev/null)"
 
 # resolve_uids <targets_file> — prints one UID per line to stdout.
 # Splits the comma-separated UID list so every profile's copy of the
-# target package ends up individually in /proc/vpnhide_targets.
+# target package becomes its own `target` line in the emitted config.
 resolve_uids() {
     local targets_file="$1"
     [ -f "$targets_file" ] || return

--- a/kmod/shared/vpnhide_logic.h
+++ b/kmod/shared/vpnhide_logic.h
@@ -130,7 +130,8 @@ vpnhide_compact_seq_lines(char *buf, unsigned long start, unsigned long count,
 /*
  * Parse a newline-separated list of decimal UIDs (with `#` comments and
  * blank lines) from `buf` into `out` (capacity `max`). Returns the count.
- * Pure string work — shared by both backends' /proc/vpnhide_targets writer.
+ * Pure string work for the legacy decimal load-args path (KPM bring-up + host
+ * tests). The protocol config channel uses vpnhide_parse_config instead.
  */
 static inline int
 vpnhide_parse_target_uids(const char *buf, unsigned long len,

--- a/kmod/test/init.sh
+++ b/kmod/test/init.sh
@@ -31,7 +31,15 @@ if apk add --no-cache iproute2 >/dev/null 2>&1; then echo "IPROUTE2=ok"; else ec
 if insmod /vpnhide_kmod.ko; then echo "INSMOD=ok"; else echo "INSMOD=FAIL"; fi
 REGISTERED=$(dmesg | grep -c 'vpnhide:.*registered')
 echo "REGISTERED=$REGISTERED"
-echo 1 > /proc/vpnhide_debug 2>/dev/null
+
+# Write a control-protocol config snapshot (docs/protocol.md) enabling every
+# kernel hook (mask 0x3ff) for a single UID, with debug logging on. Replaces
+# the old `echo <uid> > /proc/vpnhide_targets` + `echo 1 > /proc/vpnhide_debug`
+# — both folded into the one /proc/vpnhide_ctl node.
+set_target() {
+	printf 'vpnhide 1 config\ndebug 1\ntarget 0x%x 0x3ff\n' "$1" \
+		> /proc/vpnhide_ctl 2>/dev/null
+}
 
 # --- fabricate a VPN-like interface + routes + a per-uid policy rule ---------
 ip link add vpn0 type dummy 2>/dev/null
@@ -51,9 +59,9 @@ check() {
 	_name=$1
 	_cmd=$2
 	_pat=$3
-	echo 5555 > /proc/vpnhide_targets 2>/dev/null
+	set_target 5555
 	_nt=$(eval "$_cmd" 2>/dev/null | grep -c -- "$_pat")
-	echo 0 > /proc/vpnhide_targets 2>/dev/null
+	set_target 0
 	_tg=$(eval "$_cmd" 2>/dev/null | grep -c -- "$_pat")
 	if [ "$_nt" -gt 0 ] && [ "$_tg" -eq 0 ]; then
 		echo "RESULT $_name=PASS (nontarget=$_nt target=$_tg)"

--- a/kmod/vpnhide_kmod.c
+++ b/kmod/vpnhide_kmod.c
@@ -19,7 +19,12 @@
  *   - rt6_fill_node: filters IPv6 RTM_GETROUTE replies
  *   - fib_nl_fill_rule: filters policy routing rules for target UIDs
  *
- * Target UIDs are written to /proc/vpnhide_targets from userspace.
+ * Control plane: a single folded node /proc/vpnhide_ctl carries the shared
+ * control/stats protocol (docs/protocol.md). A write is a `vpnhide 1 config`
+ * snapshot (per-UID hook mask + debug flag); a read returns the backend
+ * `status` + `stats`. This replaces the old /proc/vpnhide_targets (decimal UID
+ * list) and /proc/vpnhide_debug nodes — the same wire format every backend now
+ * speaks (parser shared verbatim with the KPM via shared/vpnhide_logic.h).
  *
  * Architecture: arm64 only. The handlers read syscall arguments via
  * `regs->regs[N]` (AAPCS64 calling convention). On other architectures
@@ -52,6 +57,8 @@
 #include <net/fib_rules.h>
 
 #include "generated/iface_lists.h"
+#include "generated/hook_ids.h"
+#include "shared/vpnhide_logic.h"
 
 #ifndef CONFIG_ARM64
 #error "vpnhide_kmod currently supports only arm64 (handlers read regs->regs[N] directly)"
@@ -75,16 +82,16 @@
 #define VPNHIDE_KRETPROBE_MAXACTIVE 64
 
 /* ------------------------------------------------------------------ */
-/*  Debug logging — toggled via /proc/vpnhide_debug                   */
+/*  Debug logging — folded into the /proc/vpnhide_ctl config snapshot  */
 /* ------------------------------------------------------------------ */
 
 static bool debug_enabled;
 
 /*
- * `debug_enabled` is a single bool, written from /proc/vpnhide_debug
- * and read from every probe handler. Use READ_ONCE/WRITE_ONCE so the
- * compiler doesn't tear the access or hoist it across the probe-hot
- * path — kosher kernel style for unsynchronised flags.
+ * `debug_enabled` is a single bool, set from the `debug` line of a config
+ * snapshot written to /proc/vpnhide_ctl and read from every probe handler.
+ * Use READ_ONCE/WRITE_ONCE so the compiler doesn't tear the access or hoist
+ * it across the probe-hot path — kosher kernel style for unsynchronised flags.
  */
 #define vpnhide_dbg(fmt, ...)                                     \
 	do {                                                      \
@@ -99,40 +106,56 @@ static bool debug_enabled;
 #define is_vpn_ifname(name) vpnhide_iface_is_vpn(name)
 
 /* ------------------------------------------------------------------ */
-/*  Target UID list                                                   */
+/*  Live config (control protocol §4.3)                               */
+/*                                                                    */
+/*  Each target carries a per-hook mask so the app can enable hooks   */
+/*  individually; a hook fires only when its bit is set for the       */
+/*  calling UID. Written via /proc/vpnhide_ctl; the same `vpnhide      */
+/*  target` struct + parser the KPM uses (shared/vpnhide_logic.h).    */
 /* ------------------------------------------------------------------ */
 
-static uid_t target_uids[MAX_TARGET_UIDS];
-static int nr_target_uids;
-static DEFINE_SPINLOCK(uids_lock);
+static struct vpnhide_target targets[MAX_TARGET_UIDS];
+static int nr_targets;
+static DEFINE_SPINLOCK(targets_lock);
 
-static bool is_target_uid(void)
+/* The enabled-hook mask for the calling UID (0 if it is not a target). */
+static u32 target_mask(void)
 {
 	uid_t uid = from_kuid(&init_user_ns, current_uid());
-	bool found = false;
+	u32 mask = 0;
 	int i;
 
-	spin_lock(&uids_lock);
-	for (i = 0; i < nr_target_uids; i++) {
-		if (target_uids[i] == uid) {
-			found = true;
+	spin_lock(&targets_lock);
+	for (i = 0; i < nr_targets; i++) {
+		if (targets[i].uid == uid) {
+			mask = targets[i].hookmask;
 			break;
 		}
 	}
-	spin_unlock(&uids_lock);
-	return found;
+	spin_unlock(&targets_lock);
+	return mask;
+}
+
+/* True if `hook_id` is enabled for the calling UID (per-hook gate, §4.3).
+ * The .ko owns the full kernel hook mask, so it never masks foreign bits. */
+static bool hook_active(u32 hook_id)
+{
+	return (target_mask() & (1u << hook_id)) != 0;
 }
 
 /* ------------------------------------------------------------------ */
-/*  /proc/vpnhide_targets                                             */
+/*  /proc/vpnhide_ctl — the folded control + stats channel            */
 /* ------------------------------------------------------------------ */
 
-static ssize_t targets_write(struct file *file, const char __user *ubuf,
-			     size_t count, loff_t *ppos)
+/* Forward decl: the probe registration table drives the `status` hooks mask. */
+static u32 installed_hook_mask(void);
+
+static ssize_t ctl_write(struct file *file, const char __user *ubuf,
+			 size_t count, loff_t *ppos)
 {
-	char *buf, *line, *next;
-	int new_count = 0;
-	uid_t new_uids[MAX_TARGET_UIDS];
+	char *buf;
+	struct vpnhide_target newt[MAX_TARGET_UIDS];
+	int n, dbg;
 
 	if (count > PAGE_SIZE)
 		return -EINVAL;
@@ -147,92 +170,65 @@ static ssize_t targets_write(struct file *file, const char __user *ubuf,
 	}
 	buf[count] = '\0';
 
-	for (line = buf; line && *line && new_count < MAX_TARGET_UIDS;
-	     line = next) {
-		unsigned long uid;
-
-		next = strchr(line, '\n');
-		if (next)
-			*next++ = '\0';
-
-		while (*line == ' ' || *line == '\t')
-			line++;
-		if (!*line || *line == '#')
-			continue;
-
-		if (kstrtoul(line, 10, &uid) == 0)
-			new_uids[new_count++] = (uid_t)uid;
-	}
-
-	spin_lock(&uids_lock);
-	memcpy(target_uids, new_uids, new_count * sizeof(uid_t));
-	nr_target_uids = new_count;
-	spin_unlock(&uids_lock);
-
+	/* Seed `dbg` with the live value so an absent `debug` line means
+	 * "unchanged from current", per §4.3. */
+	dbg = READ_ONCE(debug_enabled) ? 1 : 0;
+	n = vpnhide_parse_config(buf, count, newt, MAX_TARGET_UIDS, &dbg);
 	kfree(buf);
-	pr_info(MODNAME ": loaded %d target UIDs\n", new_count);
+
+	/* A payload with no valid header / a too-new version is rejected
+	 * whole (§3) — a loud -EINVAL, never a silent partial wipe. */
+	if (n < 0)
+		return -EINVAL;
+
+	spin_lock(&targets_lock);
+	memcpy(targets, newt, (size_t)n * sizeof(*targets));
+	nr_targets = n;
+	spin_unlock(&targets_lock);
+	WRITE_ONCE(debug_enabled, dbg ? true : false);
+
+	pr_info(MODNAME ": config applied — %d targets, debug=%d\n", n, dbg);
 	return count;
 }
 
-static int targets_show(struct seq_file *m, void *v)
+/*
+ * Read side: a self-documenting banner + `status` + `stats` (§4.3/§7.1).
+ * The shared formatters render into a stack buffer which we hand to seq_file.
+ * Stats counters are not yet maintained (same TODO as the KPM): emit a valid
+ * empty `stats` snapshot so the channel + format are wired and the app can
+ * already read status.
+ */
+static int ctl_show(struct seq_file *m, void *v)
 {
-	int i;
+	char buf[256];
+	struct vpnhide_status st;
+	unsigned long len;
 
-	spin_lock(&uids_lock);
-	for (i = 0; i < nr_target_uids; i++)
-		seq_printf(m, "%u\n", target_uids[i]);
-	spin_unlock(&uids_lock);
+	seq_puts(m, VPNHIDE_READ_BANNER);
+
+	st.backend = VPNHIDE_BACKEND_KMOD;
+	st.kver = LINUX_VERSION_CODE;
+	st.hooks = installed_hook_mask();
+	st.error = (st.hooks == VPNHIDE_KERNEL_HOOK_MASK) ?
+			   VPNHIDE_ERR_OK :
+			   VPNHIDE_ERR_PARTIAL_HOOKS;
+	len = vpnhide_format_status(buf, sizeof(buf), &st);
+	seq_write(m, buf, min_t(size_t, len, sizeof(buf)));
+
+	len = vpnhide_format_stats(buf, sizeof(buf), NULL, 0);
+	seq_write(m, buf, min_t(size_t, len, sizeof(buf)));
 	return 0;
 }
 
-static int targets_open(struct inode *inode, struct file *file)
+static int ctl_open(struct inode *inode, struct file *file)
 {
-	return single_open(file, targets_show, NULL);
+	return single_open(file, ctl_show, NULL);
 }
 
-static const struct proc_ops targets_proc_ops = {
-	.proc_open = targets_open,
+static const struct proc_ops ctl_proc_ops = {
+	.proc_open = ctl_open,
 	.proc_read = seq_read,
-	.proc_write = targets_write,
-	.proc_lseek = seq_lseek,
-	.proc_release = single_release,
-};
-
-/* ------------------------------------------------------------------ */
-/*  /proc/vpnhide_debug                                               */
-/* ------------------------------------------------------------------ */
-
-static ssize_t debug_write(struct file *file, const char __user *ubuf,
-			   size_t count, loff_t *ppos)
-{
-	char c;
-
-	if (count == 0)
-		return 0;
-	if (get_user(c, ubuf))
-		return -EFAULT;
-
-	WRITE_ONCE(debug_enabled, c == '1' || c == 'Y' || c == 'y');
-	pr_info(MODNAME ": debug %s\n",
-		READ_ONCE(debug_enabled) ? "enabled" : "disabled");
-	return count;
-}
-
-static int debug_show(struct seq_file *m, void *v)
-{
-	seq_printf(m, "%d\n", READ_ONCE(debug_enabled) ? 1 : 0);
-	return 0;
-}
-
-static int debug_open(struct inode *inode, struct file *file)
-{
-	return single_open(file, debug_show, NULL);
-}
-
-static const struct proc_ops debug_proc_ops = {
-	.proc_open = debug_open,
-	.proc_read = seq_read,
-	.proc_write = debug_write,
+	.proc_write = ctl_write,
 	.proc_lseek = seq_lseek,
 	.proc_release = single_release,
 };
@@ -267,7 +263,7 @@ static int dev_ioctl_entry(struct kretprobe_instance *ri, struct pt_regs *regs)
 
 	data->cmd = (unsigned int)regs->regs[1];
 	data->kifr = (struct ifreq *)regs->regs[2];
-	data->active = is_target_uid();
+	data->active = hook_active(VPNHIDE_HOOK_DEV_IOCTL);
 
 	vpnhide_dbg("dev_ioctl_entry: uid=%u target=%d cmd=0x%x\n",
 		    from_kuid(&init_user_ns, current_uid()), data->active,
@@ -340,7 +336,7 @@ static struct kretprobe dev_ioctl_krp = {
 /*  arm64: x0=file, x1=cmd, x2=arg (__user ptr)                      */
 /*                                                                    */
 /*  Performance: entry handler checks cmd == SIOCGIFCONF first (one   */
-/*  compare), then is_target_uid(). For all other ioctls, overhead    */
+/*  compare), then hook_active(). For all other ioctls, overhead      */
 /*  is a single branch. SIOCGIFCONF is rare (once per getifaddrs).    */
 /* ================================================================== */
 
@@ -358,7 +354,7 @@ static int sock_ioctl_entry(struct kretprobe_instance *ri, struct pt_regs *regs)
 
 	if (cmd != SIOCGIFCONF)
 		return 0;
-	if (!is_target_uid())
+	if (!hook_active(VPNHIDE_HOOK_SOCK_IOCTL))
 		return 0;
 
 	data->target = true;
@@ -507,7 +503,7 @@ static int rtnl_fill_entry(struct kretprobe_instance *ri, struct pt_regs *regs)
 
 	data->should_filter = false;
 
-	if (!is_target_uid()) {
+	if (!hook_active(VPNHIDE_HOOK_RTNL_FILL_IFINFO)) {
 		vpnhide_dbg("rtnl_fill_entry: uid=%u target=0\n",
 			    from_kuid(&init_user_ns, current_uid()));
 		return 0;
@@ -592,7 +588,7 @@ static int inet6_fill_entry(struct kretprobe_instance *ri, struct pt_regs *regs)
 
 	data->should_filter = false;
 
-	if (!is_target_uid())
+	if (!hook_active(VPNHIDE_HOOK_INET6_FILL_IFADDR))
 		return 0;
 
 	ifa = (struct inet6_ifaddr *)regs->regs[1];
@@ -661,7 +657,7 @@ static int inet_fill_entry(struct kretprobe_instance *ri, struct pt_regs *regs)
 
 	data->should_filter = false;
 
-	if (!is_target_uid())
+	if (!hook_active(VPNHIDE_HOOK_INET_FILL_IFADDR))
 		return 0;
 
 	ifa = (struct in_ifaddr *)regs->regs[1];
@@ -730,7 +726,7 @@ static int fib_route_entry(struct kretprobe_instance *ri, struct pt_regs *regs)
 	 * return handler knows where this call's output begins.
 	 */
 	data->seq = (struct seq_file *)regs->regs[0];
-	data->target = is_target_uid();
+	data->target = hook_active(VPNHIDE_HOOK_FIB_ROUTE_SEQ_SHOW);
 
 	if (data->target && data->seq) {
 		data->start_count = data->seq->count;
@@ -827,7 +823,7 @@ static int ipv6_route_entry(struct kretprobe_instance *ri, struct pt_regs *regs)
 	struct fib_route_data *data = (void *)ri->data;
 
 	data->seq = (struct seq_file *)regs->regs[0];
-	data->target = is_target_uid();
+	data->target = hook_active(VPNHIDE_HOOK_IPV6_ROUTE_SEQ_SHOW);
 
 	if (data->target && data->seq) {
 		data->start_count = data->seq->count;
@@ -1149,7 +1145,7 @@ static int fib_dump_entry(struct kretprobe_instance *ri, struct pt_regs *regs)
 
 	init_route_skb_data(data);
 
-	if (!is_target_uid() || !fri)
+	if (!hook_active(VPNHIDE_HOOK_FIB_DUMP_INFO) || !fri)
 		return 0;
 	if (copy_from_kernel_nofault(&fri_copy, fri, sizeof(fri_copy)) != 0)
 		return 0;
@@ -1204,7 +1200,7 @@ static int rt6_fill_entry(struct kretprobe_instance *ri, struct pt_regs *regs)
 
 	init_route_skb_data(data);
 
-	if (!is_target_uid())
+	if (!hook_active(VPNHIDE_HOOK_RT6_FILL_NODE))
 		return 0;
 
 	rcu_read_lock();
@@ -1285,7 +1281,7 @@ static int fib_rule_fill_entry(struct kretprobe_instance *ri,
 
 	init_route_skb_data(data);
 
-	if (!is_target_uid() || !rule)
+	if (!hook_active(VPNHIDE_HOOK_FIB_NL_FILL_RULE) || !rule)
 		return 0;
 	if (copy_from_kernel_nofault(&rule_copy, rule, sizeof(rule_copy)) != 0)
 		return 0;
@@ -1342,27 +1338,39 @@ static struct kretprobe fib_rule_fill_krp = {
 /*  Module init / exit                                                */
 /* ================================================================== */
 
-static struct proc_dir_entry *targets_entry;
-static struct proc_dir_entry *debug_entry;
+static struct proc_dir_entry *ctl_entry;
 
 struct kretprobe_reg {
 	struct kretprobe *krp;
 	const char *name;
+	u32 hook_id; /* registry id (generated/hook_ids.h) — for the status mask */
 	bool registered;
 };
 
 static struct kretprobe_reg probes[] = {
-	{ &dev_ioctl_krp, "dev_ioctl", false },
-	{ &sock_ioctl_krp, "sock_ioctl", false },
-	{ &rtnl_fill_krp, "rtnl_fill_ifinfo", false },
-	{ &inet6_fill_krp, "inet6_fill_ifaddr", false },
-	{ &inet_fill_krp, "inet_fill_ifaddr", false },
-	{ &fib_route_krp, "fib_route_seq_show", false },
-	{ &ipv6_route_krp, "ipv6_route_seq_show", false },
-	{ &fib_dump_krp, "fib_dump_info", false },
-	{ &rt6_fill_krp, "rt6_fill_node", false },
-	{ &fib_rule_fill_krp, "fib_nl_fill_rule", false },
+	{ &dev_ioctl_krp, "dev_ioctl", VPNHIDE_HOOK_DEV_IOCTL, false },
+	{ &sock_ioctl_krp, "sock_ioctl", VPNHIDE_HOOK_SOCK_IOCTL, false },
+	{ &rtnl_fill_krp, "rtnl_fill_ifinfo", VPNHIDE_HOOK_RTNL_FILL_IFINFO, false },
+	{ &inet6_fill_krp, "inet6_fill_ifaddr", VPNHIDE_HOOK_INET6_FILL_IFADDR, false },
+	{ &inet_fill_krp, "inet_fill_ifaddr", VPNHIDE_HOOK_INET_FILL_IFADDR, false },
+	{ &fib_route_krp, "fib_route_seq_show", VPNHIDE_HOOK_FIB_ROUTE_SEQ_SHOW, false },
+	{ &ipv6_route_krp, "ipv6_route_seq_show", VPNHIDE_HOOK_IPV6_ROUTE_SEQ_SHOW, false },
+	{ &fib_dump_krp, "fib_dump_info", VPNHIDE_HOOK_FIB_DUMP_INFO, false },
+	{ &rt6_fill_krp, "rt6_fill_node", VPNHIDE_HOOK_RT6_FILL_NODE, false },
+	{ &fib_rule_fill_krp, "fib_nl_fill_rule", VPNHIDE_HOOK_FIB_NL_FILL_RULE, false },
 };
+
+/* Bitset of hooks that actually registered — the `status` hooks mask (§4.3). */
+static u32 installed_hook_mask(void)
+{
+	u32 mask = 0;
+	int i;
+
+	for (i = 0; i < ARRAY_SIZE(probes); i++)
+		if (probes[i].registered)
+			mask |= (1u << probes[i].hook_id);
+	return mask;
+}
 
 static int __init vpnhide_init(void)
 {
@@ -1390,27 +1398,23 @@ static int __init vpnhide_init(void)
 				"some detection paths are not covered\n",
 			ok, ARRAY_SIZE(probes));
 
-	/* 0600: root-only read/write. UIDs are written here by service.sh
-	 * and the VPN Hide app (both root). Apps must not see the target list. */
-	targets_entry =
-		proc_create("vpnhide_targets", 0600, NULL, &targets_proc_ops);
-	if (!targets_entry) {
-		/* Without /proc/vpnhide_targets userspace cannot configure
-		 * the target UID list, so the module would silently filter
-		 * nothing — fail loudly instead of pretending to work. */
-		pr_err(MODNAME
-		       ": proc_create(vpnhide_targets) failed; aborting\n");
+	/* 0600: root-only read/write. The config snapshot is written here by
+	 * service.sh and the VPN Hide app (both root). Apps must not see the
+	 * control channel. (Renamed from vpnhide_targets for semantic accuracy
+	 * — it is now control+stats, not just targets, §OPEN-4.) */
+	ctl_entry = proc_create("vpnhide_ctl", 0600, NULL, &ctl_proc_ops);
+	if (!ctl_entry) {
+		/* Without /proc/vpnhide_ctl userspace cannot configure the
+		 * target list, so the module would silently filter nothing —
+		 * fail loudly instead of pretending to work. */
+		pr_err(MODNAME ": proc_create(vpnhide_ctl) failed; aborting\n");
 		for (i = 0; i < ARRAY_SIZE(probes); i++)
 			if (probes[i].registered)
 				unregister_kretprobe(probes[i].krp);
 		return -ENOMEM;
 	}
-	debug_entry = proc_create("vpnhide_debug", 0600, NULL, &debug_proc_ops);
-	if (!debug_entry)
-		pr_warn(MODNAME
-			": proc_create(vpnhide_debug) failed; debug toggle unavailable\n");
 
-	pr_info(MODNAME ": loaded — write UIDs to /proc/vpnhide_targets\n");
+	pr_info(MODNAME ": loaded — write a config snapshot to /proc/vpnhide_ctl\n");
 	return 0;
 }
 
@@ -1418,10 +1422,8 @@ static void __exit vpnhide_exit(void)
 {
 	int i;
 
-	if (debug_entry)
-		proc_remove(debug_entry);
-	if (targets_entry)
-		proc_remove(targets_entry);
+	if (ctl_entry)
+		proc_remove(ctl_entry);
 
 	for (i = 0; i < ARRAY_SIZE(probes); i++) {
 		if (probes[i].registered) {

--- a/kmod/vpnhide_kmod.c
+++ b/kmod/vpnhide_kmod.c
@@ -1350,14 +1350,20 @@ struct kretprobe_reg {
 static struct kretprobe_reg probes[] = {
 	{ &dev_ioctl_krp, "dev_ioctl", VPNHIDE_HOOK_DEV_IOCTL, false },
 	{ &sock_ioctl_krp, "sock_ioctl", VPNHIDE_HOOK_SOCK_IOCTL, false },
-	{ &rtnl_fill_krp, "rtnl_fill_ifinfo", VPNHIDE_HOOK_RTNL_FILL_IFINFO, false },
-	{ &inet6_fill_krp, "inet6_fill_ifaddr", VPNHIDE_HOOK_INET6_FILL_IFADDR, false },
-	{ &inet_fill_krp, "inet_fill_ifaddr", VPNHIDE_HOOK_INET_FILL_IFADDR, false },
-	{ &fib_route_krp, "fib_route_seq_show", VPNHIDE_HOOK_FIB_ROUTE_SEQ_SHOW, false },
-	{ &ipv6_route_krp, "ipv6_route_seq_show", VPNHIDE_HOOK_IPV6_ROUTE_SEQ_SHOW, false },
+	{ &rtnl_fill_krp, "rtnl_fill_ifinfo", VPNHIDE_HOOK_RTNL_FILL_IFINFO,
+	  false },
+	{ &inet6_fill_krp, "inet6_fill_ifaddr", VPNHIDE_HOOK_INET6_FILL_IFADDR,
+	  false },
+	{ &inet_fill_krp, "inet_fill_ifaddr", VPNHIDE_HOOK_INET_FILL_IFADDR,
+	  false },
+	{ &fib_route_krp, "fib_route_seq_show", VPNHIDE_HOOK_FIB_ROUTE_SEQ_SHOW,
+	  false },
+	{ &ipv6_route_krp, "ipv6_route_seq_show",
+	  VPNHIDE_HOOK_IPV6_ROUTE_SEQ_SHOW, false },
 	{ &fib_dump_krp, "fib_dump_info", VPNHIDE_HOOK_FIB_DUMP_INFO, false },
 	{ &rt6_fill_krp, "rt6_fill_node", VPNHIDE_HOOK_RT6_FILL_NODE, false },
-	{ &fib_rule_fill_krp, "fib_nl_fill_rule", VPNHIDE_HOOK_FIB_NL_FILL_RULE, false },
+	{ &fib_rule_fill_krp, "fib_nl_fill_rule", VPNHIDE_HOOK_FIB_NL_FILL_RULE,
+	  false },
 };
 
 /* Bitset of hooks that actually registered — the `status` hooks mask (§4.3). */
@@ -1414,7 +1420,8 @@ static int __init vpnhide_init(void)
 		return -ENOMEM;
 	}
 
-	pr_info(MODNAME ": loaded — write a config snapshot to /proc/vpnhide_ctl\n");
+	pr_info(MODNAME
+		": loaded — write a config snapshot to /proc/vpnhide_ctl\n");
 	return 0;
 }
 

--- a/lsposed/AGENTS.md
+++ b/lsposed/AGENTS.md
@@ -27,9 +27,19 @@ reinvent them.** `grep` for an existing helper before writing a new one.
 - **`ShellUtils`** — `suExec`/`suExecAsync`, and the parsers `parseConfigLines`,
   `parseKeyValueLines`, `parsePackageUidMap`. **Never write another `pm list`
   or `key=value` parser** — there used to be four; there is now one of each.
-- **`ShellCommandBuilders`** — `buildConfigWriteCommand` / `managedConfigBody` /
-  `systemDataFilePermsParts` / `buildUidResolverCommand`. Every managed-config
-  file write goes through here so the on-disk format lives in one place.
+- **`ConfigChannels`** — the single serialiser of the `vpnhide 1 config` wire
+  (docs/protocol.md) and the one place that fans it to every runtime channel
+  (kmod `/proc/vpnhide_ctl`, the zygisk module dir, the system_server UID file).
+  Save, the debug toggle, and the startup reconcile all go through it. **Don't
+  hand-build a config snapshot anywhere else** — use `Protocol.formatConfig` via
+  this object.
+- **`ShellCommandBuilders`** — `buildRawWriteCommand` (the base64 `echo | base64
+  -d > path` primitive every file write uses), `buildConfigWriteCommand` /
+  `managedConfigBody` (the persistent **package-list** files, NOT the wire),
+  `systemDataFilePermsParts`, and `buildUidResolverCommand` (now only the
+  observer-UID file — the app-hiding "A" role; it is **not** the target-config
+  path anymore, that's `ConfigChannels`). The persistent package lists and the
+  resolved-UID runtime channels are deliberately separate (protocol §1.2).
 - **`TargetPickerScaffold`** — `TargetPickerScreen<T>`, `TargetRowShell`,
   `TargetChip`, `AppListScrollbar`. All three picker screens (tun / hiding /
   ports) are thin configs over this; a new picker is too.

--- a/lsposed/README.md
+++ b/lsposed/README.md
@@ -41,7 +41,7 @@ The APK includes a Compose UI for managing target apps across all vpnhide module
   - `/data/adb/vpnhide_kmod/targets.txt` (if kmod is installed)
   - `/data/adb/vpnhide_zygisk/targets.txt` (if zygisk is installed)
   - `/data/adb/modules/vpnhide_zygisk/targets.txt` (Magisk module dir copy)
-  - `/proc/vpnhide_targets` (kmod live update, no reboot needed)
+  - `/proc/vpnhide_ctl` (kmod live update, no reboot needed)
   - `/data/system/vpnhide_uids.txt` (system_server hooks, live reload via inotify)
 
 Works on KernelSU, Magisk, and any other root solution.

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/AppPickerScreen.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/AppPickerScreen.kt
@@ -91,12 +91,16 @@ fun AppPickerScreen(
         countText = { entries, res ->
             res.getString(R.string.selected_count, entries.count { it.anySelected })
         },
-        buildSaveCommand = { entries, selfPkg, header ->
-            val javaPkgs = (entries.filter { it.java }.map { it.packageName } + selfPkg).distinct().sorted()
-            val nativePkgs = (entries.filter { it.native }.map { it.packageName } + selfPkg).distinct().sorted()
+        buildSaveCommand = { entries, ctx ->
+            val javaPkgs = (entries.filter { it.java }.map { it.packageName } + ctx.selfPkg).distinct().sorted()
+            val nativePkgs = (entries.filter { it.native }.map { it.packageName } + ctx.selfPkg).distinct().sorted()
             val observerPkgs = entries.filter { it.appHiding }.map { it.packageName }.sorted()
             val portsPkgs = entries.filter { it.ports }.map { it.packageName }.sorted()
-            buildUnifiedSaveCommand(header, javaPkgs, nativePkgs, observerPkgs, portsPkgs, selfPkg)
+            // Resolved UIDs for the runtime config channels (entries carry their
+            // all-profile UIDs; self is added explicitly — it's never a row).
+            val javaUids = (entries.filter { it.java }.flatMap { it.userIds } + ctx.selfUids).distinct()
+            val nativeUids = (entries.filter { it.native }.flatMap { it.userIds } + ctx.selfUids).distinct()
+            buildUnifiedSaveCommand(ctx, javaPkgs, nativePkgs, javaUids, nativeUids, observerPkgs, portsPkgs)
         },
         successMessage = { entries, res ->
             res.getString(R.string.save_success, entries.count { it.anySelected })
@@ -133,36 +137,34 @@ fun AppPickerScreen(
 }
 
 /**
- * Build the single root command that persists every role at once.
+ * Build the single root command that persists every role at once. Two layers,
+ * kept apart (protocol §1.2):
  *
- *  - Java   -> LSPosed targets file + system_server UID file.
- *  - Native -> one list written to every installed backend (kmod /proc + file,
- *              Zygisk file + module mirror, KPM file). Only the active backend
- *              acts (§1.5).
- *  - App-hiding -> observer UID file + the (auto-detected) hidden-package file.
- *  - Ports  -> observers file + apply script, when the ports module is present.
+ *  - **Persistent PACKAGE lists** (the per-backend `targets.txt`) — survive reinstall, feed
+ *    the picker + boot re-resolution. One per backend; NOT the wire protocol.
+ *  - **Runtime CONFIG channels** — the resolved-UID `vpnhide 1 config` wire,
+ *    serialised once via [ConfigChannels]: the Java set to the LSPosed channel,
+ *    the native set fanned to every installed native backend (only the active
+ *    one acts, §1.5; the KPM boot-applies from its package list — live ctl0
+ *    push is a TODO).
+ *  - **App-hiding** (observer UID file + hidden-package file) and **Ports**
+ *    (observers + apply script) stay NON-protocol, written as before.
  */
 private fun buildUnifiedSaveCommand(
-    header: String,
+    ctx: SaveContext,
     javaPkgs: List<String>,
     nativePkgs: List<String>,
+    javaUids: List<Int>,
+    nativeUids: List<Int>,
     observerPkgs: List<String>,
     portsPkgs: List<String>,
-    selfPkg: String,
 ): String {
+    val header = ctx.header
     val parts = mutableListOf<String>()
 
-    // --- Java (LSPosed) ---
+    // --- Persistent PACKAGE lists ---
     parts += "mkdir -p /data/adb/vpnhide_lsposed"
     parts += "${buildConfigWriteCommand(LSPOSED_TARGETS, header, javaPkgs)} && chmod 644 $LSPOSED_TARGETS"
-    if (javaPkgs.isNotEmpty()) {
-        parts += buildUidResolverCommand(javaPkgs, SS_UIDS_FILE)
-    } else {
-        parts += "echo > $SS_UIDS_FILE 2>/dev/null"
-    }
-    parts += systemDataFilePermsParts(SS_UIDS_FILE, "640")
-
-    // --- Native: one list, fanned out to every installed backend ---
     parts +=
         "if [ -d /data/adb/vpnhide_kmod ]; then ${buildConfigWriteCommand(KMOD_TARGETS, header, nativePkgs)} && chmod 644 $KMOD_TARGETS; fi"
     parts +=
@@ -171,22 +173,16 @@ private fun buildUnifiedSaveCommand(
             header,
             nativePkgs,
         )} && chmod 644 $ZYGISK_TARGETS; fi"
-    parts += "cp $ZYGISK_TARGETS $ZYGISK_MODULE_TARGETS 2>/dev/null; true"
     parts +=
         "if [ -d /data/adb/vpnhide_kpm ]; then ${buildConfigWriteCommand(KPM_TARGETS, header, nativePkgs)} && chmod 644 $KPM_TARGETS; fi"
-    // kmod live-applies via /proc; resolve native UIDs there. The KPM applies
-    // its targets at boot from the file above — a live `kpatch kpm ctl0` push
-    // needs the runtime CLI + (APatch) superkey and lands with the on-device
-    // KPM integration (TODO).
-    if (nativePkgs.isNotEmpty()) {
-        parts += buildUidResolverCommand(nativePkgs, PROC_TARGETS)
-    } else {
-        parts += "echo > $PROC_TARGETS 2>/dev/null; true"
-    }
+
+    // --- Runtime CONFIG channels (the `vpnhide 1 config` wire) ---
+    parts += ConfigChannels.javaWriteParts(ctx.debug, javaUids)
+    parts += ConfigChannels.nativeWriteParts(ctx.debug, nativeUids)
 
     // --- App hiding: observers (A) + hidden packages (auto-detected, stub) ---
     val existingHidden = TargetsCache.snapshot.value?.hiddenPkgs ?: emptySet()
-    val hiddenPkgs = resolveHiddenPackages(existingHidden, observerPkgs.toSet(), selfPkg)
+    val hiddenPkgs = resolveHiddenPackages(existingHidden, observerPkgs.toSet(), ctx.selfPkg)
     parts += appHidingSaveParts(header, hiddenPkgs, observerPkgs)
 
     // --- Ports (only when the module is installed) ---

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/ConfigChannels.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/ConfigChannels.kt
@@ -1,0 +1,108 @@
+package dev.okhsunrog.vpnhide
+
+import android.content.Context
+import dev.okhsunrog.vpnhide.generated.HookIds
+
+/**
+ * The single place that turns a desired target set into the §4 control-config
+ * wire (docs/protocol.md) and fans it to every backend's RUNTIME channel. This
+ * is the app's serialiser end (protocol §1.4) — [Protocol.formatConfig] is the
+ * one Kotlin serialiser, parity-tested against the C/Rust sides by the golden
+ * vectors. Save, the debug toggle, and the startup reconcile all go through
+ * here, so there is exactly one config-emission path in the app.
+ *
+ * Two storage layers are kept apart (protocol §1.2):
+ *  - **Persistent PACKAGE lists** (the per-backend `targets.txt`) — NOT
+ *    protocol. They survive
+ *    reinstall and feed the picker + boot re-resolution. Written elsewhere via
+ *    [buildConfigWriteCommand].
+ *  - **Runtime CONFIG channels** (here) — resolved UIDs in the `vpnhide 1
+ *    config` wire:
+ *      - kmod   → `/proc/vpnhide_ctl`           (live, kernel reads on write)
+ *      - zygisk → module-dir `targets.txt`      (read by the .so via dir-fd)
+ *      - lsposed → `/data/system/vpnhide_uids.txt` (read by system_server)
+ *      - KPM    → live `ctl0` push is a TODO; it boot-applies from its package
+ *                 list, so Save/reconcile only refresh the persistent list.
+ */
+internal object ConfigChannels {
+    // The hookmask written for every target: the full kernel hook mask. Kernel
+    // backends gate per-hook on it; zygisk/lsposed own no registry bits yet, so
+    // they act on target *presence* and ignore it (protocol §6 note).
+    private val FULL_MASK = HookIds.KERNEL_HOOK_MASK.toLong()
+
+    /** A `vpnhide 1 config` snapshot for [uids] with [debug] folded in (§4.3). */
+    fun config(
+        debug: Boolean,
+        uids: Collection<Int>,
+    ): String =
+        Protocol.formatConfig(
+            debug,
+            uids.toSortedSet().map { Protocol.Target(it.toLong(), FULL_MASK) },
+        )
+
+    /**
+     * Shell parts writing the native config to every installed native runtime
+     * channel: the kmod `/proc` node (only when loaded — the node's presence is
+     * the liveness signal) and the zygisk module dir (only when installed). The
+     * KPM has no live push yet (boot-applies from its package list).
+     */
+    fun nativeWriteParts(
+        debug: Boolean,
+        nativeUids: Collection<Int>,
+    ): List<String> {
+        val body = config(debug, nativeUids)
+        return listOf(
+            "if [ -e $PROC_CTL ]; then ${buildRawWriteCommand(PROC_CTL, body)}; fi",
+            "if [ -d $ZYGISK_MODULE_DIR ]; then ${buildRawWriteCommand(
+                ZYGISK_MODULE_TARGETS,
+                body,
+            )} && chmod 644 $ZYGISK_MODULE_TARGETS; fi",
+        )
+    }
+
+    /**
+     * Shell parts writing the LSPosed (Java-layer) config to the system_server
+     * UID file at 0640 root:system (system_data_file), the same perms the file
+     * has always carried.
+     */
+    fun javaWriteParts(
+        debug: Boolean,
+        javaUids: Collection<Int>,
+    ): List<String> = listOf(buildRawWriteCommand(SS_UIDS_FILE, config(debug, javaUids))) + systemDataFilePermsParts(SS_UIDS_FILE, "640")
+
+    /**
+     * Re-emit the runtime config for the CURRENT persisted targets — used by the
+     * startup reconcile (seeds the runtime channels from the persistent package
+     * lists, e.g. after a fresh install or a target-app reinstall that rotated
+     * its UID, without waiting for a reboot) and by the debug toggle (re-emits
+     * with the new flag so a running kernel/zygisk backend picks it up). Targets
+     * are resolved in-process from the snapshot's package→UID map; self is
+     * already in every persistent list so it resolves like any other target.
+     */
+    fun reconcileCommand(
+        snapshot: TargetsSnapshot,
+        debug: Boolean,
+    ): String {
+        val pkgToUids = HashMap<String, MutableList<Int>>()
+        snapshot.uidToPkg.forEach { (uid, pkg) -> pkgToUids.getOrPut(pkg) { mutableListOf() }.add(uid) }
+
+        fun uidsFor(pkgs: Set<String>): List<Int> = pkgs.flatMap { pkgToUids[it].orEmpty() }
+        val parts = javaWriteParts(debug, uidsFor(snapshot.lsposedTargets)) + nativeWriteParts(debug, uidsFor(snapshot.nativeTargets))
+        return parts.joinToString(" ; ")
+    }
+}
+
+/**
+ * Run the startup runtime-config reconcile over root: derive the targets from
+ * [rootSnapshot], fold in the persisted debug flag, and (re-)write the
+ * `vpnhide 1 config` snapshot to every live channel. Blocking — call from a
+ * background dispatcher. Best-effort: a non-zero exit is logged, not fatal.
+ */
+internal fun runRuntimeConfigReconcile(
+    context: Context,
+    rootSnapshot: RootSnapshot,
+) {
+    val cmd = ConfigChannels.reconcileCommand(parseTargetsSnapshot(rootSnapshot), isEnabledInPrefs(context))
+    val (exit, _) = suExec(cmd)
+    if (exit != 0) VpnHideLog.w("VpnHide-Startup", "runtime config reconcile failed (exit=$exit)")
+}

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DashboardData.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DashboardData.kt
@@ -577,7 +577,7 @@ internal sealed interface KmodProblemKind {
  * ambiguous-load-failed (one of two valid candidates failed this boot), and
  * finally a generic insmod failure when we have stderr to show.
  *
- * An active kmod (`/proc/vpnhide_targets` present) is empirical proof the
+ * An active kmod (`/proc/vpnhide_ctl` present) is empirical proof the
  * install works, so every check except the activity-independent kprobes probe
  * is gated on `!active`.
  *

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DebugLoggingPrefs.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DebugLoggingPrefs.kt
@@ -3,35 +3,25 @@ package dev.okhsunrog.vpnhide
 import android.content.Context
 
 /**
- * Persisted "debug logging" preference and its propagation to the
- * out-of-process logging sinks:
+ * Persisted "debug logging" preference and its propagation. Debug is now folded
+ * into the control-config wire (`debug` line, docs/protocol.md §4.3), so the
+ * kmod and Zygisk learn it from their config snapshot rather than from a private
+ * debug node/file (those are gone). The sinks are:
  *
- *  - App Kotlin code → [VpnHideLog.enabled] (volatile)
- *  - system_server LSPosed hooks → [SS_DEBUG_LOGGING_FILE] (inotify-
- *    watched; flip takes effect immediately for already-running apps)
- *  - Zygisk module → [ZYGISK_DEBUG_LOGGING_FILE] (read when the module
- *    is injected into a forked app, so target apps need to be restarted
- *    before a flip takes effect for them — identical to targets.txt)
- *  - Kernel module → [KMOD_DEBUG_PROC] (in-kernel volatile; per-boot
- *    only, re-seeded from [SS_DEBUG_LOGGING_FILE] by `kmod/module/
- *    service.sh` at boot so the persistent toggle survives reboots
- *    even when the app isn't opened)
+ *  - App Kotlin code → [VpnHideLog.enabled] (volatile).
+ *  - system_server LSPosed hooks → [SS_DEBUG_LOGGING_FILE], the single canonical
+ *    persistent flag. The hook ([HookLog]) inotify-watches it (a flip takes
+ *    effect immediately for already-running apps), and the boot scripts read it
+ *    as the source for the `debug` line they emit into each backend's config.
+ *  - kmod (`/proc/vpnhide_ctl`) + Zygisk (module-dir config) → re-emitted via
+ *    [ConfigChannels.reconcileCommand] with the new flag, so a running native
+ *    backend picks it up without a Save (Zygisk takes effect on the target
+ *    app's next restart, as targets always have).
  */
 private const val PREFS_NAME = "vpnhide_prefs"
 private const val KEY_DEBUG_LOGGING = "debug_logging"
 
 internal const val SS_DEBUG_LOGGING_FILE = "/data/system/vpnhide_debug_logging"
-
-// Canonical persistent location — survives zygisk module reinstall.
-// `zygisk/module/service.sh` copies this into the module dir below at
-// every boot, so a reinstall doesn't lose the user's preference.
-internal const val ZYGISK_DEBUG_LOGGING_PERSIST = "/data/adb/vpnhide_zygisk/debug_logging"
-
-// Module-dir mirror — what `zygisk/src/lib.rs::apply_debug_logging_flag`
-// reads via the `get_module_dir()` fd at every fork. Wiped on module
-// reinstall (KSU/Magisk replaces the whole tree from the zip).
-internal const val ZYGISK_DEBUG_LOGGING_FILE = "/data/adb/modules/vpnhide_zygisk/debug_logging"
-internal const val ZYGISK_PERSIST_DIR = "/data/adb/vpnhide_zygisk"
 
 /** Default is OFF — stealth-first matches the project's anti-detection stance. */
 internal fun isEnabledInPrefs(context: Context): Boolean =
@@ -73,37 +63,28 @@ internal fun applyDebugLoggingRuntime(enabled: Boolean) {
 
 private fun writeDebugFlagFiles(enabled: Boolean) {
     val value = if (enabled) "1" else "0"
-    // Independent writes batched into one su invocation to keep the
-    // toggle UI snappy — each round-trip is ~50-100ms from Kotlin.
-    // Sinks fail silently when the corresponding component isn't
-    // installed / loaded (zygisk module dir absent, kmod /proc node
-    // absent), which is the desired behavior: the flag has no target.
-    //
-    //   1. system_server hook file: /data/system, labelled
-    //      system_data_file so system_server (and nothing else) can
-    //      read it. `chcon || true` so devices without chcon still
-    //      end up with a working file at the kernel-default label.
-    //   2. Zygisk persistent file: survives module reinstall.
-    //      service.sh copies it into the module dir at every boot.
-    //   3. Zygisk module-dir mirror: what the .so actually reads via
-    //      get_module_dir() fd on every fork. Wiped on module
-    //      reinstall — MainActivity re-propagates from prefs as a
-    //      safety-net for "reinstall mid-session, no reboot yet".
-    //   4. Kernel module /proc toggle: in-kernel volatile, per-boot.
-    //      service.sh re-seeds it at every boot from SS_DEBUG_LOGGING_FILE,
-    //      so a persistent ON survives reboots without the app needing
-    //      to open.
-    suExec(
-        "echo '$value' > $SS_DEBUG_LOGGING_FILE" +
-            " && chmod 644 $SS_DEBUG_LOGGING_FILE" +
-            " && chcon u:object_r:system_data_file:s0 $SS_DEBUG_LOGGING_FILE 2>/dev/null; " +
-            "[ -d $ZYGISK_PERSIST_DIR ] && {" +
-            " echo '$value' > $ZYGISK_DEBUG_LOGGING_PERSIST" +
-            " && chmod 644 $ZYGISK_DEBUG_LOGGING_PERSIST 2>/dev/null; }; " +
-            "[ -d $ZYGISK_MODULE_DIR ] &&" +
-            " echo '$value' > $ZYGISK_DEBUG_LOGGING_FILE" +
-            " && chmod 644 $ZYGISK_DEBUG_LOGGING_FILE 2>/dev/null; " +
-            "[ -e $KMOD_DEBUG_PROC ] && echo '$value' > $KMOD_DEBUG_PROC; " +
-            "true",
-    )
+    val parts = mutableListOf<String>()
+
+    // The single canonical persistent flag: /data/system, labelled
+    // system_data_file so system_server (and nothing else) can read it. The
+    // LSPosed hook watches it directly; the boot scripts read it as the source
+    // for each config's `debug` line. `chcon || true` so devices without chcon
+    // still land on a working file at the kernel-default label.
+    parts += "echo '$value' > $SS_DEBUG_LOGGING_FILE"
+    parts += "chmod 644 $SS_DEBUG_LOGGING_FILE 2>/dev/null"
+    parts += "chcon u:object_r:system_data_file:s0 $SS_DEBUG_LOGGING_FILE 2>/dev/null || true"
+
+    // Re-emit the runtime config with the new flag so a running kmod/Zygisk
+    // backend picks it up (debug is folded into the config, §4.3). Needs the
+    // current targets; if the snapshot isn't loaded yet, the flag file alone is
+    // written and the next reconcile/Save carries the flag into the channels.
+    TargetsCache.snapshot.value?.let { snap ->
+        parts += ConfigChannels.reconcileCommand(snap, enabled)
+    }
+    parts += "true"
+
+    // Batched into one su invocation to keep the toggle UI snappy — each
+    // round-trip is ~50-100ms. Channels whose component isn't installed/loaded
+    // are skipped by the guards inside the config-write parts.
+    suExec(parts.joinToString(" ; "))
 }

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DiagnosticsScreen.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DiagnosticsScreen.kt
@@ -1170,8 +1170,8 @@ private fun buildModuleInfoText(): String =
 
 private fun buildTargetsText(): String =
     buildString {
-        appendLine("=== /proc/vpnhide_targets (live UIDs) ===")
-        appendLine(suExec("cat /proc/vpnhide_targets 2>/dev/null").second.ifEmpty { "(empty)" })
+        appendLine("=== /proc/vpnhide_ctl (live status + stats) ===")
+        appendLine(suExec("cat $PROC_CTL 2>/dev/null").second.ifEmpty { "(empty)" })
         appendLine()
         appendLine("=== kmod targets ===")
         appendLine(suExec("cat $KMOD_TARGETS 2>/dev/null").second.ifEmpty { "(empty)" })

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/Protocol.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/Protocol.kt
@@ -1,0 +1,288 @@
+package dev.okhsunrog.vpnhide
+
+/**
+ * Kotlin side of the vpnhide control/stats wire format (docs/protocol.md §4).
+ *
+ * Mirrors the freestanding C (`kmod/shared/vpnhide_logic.h`) and the Rust
+ * (`zygisk/src/protocol.rs`) byte for byte; parity is held by the shared golden
+ * vectors (`kmod/shared/protocol_vectors.tsv`), run by ProtocolTest. This is the
+ * "thick" end (protocol §1.4): the app **serialises** config snapshots into
+ * every channel and **parses** stats/status back; the `system_server` LSPosed
+ * hook **parses** config from its file. So both directions live here.
+ *
+ * Numbers are carried as [Long]: `uid`/`hookmask`/`hook_id` are u32 (always
+ * non-negative here); `count` is u64 carried as raw bits (use the unsigned
+ * formatter/parser), so a full-range counter round-trips exactly.
+ */
+internal object Protocol {
+    const val VERSION = 1
+
+    enum class Kind { CONFIG, STATS, STATUS }
+
+    data class Target(
+        val uid: Long,
+        val hookmask: Long,
+    )
+
+    /** A parsed config. [debug] is null when no `debug` line was present
+     * ("unchanged from default", §4.3), else the flag. */
+    data class Config(
+        val debug: Boolean?,
+        val targets: List<Target>,
+    )
+
+    data class StatEntry(
+        val uid: Long,
+        val hookId: Long,
+        val count: Long,
+    )
+
+    data class Status(
+        val backend: Long,
+        val kver: Long,
+        val hooks: Long,
+        val error: Long,
+    )
+
+    /**
+     * Self-documenting banner a read endpoint prepends to its snapshot
+     * (§OPEN-7). It's a `#` comment line, ignored by every parser.
+     */
+    const val READ_BANNER = "# vpnhide v1 — a WRITE replaces ENTIRE state; this read is status+stats\n"
+
+    // ── lexical helpers (§4.1) ────────────────────────────────────────────
+
+    private fun isSep(c: Char) = c == ' ' || c == '\t'
+
+    private fun isAsciiPrintable(c: Char) = c.code in 0x20..0x7e
+
+    /** Split on `\n`, stripping a trailing `\r` per line (CRLF → LF). */
+    private fun lines(text: String): List<String> = text.split('\n').map { it.removeSuffix("\r") }
+
+    /** Blank line or a `#` comment — ignored on both header search and records. */
+    private fun isIgnorable(line: String): Boolean {
+        val s = line.indexOfFirst { !isSep(it) }
+        return s < 0 || line[s] == '#'
+    }
+
+    /** A line is acceptable only if every byte is printable ASCII or a tab. */
+    private fun isAscii(line: String) = line.all { isAsciiPrintable(it) || it == '\t' }
+
+    private fun contentAfterWs(line: String): String = line.substring(line.indexOfFirst { !isSep(it) })
+
+    private fun tokens(content: String): List<String> = content.split(' ', '\t').filter { it.isNotEmpty() }
+
+    /**
+     * Parse the one numeric primitive (§4.4): `0x` (mandatory) + ≥1 hex digit,
+     * any case; reject if it overflows `bits` (32/64). Returns the value as raw
+     * Long bits, or null on any malformation.
+     */
+    private fun parseHex(
+        tok: String,
+        bits: Int,
+    ): Long? {
+        if (tok.length < 3 || tok[0] != '0' || (tok[1] != 'x' && tok[1] != 'X')) return null
+        val max = if (bits >= 64) ULong.MAX_VALUE else 0xffffffffuL
+        var v = 0uL
+        for (c in tok.substring(2)) {
+            val d =
+                when (c) {
+                    in '0'..'9' -> c - '0'
+                    in 'a'..'f' -> c - 'a' + 10
+                    in 'A'..'F' -> c - 'A' + 10
+                    else -> return null
+                }.toULong()
+            if (v > (max - d) / 16uL) return null // width overflow
+            v = v * 16uL + d
+        }
+        return v.toLong()
+    }
+
+    /** Always lowercase out (§4.4: liberal-in / strict-out). Unsigned so a u64
+     * value with the high bit set still renders correctly. */
+    private fun hex(v: Long): String = "0x" + java.lang.Long.toUnsignedString(v, 16)
+
+    // ── header (§4.2) ─────────────────────────────────────────────────────
+
+    private data class Header(
+        val kind: Kind,
+        val records: List<String>,
+    )
+
+    private fun parseHeader(text: String): Header? {
+        val ls = lines(text)
+        for (i in ls.indices) {
+            val line = ls[i]
+            if (isIgnorable(line)) continue // blank / comment before the header is fine
+            // first significant line == the mandatory header
+            if (!isAscii(line)) return null
+            val toks = tokens(contentAfterWs(line))
+            if (toks.getOrNull(0) != "vpnhide") return null
+            val ver = toks.getOrNull(1)?.toIntOrNull() ?: return null
+            if (ver > VERSION) return null
+            val kind =
+                when (toks.getOrNull(2)) {
+                    "config" -> Kind.CONFIG
+                    "stats" -> Kind.STATS
+                    "status" -> Kind.STATUS
+                    else -> return null
+                }
+            return Header(kind, ls.subList(i + 1, ls.size))
+        }
+        return null
+    }
+
+    fun peekKind(text: String): Kind? = parseHeader(text)?.kind
+
+    /** Records that are significant (not blank/comment) and ASCII-clean (§4.5). */
+    private inline fun forEachRecord(
+        records: List<String>,
+        body: (List<String>) -> Unit,
+    ) {
+        for (line in records) {
+            if (isIgnorable(line) || !isAscii(line)) continue
+            body(tokens(contentAfterWs(line)))
+        }
+    }
+
+    // ── config (§4.3) ─────────────────────────────────────────────────────
+
+    /** Parse a `config` payload, or null if rejected whole (bad/missing header,
+     * version too new, wrong kind). Duplicate uid ⇒ last wins; unknown keywords
+     * and malformed lines are skipped. */
+    fun parseConfig(text: String): Config? {
+        val h = parseHeader(text) ?: return null
+        if (h.kind != Kind.CONFIG) return null
+        var debug: Boolean? = null
+        val targets = mutableListOf<Target>()
+        forEachRecord(h.records) { toks ->
+            when (toks.getOrNull(0)) {
+                "debug" -> {
+                    when (toks.getOrNull(1)) {
+                        "0" -> {
+                            debug = false
+                        }
+
+                        "1" -> {
+                            debug = true
+                        }
+
+                        else -> {} // malformed flag ⇒ skip
+                    }
+                }
+
+                "target" -> {
+                    val uid = toks.getOrNull(1)?.let { parseHex(it, 32) }
+                    val hm = toks.getOrNull(2)?.let { parseHex(it, 32) }
+                    if (uid != null && hm != null) setTarget(targets, uid, hm)
+                }
+            }
+        }
+        return Config(debug, targets)
+    }
+
+    private fun setTarget(
+        targets: MutableList<Target>,
+        uid: Long,
+        hookmask: Long,
+    ) {
+        val idx = targets.indexOfFirst { it.uid == uid }
+        if (idx >= 0) targets[idx] = Target(uid, hookmask) else targets += Target(uid, hookmask)
+    }
+
+    fun formatConfig(
+        debug: Boolean?,
+        targets: List<Target>,
+    ): String =
+        buildString {
+            append("vpnhide ").append(VERSION).append(" config\n")
+            if (debug != null) append("debug ").append(if (debug) "1" else "0").append('\n')
+            for (t in targets) {
+                append("target ")
+                    .append(hex(t.uid))
+                    .append(' ')
+                    .append(hex(t.hookmask))
+                    .append('\n')
+            }
+        }
+
+    // ── stats (§4.3) ──────────────────────────────────────────────────────
+
+    fun parseStats(text: String): List<StatEntry>? {
+        val h = parseHeader(text) ?: return null
+        if (h.kind != Kind.STATS) return null
+        val out = mutableListOf<StatEntry>()
+        forEachRecord(h.records) { toks ->
+            val uid = toks.getOrNull(0)?.let { parseHex(it, 32) }
+            if (uid != null) {
+                for (j in 1 until toks.size) {
+                    val pair = toks[j].split(':')
+                    val hid = pair.getOrNull(0)?.let { parseHex(it, 32) }
+                    val cnt = pair.getOrNull(1)?.let { parseHex(it, 64) }
+                    if (pair.size == 2 && hid != null && cnt != null) {
+                        out += StatEntry(uid, hid, cnt)
+                    }
+                }
+            }
+        }
+        return out
+    }
+
+    fun formatStats(entries: List<StatEntry>): String =
+        buildString {
+            append("vpnhide ").append(VERSION).append(" stats\n")
+            var i = 0
+            while (i < entries.size) {
+                val uid = entries[i].uid
+                append(hex(uid))
+                while (i < entries.size && entries[i].uid == uid) {
+                    append(' ').append(hex(entries[i].hookId)).append(':').append(hex(entries[i].count))
+                    i++
+                }
+                append('\n')
+            }
+        }
+
+    // ── status (§4.3) ─────────────────────────────────────────────────────
+
+    fun parseStatus(text: String): Status? {
+        val h = parseHeader(text) ?: return null
+        if (h.kind != Kind.STATUS) return null
+        var backend = 0L
+        var kver = 0L
+        var hooks = 0L
+        var error = 0L
+        forEachRecord(h.records) { toks ->
+            val v = toks.getOrNull(1)?.let { parseHex(it, 32) }
+            if (v != null) {
+                when (toks.getOrNull(0)) {
+                    "backend" -> backend = v
+                    "kver" -> kver = v
+                    "hooks" -> hooks = v
+                    "error" -> error = v
+                }
+            }
+        }
+        return Status(backend, kver, hooks, error)
+    }
+
+    fun formatStatus(s: Status): String =
+        "vpnhide $VERSION status\n" +
+            "backend ${hex(s.backend)}\nkver ${hex(s.kver)}\nhooks ${hex(s.hooks)}\nerror ${hex(s.error)}\n"
+
+    /**
+     * Clamp a fully-serialised snapshot to `outlen` bytes on a line boundary
+     * (§7.2). Whole thing fits ⇒ returns its length (ends in `\n`, complete);
+     * else the largest run of complete lines minus the trailing `\n` (the
+     * missing newline is the truncation signal).
+     */
+    fun clampToLine(
+        buf: String,
+        outlen: Int,
+    ): Int {
+        if (buf.length <= outlen) return buf.length
+        var p = outlen
+        while (p > 0 && buf[p - 1] != '\n') p--
+        return if (p > 0) p - 1 else 0
+    }
+}

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/RootSnapshotCache.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/RootSnapshotCache.kt
@@ -232,7 +232,7 @@ internal fun buildRootShellSnapshotCommand(includePmPackages: Boolean = true): S
     __VPNHIDE_PM_PACKAGES_FUNCTION__
     phase_proc_exists() {
       phase_start shell_probe_proc_exists
-      emit_eval proc_exists '[ -f $PROC_TARGETS ] && echo 1 || echo 0'
+      emit_eval proc_exists '[ -e $PROC_CTL ] && echo 1 || echo 0'
       phase_end
     }
     phase_ports_chain() {

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/ShellCommandBuilders.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/ShellCommandBuilders.kt
@@ -17,24 +17,32 @@ internal fun managedConfigBody(
 ): String = (listOf(header) + lines).joinToString(separator = "\n", postfix = "\n")
 
 /**
- * Shell fragment writing a managed config file via a base64 round-trip:
+ * Shell fragment writing arbitrary [content] to [path] via a base64 round-trip:
  * `echo '<b64>' | base64 -d > path`. base64 sidesteps every quoting/escaping
- * hazard from package names or the header text inside the single `su -c`
- * string. Callers append their own `chmod` / dir-guard / perms tail — those
- * differ per file (644 vs system_data_file 640), see [systemDataFilePermsParts].
+ * hazard inside the single `su -c` string — package names, the header text, and
+ * the newline-separated `vpnhide 1 config` snapshots alike. Callers append their
+ * own `chmod` / dir-guard / perms tail.
+ */
+internal fun buildRawWriteCommand(
+    path: String,
+    content: String,
+): String {
+    val b64 = android.util.Base64.encodeToString(content.toByteArray(), android.util.Base64.NO_WRAP)
+    return "echo '$b64' | base64 -d > $path"
+}
+
+/**
+ * Shell fragment writing a managed PACKAGE-list file (the persistent
+ * per-backend `targets.txt` etc.): the `# Managed …` header comment + one
+ * package per line. NOT the wire protocol — they survive reinstall and feed the
+ * picker + boot re-resolution. The resolved-UID runtime channels carry the
+ * `vpnhide 1 config` wire instead (see [ConfigChannels]).
  */
 internal fun buildConfigWriteCommand(
     path: String,
     header: String,
     lines: List<String>,
-): String {
-    val b64 =
-        android.util.Base64.encodeToString(
-            managedConfigBody(header, lines).toByteArray(),
-            android.util.Base64.NO_WRAP,
-        )
-    return "echo '$b64' | base64 -d > $path"
-}
+): String = buildRawWriteCommand(path, managedConfigBody(header, lines))
 
 /**
  * The chmod/chown/chcon tail applied to a `/data/system` file so that
@@ -134,22 +142,13 @@ internal fun buildEnsureSelfInTargetsCommand(selfPkg: String): String =
         append("; echo $SELF_PM_PACKAGES_BEGIN")
         append("; printf '%s\\n' \"\$ALL_PKGS\"")
         append("; echo $SELF_PM_PACKAGES_END")
-        append("; ")
-        append(buildPackageUidsExpression(selfPkg, "SELF_UIDS"))
-        append("; if [ -n \"\$SELF_UIDS\" ]; then")
-        append(" for U in \$SELF_UIDS; do")
-        append("   case \"\$U\" in ''|*[!0-9]*) continue;; esac")
-        append(" ; if [ -f $PROC_TARGETS ]; then")
-        append("     grep -qx \"\$U\" $PROC_TARGETS 2>/dev/null || echo \"\$U\" >> $PROC_TARGETS")
-        append("   ; fi")
-        append(" ; grep -qx \"\$U\" $SS_UIDS_FILE 2>/dev/null || {")
-        append("     echo \"\$U\" >> $SS_UIDS_FILE")
-        append("   ; chmod 640 $SS_UIDS_FILE")
-        append("   ; chown root:system $SS_UIDS_FILE")
-        append("   ; chcon u:object_r:system_data_file:s0 $SS_UIDS_FILE 2>/dev/null || true")
-        append("   ; }")
-        append(" ; done")
-        append("; fi")
+        // The runtime channels (/proc/vpnhide_ctl, the zygisk module dir, the
+        // system_server UID file) are no longer seeded here with a bare UID:
+        // they carry a `vpnhide 1 config` snapshot now (docs/protocol.md), which
+        // can't be appended to line-by-line. They are (re-)written wholesale by
+        // the Kotlin reconcile (ConfigChannels.reconcileCommand) that runs once
+        // the root snapshot is available — it resolves every persistent target
+        // list (self included) to UIDs and emits the config to each channel.
         append("; echo BOOT_ID=\$(cat /proc/sys/kernel/random/boot_id 2>/dev/null)")
         append("; echo ADDED=\$ADDED")
     }

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/ShellUtils.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/ShellUtils.kt
@@ -14,8 +14,11 @@ internal const val KMOD_TARGETS = "/data/adb/vpnhide_kmod/targets.txt"
 internal const val ZYGISK_TARGETS = "/data/adb/vpnhide_zygisk/targets.txt"
 internal const val ZYGISK_MODULE_TARGETS = "/data/adb/modules/vpnhide_zygisk/targets.txt"
 internal const val LSPOSED_TARGETS = "/data/adb/vpnhide_lsposed/targets.txt"
-internal const val PROC_TARGETS = "/proc/vpnhide_targets"
-internal const val KMOD_DEBUG_PROC = "/proc/vpnhide_debug"
+
+// The kmod's folded control+stats node (docs/protocol.md §OPEN-4): a write is a
+// `vpnhide 1 config` snapshot, a read returns status+stats. Replaces the old
+// /proc/vpnhide_targets (decimal UID list) + /proc/vpnhide_debug nodes.
+internal const val PROC_CTL = "/proc/vpnhide_ctl"
 internal const val SS_UIDS_FILE = "/data/system/vpnhide_uids.txt"
 internal const val SS_HIDDEN_PKGS_FILE = "/data/system/vpnhide_hidden_pkgs.txt"
 internal const val SS_OBSERVER_UIDS_FILE = "/data/system/vpnhide_observer_uids.txt"

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/StartupCoordinator.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/StartupCoordinator.kt
@@ -28,9 +28,18 @@ internal class StartupCoordinator(
     private val cleanupZygiskStatus: (Context, String?) -> Unit = ::cleanupStaleZygiskStatus,
     private val seedRootSnapshotPackages: (String?) -> Unit = RootSnapshotCache::seedPmPackages,
     private val markStartupEvent: (String) -> Unit = StartupTrace::mark,
+    private val reconcileRuntimeConfig: (RootSnapshot) -> Unit = { runRuntimeConfigReconcile(appContext, it) },
 ) {
     private val _selfTargetState = MutableStateFlow<StartupSelfTargetState>(StartupSelfTargetState.Preparing)
     val selfTargetState: StateFlow<StartupSelfTargetState> = _selfTargetState.asStateFlow()
+
+    // The runtime channels carry a `vpnhide 1 config` snapshot that can't be
+    // appended to, so they're (re-)written wholesale from the persistent target
+    // lists once the root snapshot is available — once per session is enough
+    // (Save / the debug toggle re-emit on their own afterwards).
+    private val reconcileStarted =
+        java.util.concurrent.atomic
+            .AtomicBoolean(false)
 
     suspend fun prepareSelfTargets() {
         _selfTargetState.value = StartupSelfTargetState.Preparing
@@ -76,6 +85,9 @@ internal class StartupCoordinator(
     ) {
         if (selfNeedsRestart != null && rootSnapshot != null) {
             TargetsCache.ensureLoaded(scope, appContext)
+            if (reconcileStarted.compareAndSet(false, true)) {
+                scope.launch(Dispatchers.IO) { reconcileRuntimeConfig(rootSnapshot) }
+            }
         }
     }
 

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/SystemServerTargetUidCache.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/SystemServerTargetUidCache.kt
@@ -71,7 +71,18 @@ internal class SystemServerTargetUidCache(
             if (!file.exists()) {
                 emptySet()
             } else {
-                parseConfigLines(file.readText()).mapNotNull { it.toIntOrNull() }.toSet()
+                // The file is a `vpnhide 1 config` snapshot (docs/protocol.md):
+                // the LSPosed channel speaks the same wire as every other
+                // backend. We act on target *presence* (UID is the key, §4.3);
+                // LSPosed owns no registry hook bits yet, so the per-hook mask
+                // is ignored (§6 note). An invalid/old-format file parses to
+                // null ⇒ no targets, rewritten on the next boot or Save.
+                Protocol
+                    .parseConfig(file.readText())
+                    ?.targets
+                    ?.map { it.uid.toInt() }
+                    ?.toSet()
+                    ?: emptySet()
             }
         } catch (t: Throwable) {
             HookLog.e("VpnHide: failed to read UIDs: ${t.message}")

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/TargetPickerScaffold.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/TargetPickerScaffold.kt
@@ -93,6 +93,19 @@ internal data class MergeResult<T : TargetEntry>(
 )
 
 /**
+ * Everything a Save needs beyond the row entries themselves. The scaffold
+ * resolves [selfUids] (the VPN Hide app's own UID(s), always a target) and the
+ * current [debug] flag once, so [buildSaveCommand] can serialise the `vpnhide 1
+ * config` snapshots in-process (debug is folded into config, §4.3).
+ */
+internal data class SaveContext(
+    val selfPkg: String,
+    val selfUids: List<Int>,
+    val debug: Boolean,
+    val header: String,
+)
+
+/**
  * Shared scaffold for the three Protection picker screens. Owns all the
  * machinery they had copy-pasted: the cached-apps / targets subscription,
  * the dirty-guarded merge, search+system+russian filtering, the alphabetical
@@ -121,7 +134,7 @@ internal fun <T : TargetEntry> TargetPickerScreen(
     help: @Composable () -> Unit,
     merge: (apps: List<AppSummary>, targets: TargetsSnapshot, selfPkg: String) -> MergeResult<T>,
     countText: (entries: List<T>, resources: Resources) -> String,
-    buildSaveCommand: (entries: List<T>, selfPkg: String, header: String) -> String,
+    buildSaveCommand: (entries: List<T>, ctx: SaveContext) -> String,
     successMessage: (entries: List<T>, resources: Resources) -> String,
     moduleMissing: (TargetsSnapshot) -> Boolean = { false },
     moduleMissingContent: @Composable (Modifier) -> Unit = {},
@@ -293,9 +306,18 @@ internal fun <T : TargetEntry> TargetPickerScreen(
         LaunchedEffect(Unit) {
             val header = resources.getString(R.string.save_header_comment)
             val entries = allApps
+            val selfPkg = context.packageName
+            // Self is always a target but is never a row (the picker filters it
+            // out). Pull its resolved UID(s) from the cached app list (all
+            // profiles, from `pm list packages -U -f --user all`); fall back to
+            // this process's UID if the list isn't loaded yet.
+            val selfUids =
+                cachedApps?.firstOrNull { it.packageName == selfPkg }?.userIds
+                    ?: listOf(android.os.Process.myUid())
+            val ctx = SaveContext(selfPkg, selfUids, isEnabledInPrefs(context), header)
             try {
                 val (exitCode, _) =
-                    suExecAsync(buildSaveCommand(entries, context.packageName, header))
+                    suExecAsync(buildSaveCommand(entries, ctx))
                 when (exitCode) {
                     0 -> {
                         snackMessage = successMessage(entries, resources)

--- a/lsposed/app/src/test/kotlin/dev/okhsunrog/vpnhide/ConfigChannelsTest.kt
+++ b/lsposed/app/src/test/kotlin/dev/okhsunrog/vpnhide/ConfigChannelsTest.kt
@@ -1,0 +1,37 @@
+package dev.okhsunrog.vpnhide
+
+import dev.okhsunrog.vpnhide.generated.HookIds
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class ConfigChannelsTest {
+    @Test
+    fun `config emits a valid snapshot with the full kernel mask, sorted and deduped`() {
+        // Out of order + duplicate UID in → sorted, deduped, full-mask out.
+        val wire = ConfigChannels.config(debug = false, uids = listOf(10234, 10001, 10234))
+        assertEquals(
+            """
+            vpnhide 1 config
+            debug 0
+            target 0x2711 0x3ff
+            target 0x27fa 0x3ff
+            """.trimIndent() + "\n",
+            wire,
+        )
+        // The mask is exactly the generated kernel hook mask.
+        assertEquals("0x${HookIds.KERNEL_HOOK_MASK.toString(16)}", "0x3ff")
+    }
+
+    @Test
+    fun `config round-trips through the parser`() {
+        val wire = ConfigChannels.config(debug = true, uids = listOf(10500))
+        val parsed = requireNotNull(Protocol.parseConfig(wire))
+        assertEquals(true, parsed.debug)
+        assertEquals(listOf(Protocol.Target(10500L, HookIds.KERNEL_HOOK_MASK.toLong())), parsed.targets)
+    }
+
+    @Test
+    fun `empty target set is still a valid header-only config`() {
+        assertEquals("vpnhide 1 config\ndebug 0\n", ConfigChannels.config(debug = false, uids = emptyList()))
+    }
+}

--- a/lsposed/app/src/test/kotlin/dev/okhsunrog/vpnhide/ProtocolTest.kt
+++ b/lsposed/app/src/test/kotlin/dev/okhsunrog/vpnhide/ProtocolTest.kt
@@ -1,0 +1,178 @@
+package dev.okhsunrog.vpnhide
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.io.File
+
+/**
+ * Runs the language-independent golden vectors (kmod/shared/protocol_vectors.tsv)
+ * against the Kotlin [Protocol] — the same file the C and Rust ports run, so a
+ * divergence on any covered corner fails here (docs/protocol.md §8 Layer 1).
+ */
+class ProtocolTest {
+    private fun vectorsFile(): File {
+        var dir: File? = File(System.getProperty("user.dir") ?: ".").absoluteFile
+        repeat(8) {
+            val f = File(dir, "kmod/shared/protocol_vectors.tsv")
+            if (f.isFile) return f
+            dir = dir?.parentFile
+        }
+        error("protocol_vectors.tsv not found from ${System.getProperty("user.dir")}")
+    }
+
+    /** Decode the `\n \t \r \\ \xNN` escapes used in the vectors file. */
+    private fun decode(s: String): String =
+        buildString {
+            var i = 0
+            while (i < s.length) {
+                if (s[i] == '\\' && i + 1 < s.length) {
+                    when (s[i + 1]) {
+                        'n' -> {
+                            append('\n')
+                            i += 2
+                        }
+
+                        't' -> {
+                            append('\t')
+                            i += 2
+                        }
+
+                        'r' -> {
+                            append('\r')
+                            i += 2
+                        }
+
+                        '\\' -> {
+                            append('\\')
+                            i += 2
+                        }
+
+                        'x' -> {
+                            if (i + 3 < s.length) {
+                                append(s.substring(i + 2, i + 4).toInt(16).toChar())
+                                i += 4
+                            } else {
+                                append(s[i])
+                                i++
+                            }
+                        }
+
+                        else -> {
+                            append(s[i])
+                            i++
+                        }
+                    }
+                } else {
+                    append(s[i])
+                    i++
+                }
+            }
+        }
+
+    private fun hexToLong(s: String): Long = java.lang.Long.parseUnsignedLong(s.trim().removePrefix("0x"), 16)
+
+    private fun runCfg(
+        input: String,
+        expect: String,
+    ) {
+        val cfg = Protocol.parseConfig(decode(input))
+        if (expect == "REJECT") {
+            assertNull("expected REJECT for <$input>", cfg)
+            return
+        }
+        requireNotNull(cfg) { "unexpected REJECT for <$input>" }
+        val dbg =
+            when (cfg.debug) {
+                null -> -1
+                false -> 0
+                true -> 1
+            }
+        val got =
+            buildString {
+                append("debug=").append(dbg)
+                for (t in cfg.targets) append(";0x").append(t.uid.toString(16)).append(":0x").append(t.hookmask.toString(16))
+            }
+        assertEquals("cfg <$input>", expect, got)
+    }
+
+    private fun runKind(
+        input: String,
+        expect: String,
+    ) {
+        val got =
+            when (Protocol.peekKind(decode(input))) {
+                Protocol.Kind.CONFIG -> "CONFIG"
+                Protocol.Kind.STATS -> "STATS"
+                Protocol.Kind.STATUS -> "STATUS"
+                null -> "INVALID"
+            }
+        assertEquals("kind <$input>", expect, got)
+    }
+
+    private fun runStats(
+        entries: String,
+        expect: String,
+    ) {
+        val e =
+            decode(entries).split(';').filter { it.isNotEmpty() }.map { grp ->
+                val p = grp.split(',')
+                Protocol.StatEntry(hexToLong(p[0]), hexToLong(p[1]), hexToLong(p[2]))
+            }
+        assertEquals("stats", decode(expect), Protocol.formatStats(e))
+    }
+
+    private fun runStatus(
+        fields: String,
+        expect: String,
+    ) {
+        val f = decode(fields).split(',')
+        val s = Protocol.Status(hexToLong(f[0]), hexToLong(f[1]), hexToLong(f[2]), hexToLong(f[3]))
+        assertEquals("status", decode(expect), Protocol.formatStatus(s))
+    }
+
+    private fun runClamp(
+        full: String,
+        outlen: String,
+        expect: String,
+    ) {
+        val b = decode(full)
+        val n = Protocol.clampToLine(b, outlen.toInt())
+        assertEquals("clamp", decode(expect), b.substring(0, n))
+    }
+
+    @Test
+    fun goldenVectors() {
+        var count = 0
+        vectorsFile().forEachLine { line ->
+            if (line.isEmpty() || line.startsWith("#")) return@forEachLine
+            val f = line.split('|')
+            when (f[0]) {
+                "cfg" -> runCfg(f[1], f[2])
+                "kind" -> runKind(f[1], f[2])
+                "stats" -> runStats(f[1], f[2])
+                "status" -> runStatus(f[1], f[2])
+                "clamp" -> runClamp(f[1], f[2], f[3])
+                else -> error("unrecognised vector: $line")
+            }
+            count++
+        }
+        assertTrue("expected the full vector set, ran $count", count >= 30)
+    }
+
+    @Test
+    fun configRoundTrips() {
+        // formatConfig isn't covered by the shared vectors (no producer on the
+        // C/Rust side), so pin the app's serialise direction with a round-trip.
+        val targets = listOf(Protocol.Target(0x27faL, 0x3ffL), Protocol.Target(0x2947L, 0x4L))
+        val text = Protocol.formatConfig(debug = true, targets = targets)
+        assertEquals("vpnhide 1 config\ndebug 1\ntarget 0x27fa 0x3ff\ntarget 0x2947 0x4\n", text)
+        val parsed = requireNotNull(Protocol.parseConfig(text))
+        assertEquals(true, parsed.debug)
+        assertEquals(targets, parsed.targets)
+        // debug omitted ⇒ null on parse.
+        val reparsed = requireNotNull(Protocol.parseConfig(Protocol.formatConfig(null, targets)))
+        assertNull(reparsed.debug)
+    }
+}

--- a/portshide/module/vpnhide_ports_apply.sh
+++ b/portshide/module/vpnhide_ports_apply.sh
@@ -80,6 +80,15 @@ fi
 # Build an iptables-restore ruleset for a given chain + loopback destination.
 # UDP reject differs by family: `icmp-port-unreachable` on IPv4,
 # `icmp6-port-unreachable` on IPv6.
+#
+# TODO(per-port ranges): today every observer UID is blocked from ALL localhost
+# ports (coarse, breaks apps that legitimately use 127.0.0.1 — Chromium dev/PWA).
+# iptables can scope this per app via `-m multiport --dports <range>` (or repeated
+# `--dport`), so observers.txt should grow optional per-UID port-range rules
+# (start-end, tcp/udp) and this builder should emit a `--dports` match instead of
+# the blanket loopback REJECT. Keeps the backend-independent netfilter approach
+# (no kernel connect-hook); see the vpnhide_next fork's per-app PortRules for the
+# UX shape. Until then, an observer = all-localhost-blocked.
 build_ruleset() {
     chain="$1"
     loopback="$2"

--- a/zygisk/module/service.sh
+++ b/zygisk/module/service.sh
@@ -1,27 +1,33 @@
 #!/system/bin/sh
-# Copies zygisk targets to module dir and resolves lsposed targets at boot.
-# zygisk targets → module dir (read by Zygisk via get_module_dir() fd)
-# lsposed targets → /data/system/vpnhide_uids.txt
+# Resolves package names → UIDs at boot and writes a `vpnhide 1 config` snapshot
+# (docs/protocol.md) to each runtime channel — the same wire every backend
+# speaks. zygisk config → module dir (read by the .so via get_module_dir() fd),
+# lsposed config → /data/system/vpnhide_uids.txt. The debug flag is folded into
+# the config now (§4.3), so there is no separate debug_logging file to copy.
 
 ZYGISK_TARGETS="/data/adb/vpnhide_zygisk/targets.txt"
-ZYGISK_DEBUG_LOGGING="/data/adb/vpnhide_zygisk/debug_logging"
 LSPOSED_TARGETS="/data/adb/vpnhide_lsposed/targets.txt"
 MODULE_DIR="${0%/*}"
 SS_UIDS_FILE="/data/system/vpnhide_uids.txt"
+# Canonical persistent debug-logging flag; folded into each config's `debug`
+# line (§4.3). Absent ⇒ off (stealth-first default).
+SS_DEBUG_LOGGING="/data/system/vpnhide_debug_logging"
 
-# Copy zygisk targets to module dir so Zygisk can read via get_module_dir() fd.
-if [ -f "$ZYGISK_TARGETS" ]; then
-    cp "$ZYGISK_TARGETS" "$MODULE_DIR/targets.txt" 2>/dev/null
-fi
+DBG="$(cat "$SS_DEBUG_LOGGING" 2>/dev/null)"
+[ "$DBG" = 1 ] || DBG=0
 
-# Copy the persistent debug-logging flag into the module dir, same
-# pattern as targets.txt above — the .so reads it via the module dir
-# fd on every fork. The persistent file lives outside the module dir
-# so it survives module reinstall; this re-seed restores the module-
-# dir copy after a reinstall, before the user opens the app.
-if [ -f "$ZYGISK_DEBUG_LOGGING" ]; then
-    cp "$ZYGISK_DEBUG_LOGGING" "$MODULE_DIR/debug_logging" 2>/dev/null
-fi
+# Emit a `vpnhide 1 config` snapshot to stdout for a newline-separated UID list
+# (header + folded debug flag + one `target <uid> 0x3ff` line per UID). See the
+# matching helper in kmod/module/service.sh.
+emit_config() {
+    _uids="$1"
+    printf 'vpnhide 1 config\n'
+    printf 'debug %s\n' "$DBG"
+    [ -n "$_uids" ] && printf '%s\n' "$_uids" | while IFS= read -r u; do
+        [ -z "$u" ] && continue
+        printf 'target 0x%x 0x3ff\n' "$u"
+    done
+}
 
 # Wait until PackageManager has actually indexed user-installed apps.
 # `pm list packages` starts responding very early in boot but returns
@@ -79,7 +85,18 @@ ${expanded}"; fi
     [ -n "$uids" ] && echo "$uids"
 }
 
-# Resolve lsposed targets → /data/system/vpnhide_uids.txt
+# Resolve zygisk targets → config snapshot → module dir (read by the .so via
+# the get_module_dir() fd). The persistent package list lives outside the module
+# dir so it survives reinstall; this re-resolves it into the module-dir config
+# after a reinstall, before the user opens the app.
+if [ -f "$ZYGISK_TARGETS" ]; then
+    ZYGISK_UIDS="$(resolve_uids "$ZYGISK_TARGETS")"
+    printf '%s\n' "$(emit_config "$ZYGISK_UIDS")" > "$MODULE_DIR/targets.txt"
+    count="$(printf '%s\n' "$ZYGISK_UIDS" | grep -c .)"
+    log -t vpnhide "zygisk: applied config for $count target UIDs (debug=$DBG)"
+fi
+
+# Resolve lsposed targets → config snapshot → /data/system/vpnhide_uids.txt
 # Create persist dir if needed (for first-time installs)
 mkdir -p /data/adb/vpnhide_lsposed 2>/dev/null
 if [ -f "$LSPOSED_TARGETS" ]; then
@@ -88,19 +105,12 @@ if [ -f "$LSPOSED_TARGETS" ]; then
     # reads via the group bit; untrusted apps fall to "other" and get EACCES.
     # Default 0644 was a fingerprint vector — `/data/system/` itself is mode
     # 0775 traversable by untrusted, so any o+r file is enumerable + readable.
-    if [ -n "$LSPOSED_UIDS" ]; then
-        echo "$LSPOSED_UIDS" > "$SS_UIDS_FILE"
-        chmod 640 "$SS_UIDS_FILE"
-        chown root:system "$SS_UIDS_FILE"
-        chcon u:object_r:system_data_file:s0 "$SS_UIDS_FILE" 2>/dev/null
-        count="$(echo "$LSPOSED_UIDS" | wc -l)"
-        log -t vpnhide "zygisk: wrote $count lsposed UIDs to $SS_UIDS_FILE"
-    else
-        echo > "$SS_UIDS_FILE"
-        chmod 640 "$SS_UIDS_FILE"
-        chown root:system "$SS_UIDS_FILE"
-        log -t vpnhide "zygisk: no lsposed UIDs resolved"
-    fi
+    printf '%s\n' "$(emit_config "$LSPOSED_UIDS")" > "$SS_UIDS_FILE"
+    chmod 640 "$SS_UIDS_FILE"
+    chown root:system "$SS_UIDS_FILE"
+    chcon u:object_r:system_data_file:s0 "$SS_UIDS_FILE" 2>/dev/null
+    count="$(printf '%s\n' "$LSPOSED_UIDS" | grep -c .)"
+    log -t vpnhide "zygisk: wrote lsposed config for $count UIDs to $SS_UIDS_FILE"
 fi
 
 # Migrate pre-PR files written by older versions with mode 0644: any

--- a/zygisk/src/lib.rs
+++ b/zygisk/src/lib.rs
@@ -32,9 +32,10 @@
 //!    `/data/adb/modules/<id>` via `get_module_dir()` — usable now,
 //!    closed by SELinux later.
 //! 5. **`pre_app_specialize`** — last call before the kernel transitions
-//!    the process to the app's UID and SELinux context. `args.nice_name`
-//!    tells us which package this fork is for. We decide here whether
-//!    to install hooks; for non-targets we set `DlCloseModuleLibrary`.
+//!    the process to the app's UID and SELinux context. `args.uid` holds the
+//!    UID this fork will become; we match it against the config's target UIDs
+//!    to decide whether to install hooks. For non-targets we set
+//!    `DlCloseModuleLibrary`.
 //! 6. The kernel/zygote applies app specialisation: setuid to the app's
 //!    UID, switch SELinux context, install seccomp filter, drop caps.
 //! 7. **`post_app_specialize`** — runs as the app, before the app's
@@ -50,11 +51,11 @@
 //! Because the `.so` is `dlopen`ed afresh in every child, **every Rust
 //! `static` is reset to its initial state on every app launch**. Concretely:
 //!
-//!   * `static CACHED_TARGETS: OnceLock<…>` re-initialises in every
-//!     forked child. `targets.txt` is read on every app launch — so a
-//!     force-stop + restart of a target app picks up edits to the file
-//!     immediately. There is no zygote-side cache to invalidate; live-
-//!     reload is automatic by virtue of the lifecycle.
+//!   * `static CACHED_CONFIG: OnceLock<…>` re-initialises in every
+//!     forked child. `targets.txt` (a `vpnhide 1 config` snapshot) is read on
+//!     every app launch — so a force-stop + restart of a target app picks up
+//!     edits to the file immediately. There is no zygote-side cache to
+//!     invalidate; live-reload is automatic by virtue of the lifecycle.
 //!   * Saved-original libc pointers (`REAL_IOCTL` etc.) are also fresh
 //!     per child, which is fine because we only ever set them inside
 //!     `install_hooks()` from `post_app_specialize`.
@@ -97,23 +98,20 @@ use crate::hooks::{
 const LOG_TAG: &str = "vpnhide-zygisk";
 const APP_PACKAGE: &str = "dev.okhsunrog.vpnhide";
 const APP_STATUS_FILE: &str = "/data/user/0/dev.okhsunrog.vpnhide/files/vpnhide_zygisk_active";
-/// Path to the user's allowlist. Lives OUTSIDE the module directory so
-/// it survives module updates (KSU/Magisk wipe `/data/adb/modules/<id>/`
-/// on every install). `customize.sh` is responsible for creating the
-/// directory and migrating the legacy in-module file on first run.
-/// Targets filename within the module directory.
+/// Config-snapshot filename within the module directory. Carries a
+/// `vpnhide 1 config` payload (docs/protocol.md): the target UIDs this module
+/// hides for, plus the folded `debug` flag — the same wire format every
+/// backend speaks. Package→UID resolution is the producer's job (the app on
+/// Save, the boot script at boot). Read once per app launch via the module
+/// dir-fd.
 const TARGETS_FILENAME: &str = "targets.txt";
-/// Runtime debug-logging flag file. Written by the VPN Hide app when
-/// the user toggles the setting. Absent or not "1" ⇒ logging is off —
-/// stealth-first default matches the rest of the project.
-const DEBUG_LOGGING_FILENAME: &str = "debug_logging";
 
 /// Initialize `android_logger` exactly once. Cheap to call from every
 /// forked process — subsequent calls are no-ops. The compile-time log
 /// filter is controlled by the `log` crate's `release_max_level_*`
 /// Cargo feature (see our `Cargo.toml`); anything below that level is
 /// monomorphized away to a no-op. Runtime level is then narrowed by
-/// [apply_debug_logging_flag] so the user's toggle silences logcat.
+/// [set_log_level] so the user's toggle silences logcat.
 fn init_logger() {
     static INIT: Once = Once::new();
     INIT.call_once(|| {
@@ -125,30 +123,14 @@ fn init_logger() {
     });
 }
 
-/// Read the debug-logging flag file from the module dir fd and drop
-/// the global `log` filter to `Off` unless the flag is set to `1`.
-/// Any read error is treated as "disabled": if the file doesn't exist
-/// yet (fresh install, flag never toggled), we shouldn't leak logs.
-fn apply_debug_logging_flag(dir_fd: std::os::fd::RawFd) {
-    use std::io::Read;
-    use std::os::fd::FromRawFd;
-    let enabled = (|| -> Option<bool> {
-        let filename = std::ffi::CString::new(DEBUG_LOGGING_FILENAME).ok()?;
-        let fd =
-            unsafe { libc::openat(dir_fd, filename.as_ptr(), libc::O_RDONLY | libc::O_CLOEXEC) };
-        if fd < 0 {
-            return None;
-        }
-        let mut file = unsafe { std::fs::File::from_raw_fd(fd) };
-        let mut content = String::new();
-        file.read_to_string(&mut content).ok()?;
-        Some(content.trim() == "1")
-    })()
-    .unwrap_or(false);
-    // Leave errors on even when the user disables logging — the handful of
-    // `error!` calls (hook-install failures, status-file write failures)
-    // fire at most once per process and are the only signal we have if
-    // things go wrong. Same principle as HookLog.e on the Kotlin side.
+/// Narrow the global `log` filter to the user's debug-logging choice. The flag
+/// is now folded into the config snapshot (`debug` line, §4.3) rather than a
+/// separate file — `on_load` reads it from the same `targets.txt` it reads the
+/// target UIDs from. Errors stay on even when disabled: the handful of
+/// `error!` calls (hook-install failures, status-file write failures) fire at
+/// most once per process and are the only signal we have if things go wrong.
+/// Same principle as HookLog.e on the Kotlin side.
+fn set_log_level(enabled: bool) {
     let level = if enabled {
         log::LevelFilter::Trace
     } else {
@@ -173,36 +155,38 @@ pub struct VpnHide {
 // Single-threaded access by construction.
 unsafe impl Sync for VpnHide {}
 
-/// Cached targets, loaded once per process via Zygisk's module dir fd.
+/// The parsed control config this module acts on, cached once per process via
+/// Zygisk's module dir fd.
 ///
 /// **Lifetime is per app launch, not per zygote boot.** The `.so` is
-/// `dlopen`ed fresh in every forked child, so this `OnceLock` starts
-/// empty and gets initialised by `on_load` on every app launch. That
-/// means edits to `targets.txt` are picked up on the next force-stop +
-/// restart — no zygote restart, no reboot needed. See the lifecycle
-/// block at the top of this file for the full reasoning.
-static CACHED_TARGETS: std::sync::OnceLock<Vec<String>> = std::sync::OnceLock::new();
-
-fn parse_targets(content: &str) -> Vec<String> {
-    content
-        .lines()
-        .filter_map(|line| {
-            let line = line.trim();
-            if line.is_empty() || line.starts_with('#') {
-                None
-            } else {
-                Some(line.to_string())
-            }
-        })
-        .collect()
+/// `dlopen`ed fresh in every forked child, so this `OnceLock` starts empty and
+/// gets initialised by `on_load` on every app launch. That means edits to
+/// `targets.txt` are picked up on the next force-stop + restart — no zygote
+/// restart, no reboot needed. See the lifecycle block at the top of this file.
+///
+/// `target_uids` is the set of UIDs to hide for (protocol §4.3 — UID is the
+/// key on every channel, including Zygisk); `debug` is the folded debug flag.
+/// Zygisk owns no registry hook bits yet, so it acts on target *presence* and
+/// ignores the per-hook mask (protocol §6 note).
+struct ZygiskConfig {
+    target_uids: Vec<u32>,
+    debug: bool,
 }
 
-/// Read targets.txt via the module directory fd provided by Zygisk.
-/// This fd is opened by Zygisk with root privileges, bypassing SELinux
-/// restrictions that block direct file access on Magisk.
-fn load_targets_from_dir_fd(dir_fd: std::os::fd::RawFd) -> Vec<String> {
+static CACHED_CONFIG: std::sync::OnceLock<ZygiskConfig> = std::sync::OnceLock::new();
+
+/// Read + parse the `vpnhide 1 config` snapshot from targets.txt via the module
+/// directory fd Zygisk provides. This fd is opened by Zygisk with root
+/// privileges, bypassing the SELinux restrictions that block direct file
+/// access on Magisk. A missing/unreadable/invalid file fails closed: no
+/// targets, logging off.
+fn load_config_from_dir_fd(dir_fd: std::os::fd::RawFd) -> ZygiskConfig {
     use std::io::Read;
     use std::os::fd::FromRawFd;
+    let empty = ZygiskConfig {
+        target_uids: Vec::new(),
+        debug: false,
+    };
     let filename = std::ffi::CString::new(TARGETS_FILENAME).unwrap();
     let fd = unsafe { libc::openat(dir_fd, filename.as_ptr(), libc::O_RDONLY | libc::O_CLOEXEC) };
     if fd < 0 {
@@ -210,15 +194,26 @@ fn load_targets_from_dir_fd(dir_fd: std::os::fd::RawFd) -> Vec<String> {
             "can't open {TARGETS_FILENAME} via module dir fd: {}",
             std::io::Error::last_os_error()
         );
-        return Vec::new();
+        return empty;
     }
     let mut file = unsafe { std::fs::File::from_raw_fd(fd) };
-    let mut content = String::new();
-    if let Err(e) = file.read_to_string(&mut content) {
+    let mut content = Vec::new();
+    if let Err(e) = file.read_to_end(&mut content) {
         log::warn!("can't read {TARGETS_FILENAME}: {e}");
-        return Vec::new();
+        return empty;
     }
-    parse_targets(&content)
+    match protocol::parse_config(&content) {
+        Some(cfg) => ZygiskConfig {
+            target_uids: cfg.targets.iter().map(|t| t.uid).collect(),
+            debug: cfg.debug.unwrap_or(false),
+        },
+        None => {
+            // Rejected whole — bad/missing header, or a version newer than
+            // this build knows (§3 version fuse). Fail closed.
+            log::warn!("{TARGETS_FILENAME}: not a valid config snapshot; ignoring");
+            empty
+        }
+    }
 }
 
 impl ZygiskModule for VpnHide {
@@ -238,14 +233,14 @@ impl ZygiskModule for VpnHide {
         //      child inherits our open fd unless we close it here.
         // Either way the fd needs to die before pre_app_specialize returns.
         let dir_fd = unsafe { OwnedFd::from_raw_fd(api.get_module_dir()) };
-        // Apply the user's debug-logging preference before anything below
-        // gets a chance to log. Default is Off, so silence is the no-config
-        // behavior even on a fresh install where the flag file is absent.
-        apply_debug_logging_flag(dir_fd.as_raw_fd());
-        CACHED_TARGETS.get_or_init(|| load_targets_from_dir_fd(dir_fd.as_raw_fd()));
+        let cfg = CACHED_CONFIG.get_or_init(|| load_config_from_dir_fd(dir_fd.as_raw_fd()));
+        // Debug is folded into the config snapshot now (§4.3); apply it before
+        // anything below logs. Default Off ⇒ silence on a fresh/empty install.
+        set_log_level(cfg.debug);
         debug!(
-            "on_load: {} targets cached",
-            CACHED_TARGETS.get().map_or(0, |v| v.len())
+            "on_load: {} target uids cached, debug={}",
+            cfg.target_uids.len(),
+            cfg.debug
         );
         // dir_fd drops here → closed before any app fork.
     }
@@ -256,18 +251,21 @@ impl ZygiskModule for VpnHide {
         env: JNIEnv<'a>,
         args: &'a mut AppSpecializeArgs<'_>,
     ) {
+        // UID is the targeting key (protocol §4.3). args.uid already holds the
+        // UID this child will become, and one UID covers every process of a
+        // multi-process app — so no package/sub-process name matching needed.
+        let uid = *args.uid as u32;
+        // nice_name is still read, but only to recognise the VPN Hide app
+        // itself for the status heartbeat — an identity check, not targeting.
         let package = read_jstring(&env, args.nice_name);
-        match package.as_deref() {
-            Some(p) if is_targeted(p) => {
-                info!("pre_app_specialize: targeting {p}");
-                self.is_target.set(true);
-                self.report_status.set(p == APP_PACKAGE);
-            }
-            _ => {
-                self.is_target.set(false);
-                self.report_status.set(false);
-                mark_cleanup(&mut api);
-            }
+        if is_target_uid(uid) {
+            info!("pre_app_specialize: targeting uid {uid}");
+            self.is_target.set(true);
+            self.report_status.set(package.as_deref() == Some(APP_PACKAGE));
+        } else {
+            self.is_target.set(false);
+            self.report_status.set(false);
+            mark_cleanup(&mut api);
         }
     }
 
@@ -553,30 +551,19 @@ fn scrub_shadowhook_maps() {
     }
 }
 
-/// Is this package on our allowlist?
+/// Is this UID one of our targets? (protocol §4.3 — UID is the key on every
+/// channel, including Zygisk.)
 ///
-/// Called from `pre_app_specialize`, which runs on the zygote side BEFORE
-/// the uid drop and SELinux context transition, so `/data/adb/modules/...`
-/// is still readable here.
-///
-/// An entry matches if the target file contains either the exact package
-/// name (e.g. `com.example.app`) or the process base name that is the
-/// package of a multi-process app (e.g. `com.example.app:background` is
-/// matched by an entry for `com.example.app`). This means a single line
-/// per app in `targets.txt` covers all of its subprocesses.
+/// Called from `pre_app_specialize`, which runs on the zygote side BEFORE the
+/// uid drop, so `args.uid` already holds the UID this child will become. One
+/// UID covers every process of a multi-process app, so this needs no
+/// sub-process name handling (the old package-name path did).
 #[inline(never)]
-fn is_targeted(package: &str) -> bool {
-    let targets = match CACHED_TARGETS.get() {
-        Some(t) => t,
-        None => return false,
-    };
-
-    let base_package = match package.split_once(':') {
-        Some((base, _)) => base,
-        None => package,
-    };
-
-    targets.iter().any(|t| t == package || t == base_package)
+fn is_target_uid(uid: u32) -> bool {
+    match CACHED_CONFIG.get() {
+        Some(cfg) => cfg.target_uids.contains(&uid),
+        None => false,
+    }
 }
 
 /// Decode a `JString` (as stored in `AppSpecializeArgs::nice_name`) into

--- a/zygisk/src/lib.rs
+++ b/zygisk/src/lib.rs
@@ -261,7 +261,8 @@ impl ZygiskModule for VpnHide {
         if is_target_uid(uid) {
             info!("pre_app_specialize: targeting uid {uid}");
             self.is_target.set(true);
-            self.report_status.set(package.as_deref() == Some(APP_PACKAGE));
+            self.report_status
+                .set(package.as_deref() == Some(APP_PACKAGE));
         } else {
             self.is_target.set(false);
             self.report_status.set(false);


### PR DESCRIPTION
Completes the control/stats protocol rollout: the app, kmod, KPM, Zygisk and LSPosed now exchange targets over the single versioned `vpnhide 1 config` wire (docs/protocol.md) instead of four bespoke per-backend formats. Previously only the KPM spoke it; the `.ko`, the live Zygisk/LSPosed readers, and the app all used legacy plain-UID files and a pair of `/proc` nodes. This unifies the wire end-to-end and removes the legacy code, with the Kotlin side built around one serialiser (`ConfigChannels` → `Protocol.formatConfig`) and one config-emission path.

Two storage layers are kept deliberately separate (protocol §1.2): the persistent per-backend package lists (`*targets.txt`, unchanged — they survive reinstall and feed the picker + boot re-resolution) and the resolved-UID runtime channels that now carry the wire.

- kmod: folds `/proc/vpnhide_targets` (decimal UIDs) + `/proc/vpnhide_debug` into one `/proc/vpnhide_ctl` — write is a config snapshot parsed by the parser shared verbatim with the KPM (per-UID hook mask + folded debug, version-gated, rejected-whole on a bad header); read is a banner + `status` + `stats`. Each kretprobe is now per-hook gated (`hook_active`).
- Zygisk: keys on `args.uid` (protocol §4.3) instead of package name, parsing `targets.txt` as a config snapshot; one UID covers all of an app's processes, so the old base-package matching is gone. Its separate `debug_logging` mirror is removed (folded into config).
- LSPosed: the `system_server` target-UID reader parses the config snapshot.
- App: `ConfigChannels` serialises the wire once and fans it to every runtime channel on Save, on the debug toggle, and via a once-per-session startup reconcile (which also catches a target-app reinstall that rotated its UID without a reboot). Debug folds into config; `vpnhide_debug_logging` stays as the one canonical persistent flag (the LSPosed hook reads it live; boot scripts read it as each config's `debug` source).
- Boot scripts (kmod + zygisk `service.sh`) resolve packages → UIDs and emit the config wire, with debug folded in.
- Docs (state.md, protocol.md, detection-vectors.md, READMEs) updated; legacy node names and dead code removed.

Breaking changes

The app↔backend runtime format changes, so all components must be updated together — a new app paired with an un-reflashed old `.ko` (which still exposes `/proc/vpnhide_targets`) will not configure the kernel. Reflash the kmod/zygisk modules and reboot (or reopen the app) after updating; the boot scripts and startup reconcile re-emit the config in the new format.

Testing

Verified locally: kmod host protocol/logic tests + clang-format + shellcheck; `zygisk` cargo build + tests; lsposed compile + detekt + ktlint + unit tests (incl. new `ConfigChannelsTest`); `make kpm`. The `.ko` runtime is exercised by the CI QEMU matrix. Not yet validated on a physical device end-to-end (kmod live config apply, KPM ctl0 push, real multi-backend boot).