### PR TITLE
Trim QEMU image cache exports

### DIFF
--- a/.github/workflows/qemu-image.yml
+++ b/.github/workflows/qemu-image.yml
@@ -84,8 +84,11 @@ jobs:
           build-args: KMI=${{ matrix.kmi }}
           push: true
           tags: ${{ steps.img.outputs.image }}
+          # Keep reading any existing per-KMI GHA cache entries while they
+          # expire, but do not export new ones. The kernel-build layers are
+          # huge and recent runs spent minutes exporting cache with little
+          # practical reuse.
           cache-from: type=gha,scope=ddk-qemu-${{ matrix.kmi }}
-          cache-to: type=gha,mode=max,scope=ddk-qemu-${{ matrix.kmi }}
 
   # One lightweight image with the 3 from-source legacy kernels (4.14/4.19/5.4)
   # for the KPM harness. Not a matrix — a single image with all three Images,
@@ -124,5 +127,6 @@ jobs:
           file: .github/docker/kpm-qemu-legacy/Dockerfile
           push: true
           tags: ${{ steps.img.outputs.image }}
+          # Same tradeoff as the per-KMI images: import old cache if present,
+          # skip the expensive export path.
           cache-from: type=gha,scope=kpm-qemu-legacy
-          cache-to: type=gha,mode=max,scope=kpm-qemu-legacy

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,7 +48,7 @@ These short files cover everything specific to this repo. Skipping them leads to
 
 Single-command builds for both CI and local — the same scripts run in both places.
 
-- **kmod**: `./kmod/build.py --kmi <kmi>` (or `--all`). Auto-spawns the DDK podman/docker container if you're not already inside it; CI passes `--inside-container` to skip the spawn. The DDK image tag is `DDK_IMAGE_TAG` in `kmod/build.py` — `.github/workflows/ci.yml` mirrors it, bump both together.
+- **kmod**: `./kmod/build.py --kmi <kmi>` (or `--all`). Auto-spawns the DDK Docker/podman container if you're not already inside it; CI passes `--inside-container` to skip the spawn. The DDK image tag is `DDK_IMAGE_TAG` in `kmod/build.py` — `.github/workflows/ci.yml` mirrors it, bump both together.
 - **zygisk**: `cd zygisk && ./build.py` — host-side cargo-ndk build, same script in CI image.
 - **lsposed APK**: `cd lsposed && ./gradlew :app:assembleRelease`.
 

--- a/changelog.d/changed-prefer-docker-over-podman-for-local-34ea.md
+++ b/changelog.d/changed-prefer-docker-over-podman-for-local-34ea.md
@@ -1,0 +1,9 @@
+_2026-06-29_
+
+## English
+
+Prefer Docker over podman for local kmod container builds and stop exporting QEMU image build caches.
+
+## Русский
+
+Для локальной сборки kmod контейнером теперь предпочитается Docker вместо podman, а QEMU image workflow больше не экспортирует build cache.

--- a/changelog.d/changed-prefer-docker-over-podman-for-local-34ea.md
+++ b/changelog.d/changed-prefer-docker-over-podman-for-local-34ea.md
@@ -1,9 +1,0 @@
-_2026-06-29_
-
-## English
-
-Prefer Docker over podman for local kmod container builds and stop exporting QEMU image build caches.
-
-## Русский
-
-Для локальной сборки kmod контейнером теперь предпочитается Docker вместо podman, а QEMU image workflow больше не экспортирует build cache.

--- a/docs/development.md
+++ b/docs/development.md
@@ -12,7 +12,7 @@ How to build vpnhide from source.
   rustup target add aarch64-linux-android
   cargo install cargo-ndk
   ```
-- **`podman` or `docker`** — only for building the kernel module via DDK images. See [kmod/BUILDING.md](../kmod/BUILDING.md).
+- **`docker` or `podman`** — only for building the kernel module via DDK images. Docker is preferred when both are installed, matching CI and device-test workflows. See [kmod/BUILDING.md](../kmod/BUILDING.md).
 - **`zip`** — packaging module zips.
 - **`adb`** — installing builds on a device.
 
@@ -79,7 +79,7 @@ cd lsposed && ./gradlew :app:assembleRelease
 # → vpnhide-kmod-<kmi>.zip at the repo root
 ```
 
-The script auto-spawns the `ghcr.io/ylarod/ddk-min:<kmi>-<TAG>` container via podman/docker (same image CI uses). For local kernel-source builds via `direnv` and the GKI matrix details, see [kmod/BUILDING.md](../kmod/BUILDING.md).
+The script auto-spawns the `ghcr.io/ylarod/ddk-min:<kmi>-<TAG>` container via Docker or podman (same image CI uses; Docker is preferred when both are installed). For local kernel-source builds via `direnv` and the GKI matrix details, see [kmod/BUILDING.md](../kmod/BUILDING.md).
 
 ## Install on device
 

--- a/kmod/BUILDING.md
+++ b/kmod/BUILDING.md
@@ -11,9 +11,9 @@ One command — same script CI runs, no container invocation to memorize:
 ./kmod/build.py --all                   # every supported GKI
 ```
 
-The script auto-detects whether to build natively (you're already inside the DDK image, or you've pointed `--kdir` at a kernel source tree) or to spawn a `ghcr.io/ylarod/ddk-min:<kmi>-<TAG>` container via podman/docker. On rootless podman (Fedora etc) it adds `--userns=keep-id` and `:Z` automatically. The output is `vpnhide-kmod-<kmi>.zip` at the repo root.
+The script auto-detects whether to build natively (you're already inside the DDK image, or you've pointed `--kdir` at a kernel source tree) or to spawn a `ghcr.io/ylarod/ddk-min:<kmi>-<TAG>` container via Docker or podman. Docker is preferred when both are installed, matching CI and device-test workflows. On rootless podman (Fedora etc) it adds `--userns=keep-id` and `:Z` automatically. The output is `vpnhide-kmod-<kmi>.zip` at the repo root.
 
-Requires `podman` or `docker`. The container image weighs ~1 GB per GKI variant on first pull.
+Requires `docker` or `podman`. The container image weighs ~1 GB per GKI variant on first pull.
 
 ### Identifying your GKI generation
 
@@ -69,6 +69,6 @@ adb shell "su -c 'cat /proc/vpnhide_ctl'"
 
 **kretprobe not firing** — check `dmesg | grep vpnhide` for registration messages and `/proc/vpnhide_ctl` for correct UIDs. Target app UIDs change on reinstall — re-resolve via the VPN Hide app.
 
-**`./kmod/build.py` says "neither podman nor docker found"** — install one (`dnf install podman` / `apt install docker.io`), or build natively against a local kernel source via `--kdir`.
+**`./kmod/build.py` says "neither podman nor docker found"** — install one (`apt install docker.io` / `dnf install podman`), or build natively against a local kernel source via `--kdir`.
 
 **Bumping the DDK image tag** — single source of truth is `DDK_IMAGE_TAG` in `kmod/build.py`. Both this script and `.github/workflows/ci.yml`'s kmod matrix pin to the same value, so update both together.

--- a/kmod/build.py
+++ b/kmod/build.py
@@ -14,7 +14,7 @@ Two modes, picked automatically:
       `ghcr.io/ylarod/ddk-min` image — auto-detects kdir + clang under
       `/opt/ddk`).
 
- 2. **Container build** — this Python process spawns podman/docker,
+ 2. **Container build** — this Python process spawns docker/podman,
     bind-mounts the repo, and re-invokes itself with
     `--inside-container`. Used when none of the native conditions apply,
     i.e. the typical local `./kmod/build.py --kmi android14-6.1`
@@ -219,15 +219,18 @@ def run_native_mode(args: argparse.Namespace, kmod_dir: Path) -> int:
 
 
 def find_runtime() -> tuple[str, bool]:
-    """(binary, is_podman). Prefer podman when both are present —
-    rootless podman has the awkward SELinux/userns flags, so being
-    explicit about it avoids surprises on Fedora-family hosts."""
-    podman = shutil.which("podman")
+    """(binary, is_podman). Prefer Docker when both are present.
+
+    The CI and device-test workflows use Docker, so matching that locally
+    avoids rootless podman bind-mount/userns surprises. Podman remains a
+    supported fallback for hosts without Docker.
+    """
     docker = shutil.which("docker")
-    if podman:
-        return podman, True
     if docker:
         return docker, False
+    podman = shutil.which("podman")
+    if podman:
+        return podman, True
     print(
         "error: neither podman nor docker found in PATH. Install one, or "
         "build natively by passing --kdir <kernel source> + --inside-container.",


### PR DESCRIPTION
## Summary

- Stop exporting BuildKit GHA cache from the QEMU image workflow while still importing existing cache entries until they expire.
- Prefer Docker over podman for local kmod DDK container builds, keeping podman as a fallback.
- Update build docs to match the Docker-first behavior.

## Rationale

Recent QEMU image logs showed several minutes spent preparing and sending cache exports, while the heavy kernel-build layers were still rebuilt. Skipping `cache-to` removes that tail cost without breaking existing `cache-from` reads.

## Validation

- `python3 -m py_compile kmod/build.py`
- `./kmod/build.py --help`
- `ruff format --check kmod/build.py`
- `ruff check kmod/build.py`
- `git diff --check`
