### PR TITLE
Fix APatch SuperKey saved-state reporting

### DIFF
--- a/changelog.d/fixed-show-apatch-superkey-as-saved-when-0d7b.md
+++ b/changelog.d/fixed-show-apatch-superkey-as-saved-when-0d7b.md
@@ -1,0 +1,9 @@
+_2026-06-29_
+
+## English
+
+Show APatch SuperKey as saved when the root-only key file actually exists and stop masking failed key writes.
+
+## Русский
+
+Показывать APatch SuperKey как сохранённый, если root-only файл ключа реально существует, и не маскировать ошибки записи ключа.

--- a/docs/adb-root-debugging.md
+++ b/docs/adb-root-debugging.md
@@ -60,6 +60,15 @@ The canonical JSON is `/data/system/vpnhide_config.json`, not `/data/adb`.
 `/data/adb` is still important for module files, KPM status, superkey storage,
 KernelSU/APatch CLIs, and LSPosed module state.
 
+## APK variant for LSPosed-enabled devices
+
+Use the release APK for cold-start checks on devices where VPN Hide itself is
+enabled in LSPosed/Vector. The debug APK is intentionally unminified and can
+carry tens of megabytes of dex; LSPosed/Vector may spend longer than Android's
+process-start timeout obfuscating that dex before the app attaches, producing
+`Process ... failed to attach` / `start timeout` in logcat. The release APK is
+R8-shrunk and is the representative path for app-start diagnostics.
+
 ## KernelSU Next Shell profile
 
 If `com.android.shell` has UID 0 but zero capabilities, fix the KernelSU Next

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/RootSnapshotCache.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/RootSnapshotCache.kt
@@ -39,6 +39,7 @@ internal val REQUIRED_ROOT_SNAPSHOT_SECTIONS =
         "hidden_pkgs",
         "observer_uids",
         "ports_observers",
+        "superkey_saved",
         "current_boot_id",
         "kmod_load_status",
         "kmod_load_dmesg",
@@ -215,6 +216,7 @@ internal fun buildRootShellSnapshotCommand(includePmPackages: Boolean = true): S
       emit_file hidden_pkgs $SS_HIDDEN_PKGS_FILE
       emit_file observer_uids $SS_OBSERVER_UIDS_FILE
       emit_file ports_observers $PORTS_OBSERVERS_FILE
+      emit_eval superkey_saved '[ -s $SUPERKEY_FILE ] && echo 1 || echo 0'
       phase_end
     }
     phase_kmod_status_files() {

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/SettingsScreen.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/SettingsScreen.kt
@@ -196,7 +196,7 @@ private fun SuperkeySettingsSection() {
     var superkey by remember { mutableStateOf("") }
     var saving by remember { mutableStateOf(false) }
     var status by remember { mutableStateOf<String?>(null) }
-    val remembered = targets?.canonicalConfig?.settings?.rememberSuperkey == true
+    val remembered = targets?.apatchSuperkeySaved == true
     val storedMessage = stringResource(R.string.settings_superkey_stored)
     val clearedMessage = stringResource(R.string.settings_superkey_cleared)
     val failedMessage = stringResource(R.string.settings_superkey_failed)
@@ -299,14 +299,18 @@ private fun writeSuperkeySetting(
         snapshot?.let(::buildCanonicalConfigFromTargetsSnapshot)
             ?: CanonicalConfig(debug = isEnabledInPrefs(context))
     val canonical = base.copy(settings = base.settings.copy(rememberSuperkey = remember))
-    val parts =
-        buildList {
-            add(buildCanonicalConfigWriteCommand(canonical))
-            add(if (remember) buildSuperkeyWriteCommand(superkey) else buildSuperkeyClearCommand())
-            if (remember) add(ConfigChannels.reconcileCommand())
-            add("true")
+    val requiredParts =
+        listOf(
+            buildCanonicalConfigWriteCommand(canonical),
+            if (remember) buildSuperkeyWriteCommand(superkey) else buildSuperkeyClearCommand(),
+        )
+    val cmd =
+        if (remember) {
+            requiredParts.joinToString(" && ") + " && " + ConfigChannels.reconcileCommand()
+        } else {
+            requiredParts.joinToString(" && ")
         }
-    val (exit, _) = suExec(parts.joinToString(" ; "))
+    val (exit, _) = suExec(cmd)
     if (exit == 0) {
         RootSnapshotCache.invalidate()
         DashboardCache.invalidate()

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/ShellCommandBuilders.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/ShellCommandBuilders.kt
@@ -26,6 +26,20 @@ internal fun buildAtomicRawWriteCommand(
     return "TMP=$path.tmp.\$\$ ; echo '$b64' | base64 -d > \"\$TMP\" && mv \"\$TMP\" $path"
 }
 
+internal fun buildAtomicRootOnlyRawWriteCommand(
+    path: String,
+    content: String,
+): String {
+    val b64 = base64NoWrap(content)
+    return listOf(
+        "TMP=$path.tmp.\$\$",
+        "echo '$b64' | base64 -d > \"\$TMP\"",
+        "chmod 600 \"\$TMP\" 2>/dev/null",
+        "chown root:root \"\$TMP\" 2>/dev/null",
+        "mv \"\$TMP\" $path",
+    ).joinToString(" && ")
+}
+
 internal fun buildAtomicSystemDataRawWriteCommand(
     path: String,
     content: String,

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/StorageConfig.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/StorageConfig.kt
@@ -271,10 +271,8 @@ internal fun buildCanonicalConfigWriteCommand(config: CanonicalConfig): String =
 internal fun buildSuperkeyWriteCommand(superkey: String): String =
     listOf(
         "mkdir -p /data/adb/vpnhide",
-        buildAtomicRawWriteCommand(SUPERKEY_FILE, superkey.trim() + "\n"),
-        "chmod 600 $SUPERKEY_FILE 2>/dev/null",
-        "chown root:root $SUPERKEY_FILE 2>/dev/null",
-    ).joinToString(" ; ")
+        buildAtomicRootOnlyRawWriteCommand(SUPERKEY_FILE, superkey.trim() + "\n"),
+    ).joinToString(" && ")
 
 internal fun buildSuperkeyClearCommand(): String = "rm -f $SUPERKEY_FILE"
 

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/TargetsCache.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/TargetsCache.kt
@@ -35,6 +35,7 @@ internal data class TargetsSnapshot(
     val portsObservers: Set<String>,
     val uidToPkg: Map<Int, String>,
     val canonicalConfig: CanonicalConfig?,
+    val apatchSuperkeySaved: Boolean = false,
 ) {
     /** True if any native backend is installed (kmod / KPM / Zygisk). The
      * picker's "N" toggle is meaningful only when at least one is present. */
@@ -142,6 +143,7 @@ internal fun parseTargetsSnapshot(rootSnapshot: RootSnapshot): TargetsSnapshot {
             portsObservers = portsObservers,
             uidToPkg = uidToPkg,
             canonicalConfig = canonical,
+            apatchSuperkeySaved = sections["superkey_saved"]?.trim() == "1",
         )
     }
 
@@ -161,5 +163,6 @@ internal fun parseTargetsSnapshot(rootSnapshot: RootSnapshot): TargetsSnapshot {
         portsObservers = nonEmptyLines(sections["ports_observers"]),
         uidToPkg = uidToPkg,
         canonicalConfig = null,
+        apatchSuperkeySaved = sections["superkey_saved"]?.trim() == "1",
     )
 }

--- a/lsposed/app/src/test/kotlin/dev/okhsunrog/vpnhide/RootSnapshotCacheTest.kt
+++ b/lsposed/app/src/test/kotlin/dev/okhsunrog/vpnhide/RootSnapshotCacheTest.kt
@@ -73,6 +73,7 @@ class RootSnapshotCacheTest {
         assertTrue(command.contains("cat \"${'$'}PATH_TO_READ\""))
         assertTrue(command.contains("pm list packages -U --user all"))
         assertTrue(command.contains("grep -H . /sys/class/net/*/operstate"))
+        assertTrue(command.contains("[ -s $SUPERKEY_FILE ] && echo 1 || echo 0"))
         assertTrue(command.contains("probe_ok=1"))
         assertTrue(command.contains("iptables -C OUTPUT -j vpnhide_out"))
         assertTrue(command.contains("ip6tables -C OUTPUT -j vpnhide_out6"))

--- a/lsposed/app/src/test/kotlin/dev/okhsunrog/vpnhide/ShellCommandBuildersTest.kt
+++ b/lsposed/app/src/test/kotlin/dev/okhsunrog/vpnhide/ShellCommandBuildersTest.kt
@@ -26,4 +26,14 @@ class ShellCommandBuildersTest {
 
         assertEquals("rm -f $SUPERKEY_FILE", cmd)
     }
+
+    @Test
+    fun `superkey write prepares tmp permissions before rename`() {
+        val cmd = buildSuperkeyWriteCommand("keyy51311")
+
+        assertTrue(cmd.startsWith("mkdir -p /data/adb/vpnhide && TMP=$SUPERKEY_FILE.tmp."))
+        assertTrue(cmd.contains("base64 -d > \"\$TMP\" && chmod 600 \"\$TMP\" 2>/dev/null"))
+        assertTrue(cmd.contains("&& chown root:root \"\$TMP\" 2>/dev/null && mv \"\$TMP\" $SUPERKEY_FILE"))
+        assertTrue(!cmd.contains("mv \"\$TMP\" $SUPERKEY_FILE && chmod"))
+    }
 }

--- a/lsposed/app/src/test/kotlin/dev/okhsunrog/vpnhide/TargetsCacheTest.kt
+++ b/lsposed/app/src/test/kotlin/dev/okhsunrog/vpnhide/TargetsCacheTest.kt
@@ -21,6 +21,7 @@ class TargetsCacheTest {
                         "hidden_pkgs" to "com.hidden.one\ncom.hidden.two\n",
                         "observer_uids" to "10123\n1010123\nnot-a-uid\n",
                         "ports_observers" to "com.browser\n",
+                        "superkey_saved" to "1",
                         "pm_packages" to
                             "package:com.observer uid:10123,1010123\n" +
                             "package:com.other uid:20222\n",
@@ -39,6 +40,7 @@ class TargetsCacheTest {
         assertEquals(setOf(10123, 1010123), targets.observerUids)
         assertEquals(setOf("com.observer"), targets.observerNames)
         assertEquals(setOf("com.browser"), targets.portsObservers)
+        assertTrue(targets.apatchSuperkeySaved)
     }
 
     @Test


### PR DESCRIPTION
## Summary
- report APatch SuperKey saved state from the actual root-only key file in the batched root snapshot
- stop masking SuperKey write failures with a trailing `true`; required writes now short-circuit with `&&`
- prepare SuperKey tmp file permissions before rename, matching the canonical JSON atomic-write pattern
- document that LSPosed-enabled cold-start checks should use the release APK, not the large debug APK

## Root cause
The Settings screen only looked at `settings.rememberSuperkey` in canonical JSON. On the Pixel 4a, `/data/adb/vpnhide/superkey` existed and APatch boot activation could use it, but the canonical flag was false, so the UI showed `Not saved`.

## Validation
- ktlint on changed Kotlin files
- `cd lsposed && ./gradlew :app:testDebugUnitTest`
- `cd lsposed && ./gradlew :app:detekt cpdCheck`
- `cd lsposed && ./gradlew :app:assembleRelease`
- Pixel 4a APatch: installed release APK and verified Settings shows `APatch SuperKey` / `Saved for boot-time KPM activation.`
- Pixel 4a APatch: release first launch after reinstall reaches dashboard (`Displayed ... +2s534ms`, dashboard ready ~964 ms). The earlier debug APK first-launch timeout reproduced as LSPosed/Vector obfuscating a 68 MB debug dex before app attach; this is now documented for diagnostics.