### PR TITLE
Add canonical config backup

### DIFF
--- a/changelog.d/added-export-and-import-the-full-canonical-7e16.md
+++ b/changelog.d/added-export-and-import-the-full-canonical-7e16.md
@@ -1,0 +1,9 @@
+_2026-06-29_
+
+## English
+
+Export and import the full canonical JSON configuration from Settings
+
+## Русский
+
+Добавлен экспорт и импорт полного канонического JSON-конфига из настроек

--- a/changelog.d/fixed-preserve-selected-apps-that-are-temporarily-2a54.md
+++ b/changelog.d/fixed-preserve-selected-apps-that-are-temporarily-2a54.md
@@ -1,0 +1,9 @@
+_2026-06-29_
+
+## English
+
+Preserve selected apps that are temporarily missing from the app list when saving Protection settings
+
+## Русский
+
+Сохраняем выбранные приложения, временно отсутствующие в списке, при сохранении настроек защиты

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/AppPickerData.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/AppPickerData.kt
@@ -21,3 +21,60 @@ internal fun resolveHiddenPackages(
     observers: Set<String>,
     selfPkg: String,
 ): List<String> = (existing.filterNot { it in observers } + selfPkg).distinct().sorted()
+
+internal data class AppRoleSelection(
+    val packageName: String,
+    val java: Boolean = false,
+    val native: Boolean = false,
+    val appHiding: Boolean = false,
+    val ports: Boolean = false,
+)
+
+internal fun buildCanonicalConfigForAppPickerSave(
+    debug: Boolean,
+    selfPkg: String,
+    selections: Collection<AppRoleSelection>,
+    snapshot: TargetsSnapshot?,
+): CanonicalConfig {
+    val base = canonicalBaseForSave(debug, snapshot)
+    val visiblePkgs = selections.mapTo(mutableSetOf()) { it.packageName }
+
+    fun preserved(predicate: (CanonicalApp) -> Boolean): Set<String> =
+        base.apps
+            .filter { (pkg, app) -> pkg !in visiblePkgs && predicate(app) }
+            .keys
+
+    val javaPkgs = preserved { it.java } + selections.selectedPkgs { it.java } + selfPkg
+    val nativePkgs = preserved { it.native.enabled } + selections.selectedPkgs { it.native } + selfPkg
+    val observerPkgs = preserved { it.appHiding } + selections.selectedPkgs { it.appHiding }
+    val portsPkgs = preserved { it.ports } + selections.selectedPkgs { it.ports }
+    val hiddenPkgs =
+        resolveHiddenPackages(
+            existing = base.apps.filterValues { it.hidden }.keys,
+            observers = observerPkgs,
+            selfPkg = selfPkg,
+        )
+
+    return buildCanonicalConfig(
+        debug = debug,
+        javaPkgs = javaPkgs,
+        nativePkgs = nativePkgs,
+        hiddenPkgs = hiddenPkgs,
+        observerPkgs = observerPkgs,
+        portsPkgs = portsPkgs,
+        existing = base,
+    )
+}
+
+private fun canonicalBaseForSave(
+    debug: Boolean,
+    snapshot: TargetsSnapshot?,
+): CanonicalConfig =
+    when {
+        snapshot?.canonicalConfig != null -> snapshot.canonicalConfig.copy(debug = debug)
+        snapshot != null -> buildCanonicalConfigFromTargetsSnapshot(snapshot, debug = debug)
+        else -> CanonicalConfig(debug = debug)
+    }
+
+private fun Collection<AppRoleSelection>.selectedPkgs(predicate: (AppRoleSelection) -> Boolean): Set<String> =
+    filter(predicate).mapTo(mutableSetOf()) { it.packageName }

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/AppPickerScreen.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/AppPickerScreen.kt
@@ -92,11 +92,7 @@ fun AppPickerScreen(
             res.getString(R.string.selected_count, entries.count { it.anySelected })
         },
         buildSaveCommand = { entries, ctx ->
-            val javaPkgs = (entries.filter { it.java }.map { it.packageName } + ctx.selfPkg).distinct().sorted()
-            val nativePkgs = (entries.filter { it.native }.map { it.packageName } + ctx.selfPkg).distinct().sorted()
-            val observerPkgs = entries.filter { it.appHiding }.map { it.packageName }.sorted()
-            val portsPkgs = entries.filter { it.ports }.map { it.packageName }.sorted()
-            buildUnifiedSaveCommand(ctx, javaPkgs, nativePkgs, observerPkgs, portsPkgs)
+            buildUnifiedSaveCommand(ctx, entries.map(AppEntry::toRoleSelection))
         },
         successMessage = { entries, res ->
             res.getString(R.string.save_success, entries.count { it.anySelected })
@@ -140,25 +136,16 @@ fun AppPickerScreen(
  */
 private fun buildUnifiedSaveCommand(
     ctx: SaveContext,
-    javaPkgs: List<String>,
-    nativePkgs: List<String>,
-    observerPkgs: List<String>,
-    portsPkgs: List<String>,
+    selections: Collection<AppRoleSelection>,
 ): String {
     val parts = mutableListOf<String>()
 
-    val existingSnapshot = TargetsCache.snapshot.value
-    val existingHidden = existingSnapshot?.hiddenPkgs ?: emptySet()
-    val hiddenPkgs = resolveHiddenPackages(existingHidden, observerPkgs.toSet(), ctx.selfPkg)
     val canonical =
-        buildCanonicalConfig(
+        buildCanonicalConfigForAppPickerSave(
             debug = ctx.debug,
-            javaPkgs = javaPkgs,
-            nativePkgs = nativePkgs,
-            hiddenPkgs = hiddenPkgs,
-            observerPkgs = observerPkgs,
-            portsPkgs = portsPkgs,
-            existing = existingSnapshot?.canonicalConfig,
+            selfPkg = ctx.selfPkg,
+            selections = selections,
+            snapshot = TargetsCache.snapshot.value,
         )
     parts += buildCanonicalConfigWriteCommand(canonical)
 
@@ -168,6 +155,15 @@ private fun buildUnifiedSaveCommand(
 
     return parts.joinToString(" ; ")
 }
+
+private fun AppEntry.toRoleSelection(): AppRoleSelection =
+    AppRoleSelection(
+        packageName = packageName,
+        java = java,
+        native = native,
+        appHiding = appHiding,
+        ports = ports,
+    )
 
 @Composable
 private fun AppRow(

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DebugLoggingPrefs.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DebugLoggingPrefs.kt
@@ -31,14 +31,22 @@ internal fun setDebugLoggingEnabled(
     context: Context,
     enabled: Boolean,
 ) {
+    storeDebugLoggingPreference(context, enabled)
+    writeDebugFlagFiles(enabled)
+    RootSnapshotCache.invalidate()
+    DashboardCache.invalidate()
+}
+
+internal fun storeDebugLoggingPreference(
+    context: Context,
+    enabled: Boolean,
+) {
     context
         .getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
         .edit()
         .putBoolean(KEY_DEBUG_LOGGING, enabled)
         .apply()
-    applyDebugLoggingRuntime(enabled)
-    RootSnapshotCache.invalidate()
-    DashboardCache.invalidate()
+    VpnHideLog.enabled = enabled
 }
 
 /**

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/SettingsScreen.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/SettingsScreen.kt
@@ -1,5 +1,8 @@
 package dev.okhsunrog.vpnhide
 
+import android.net.Uri
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -16,6 +19,8 @@ import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Animation
 import androidx.compose.material.icons.filled.BrightnessMedium
 import androidx.compose.material.icons.filled.DarkMode
+import androidx.compose.material.icons.filled.FileDownload
+import androidx.compose.material.icons.filled.FileUpload
 import androidx.compose.material.icons.filled.Layers
 import androidx.compose.material.icons.filled.Lock
 import androidx.compose.material.icons.filled.Palette
@@ -50,12 +55,14 @@ import dev.okhsunrog.vpnhide.settings.LocalSettingsInteractor
 import dev.okhsunrog.vpnhide.settings.LocalSettingsState
 import dev.okhsunrog.vpnhide.settings.ThemeMode
 import dev.okhsunrog.vpnhide.ui.components.EnhancedButton
+import dev.okhsunrog.vpnhide.ui.components.EnhancedOutlinedButton
 import dev.okhsunrog.vpnhide.ui.components.PreferenceRow
 import dev.okhsunrog.vpnhide.ui.components.PreferenceRowSwitch
 import dev.okhsunrog.vpnhide.ui.theme.AppColors
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import java.nio.charset.StandardCharsets
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -183,7 +190,146 @@ fun SettingsScreen(onBack: () -> Unit) {
                 )
             }
 
+            ConfigBackupSection()
             SuperkeySettingsSection()
+        }
+    }
+}
+
+@Composable
+private fun ConfigBackupSection() {
+    val context = LocalContext.current
+    val scope = rememberCoroutineScope()
+    val targets by TargetsCache.snapshot.collectAsState()
+    var operation by remember { mutableStateOf(ConfigOperation.Idle) }
+    var pendingExport by remember { mutableStateOf<String?>(null) }
+    var status by remember { mutableStateOf<String?>(null) }
+    val exportDone = stringResource(R.string.settings_config_export_done)
+    val exportFailed = stringResource(R.string.settings_config_export_failed)
+    val importDone = stringResource(R.string.settings_config_import_done)
+    val importInvalid = stringResource(R.string.settings_config_import_invalid)
+    val importRootFailed = stringResource(R.string.settings_config_import_root_failed)
+
+    val exportLauncher =
+        rememberLauncherForActivityResult(
+            ActivityResultContracts.CreateDocument("application/json"),
+        ) { uri ->
+            val raw = pendingExport
+            pendingExport = null
+            if (uri == null || raw == null) return@rememberLauncherForActivityResult
+            operation = ConfigOperation.Export
+            scope.launch {
+                val ok = withContext(Dispatchers.IO) { writeTextToUri(context, uri, raw) }
+                operation = ConfigOperation.Idle
+                status = if (ok) exportDone else exportFailed
+            }
+        }
+
+    val importLauncher =
+        rememberLauncherForActivityResult(
+            ActivityResultContracts.OpenDocument(),
+        ) { uri ->
+            if (uri == null) return@rememberLauncherForActivityResult
+            operation = ConfigOperation.Import
+            status = null
+            scope.launch {
+                val result = withContext(Dispatchers.IO) { importConfigFromUri(context, uri) }
+                operation = ConfigOperation.Idle
+                status =
+                    when (result) {
+                        ConfigImportResult.Success -> {
+                            TargetsCache.refreshAfterSave(scope, context)
+                            importDone
+                        }
+
+                        ConfigImportResult.InvalidJson -> {
+                            importInvalid
+                        }
+
+                        ConfigImportResult.RootFailed -> {
+                            importRootFailed
+                        }
+                    }
+            }
+        }
+
+    LaunchedEffect(Unit) {
+        TargetsCache.ensureLoaded(scope, context)
+    }
+
+    Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+        SettingsSectionHeader(stringResource(R.string.settings_config_section))
+        PreferenceRow(
+            title = stringResource(R.string.settings_config_backup_title),
+            subtitle = stringResource(R.string.settings_config_backup_sub),
+            icon = Icons.Default.FileDownload,
+        )
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
+        ) {
+            EnhancedOutlinedButton(
+                onClick = {
+                    pendingExport = buildConfigExportJson(context, targets)
+                    status = null
+                    exportLauncher.launch("vpnhide_config.json")
+                },
+                enabled = operation == ConfigOperation.Idle && targets != null,
+                modifier = Modifier.weight(1f),
+            ) {
+                if (operation == ConfigOperation.Export) {
+                    CircularProgressIndicator(
+                        modifier = Modifier.size(18.dp).padding(end = 8.dp),
+                        strokeWidth = 2.dp,
+                        color = MaterialTheme.colorScheme.primary,
+                    )
+                } else {
+                    Icon(Icons.Default.FileDownload, contentDescription = null, modifier = Modifier.size(18.dp))
+                    Spacer(Modifier.width(8.dp))
+                }
+                Text(stringResource(R.string.settings_config_export))
+            }
+            EnhancedButton(
+                onClick = {
+                    importLauncher.launch(
+                        arrayOf(
+                            "application/json",
+                            "text/json",
+                            "text/plain",
+                            "application/octet-stream",
+                            "*/*",
+                        ),
+                    )
+                },
+                enabled = operation == ConfigOperation.Idle,
+                modifier = Modifier.weight(1f),
+            ) {
+                if (operation == ConfigOperation.Import) {
+                    CircularProgressIndicator(
+                        modifier = Modifier.size(18.dp).padding(end = 8.dp),
+                        strokeWidth = 2.dp,
+                        color = MaterialTheme.colorScheme.onPrimary,
+                    )
+                } else {
+                    Icon(Icons.Default.FileUpload, contentDescription = null, modifier = Modifier.size(18.dp))
+                    Spacer(Modifier.width(8.dp))
+                }
+                Text(stringResource(R.string.settings_config_import))
+            }
+        }
+        Text(
+            text = stringResource(R.string.settings_config_import_note),
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            modifier = Modifier.padding(start = 4.dp),
+        )
+        status?.let {
+            Text(
+                text = it,
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.padding(start = 4.dp),
+            )
         }
     }
 }
@@ -312,6 +458,68 @@ private fun writeSuperkeySetting(
         DashboardCache.invalidate()
     }
     return exit
+}
+
+private enum class ConfigImportResult {
+    Success,
+    InvalidJson,
+    RootFailed,
+}
+
+private enum class ConfigOperation {
+    Idle,
+    Export,
+    Import,
+}
+
+private fun buildConfigExportJson(
+    context: android.content.Context,
+    snapshot: TargetsSnapshot?,
+): String {
+    val canonical =
+        when {
+            snapshot?.canonicalConfig != null -> snapshot.canonicalConfig
+            snapshot != null -> buildCanonicalConfigFromTargetsSnapshot(snapshot)
+            else -> CanonicalConfig(debug = isEnabledInPrefs(context))
+        }
+    return canonicalConfigJson(canonical)
+}
+
+private fun writeTextToUri(
+    context: android.content.Context,
+    uri: Uri,
+    text: String,
+): Boolean =
+    runCatching {
+        context.contentResolver.openOutputStream(uri)?.use { out ->
+            out.write(text.toByteArray(StandardCharsets.UTF_8))
+        } ?: error("openOutputStream returned null")
+    }.isSuccess
+
+private fun importConfigFromUri(
+    context: android.content.Context,
+    uri: Uri,
+): ConfigImportResult {
+    val raw =
+        runCatching {
+            context.contentResolver
+                .openInputStream(uri)
+                ?.bufferedReader(StandardCharsets.UTF_8)
+                ?.use { it.readText() }
+        }.getOrNull() ?: return ConfigImportResult.InvalidJson
+    val canonical = parseImportedCanonicalConfig(raw, context.packageName) ?: return ConfigImportResult.InvalidJson
+    val cmd =
+        listOf(
+            buildCanonicalConfigWriteCommand(canonical),
+            ConfigChannels.reconcileCommand(),
+            "if [ -x $PORTS_ACTIVATOR ]; then $PORTS_ACTIVATOR; fi",
+        ).joinToString(" ; ")
+    val (exit, _) = suExec(cmd)
+    if (exit != 0) return ConfigImportResult.RootFailed
+    storeDebugLoggingPreference(context, canonical.debug)
+    RootSnapshotCache.invalidate()
+    DashboardCache.invalidate()
+    return ConfigImportResult.Success
 }
 
 @Composable

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/StorageConfig.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/StorageConfig.kt
@@ -154,6 +154,16 @@ internal fun canonicalConfigWithSelfTarget(
     return config.copy(apps = (config.apps + (selfPkg to updated)).toSortedMap())
 }
 
+internal fun parseImportedCanonicalConfig(
+    raw: String,
+    selfPkg: String,
+): CanonicalConfig? =
+    try {
+        parseCanonicalConfig(raw)?.let { canonicalConfigWithSelfTarget(it, selfPkg) }
+    } catch (_: Throwable) {
+        null
+    }
+
 internal fun canonicalConfigJson(config: CanonicalConfig): String =
     buildString {
         append("{\n")

--- a/lsposed/app/src/main/res/values-ru/strings.xml
+++ b/lsposed/app/src/main/res/values-ru/strings.xml
@@ -212,6 +212,17 @@
     <string name="settings_haptics_sub">Вибрация при нажатиях и переключениях</string>
     <string name="settings_animations">Анимации</string>
     <string name="settings_animations_sub">Пружинные переходы и морфинг форм</string>
+    <string name="settings_config_section">Конфигурация</string>
+    <string name="settings_config_backup_title">Резервная копия конфига</string>
+    <string name="settings_config_backup_sub">Сохранить или восстановить канонический JSON-конфиг</string>
+    <string name="settings_config_export">Экспорт JSON</string>
+    <string name="settings_config_import">Импорт JSON</string>
+    <string name="settings_config_import_note">Импорт заменяет текущий конфиг и применяет установленные модули заново.</string>
+    <string name="settings_config_export_done">Конфиг экспортирован.</string>
+    <string name="settings_config_export_failed">Не удалось экспортировать конфиг.</string>
+    <string name="settings_config_import_done">Конфиг импортирован.</string>
+    <string name="settings_config_import_invalid">Импорт не удался: некорректный JSON-конфиг.</string>
+    <string name="settings_config_import_root_failed">Импорт не удался: не получилось записать root-конфиг.</string>
     <string name="settings_security">Безопасность</string>
     <string name="settings_superkey_title">APatch SuperKey</string>
     <string name="settings_superkey_saved">Сохранён для активации KPM при загрузке.</string>

--- a/lsposed/app/src/main/res/values/strings.xml
+++ b/lsposed/app/src/main/res/values/strings.xml
@@ -255,6 +255,17 @@
     <string name="settings_haptics_sub">Vibrate on taps and toggles</string>
     <string name="settings_animations">Animations</string>
     <string name="settings_animations_sub">Springy transitions and shape morphing</string>
+    <string name="settings_config_section">Configuration</string>
+    <string name="settings_config_backup_title">Config backup</string>
+    <string name="settings_config_backup_sub">Save or restore the canonical JSON config</string>
+    <string name="settings_config_export">Export JSON</string>
+    <string name="settings_config_import">Import JSON</string>
+    <string name="settings_config_import_note">Import replaces the current config and reapplies installed modules.</string>
+    <string name="settings_config_export_done">Config exported.</string>
+    <string name="settings_config_export_failed">Config export failed.</string>
+    <string name="settings_config_import_done">Config imported.</string>
+    <string name="settings_config_import_invalid">Import failed: invalid config JSON.</string>
+    <string name="settings_config_import_root_failed">Import failed: root config write failed.</string>
     <string name="settings_security">Security</string>
     <string name="settings_superkey_title">APatch SuperKey</string>
     <string name="settings_superkey_saved">Saved for boot-time KPM activation.</string>

--- a/lsposed/app/src/test/kotlin/dev/okhsunrog/vpnhide/AppPickerDataTest.kt
+++ b/lsposed/app/src/test/kotlin/dev/okhsunrog/vpnhide/AppPickerDataTest.kt
@@ -44,4 +44,117 @@ class AppPickerDataTest {
             resolveHiddenPackages(existing = setOf("com.z", "com.a", self), observers = emptySet(), selfPkg = self),
         )
     }
+
+    @Test
+    fun `save preserves selected apps missing from current picker list`() {
+        val snapshot =
+            snapshotWithCanonical(
+                "com.frozen" to CanonicalApp(java = true, native = NativeRole.All, appHiding = true, ports = true),
+            )
+
+        val cfg =
+            buildCanonicalConfigForAppPickerSave(
+                debug = false,
+                selfPkg = self,
+                selections =
+                    listOf(
+                        AppRoleSelection(packageName = "com.visible", java = true),
+                    ),
+                snapshot = snapshot,
+            )
+
+        val frozen = cfg.apps.getValue("com.frozen")
+        assertEquals(true, frozen.java)
+        assertEquals(NativeRole.All, frozen.native)
+        assertEquals(true, frozen.appHiding)
+        assertEquals(true, frozen.ports)
+    }
+
+    @Test
+    fun `save can remove a visible app without dropping missing apps`() {
+        val snapshot =
+            snapshotWithCanonical(
+                "com.visible" to CanonicalApp(java = true, native = NativeRole.All, appHiding = true, ports = true),
+                "com.frozen" to CanonicalApp(java = true, native = NativeRole.All),
+            )
+
+        val cfg =
+            buildCanonicalConfigForAppPickerSave(
+                debug = false,
+                selfPkg = self,
+                selections =
+                    listOf(
+                        AppRoleSelection(packageName = "com.visible"),
+                    ),
+                snapshot = snapshot,
+            )
+
+        assertEquals(false, cfg.apps.containsKey("com.visible"))
+        assertEquals(true, cfg.apps.getValue("com.frozen").java)
+        assertEquals(NativeRole.All, cfg.apps.getValue("com.frozen").native)
+    }
+
+    @Test
+    fun `save preserves custom native hooks for missing and still selected apps`() {
+        val customNative = NativeRole(enabled = true, hooks = listOf("sock_ioctl"))
+        val snapshot =
+            snapshotWithCanonical(
+                "com.visible" to CanonicalApp(native = customNative),
+                "com.frozen" to CanonicalApp(native = customNative),
+            )
+
+        val cfg =
+            buildCanonicalConfigForAppPickerSave(
+                debug = false,
+                selfPkg = self,
+                selections =
+                    listOf(
+                        AppRoleSelection(packageName = "com.visible", native = true),
+                    ),
+                snapshot = snapshot,
+            )
+
+        assertEquals(customNative, cfg.apps.getValue("com.visible").native)
+        assertEquals(customNative, cfg.apps.getValue("com.frozen").native)
+    }
+
+    @Test
+    fun `observer role still wins over hidden for visible packages`() {
+        val snapshot =
+            snapshotWithCanonical(
+                "com.vpn" to CanonicalApp(hidden = true),
+            )
+
+        val cfg =
+            buildCanonicalConfigForAppPickerSave(
+                debug = false,
+                selfPkg = self,
+                selections =
+                    listOf(
+                        AppRoleSelection(packageName = "com.vpn", appHiding = true),
+                    ),
+                snapshot = snapshot,
+            )
+
+        assertEquals(true, cfg.apps.getValue("com.vpn").appHiding)
+        assertEquals(false, cfg.apps.getValue("com.vpn").hidden)
+        assertEquals(true, cfg.apps.getValue(self).hidden)
+    }
+
+    private fun snapshotWithCanonical(vararg apps: Pair<String, CanonicalApp>): TargetsSnapshot =
+        TargetsSnapshot(
+            kmodModuleInstalled = true,
+            kpmModuleInstalled = false,
+            zygiskModuleInstalled = false,
+            portsModuleInstalled = true,
+            kmodTargets = emptySet(),
+            kpmTargets = emptySet(),
+            zygiskTargets = emptySet(),
+            lsposedTargets = emptySet(),
+            hiddenPkgs = emptySet(),
+            observerUids = emptySet(),
+            portsObservers = emptySet(),
+            uidToPkg = emptyMap(),
+            canonicalConfig = CanonicalConfig(apps = apps.toMap()),
+        )
 }

--- a/lsposed/app/src/test/kotlin/dev/okhsunrog/vpnhide/StorageConfigTest.kt
+++ b/lsposed/app/src/test/kotlin/dev/okhsunrog/vpnhide/StorageConfigTest.kt
@@ -105,6 +105,41 @@ class StorageConfigTest {
     }
 
     @Test
+    fun `import parser accepts canonical json and adds self target`() {
+        val cfg =
+            requireNotNull(
+                parseImportedCanonicalConfig(
+                    """
+                    {
+                      "version": 1,
+                      "debug": true,
+                      "apps": {
+                        "com.bank": { "java": true }
+                      },
+                      "settings": { "rememberSuperkey": true }
+                    }
+                    """.trimIndent(),
+                    selfPkg = "dev.okhsunrog.vpnhide",
+                ),
+            )
+
+        assertTrue(cfg.debug)
+        assertTrue(cfg.apps.getValue("com.bank").java)
+        assertEquals(CanonicalSettings(rememberSuperkey = true), cfg.settings)
+        assertEquals(
+            CanonicalApp(java = true, native = NativeRole.All, hidden = true),
+            cfg.apps.getValue("dev.okhsunrog.vpnhide"),
+        )
+    }
+
+    @Test
+    fun `import parser rejects invalid or unsupported json`() {
+        assertEquals(null, parseImportedCanonicalConfig("", "dev.okhsunrog.vpnhide"))
+        assertEquals(null, parseImportedCanonicalConfig("{not-json", "dev.okhsunrog.vpnhide"))
+        assertEquals(null, parseImportedCanonicalConfig("""{"version": 999, "apps": {}}""", "dev.okhsunrog.vpnhide"))
+    }
+
+    @Test
     fun `snapshot builder folds legacy roles into canonical config`() {
         val snapshot =
             TargetsSnapshot(


### PR DESCRIPTION
## Summary

- Add Settings controls to export and import the canonical JSON configuration through Android's document picker.
- Validate imported configs, restore the self target automatically, reapply installed runtime channels, and sync the debug logging preference from the imported JSON.
- Preserve selected apps that are temporarily missing from the app picker when saving Protection settings.

## Validation

- `cd lsposed && ./gradlew :app:testDebugUnitTest`
- `cd lsposed && ./gradlew :app:ktlintCheck`
- `cd lsposed && ./gradlew :app:detekt`
- `cd lsposed && ./gradlew cpdCheck`
- `git diff --check`
