### PR TITLE
Auto-hide VPN apps for app hiding

### DIFF
--- a/changelog.d/added-auto-hide-installed-vpn-apps-from-c6f1.md
+++ b/changelog.d/added-auto-hide-installed-vpn-apps-from-c6f1.md
@@ -1,0 +1,9 @@
+_2026-06-29_
+
+## English
+
+Auto-hide installed VPN apps from app-hiding targets using configurable heuristics
+
+## Русский
+
+Добавлено автоматическое скрытие VPN-приложений от целей app hiding с настраиваемыми эвристиками

--- a/docs/state.md
+++ b/docs/state.md
@@ -19,7 +19,9 @@ For each entry: format, writer, reader, lifetime, and permissions when relevant.
 The single managed desired-state file.
 
 - Format: JSON object, `version: 1`, `debug: Boolean`, `apps: { package ->
-  roles }`, `settings.rememberSuperkey: Boolean`.
+  roles }`, `settings.rememberSuperkey: Boolean`,
+  `settings.autoHideVpnServices: Boolean`, `settings.autoHideVpnName: Boolean`,
+  `settings.autoHiddenPackages: [package]`.
 - Roles per package: `java`, `native` (`Boolean` or hook-name array),
   `appHiding`, `ports`, and the app-owned extension `hidden`.
 - Writer: VPN Hide app via `su` (`StorageConfig.kt`) on Save, startup

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/AppListCache.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/AppListCache.kt
@@ -1,9 +1,13 @@
 package dev.okhsunrog.vpnhide
 
+import android.Manifest
 import android.content.Context
+import android.content.Intent
 import android.content.pm.ApplicationInfo
 import android.content.pm.PackageManager
 import android.graphics.drawable.Drawable
+import android.net.VpnService
+import android.os.Build
 import android.os.Process
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -11,6 +15,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.withContext
+import java.util.Locale
 
 /**
  * Common per-installed-app fields used by every Protection screen
@@ -23,7 +28,18 @@ internal data class AppSummary(
     val icon: Drawable?,
     val isSystem: Boolean,
     val userIds: List<Int> = emptyList(),
+    val declaresVpnService: Boolean = false,
+    val nameContainsVpn: Boolean = false,
 )
+
+internal fun AppSummary.toAutoHideSignal(): AppAutoHideSignal =
+    AppAutoHideSignal(
+        packageName = packageName,
+        declaresVpnService = declaresVpnService,
+        nameContainsVpn = nameContainsVpn,
+    )
+
+internal fun looksLikeVpnAppName(label: String): Boolean = label.uppercase(Locale.ROOT).contains("VPN")
 
 /**
  * Append a profile list to an app label so users can tell that
@@ -96,6 +112,7 @@ internal object AppListCache : StateCache<List<AppSummary>>(
         val appContext = requireNotNull(appContext) { "AppListCache.load before ensureLoaded/refresh" }
         return withContext(Dispatchers.IO) {
             val pm = appContext.packageManager
+            val vpnServicePkgs = queryVpnServiceProviders(pm)
             val (packages, users) = loadPackagesAndUsersViaRoot()
             _userNames.value = users
             if (packages.isNotEmpty()) {
@@ -120,13 +137,16 @@ internal object AppListCache : StateCache<List<AppSummary>>(
                             } else {
                                 !meta.apkPath.startsWith("/data/app/")
                             }
+                        val label = effectiveInfo?.loadLabel(pm)?.toString() ?: pkg
 
                         AppSummary(
                             packageName = pkg,
-                            label = effectiveInfo?.loadLabel(pm)?.toString() ?: pkg,
+                            label = label,
                             icon = effectiveInfo?.let { runCatching { pm.getApplicationIcon(it) }.getOrNull() },
                             isSystem = isSystem,
                             userIds = meta.userIds,
+                            declaresVpnService = pkg in vpnServicePkgs,
+                            nameContainsVpn = !isSystem && looksLikeVpnAppName(label),
                         )
                     }.sortedBy { it.label.lowercase() }
             } else {
@@ -134,16 +154,38 @@ internal object AppListCache : StateCache<List<AppSummary>>(
                 pm
                     .getInstalledApplications(0)
                     .map { info ->
+                        val label = info.loadLabel(pm).toString()
+                        val isSystem = (info.flags and ApplicationInfo.FLAG_SYSTEM) != 0
                         AppSummary(
                             packageName = info.packageName,
-                            label = info.loadLabel(pm).toString(),
+                            label = label,
                             icon = runCatching { pm.getApplicationIcon(info) }.getOrNull(),
-                            isSystem = (info.flags and ApplicationInfo.FLAG_SYSTEM) != 0,
+                            isSystem = isSystem,
                             userIds = listOf(Process.myUid() / 100000),
+                            declaresVpnService = info.packageName in vpnServicePkgs,
+                            nameContainsVpn = !isSystem && looksLikeVpnAppName(label),
                         )
                     }.sortedBy { it.label.lowercase() }
             }
         }
+    }
+
+    private fun queryVpnServiceProviders(pm: PackageManager): Set<String> {
+        val intent = Intent(VpnService.SERVICE_INTERFACE)
+        val resolveInfos =
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+                pm.queryIntentServices(intent, PackageManager.ResolveInfoFlags.of(0L))
+            } else {
+                @Suppress("DEPRECATION")
+                pm.queryIntentServices(intent, 0)
+            }
+        return resolveInfos
+            .asSequence()
+            .mapNotNull { resolveInfo ->
+                val serviceInfo = resolveInfo.serviceInfo ?: return@mapNotNull null
+                if (serviceInfo.permission != Manifest.permission.BIND_VPN_SERVICE) return@mapNotNull null
+                serviceInfo.packageName?.takeIf { it.isNotBlank() }
+            }.toSet()
     }
 
     private data class PkgMeta(

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/AppPickerData.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/AppPickerData.kt
@@ -4,23 +4,41 @@ package dev.okhsunrog.vpnhide
 // Android deps, unit-tested (see AppPickerDataTest), per lsposed/AGENTS.md.
 
 /**
- * The hidden-package set to persist on Save. Real auto-detection of sensitive
- * apps is a follow-up; for now this preserves the [existing] hidden set (so a
- * migrating user doesn't lose a prior config) and always includes [selfPkg]
- * (managed invisibly, never shown in the picker).
+ * The hidden-package set to persist on Save. This preserves manual hidden
+ * packages and auto-detected VPN apps, and always includes [selfPkg] (managed
+ * invisibly, never shown in the picker).
  *
- * Hidden and observer are **mutually exclusive**: a package that is both crashes
- * the framework on a self-lookup (an observer querying its own PackageInfo gets
- * a NameNotFoundException when it is also hidden — the bug the old AppHidingScreen
- * guarded against). So [observers] win — any package the user just marked "A" is
- * dropped from the hidden set. Self is never an observer (the picker never lists
- * it), so it always stays hidden.
+ * Hidden and app-hiding observer roles are **mutually exclusive**: a package
+ * that is both crashes the framework on a self-lookup (an observer querying its
+ * own PackageInfo gets a NameNotFoundException when it is also hidden). So
+ * [observers] win — any package the user just marked "A" is dropped from the
+ * hidden set. Self is never an observer (the picker never lists it), so it
+ * always stays hidden.
  */
 internal fun resolveHiddenPackages(
     existing: Set<String>,
     observers: Set<String>,
     selfPkg: String,
 ): List<String> = (existing.filterNot { it in observers } + selfPkg).distinct().sorted()
+
+internal data class AppAutoHideSignal(
+    val packageName: String,
+    val declaresVpnService: Boolean = false,
+    val nameContainsVpn: Boolean = false,
+)
+
+internal fun resolveAutoHiddenPackages(
+    signals: Collection<AppAutoHideSignal>,
+    settings: CanonicalSettings,
+    selfPkg: String,
+): Set<String> =
+    signals
+        .asSequence()
+        .filter { it.packageName != selfPkg }
+        .filter {
+            (settings.autoHideVpnServices && it.declaresVpnService) ||
+                (settings.autoHideVpnName && it.nameContainsVpn)
+        }.mapTo(sortedSetOf()) { it.packageName }
 
 internal data class AppRoleSelection(
     val packageName: String,
@@ -35,6 +53,7 @@ internal fun buildCanonicalConfigForAppPickerSave(
     selfPkg: String,
     selections: Collection<AppRoleSelection>,
     snapshot: TargetsSnapshot?,
+    autoHideSignals: Collection<AppAutoHideSignal> = emptyList(),
 ): CanonicalConfig {
     val base = canonicalBaseForSave(debug, snapshot)
     val visiblePkgs = selections.mapTo(mutableSetOf()) { it.packageName }
@@ -48,21 +67,54 @@ internal fun buildCanonicalConfigForAppPickerSave(
     val nativePkgs = preserved { it.native.enabled } + selections.selectedPkgs { it.native } + selfPkg
     val observerPkgs = preserved { it.appHiding } + selections.selectedPkgs { it.appHiding }
     val portsPkgs = preserved { it.ports } + selections.selectedPkgs { it.ports }
+    val manualHiddenPkgs = base.apps.filterValues { it.hidden }.keys - base.settings.autoHiddenPackages
     val hiddenPkgs =
         resolveHiddenPackages(
-            existing = base.apps.filterValues { it.hidden }.keys,
+            existing = manualHiddenPkgs,
             observers = observerPkgs,
             selfPkg = selfPkg,
         )
 
+    val canonical =
+        buildCanonicalConfig(
+            debug = debug,
+            javaPkgs = javaPkgs,
+            nativePkgs = nativePkgs,
+            hiddenPkgs = hiddenPkgs,
+            observerPkgs = observerPkgs,
+            portsPkgs = portsPkgs,
+            existing = base,
+        )
+    return applyAutoHiddenPackages(
+        config = canonical,
+        selfPkg = selfPkg,
+        signals = autoHideSignals,
+    )
+}
+
+internal fun applyAutoHiddenPackages(
+    config: CanonicalConfig,
+    selfPkg: String,
+    signals: Collection<AppAutoHideSignal>,
+): CanonicalConfig {
+    val observerPkgs = config.apps.filterValues { it.appHiding }.keys
+    val manualHiddenPkgs = config.apps.filterValues { it.hidden }.keys - config.settings.autoHiddenPackages
+    val autoHiddenPkgs = resolveAutoHiddenPackages(signals, config.settings, selfPkg)
+    val effectiveAutoHiddenPkgs = autoHiddenPkgs - observerPkgs
+    val hiddenPkgs =
+        resolveHiddenPackages(
+            existing = manualHiddenPkgs + effectiveAutoHiddenPkgs,
+            observers = observerPkgs,
+            selfPkg = selfPkg,
+        )
     return buildCanonicalConfig(
-        debug = debug,
-        javaPkgs = javaPkgs,
-        nativePkgs = nativePkgs,
+        debug = config.debug,
+        javaPkgs = config.apps.filterValues { it.java }.keys,
+        nativePkgs = config.apps.filterValues { it.native.enabled }.keys,
         hiddenPkgs = hiddenPkgs,
         observerPkgs = observerPkgs,
-        portsPkgs = portsPkgs,
-        existing = base,
+        portsPkgs = config.apps.filterValues { it.ports }.keys,
+        existing = config.copy(settings = config.settings.copy(autoHiddenPackages = effectiveAutoHiddenPkgs.toSortedSet())),
     )
 }
 

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/AppPickerScreen.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/AppPickerScreen.kt
@@ -31,6 +31,8 @@ data class AppEntry(
     val native: Boolean = false,
     val appHiding: Boolean = false,
     val ports: Boolean = false,
+    val declaresVpnService: Boolean = false,
+    val nameContainsVpn: Boolean = false,
 ) : TargetEntry {
     override val anySelected get() = java || native || appHiding || ports
 }
@@ -70,6 +72,14 @@ fun AppPickerScreen(
         merge = { apps, t, selfPkg ->
             val nativeTargets = t.nativeTargets
             val observers = t.observerNames
+            val autoHideSignals = apps.map(AppSummary::toAutoHideSignal)
+            val baseCanonical = t.canonicalConfig ?: buildCanonicalConfigFromTargetsSnapshot(t)
+            val autoApplied =
+                applyAutoHiddenPackages(
+                    config = baseCanonical,
+                    selfPkg = selfPkg,
+                    signals = autoHideSignals,
+                )
             MergeResult(
                 apps
                     .filter { it.packageName != selfPkg }
@@ -84,15 +94,22 @@ fun AppPickerScreen(
                             native = app.packageName in nativeTargets,
                             appHiding = app.packageName in observers,
                             ports = app.packageName in t.portsObservers,
+                            declaresVpnService = app.declaresVpnService,
+                            nameContainsVpn = app.nameContainsVpn,
                         )
                     },
+                resaveNeeded = autoApplied != baseCanonical,
             )
         },
         countText = { entries, res ->
             res.getString(R.string.selected_count, entries.count { it.anySelected })
         },
         buildSaveCommand = { entries, ctx ->
-            buildUnifiedSaveCommand(ctx, entries.map(AppEntry::toRoleSelection))
+            buildUnifiedSaveCommand(
+                ctx = ctx,
+                selections = entries.map(AppEntry::toRoleSelection),
+                autoHideSignals = entries.map(AppEntry::toAutoHideSignal),
+            )
         },
         successMessage = { entries, res ->
             res.getString(R.string.save_success, entries.count { it.anySelected })
@@ -137,6 +154,7 @@ fun AppPickerScreen(
 private fun buildUnifiedSaveCommand(
     ctx: SaveContext,
     selections: Collection<AppRoleSelection>,
+    autoHideSignals: Collection<AppAutoHideSignal>,
 ): String {
     val parts = mutableListOf<String>()
 
@@ -146,6 +164,7 @@ private fun buildUnifiedSaveCommand(
             selfPkg = ctx.selfPkg,
             selections = selections,
             snapshot = TargetsCache.snapshot.value,
+            autoHideSignals = autoHideSignals,
         )
     parts += buildCanonicalConfigWriteCommand(canonical)
 
@@ -163,6 +182,13 @@ private fun AppEntry.toRoleSelection(): AppRoleSelection =
         native = native,
         appHiding = appHiding,
         ports = ports,
+    )
+
+private fun AppEntry.toAutoHideSignal(): AppAutoHideSignal =
+    AppAutoHideSignal(
+        packageName = packageName,
+        declaresVpnService = declaresVpnService,
+        nameContainsVpn = nameContainsVpn,
     )
 
 @Composable

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/SettingsScreen.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/SettingsScreen.kt
@@ -25,7 +25,9 @@ import androidx.compose.material.icons.filled.Layers
 import androidx.compose.material.icons.filled.Lock
 import androidx.compose.material.icons.filled.Palette
 import androidx.compose.material.icons.filled.RoundedCorner
+import androidx.compose.material.icons.filled.TextFields
 import androidx.compose.material.icons.filled.Vibration
+import androidx.compose.material.icons.filled.VpnKey
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
@@ -190,6 +192,7 @@ fun SettingsScreen(onBack: () -> Unit) {
                 )
             }
 
+            AutoHideSettingsSection()
             ConfigBackupSection()
             SuperkeySettingsSection()
         }
@@ -524,6 +527,106 @@ private fun importConfigFromUri(
     RootSnapshotCache.invalidate()
     DashboardCache.invalidate()
     return ConfigImportResult.Success
+}
+
+@Composable
+private fun AutoHideSettingsSection() {
+    val context = LocalContext.current
+    val scope = rememberCoroutineScope()
+    val targets by TargetsCache.snapshot.collectAsState()
+    val apps by AppListCache.apps.collectAsState()
+    var saving by remember { mutableStateOf<AutoHideSetting?>(null) }
+    var status by remember { mutableStateOf<String?>(null) }
+    val savedMessage = stringResource(R.string.settings_auto_hide_saved)
+    val failedMessage = stringResource(R.string.settings_auto_hide_failed)
+    val settings = targets?.canonicalConfig?.settings ?: CanonicalSettings()
+    val canWrite = targets != null && apps != null && saving == null
+
+    fun updateSetting(
+        setting: AutoHideSetting,
+        transform: (CanonicalSettings) -> CanonicalSettings,
+    ) {
+        saving = setting
+        status = null
+        val appSignals = apps.orEmpty()
+        scope.launch {
+            val exit = withContext(Dispatchers.IO) { writeAutoHideSetting(context, appSignals, transform) }
+            saving = null
+            status = if (exit == 0) savedMessage else failedMessage
+            if (exit == 0) {
+                TargetsCache.refreshAfterSave(scope, context)
+            }
+        }
+    }
+
+    LaunchedEffect(Unit) {
+        TargetsCache.ensureLoaded(scope, context)
+        AppListCache.ensureLoaded(scope, context)
+    }
+
+    Column(verticalArrangement = Arrangement.spacedBy(3.dp)) {
+        SettingsSectionHeader(stringResource(R.string.settings_advanced_protection))
+        PreferenceRowSwitch(
+            title = stringResource(R.string.settings_auto_hide_vpn_services),
+            subtitle = stringResource(R.string.settings_auto_hide_vpn_services_sub),
+            icon = Icons.Default.VpnKey,
+            index = 0,
+            count = 2,
+            checked = settings.autoHideVpnServices,
+            enabled = canWrite,
+            onCheckedChange = { enabled ->
+                updateSetting(AutoHideSetting.VpnService) { it.copy(autoHideVpnServices = enabled) }
+            },
+        )
+        PreferenceRowSwitch(
+            title = stringResource(R.string.settings_auto_hide_vpn_name),
+            subtitle = stringResource(R.string.settings_auto_hide_vpn_name_sub),
+            icon = Icons.Default.TextFields,
+            index = 1,
+            count = 2,
+            checked = settings.autoHideVpnName,
+            enabled = canWrite,
+            onCheckedChange = { enabled ->
+                updateSetting(AutoHideSetting.VpnName) { it.copy(autoHideVpnName = enabled) }
+            },
+        )
+        status?.let {
+            Text(
+                text = it,
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.padding(start = 4.dp),
+            )
+        }
+    }
+}
+
+private enum class AutoHideSetting {
+    VpnService,
+    VpnName,
+}
+
+private fun writeAutoHideSetting(
+    context: android.content.Context,
+    apps: List<AppSummary>,
+    transform: (CanonicalSettings) -> CanonicalSettings,
+): Int {
+    val snapshot = TargetsCache.snapshot.value
+    val base =
+        snapshot?.let(::buildCanonicalConfigFromTargetsSnapshot)
+            ?: CanonicalConfig(debug = isEnabledInPrefs(context))
+    val canonical =
+        applyAutoHiddenPackages(
+            config = base.copy(settings = transform(base.settings)),
+            selfPkg = context.packageName,
+            signals = apps.map(AppSummary::toAutoHideSignal),
+        )
+    val (exit, _) = suExec(buildCanonicalConfigWriteCommand(canonical))
+    if (exit == 0) {
+        RootSnapshotCache.invalidate()
+        DashboardCache.invalidate()
+    }
+    return exit
 }
 
 @Composable

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/SettingsScreen.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/SettingsScreen.kt
@@ -621,7 +621,12 @@ private fun writeAutoHideSetting(
             selfPkg = context.packageName,
             signals = apps.map(AppSummary::toAutoHideSignal),
         )
-    val (exit, _) = suExec(buildCanonicalConfigWriteCommand(canonical))
+    val cmd =
+        listOf(
+            buildCanonicalConfigWriteCommand(canonical),
+            ConfigChannels.reconcileCommand(),
+        ).joinToString(" && ")
+    val (exit, _) = suExec(cmd)
     if (exit == 0) {
         RootSnapshotCache.invalidate()
         DashboardCache.invalidate()

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/StorageConfig.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/StorageConfig.kt
@@ -15,6 +15,9 @@ internal data class CanonicalConfig(
 
 internal data class CanonicalSettings(
     val rememberSuperkey: Boolean = false,
+    val autoHideVpnServices: Boolean = true,
+    val autoHideVpnName: Boolean = false,
+    val autoHiddenPackages: Set<String> = emptySet(),
 )
 
 internal data class CanonicalApp(
@@ -53,11 +56,22 @@ internal fun parseCanonicalConfig(raw: String): CanonicalConfig? {
             .orEmpty()
             .filterValues { it.hasAnyRole }
     val settingsJson = root.optJSONObject("settings")
+    val defaultSettings = CanonicalSettings()
     return CanonicalConfig(
         version = version,
         debug = root.optBoolean("debug", false),
         apps = apps,
-        settings = CanonicalSettings(rememberSuperkey = settingsJson?.optBoolean("rememberSuperkey", false) == true),
+        settings =
+            CanonicalSettings(
+                rememberSuperkey = settingsJson?.optBoolean("rememberSuperkey", defaultSettings.rememberSuperkey) == true,
+                autoHideVpnServices =
+                    settingsJson?.optBoolean("autoHideVpnServices", defaultSettings.autoHideVpnServices)
+                        ?: defaultSettings.autoHideVpnServices,
+                autoHideVpnName =
+                    settingsJson?.optBoolean("autoHideVpnName", defaultSettings.autoHideVpnName)
+                        ?: defaultSettings.autoHideVpnName,
+                autoHiddenPackages = parseStringSet(settingsJson?.optJSONArray("autoHiddenPackages")),
+            ),
     )
 }
 
@@ -89,6 +103,11 @@ private fun parseNativeRole(value: Any?): NativeRole =
             NativeRole.Disabled
         }
     }
+
+private fun parseStringSet(value: JSONArray?): Set<String> =
+    (0 until (value?.length() ?: 0))
+        .mapNotNull { idx -> value?.optString(idx)?.takeIf { it.isNotBlank() } }
+        .toSortedSet()
 
 internal fun buildCanonicalConfig(
     debug: Boolean,
@@ -188,7 +207,19 @@ internal fun canonicalConfigJson(config: CanonicalConfig): String =
         append("  \"settings\": {\n")
         append("    \"rememberSuperkey\": ")
         append(config.settings.rememberSuperkey)
-        append('\n')
+        append(",\n")
+        append("    \"autoHideVpnServices\": ")
+        append(config.settings.autoHideVpnServices)
+        append(",\n")
+        append("    \"autoHideVpnName\": ")
+        append(config.settings.autoHideVpnName)
+        append(",\n")
+        append("    \"autoHiddenPackages\": [")
+        config.settings.autoHiddenPackages.toSortedSet().forEachIndexed { index, pkg ->
+            if (index != 0) append(", ")
+            appendJsonString(pkg)
+        }
+        append("]\n")
         append("  }\n")
         append("}\n")
     }

--- a/lsposed/app/src/main/res/values-ru/strings.xml
+++ b/lsposed/app/src/main/res/values-ru/strings.xml
@@ -223,6 +223,13 @@
     <string name="settings_config_import_done">Конфиг импортирован.</string>
     <string name="settings_config_import_invalid">Импорт не удался: некорректный JSON-конфиг.</string>
     <string name="settings_config_import_root_failed">Импорт не удался: не получилось записать root-конфиг.</string>
+    <string name="settings_advanced_protection">Расширенная защита</string>
+    <string name="settings_auto_hide_vpn_services">Автоматически скрывать VPN-приложения</string>
+    <string name="settings_auto_hide_vpn_services_sub">Скрывать от целей app hiding установленные приложения, которые объявляют Android VpnService.</string>
+    <string name="settings_auto_hide_vpn_name">Также искать «VPN» в названиях</string>
+    <string name="settings_auto_hide_vpn_name_sub">Шумная эвристика для клонов и переименованных VPN-клиентов. По умолчанию выключена.</string>
+    <string name="settings_auto_hide_saved">Настройки app hiding сохранены.</string>
+    <string name="settings_auto_hide_failed">Не удалось обновить настройки app hiding.</string>
     <string name="settings_security">Безопасность</string>
     <string name="settings_superkey_title">APatch SuperKey</string>
     <string name="settings_superkey_saved">Сохранён для активации KPM при загрузке.</string>

--- a/lsposed/app/src/main/res/values/strings.xml
+++ b/lsposed/app/src/main/res/values/strings.xml
@@ -266,6 +266,13 @@
     <string name="settings_config_import_done">Config imported.</string>
     <string name="settings_config_import_invalid">Import failed: invalid config JSON.</string>
     <string name="settings_config_import_root_failed">Import failed: root config write failed.</string>
+    <string name="settings_advanced_protection">Advanced protection</string>
+    <string name="settings_auto_hide_vpn_services">Auto-hide VPN apps</string>
+    <string name="settings_auto_hide_vpn_services_sub">Hide installed apps that declare Android VpnService from app-hiding targets.</string>
+    <string name="settings_auto_hide_vpn_name">Also match VPN in app names</string>
+    <string name="settings_auto_hide_vpn_name_sub">Low-confidence heuristic for clones and renamed VPN clients. Off by default.</string>
+    <string name="settings_auto_hide_saved">App hiding settings saved.</string>
+    <string name="settings_auto_hide_failed">Failed to update app hiding settings.</string>
     <string name="settings_security">Security</string>
     <string name="settings_superkey_title">APatch SuperKey</string>
     <string name="settings_superkey_saved">Saved for boot-time KPM activation.</string>

--- a/lsposed/app/src/test/kotlin/dev/okhsunrog/vpnhide/AppPickerDataTest.kt
+++ b/lsposed/app/src/test/kotlin/dev/okhsunrog/vpnhide/AppPickerDataTest.kt
@@ -141,7 +141,115 @@ class AppPickerDataTest {
         assertEquals(true, cfg.apps.getValue(self).hidden)
     }
 
-    private fun snapshotWithCanonical(vararg apps: Pair<String, CanonicalApp>): TargetsSnapshot =
+    @Test
+    fun `save auto hides apps declaring vpn services by default`() {
+        val cfg =
+            buildCanonicalConfigForAppPickerSave(
+                debug = false,
+                selfPkg = self,
+                selections = emptyList(),
+                snapshot = snapshotWithCanonical(),
+                autoHideSignals =
+                    listOf(
+                        AppAutoHideSignal(packageName = "com.vpn.client", declaresVpnService = true),
+                    ),
+            )
+
+        assertEquals(true, cfg.apps.getValue("com.vpn.client").hidden)
+        assertEquals(setOf("com.vpn.client"), cfg.settings.autoHiddenPackages)
+    }
+
+    @Test
+    fun `vpn name heuristic is disabled by default and can be enabled`() {
+        val signal = AppAutoHideSignal(packageName = "com.clone", nameContainsVpn = true)
+
+        val disabled =
+            buildCanonicalConfigForAppPickerSave(
+                debug = false,
+                selfPkg = self,
+                selections = emptyList(),
+                snapshot = snapshotWithCanonical(),
+                autoHideSignals = listOf(signal),
+            )
+        val enabled =
+            buildCanonicalConfigForAppPickerSave(
+                debug = false,
+                selfPkg = self,
+                selections = emptyList(),
+                snapshot =
+                    snapshotWithCanonical(
+                        settings = CanonicalSettings(autoHideVpnName = true),
+                    ),
+                autoHideSignals = listOf(signal),
+            )
+
+        assertEquals(false, disabled.apps.containsKey("com.clone"))
+        assertEquals(true, enabled.apps.getValue("com.clone").hidden)
+    }
+
+    @Test
+    fun `app hiding observer wins over auto hidden vpn app`() {
+        val cfg =
+            buildCanonicalConfigForAppPickerSave(
+                debug = false,
+                selfPkg = self,
+                selections =
+                    listOf(
+                        AppRoleSelection(packageName = "com.vpn.client", appHiding = true),
+                    ),
+                snapshot = snapshotWithCanonical(),
+                autoHideSignals =
+                    listOf(
+                        AppAutoHideSignal(packageName = "com.vpn.client", declaresVpnService = true),
+                    ),
+            )
+
+        assertEquals(true, cfg.apps.getValue("com.vpn.client").appHiding)
+        assertEquals(false, cfg.apps.getValue("com.vpn.client").hidden)
+        assertEquals(emptySet<String>(), cfg.settings.autoHiddenPackages)
+    }
+
+    @Test
+    fun `disabling auto hide removes previous auto hidden apps but keeps manual hidden apps`() {
+        val snapshot =
+            snapshotWithCanonical(
+                "com.manual.hidden" to CanonicalApp(hidden = true),
+                "com.auto.hidden" to CanonicalApp(hidden = true),
+                settings =
+                    CanonicalSettings(
+                        autoHideVpnServices = false,
+                        autoHiddenPackages = setOf("com.auto.hidden"),
+                    ),
+            )
+
+        val cfg =
+            buildCanonicalConfigForAppPickerSave(
+                debug = false,
+                selfPkg = self,
+                selections = emptyList(),
+                snapshot = snapshot,
+                autoHideSignals =
+                    listOf(
+                        AppAutoHideSignal(packageName = "com.auto.hidden", declaresVpnService = true),
+                    ),
+            )
+
+        assertEquals(true, cfg.apps.getValue("com.manual.hidden").hidden)
+        assertEquals(false, cfg.apps.containsKey("com.auto.hidden"))
+        assertEquals(emptySet<String>(), cfg.settings.autoHiddenPackages)
+    }
+
+    @Test
+    fun `vpn name matcher is case insensitive`() {
+        assertEquals(true, looksLikeVpnAppName("Fast VPN"))
+        assertEquals(true, looksLikeVpnAppName("fast vpn"))
+        assertEquals(false, looksLikeVpnAppName("Proxy Client"))
+    }
+
+    private fun snapshotWithCanonical(
+        vararg apps: Pair<String, CanonicalApp>,
+        settings: CanonicalSettings = CanonicalSettings(),
+    ): TargetsSnapshot =
         TargetsSnapshot(
             kmodModuleInstalled = true,
             kpmModuleInstalled = false,
@@ -155,6 +263,6 @@ class AppPickerDataTest {
             observerUids = emptySet(),
             portsObservers = emptySet(),
             uidToPkg = emptyMap(),
-            canonicalConfig = CanonicalConfig(apps = apps.toMap()),
+            canonicalConfig = CanonicalConfig(apps = apps.toMap(), settings = settings),
         )
 }

--- a/lsposed/app/src/test/kotlin/dev/okhsunrog/vpnhide/StorageConfigTest.kt
+++ b/lsposed/app/src/test/kotlin/dev/okhsunrog/vpnhide/StorageConfigTest.kt
@@ -19,16 +19,55 @@ class StorageConfigTest {
                         "com.bank": { "java": true, "native": ["sock_ioctl"], "appHiding": false, "ports": true },
                         "dev.okhsunrog.vpnhide": { "hidden": true }
                       },
-                      "settings": { "rememberSuperkey": true }
+                      "settings": {
+                        "rememberSuperkey": true,
+                        "autoHideVpnServices": false,
+                        "autoHideVpnName": true,
+                        "autoHiddenPackages": ["com.vpn.client"]
+                      }
                     }
                     """.trimIndent(),
                 ),
             )
 
         assertTrue(cfg.debug)
-        assertEquals(CanonicalSettings(rememberSuperkey = true), cfg.settings)
+        assertEquals(
+            CanonicalSettings(
+                rememberSuperkey = true,
+                autoHideVpnServices = false,
+                autoHideVpnName = true,
+                autoHiddenPackages = setOf("com.vpn.client"),
+            ),
+            cfg.settings,
+        )
         assertEquals(NativeRole(enabled = true, hooks = listOf("sock_ioctl")), cfg.apps.getValue("com.bank").native)
         assertTrue(cfg.apps.getValue("dev.okhsunrog.vpnhide").hidden)
+    }
+
+    @Test
+    fun `canonical config defaults new auto hide settings for old json`() {
+        val cfg =
+            requireNotNull(
+                parseCanonicalConfig(
+                    """
+                    {
+                      "version": 1,
+                      "apps": {},
+                      "settings": { "rememberSuperkey": true }
+                    }
+                    """.trimIndent(),
+                ),
+            )
+
+        assertEquals(
+            CanonicalSettings(
+                rememberSuperkey = true,
+                autoHideVpnServices = true,
+                autoHideVpnName = false,
+                autoHiddenPackages = emptySet(),
+            ),
+            cfg.settings,
+        )
     }
 
     @Test

--- a/testdata/storage_config_v1.json
+++ b/testdata/storage_config_v1.json
@@ -7,7 +7,9 @@
     "org.example.proxy": { "java": true, "native": ["fib_route_seq_show", "sock_ioctl"], "appHiding": true, "ports": true }
   },
   "settings": {
-    "rememberSuperkey": true
+    "rememberSuperkey": true,
+    "autoHideVpnServices": true,
+    "autoHideVpnName": false,
+    "autoHiddenPackages": []
   }
 }
-


### PR DESCRIPTION
## Summary

- Detect installed apps that declare Android `VpnService` and fold them into the internal hidden package set for app-hiding targets.
- Add canonical JSON settings for auto-hide heuristics, including provenance for previously auto-hidden packages so disabling a heuristic removes only auto-generated entries.
- Add Advanced protection settings for the default `VpnService` heuristic and an optional low-confidence app-name `VPN` heuristic.

## Validation

- `cd lsposed && ./gradlew :app:testDebugUnitTest`
- `cd lsposed && ./gradlew :app:ktlintCheck`
- `cd lsposed && ./gradlew :app:detekt`
- `cd lsposed && ./gradlew cpdCheck`
- `git diff --check`
