### PR TITLE
Add native interception stats

### DIFF
--- a/changelog.d/added-native-backends-now-report-per-app-02a8.md
+++ b/changelog.d/added-native-backends-now-report-per-app-02a8.md
@@ -1,0 +1,9 @@
+_2026-06-29_
+
+## English
+
+Native backends now report per-app, per-hook interception counters through the existing stats channel.
+
+## Русский
+
+Нативные бэкенды теперь отдают счетчики перехватов по приложениям и хукам через существующий stats-канал.

--- a/docs/storage.md
+++ b/docs/storage.md
@@ -194,7 +194,7 @@ Why Zygisk needs a file in its module dir even though there is one canonical: th
 it (§7). This is a *mechanism* constraint, not a format one — the activator simply
 derives the protocol config there. (Note: the protocol text — not JSON — keeps the
 injected `.so` free of a JSON parser, and carries the per-hook `hookmask` + `debug`
-+ the future stats the way a flat package list never could.)
++ the native stats the way a flat package list never could.)
 
 ---
 
@@ -240,8 +240,9 @@ single-writer / atomic-replace, and stats are never written back into it.
 
 ### 5.3 Stats scope
 
-- **kmod / KPM: yes** — counters live in one place (kernel memory), so a pull-read is
-  natural. (Format wired; per-(uid,hook) counters are a TODO.)
+- **kmod / KPM: yes** — counters live in one place (kernel memory), so a
+  pull-read is natural. They emit cumulative-since-load non-zero
+  `(uid, hook_id)` cells for hooks that actually hid or rewrote a result.
 - **Zygisk: deferred.** Its counters would live **per app process** with no shared
   aggregation point. A unix socket is out — it violates protocol.md §2 (pull-only,
   no per-hit push) and needs a collector process (a rejected resident root daemon,

--- a/kmod/kpm/vpnhide_kpm.c
+++ b/kmod/kpm/vpnhide_kpm.c
@@ -304,7 +304,7 @@ static void rtnl_fill_before(hook_fargs12_t *fargs, void *udata)
 	fargs->local.data0 = 1; /* filter */
 	fargs->local.data1 = (uint64_t)skb;
 	fargs->local.data2 =
-		(uint64_t)*(unsigned int *)((char *)skb + off->skb_len);
+		(uint64_t) * (unsigned int *)((char *)skb + off->skb_len);
 }
 
 static void rtnl_fill_after(hook_fargs12_t *fargs, void *udata)
@@ -474,7 +474,7 @@ static void addr_fill_before(hook_fargs4_t *fargs, void *dev, uint32_t hook_id)
 	fargs->local.data0 = 1;
 	fargs->local.data1 = (uint64_t)skb;
 	fargs->local.data2 =
-		(uint64_t)*(unsigned int *)((char *)skb + off->skb_len);
+		(uint64_t) * (unsigned int *)((char *)skb + off->skb_len);
 }
 
 static void addr_fill_after_hook(hook_fargs4_t *fargs, uint32_t hook_id)
@@ -575,7 +575,7 @@ static void fib_dump_before(hook_fargs12_t *fargs, void *udata)
 	fargs->local.data0 = 1;
 	fargs->local.data1 = (uint64_t)skb;
 	fargs->local.data2 =
-		(uint64_t)*(unsigned int *)((char *)skb + off->skb_len);
+		(uint64_t) * (unsigned int *)((char *)skb + off->skb_len);
 }
 
 static void fib_dump_after(hook_fargs12_t *fargs, void *udata)
@@ -634,7 +634,7 @@ static void rt6_fill_before(hook_fargs12_t *fargs, void *udata)
 	fargs->local.data0 = 1;
 	fargs->local.data1 = (uint64_t)skb;
 	fargs->local.data2 =
-		(uint64_t)*(unsigned int *)((char *)skb + off->skb_len);
+		(uint64_t) * (unsigned int *)((char *)skb + off->skb_len);
 }
 
 static void rt6_fill_after(hook_fargs12_t *fargs, void *udata)
@@ -689,7 +689,8 @@ static void fib_rule_before(hook_fargs8_t *fargs, void *udata)
 		fargs->local.data0 = 1;
 		fargs->local.data1 = (uint64_t)skb;
 		fargs->local.data2 =
-			(uint64_t)*(unsigned int *)((char *)skb + off->skb_len);
+			(uint64_t) *
+			(unsigned int *)((char *)skb + off->skb_len);
 	}
 }
 

--- a/kmod/kpm/vpnhide_kpm.c
+++ b/kmod/kpm/vpnhide_kpm.c
@@ -73,6 +73,15 @@ static bool debug_enabled;
 static uint32_t installed_hooks;
 static uint32_t last_error;
 
+/* Native interception stats, cumulative since KPM load. The KernelPatch build
+ * does not use the target kernel's spinlock headers, so slots are reserved with
+ * atomic builtins: used=0 empty, 2 initializing, 1 ready. */
+static uint32_t stats_used[MAX_TARGET_UIDS];
+static uint32_t stats_uids[MAX_TARGET_UIDS];
+static unsigned long long stats_counts[MAX_TARGET_UIDS][VPNHIDE_HOOK_COUNT];
+static struct vpnhide_stat_entry
+	stats_snapshot[MAX_TARGET_UIDS * VPNHIDE_HOOK_COUNT];
+
 /* kernel functions resolved at init via kallsyms */
 static void *(*_proc_create_data)(const char *, uint16_t, void *, void *,
 				  void *);
@@ -128,6 +137,66 @@ static int hook_active(uint32_t hook_id)
 	return (target_mask() & (1u << hook_id)) != 0;
 }
 
+static int stats_slot_for_uid(uint32_t uid)
+{
+	int i;
+
+	for (i = 0; i < MAX_TARGET_UIDS; i++) {
+		if (__atomic_load_n(&stats_used[i], __ATOMIC_ACQUIRE) == 1 &&
+		    stats_uids[i] == uid)
+			return i;
+	}
+
+	for (i = 0; i < MAX_TARGET_UIDS; i++) {
+		if (__atomic_load_n(&stats_used[i], __ATOMIC_ACQUIRE) != 0)
+			continue;
+		if (__sync_bool_compare_and_swap(&stats_used[i], 0, 2)) {
+			stats_uids[i] = uid;
+			__sync_synchronize();
+			__atomic_store_n(&stats_used[i], 1, __ATOMIC_RELEASE);
+			return i;
+		}
+		if (__atomic_load_n(&stats_used[i], __ATOMIC_ACQUIRE) == 1 &&
+		    stats_uids[i] == uid)
+			return i;
+	}
+
+	return -1;
+}
+
+static void record_hook_hit(uint32_t hook_id)
+{
+	int slot;
+
+	if (hook_id >= VPNHIDE_HOOK_COUNT)
+		return;
+	slot = stats_slot_for_uid((uint32_t)current_uid());
+	if (slot >= 0)
+		__sync_fetch_and_add(&stats_counts[slot][hook_id], 1ULL);
+}
+
+static int snapshot_stats(struct vpnhide_stat_entry *out, int max)
+{
+	int i, hook, n = 0;
+
+	for (i = 0; i < MAX_TARGET_UIDS && n < max; i++) {
+		if (__atomic_load_n(&stats_used[i], __ATOMIC_ACQUIRE) != 1)
+			continue;
+		for (hook = 0; hook < VPNHIDE_HOOK_COUNT && n < max; hook++) {
+			unsigned long long count = __atomic_load_n(
+				&stats_counts[i][hook], __ATOMIC_RELAXED);
+
+			if (count == 0)
+				continue;
+			out[n].uid = stats_uids[i];
+			out[n].hook_id = (unsigned int)hook;
+			out[n].count = count;
+			n++;
+		}
+	}
+	return n;
+}
+
 /* NUL-safe copy of a kernel iface name, then match via the generated rules. */
 static int iface_is_vpn(const char *name)
 {
@@ -177,8 +246,15 @@ static void fib_route_after(hook_fargs2_t *fargs, void *udata)
 
 	buf = *(char **)((char *)seq + off->seqfile_buf);
 	countp = (unsigned long *)((char *)seq + off->seqfile_count);
-	*countp = vpnhide_compact_seq_lines(buf, start, *countp,
-					    VPNHIDE_FIELD_FIRST, iface_is_vpn);
+	{
+		unsigned long old = *countp;
+		unsigned long next = vpnhide_compact_seq_lines(
+			buf, start, old, VPNHIDE_FIELD_FIRST, iface_is_vpn);
+
+		*countp = next;
+		if (next != old)
+			record_hook_hit(VPNHIDE_HOOK_FIB_ROUTE_SEQ_SHOW);
+	}
 }
 
 /* ipv6_route_seq_show — /proc/net/ipv6_route. Same as fib_route but the iface
@@ -195,8 +271,15 @@ static void ipv6_route_after(hook_fargs2_t *fargs, void *udata)
 
 	buf = *(char **)((char *)seq + off->seqfile_buf);
 	countp = (unsigned long *)((char *)seq + off->seqfile_count);
-	*countp = vpnhide_compact_seq_lines(buf, start, *countp,
-					    VPNHIDE_FIELD_LAST, iface_is_vpn);
+	{
+		unsigned long old = *countp;
+		unsigned long next = vpnhide_compact_seq_lines(
+			buf, start, old, VPNHIDE_FIELD_LAST, iface_is_vpn);
+
+		*countp = next;
+		if (next != old)
+			record_hook_hit(VPNHIDE_HOOK_IPV6_ROUTE_SEQ_SHOW);
+	}
 }
 
 /* ================================================================== */
@@ -221,7 +304,7 @@ static void rtnl_fill_before(hook_fargs12_t *fargs, void *udata)
 	fargs->local.data0 = 1; /* filter */
 	fargs->local.data1 = (uint64_t)skb;
 	fargs->local.data2 =
-		(uint64_t) * (unsigned int *)((char *)skb + off->skb_len);
+		(uint64_t)*(unsigned int *)((char *)skb + off->skb_len);
 }
 
 static void rtnl_fill_after(hook_fargs12_t *fargs, void *udata)
@@ -234,6 +317,7 @@ static void rtnl_fill_after(hook_fargs12_t *fargs, void *udata)
 		_skb_trim((void *)fargs->local.data1,
 			  (unsigned int)fargs->local.data2);
 	fargs->ret = 0;
+	record_hook_hit(VPNHIDE_HOOK_RTNL_FILL_IFINFO);
 }
 
 /* ================================================================== */
@@ -286,6 +370,7 @@ static void dev_ioctl_after(hook_fargs5_t *fargs, void *udata)
 	if (is_vpn) {
 		vpnhide_dbg("dev_ioctl: hiding cmd=0x%lx\n", cmd);
 		fargs->ret = VPNHIDE_ENODEV;
+		record_hook_hit(VPNHIDE_HOOK_DEV_IOCTL);
 	}
 }
 
@@ -300,7 +385,7 @@ static void dev_ioctl_after(hook_fargs5_t *fargs, void *udata)
 #define VPNHIDE_SIOCGIFCONF 0x8912
 #define VPNHIDE_IFREQ_SZ 40 /* sizeof(struct ifreq) on arm64 */
 
-static void filter_ifconf(void *uifc)
+static int filter_ifconf(void *uifc)
 {
 	char ifc[16]; /* struct ifconf snapshot: len@0 (int), req@8 (ptr) */
 	char e[VPNHIDE_IFREQ_SZ];
@@ -308,35 +393,37 @@ static void filter_ifconf(void *uifc)
 	int len, n, i, dst = 0;
 
 	if (!_copy_from_user || !_copy_to_user)
-		return;
+		return 0;
 	if (_copy_from_user(ifc, uifc, sizeof(ifc)))
-		return;
+		return 0;
 	len = *(int *)ifc;
 	req = *(char **)(ifc + 8);
 	if (!req || len <= 0)
-		return;
+		return 0;
 
 	n = len / VPNHIDE_IFREQ_SZ;
 	for (i = 0; i < n; i++) {
 		if (_copy_from_user(e, req + (long)i * VPNHIDE_IFREQ_SZ,
 				    VPNHIDE_IFREQ_SZ))
-			return;
+			return 0;
 		e[VPNHIDE_IFNAMSIZ - 1] = '\0';
 		if (iface_is_vpn(e))
 			continue; /* drop VPN entry */
 		if (dst != i &&
 		    _copy_to_user(req + (long)dst * VPNHIDE_IFREQ_SZ, e,
 				  VPNHIDE_IFREQ_SZ))
-			return;
+			return 0;
 		dst++;
 	}
 	if (dst != n) {
 		int newlen = dst * VPNHIDE_IFREQ_SZ;
 
-		_copy_to_user(uifc, &newlen,
-			      sizeof(newlen)); /* shrink ifc_len */
+		if (_copy_to_user(uifc, &newlen, sizeof(newlen)))
+			return 0; /* failed to shrink ifc_len */
 		vpnhide_dbg("sock_ioctl: ifconf %d -> %d\n", len, newlen);
+		return 1;
 	}
+	return 0;
 }
 
 static void sock_ioctl_after(hook_fargs3_t *fargs, void *udata)
@@ -348,7 +435,8 @@ static void sock_ioctl_after(hook_fargs3_t *fargs, void *udata)
 		return;
 	if (cmd != VPNHIDE_SIOCGIFCONF || !hook_active(VPNHIDE_HOOK_SOCK_IOCTL))
 		return;
-	filter_ifconf(argp);
+	if (filter_ifconf(argp))
+		record_hook_hit(VPNHIDE_HOOK_SOCK_IOCTL);
 }
 
 /* ================================================================== */
@@ -386,10 +474,10 @@ static void addr_fill_before(hook_fargs4_t *fargs, void *dev, uint32_t hook_id)
 	fargs->local.data0 = 1;
 	fargs->local.data1 = (uint64_t)skb;
 	fargs->local.data2 =
-		(uint64_t) * (unsigned int *)((char *)skb + off->skb_len);
+		(uint64_t)*(unsigned int *)((char *)skb + off->skb_len);
 }
 
-static void addr_fill_after(hook_fargs4_t *fargs, void *udata)
+static void addr_fill_after_hook(hook_fargs4_t *fargs, uint32_t hook_id)
 {
 	if (!fargs->local.data0)
 		return;
@@ -399,6 +487,17 @@ static void addr_fill_after(hook_fargs4_t *fargs, void *udata)
 		_skb_trim((void *)fargs->local.data1,
 			  (unsigned int)fargs->local.data2);
 	fargs->ret = 0;
+	record_hook_hit(hook_id);
+}
+
+static void inet_fill_after(hook_fargs4_t *fargs, void *udata)
+{
+	addr_fill_after_hook(fargs, VPNHIDE_HOOK_INET_FILL_IFADDR);
+}
+
+static void inet6_fill_after(hook_fargs4_t *fargs, void *udata)
+{
+	addr_fill_after_hook(fargs, VPNHIDE_HOOK_INET6_FILL_IFADDR);
 }
 
 static void inet_fill_before(hook_fargs4_t *fargs, void *udata)
@@ -476,7 +575,7 @@ static void fib_dump_before(hook_fargs12_t *fargs, void *udata)
 	fargs->local.data0 = 1;
 	fargs->local.data1 = (uint64_t)skb;
 	fargs->local.data2 =
-		(uint64_t) * (unsigned int *)((char *)skb + off->skb_len);
+		(uint64_t)*(unsigned int *)((char *)skb + off->skb_len);
 }
 
 static void fib_dump_after(hook_fargs12_t *fargs, void *udata)
@@ -489,6 +588,7 @@ static void fib_dump_after(hook_fargs12_t *fargs, void *udata)
 		_skb_trim((void *)fargs->local.data1,
 			  (unsigned int)fargs->local.data2);
 	fargs->ret = 0;
+	record_hook_hit(VPNHIDE_HOOK_FIB_DUMP_INFO);
 }
 
 /* ================================================================== */
@@ -534,7 +634,7 @@ static void rt6_fill_before(hook_fargs12_t *fargs, void *udata)
 	fargs->local.data0 = 1;
 	fargs->local.data1 = (uint64_t)skb;
 	fargs->local.data2 =
-		(uint64_t) * (unsigned int *)((char *)skb + off->skb_len);
+		(uint64_t)*(unsigned int *)((char *)skb + off->skb_len);
 }
 
 static void rt6_fill_after(hook_fargs12_t *fargs, void *udata)
@@ -547,6 +647,7 @@ static void rt6_fill_after(hook_fargs12_t *fargs, void *udata)
 		_skb_trim((void *)fargs->local.data1,
 			  (unsigned int)fargs->local.data2);
 	fargs->ret = 0;
+	record_hook_hit(VPNHIDE_HOOK_RT6_FILL_NODE);
 }
 
 /* ================================================================== */
@@ -588,8 +689,7 @@ static void fib_rule_before(hook_fargs8_t *fargs, void *udata)
 		fargs->local.data0 = 1;
 		fargs->local.data1 = (uint64_t)skb;
 		fargs->local.data2 =
-			(uint64_t) *
-			(unsigned int *)((char *)skb + off->skb_len);
+			(uint64_t)*(unsigned int *)((char *)skb + off->skb_len);
 	}
 }
 
@@ -603,6 +703,7 @@ static void fib_rule_after(hook_fargs8_t *fargs, void *udata)
 		_skb_trim((void *)fargs->local.data1,
 			  (unsigned int)fargs->local.data2);
 	fargs->ret = 0;
+	record_hook_hit(VPNHIDE_HOOK_FIB_NL_FILL_RULE);
 }
 
 /*
@@ -838,11 +939,12 @@ static long vpnhide_kpm_init(const char *args, const char *event,
 			     VPNHIDE_HOOK_RTNL_FILL_IFINFO);
 	if (off->in_ifaddr_ifa_dev)
 		install_hook("inet_fill_ifaddr", off->addr_fill_argno,
-			     (void *)inet_fill_before, (void *)addr_fill_after,
+			     (void *)inet_fill_before, (void *)inet_fill_after,
 			     VPNHIDE_HOOK_INET_FILL_IFADDR);
 	if (off->inet6_ifaddr_idev)
 		install_hook("inet6_fill_ifaddr", off->addr_fill_argno,
-			     (void *)inet6_fill_before, (void *)addr_fill_after,
+			     (void *)inet6_fill_before,
+			     (void *)inet6_fill_after,
 			     VPNHIDE_HOOK_INET6_FILL_IFADDR);
 	if (off->fib_dump_fi_arg)
 		install_hook("fib_dump_info", 11, (void *)fib_dump_before,
@@ -879,7 +981,7 @@ static long vpnhide_kpm_init(const char *args, const char *event,
  * in and `out_msg` (copy_to_user) out; the `long` return is a short code only,
  * never surfaced as text. Dispatch on the header `kind`:
  *   config → apply the snapshot (per-hook masks + debug), return 0.
- *   stats  → serialise counters into out_msg.   (counters: TODO, see below)
+ *   stats  → serialise cumulative per-uid/per-hook counters into out_msg.
  *   status → serialise backend health into out_msg.
  */
 static long vpnhide_kpm_ctl0(const char *args, char *__user out_msg, int outlen)
@@ -913,14 +1015,12 @@ static long vpnhide_kpm_ctl0(const char *args, char *__user out_msg, int outlen)
 		unsigned long full, n;
 
 		if (kind == VPNHIDE_KIND_STATS) {
-			/*
-			 * TODO(stats counters): maintain per-(uid,hook) u64
-			 * counters in the filter paths and serialise the
-			 * non-zero cells here. For now emit a valid empty
-			 * snapshot (header only) so the channel + format are
-			 * wired and the app can already read it.
-			 */
-			full = vpnhide_format_stats(buf, sizeof(buf), 0, 0);
+			int count = snapshot_stats(stats_snapshot,
+						   MAX_TARGET_UIDS *
+							   VPNHIDE_HOOK_COUNT);
+
+			full = vpnhide_format_stats(buf, sizeof(buf),
+						    stats_snapshot, count);
 		} else {
 			struct vpnhide_status st;
 
@@ -960,11 +1060,11 @@ static long vpnhide_kpm_exit(void *__user reserved)
 	fn = lookup_fn("inet_fill_ifaddr");
 	if (fn)
 		hook_unwrap((void *)fn, (void *)inet_fill_before,
-			    (void *)addr_fill_after);
+			    (void *)inet_fill_after);
 	fn = lookup_fn("inet6_fill_ifaddr");
 	if (fn)
 		hook_unwrap((void *)fn, (void *)inet6_fill_before,
-			    (void *)addr_fill_after);
+			    (void *)inet6_fill_after);
 	fn = lookup_fn("dev_ioctl");
 	if (fn)
 		hook_unwrap((void *)fn, 0, (void *)dev_ioctl_after);

--- a/kmod/vpnhide_kmod.c
+++ b/kmod/vpnhide_kmod.c
@@ -66,6 +66,8 @@
 
 #define MODNAME "vpnhide"
 #define MAX_TARGET_UIDS 64
+#define MAX_STATS_ENTRIES (MAX_TARGET_UIDS * VPNHIDE_HOOK_COUNT)
+#define CTL_READ_BUF_SIZE 32768
 
 /*
  * Pre-allocated kretprobe instance pool size, applied to every probe.
@@ -144,6 +146,66 @@ static bool hook_active(u32 hook_id)
 }
 
 /* ------------------------------------------------------------------ */
+/*  Native interception stats (protocol §4.3 `stats`)                 */
+/* ------------------------------------------------------------------ */
+
+struct stats_row {
+	uid_t uid;
+	u64 counts[VPNHIDE_HOOK_COUNT];
+};
+
+static struct stats_row stats_rows[MAX_TARGET_UIDS];
+static int nr_stats_rows;
+static DEFINE_SPINLOCK(stats_lock);
+
+static void record_hook_hit(u32 hook_id)
+{
+	uid_t uid;
+	unsigned long flags;
+	int i;
+
+	if (hook_id >= VPNHIDE_HOOK_COUNT)
+		return;
+
+	uid = from_kuid(&init_user_ns, current_uid());
+	spin_lock_irqsave(&stats_lock, flags);
+	for (i = 0; i < nr_stats_rows; i++) {
+		if (stats_rows[i].uid == uid) {
+			stats_rows[i].counts[hook_id]++;
+			spin_unlock_irqrestore(&stats_lock, flags);
+			return;
+		}
+	}
+	if (nr_stats_rows < MAX_TARGET_UIDS) {
+		i = nr_stats_rows++;
+		stats_rows[i].uid = uid;
+		memset(stats_rows[i].counts, 0, sizeof(stats_rows[i].counts));
+		stats_rows[i].counts[hook_id] = 1;
+	}
+	spin_unlock_irqrestore(&stats_lock, flags);
+}
+
+static int snapshot_stats(struct vpnhide_stat_entry *out, int max)
+{
+	unsigned long flags;
+	int i, hook, n = 0;
+
+	spin_lock_irqsave(&stats_lock, flags);
+	for (i = 0; i < nr_stats_rows && n < max; i++) {
+		for (hook = 0; hook < VPNHIDE_HOOK_COUNT && n < max; hook++) {
+			if (stats_rows[i].counts[hook] == 0)
+				continue;
+			out[n].uid = stats_rows[i].uid;
+			out[n].hook_id = hook;
+			out[n].count = stats_rows[i].counts[hook];
+			n++;
+		}
+	}
+	spin_unlock_irqrestore(&stats_lock, flags);
+	return n;
+}
+
+/* ------------------------------------------------------------------ */
 /*  /proc/vpnhide_ctl — the folded control + stats channel            */
 /* ------------------------------------------------------------------ */
 
@@ -193,18 +255,26 @@ static ssize_t ctl_write(struct file *file, const char __user *ubuf,
 
 /*
  * Read side: a self-documenting banner + `status` + `stats` (§4.3/§7.1).
- * The shared formatters render into a stack buffer which we hand to seq_file.
- * Stats counters are not yet maintained (same TODO as the KPM): emit a valid
- * empty `stats` snapshot so the channel + format are wired and the app can
- * already read status.
+ * The shared formatters render into a temporary buffer which we hand to
+ * seq_file. Stats are cumulative since module load and sparse per uid/hook.
  */
 static int ctl_show(struct seq_file *m, void *v)
 {
-	char buf[256];
+	char *buf;
+	struct vpnhide_stat_entry *stats;
 	struct vpnhide_status st;
 	unsigned long len;
+	int n;
 
 	seq_puts(m, VPNHIDE_READ_BANNER);
+
+	buf = kmalloc(CTL_READ_BUF_SIZE, GFP_KERNEL);
+	stats = kcalloc(MAX_STATS_ENTRIES, sizeof(*stats), GFP_KERNEL);
+	if (!buf || !stats) {
+		kfree(stats);
+		kfree(buf);
+		return -ENOMEM;
+	}
 
 	st.backend = VPNHIDE_BACKEND_KMOD;
 	st.kver = LINUX_VERSION_CODE;
@@ -212,11 +282,15 @@ static int ctl_show(struct seq_file *m, void *v)
 	st.error = (st.hooks == VPNHIDE_KERNEL_HOOK_MASK) ?
 			   VPNHIDE_ERR_OK :
 			   VPNHIDE_ERR_PARTIAL_HOOKS;
-	len = vpnhide_format_status(buf, sizeof(buf), &st);
-	seq_write(m, buf, min_t(size_t, len, sizeof(buf)));
+	len = vpnhide_format_status(buf, CTL_READ_BUF_SIZE, &st);
+	seq_write(m, buf, min_t(size_t, len, CTL_READ_BUF_SIZE));
 
-	len = vpnhide_format_stats(buf, sizeof(buf), NULL, 0);
-	seq_write(m, buf, min_t(size_t, len, sizeof(buf)));
+	n = snapshot_stats(stats, MAX_STATS_ENTRIES);
+	len = vpnhide_format_stats(buf, CTL_READ_BUF_SIZE, stats, n);
+	seq_write(m, buf, min_t(size_t, len, CTL_READ_BUF_SIZE));
+
+	kfree(stats);
+	kfree(buf);
 	return 0;
 }
 
@@ -294,6 +368,7 @@ static int dev_ioctl_ret(struct kretprobe_instance *ri, struct pt_regs *regs)
 		vpnhide_dbg("dev_ioctl_ret: hiding iface=%s cmd=0x%x\n", name,
 			    data->cmd);
 		regs_set_return_value(regs, -ENODEV);
+		record_hook_hit(VPNHIDE_HOOK_DEV_IOCTL);
 	}
 
 	return 0;
@@ -463,6 +538,7 @@ static int sock_ioctl_ret(struct kretprobe_instance *ri, struct pt_regs *regs)
 		}
 		vpnhide_dbg("ifconf filtered %d -> %d bytes\n", orig_len,
 			    ifc.ifc_len);
+		record_hook_hit(VPNHIDE_HOOK_SOCK_IOCTL);
 	}
 
 	return 0;
@@ -547,6 +623,7 @@ static int rtnl_fill_ret(struct kretprobe_instance *ri, struct pt_regs *regs)
 	/* Undo whatever the fill function wrote to the skb */
 	skb_trim(data->skb, data->saved_len);
 	regs_set_return_value(regs, 0);
+	record_hook_hit(VPNHIDE_HOOK_RTNL_FILL_IFINFO);
 	return 0;
 }
 
@@ -624,6 +701,7 @@ static int inet6_fill_ret(struct kretprobe_instance *ri, struct pt_regs *regs)
 	/* Undo whatever the fill function wrote to the skb */
 	skb_trim(data->skb, data->saved_len);
 	regs_set_return_value(regs, 0);
+	record_hook_hit(VPNHIDE_HOOK_INET6_FILL_IFADDR);
 	return 0;
 }
 
@@ -688,6 +766,7 @@ static int inet_fill_ret(struct kretprobe_instance *ri, struct pt_regs *regs)
 		    data->saved_len);
 	skb_trim(data->skb, data->saved_len);
 	regs_set_return_value(regs, 0);
+	record_hook_hit(VPNHIDE_HOOK_INET_FILL_IFADDR);
 	return 0;
 }
 
@@ -799,6 +878,8 @@ static int fib_route_ret(struct kretprobe_instance *ri, struct pt_regs *regs)
 	}
 
 	seq->count = dst - buf;
+	if (seq->count != (size_t)(end - buf))
+		record_hook_hit(VPNHIDE_HOOK_FIB_ROUTE_SEQ_SHOW);
 	return 0;
 }
 
@@ -889,6 +970,8 @@ static int ipv6_route_ret(struct kretprobe_instance *ri, struct pt_regs *regs)
 	}
 
 	seq->count = dst - buf;
+	if (seq->count != (size_t)(end - buf))
+		record_hook_hit(VPNHIDE_HOOK_IPV6_ROUTE_SEQ_SHOW);
 	return 0;
 }
 
@@ -1113,7 +1196,7 @@ static void init_route_skb_data(struct route_skb_data *data)
 }
 
 static int route_skb_ret(struct route_skb_data *data, struct pt_regs *regs,
-			 const char *hook_name)
+			 const char *hook_name, u32 hook_id)
 {
 	if (!data->should_filter || !data->skb)
 		return 0;
@@ -1123,6 +1206,7 @@ static int route_skb_ret(struct route_skb_data *data, struct pt_regs *regs,
 			    data->skb->len, data->saved_len);
 		skb_trim(data->skb, data->saved_len);
 		regs_set_return_value(regs, 0);
+		record_hook_hit(hook_id);
 	}
 	return 0;
 }
@@ -1173,7 +1257,8 @@ static int fib_dump_entry(struct kretprobe_instance *ri, struct pt_regs *regs)
 
 static int fib_dump_ret(struct kretprobe_instance *ri, struct pt_regs *regs)
 {
-	return route_skb_ret((void *)ri->data, regs, "fib_dump_ret");
+	return route_skb_ret((void *)ri->data, regs, "fib_dump_ret",
+			     VPNHIDE_HOOK_FIB_DUMP_INFO);
 }
 
 static struct kretprobe fib_dump_krp = {
@@ -1229,7 +1314,8 @@ static int rt6_fill_entry(struct kretprobe_instance *ri, struct pt_regs *regs)
 
 static int rt6_fill_ret(struct kretprobe_instance *ri, struct pt_regs *regs)
 {
-	return route_skb_ret((void *)ri->data, regs, "rt6_fill_ret");
+	return route_skb_ret((void *)ri->data, regs, "rt6_fill_ret",
+			     VPNHIDE_HOOK_RT6_FILL_NODE);
 }
 
 static struct kretprobe rt6_fill_krp = {
@@ -1323,7 +1409,8 @@ static int fib_rule_fill_entry(struct kretprobe_instance *ri,
 static int fib_rule_fill_ret(struct kretprobe_instance *ri,
 			     struct pt_regs *regs)
 {
-	return route_skb_ret((void *)ri->data, regs, "fib_rule_fill_ret");
+	return route_skb_ret((void *)ri->data, regs, "fib_rule_fill_ret",
+			     VPNHIDE_HOOK_FIB_NL_FILL_RULE);
 }
 
 static struct kretprobe fib_rule_fill_krp = {


### PR DESCRIPTION
## Summary
- add cumulative per-app, per-hook interception counters to kmod and KPM
- emit non-zero stats through the existing `vpnhide 1 stats` wire format
- update storage docs and changelog for native backend stats

## Validation
- `clang-format --dry-run --Werror kmod/vpnhide_kmod.c kmod/kpm/vpnhide_kpm.c`
- `gcc -O2 -Wall -Werror -o /tmp/test_iface_lists kmod/test_iface_lists.c && /tmp/test_iface_lists`
- `cd kmod/shared && gcc -O2 -Wall -Wextra -Werror -I.. -o /tmp/test_vpnhide_logic test_vpnhide_logic.c && /tmp/test_vpnhide_logic`
- `cd kmod/shared && gcc -O2 -Wall -Wextra -Werror -I.. -o /tmp/test_protocol test_protocol.c && /tmp/test_protocol protocol_vectors.tsv`
- `python3 scripts/codegen-hooks.py && git diff --exit-code -- kmod/generated lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/generated zygisk/src/generated lsposed/native/src/generated`
- `make -C kmod kpm`
- `git diff --check`