### PR TITLE
Add LSPosed interception stats

### DIFF
--- a/changelog.d/added-lsposed-now-reports-per-app-java-795f.md
+++ b/changelog.d/added-lsposed-now-reports-per-app-java-795f.md
@@ -1,0 +1,9 @@
+_2026-06-29_
+
+## English
+
+LSPosed now reports per-app Java and app-hiding interception counters through its state file.
+
+## Русский
+
+LSPosed теперь отдает счетчики Java-перехватов и скрытия приложений по приложениям через свой state-файл.

--- a/crates/activator/src/lib.rs
+++ b/crates/activator/src/lib.rs
@@ -113,7 +113,8 @@ impl NativeSelection {
             NativeSelection::Enabled(false) => None,
             NativeSelection::Enabled(true) => Some(KERNEL_HOOK_MASK),
             NativeSelection::Hooks(names) => {
-                let mask = names.iter().fold(0u32, |acc, name| acc | hook_bit(name));
+                let mask =
+                    names.iter().fold(0u32, |acc, name| acc | hook_bit(name)) & KERNEL_HOOK_MASK;
                 (mask != 0).then_some(mask)
             }
         }
@@ -843,6 +844,26 @@ mod tests {
              target 0x278b 0x3ff\n\
              target 0x27fa 0x40\n\
              target 0xf69cb 0x3ff\n",
+        );
+    }
+
+    #[test]
+    fn native_projection_ignores_non_kernel_hook_names() {
+        let cfg = parse_canonical(
+            r#"{
+              "version": 1,
+              "debug": false,
+              "apps": {
+                "com.example.java": { "native": ["lsposed_network"] }
+              }
+            }"#,
+        )
+        .unwrap();
+        let resolver = parse_pm_packages("package:com.example.java uid:10123\n");
+
+        assert_eq!(
+            project_native_with_resolver(&cfg, &resolver),
+            "vpnhide 1 config\ndebug 0\n",
         );
     }
 

--- a/crates/protocol/src/generated/hook_ids.rs
+++ b/crates/protocol/src/generated/hook_ids.rs
@@ -26,14 +26,30 @@ pub enum Hook {
     Rt6FillNode = 8,
     /// RTM_GETRULE — policy routing rules
     FibNlFillRule = 9,
+    /// LinkProperties parcel/result sanitization
+    LsposedLinkProperties = 10,
+    /// NetworkCapabilities parcel/result sanitization
+    LsposedNetworkCapabilities = 11,
+    /// NetworkInfo parcel/result sanitization
+    LsposedNetworkInfo = 12,
+    /// Network handle replacement/filtering
+    LsposedNetwork = 13,
+    /// ConnectivityService synchronous result filtering
+    LsposedConnectivityResult = 14,
+    /// ConnectivityService callback filtering
+    LsposedConnectivityCallback = 15,
+    /// ConnectivityService Network handle APIs
+    LsposedConnectivityNetwork = 16,
+    /// PackageManager app-hiding filters
+    LsposedPackageVisibility = 17,
 }
 
-pub const HOOK_COUNT: u32 = 10;
+pub const HOOK_COUNT: u32 = 18;
 
 /// Hooks owned by each backend: apply `mask & own`.
 pub const KERNEL_HOOK_MASK: u32 = 0x3ff;
 pub const ZYGISK_HOOK_MASK: u32 = 0x0;
-pub const LSPOSED_HOOK_MASK: u32 = 0x0;
+pub const LSPOSED_HOOK_MASK: u32 = 0x3fc00;
 
 /// status error codes (protocol §5.1).
 #[repr(u32)]
@@ -65,7 +81,7 @@ pub enum Backend {
     Lsposed = 3,
 }
 
-pub const HOOK_NAMES: [&str; 10] = [
+pub const HOOK_NAMES: [&str; 18] = [
     "fib_route_seq_show",
     "ipv6_route_seq_show",
     "rtnl_fill_ifinfo",
@@ -76,4 +92,12 @@ pub const HOOK_NAMES: [&str; 10] = [
     "fib_dump_info",
     "rt6_fill_node",
     "fib_nl_fill_rule",
+    "lsposed_link_properties",
+    "lsposed_network_capabilities",
+    "lsposed_network_info",
+    "lsposed_network",
+    "lsposed_connectivity_result",
+    "lsposed_connectivity_callback",
+    "lsposed_connectivity_network",
+    "lsposed_package_visibility",
 ];

--- a/data/hooks.toml
+++ b/data/hooks.toml
@@ -78,8 +78,58 @@ name = "fib_nl_fill_rule"
 backend = "kernel"
 note = "RTM_GETRULE — policy routing rules"
 
-# --- zygisk libc hooks and lsposed Java hooks take the next free ids as they
-# --- are wired into the protocol; appended here then (kept here as the record).
+# --- LSPosed Java hooks (system_server) ------------------------------------
+
+[[hook]]
+id = 10
+name = "lsposed_link_properties"
+backend = "lsposed"
+note = "LinkProperties parcel/result sanitization"
+
+[[hook]]
+id = 11
+name = "lsposed_network_capabilities"
+backend = "lsposed"
+note = "NetworkCapabilities parcel/result sanitization"
+
+[[hook]]
+id = 12
+name = "lsposed_network_info"
+backend = "lsposed"
+note = "NetworkInfo parcel/result sanitization"
+
+[[hook]]
+id = 13
+name = "lsposed_network"
+backend = "lsposed"
+note = "Network handle replacement/filtering"
+
+[[hook]]
+id = 14
+name = "lsposed_connectivity_result"
+backend = "lsposed"
+note = "ConnectivityService synchronous result filtering"
+
+[[hook]]
+id = 15
+name = "lsposed_connectivity_callback"
+backend = "lsposed"
+note = "ConnectivityService callback filtering"
+
+[[hook]]
+id = 16
+name = "lsposed_connectivity_network"
+backend = "lsposed"
+note = "ConnectivityService Network handle APIs"
+
+[[hook]]
+id = 17
+name = "lsposed_package_visibility"
+backend = "lsposed"
+note = "PackageManager app-hiding filters"
+
+# --- zygisk libc hooks take the next free ids as they are wired into the
+# --- protocol; appended here then (kept here as the record).
 
 # --- backend ids (protocol §4.3 `status backend <id>`) ----------------------
 # Which backend answered a `status` read. Distinct from the hook `backend`

--- a/docs/adb-root-debugging.md
+++ b/docs/adb-root-debugging.md
@@ -49,7 +49,7 @@ Broken examples:
 ```sh
 adb -s SERIAL shell 'su -c "
 cat /data/system/vpnhide_config.json
-cat /data/system/vpnhide_hook_active 2>/dev/null
+cat /data/system/vpnhide_lsposed_state 2>/dev/null
 cat /data/adb/vpnhide_kmod/load_status 2>/dev/null
 cat /data/adb/vpnhide_kpm/load_status 2>/dev/null
 ls -lZ /data/adb/modules/vpnhide_kmod /data/adb/modules/vpnhide_kpm 2>&1

--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -365,9 +365,11 @@ is global; a backend only acts on its own bits.
 Current kernel hooks (`.ko` / KPM, 10): `fib_route_seq_show`,
 `ipv6_route_seq_show`, `rtnl_fill_ifinfo`, `inet_fill_ifaddr`,
 `inet6_fill_ifaddr`, `dev_ioctl`, `sock_ioctl`, `fib_dump_info`, `rt6_fill_node`,
-`fib_nl_fill_rule`. Plus LSPosed Java hooks (PackageManager, ConnectivityManager,
-…) and Zygisk libc hooks (`recv`/`recvfrom`/`recvmsg` netlink filtering, …),
-each taking global ids in the same space.
+`fib_nl_fill_rule`. Current LSPosed Java hooks (8): `lsposed_link_properties`,
+`lsposed_network_capabilities`, `lsposed_network_info`, `lsposed_network`,
+`lsposed_connectivity_result`, `lsposed_connectivity_callback`,
+`lsposed_connectivity_network`, `lsposed_package_visibility`. Zygisk libc hooks
+take the next free global ids when they are wired into per-hook protocol stats.
 
 ### 5.1 Error codes (`status`)
 

--- a/docs/state.md
+++ b/docs/state.md
@@ -146,14 +146,18 @@ is exportable and readable by `system_server`.
 
 ## 4. system_server Files
 
-### `/data/system/vpnhide_hook_active`
+### `/data/system/vpnhide_lsposed_state`
 
-- Format: `key=value`: `version`, `boot_id`, `timestamp`, `aosp_sdk`, optional
-  `broken_fields`.
-- Writer: LSPosed hook entry in `system_server`.
+- Format: protocol-shaped readback: `vpnhide 1 status` plus LSPosed `meta`
+  records (`version`, `boot_id`, `timestamp`, `aosp_sdk`, optional
+  `broken_fields`) and `vpnhide 1 stats` sparse counters.
+- Writer: LSPosed hooks in `system_server`.
 - Reader: app dashboard via root snapshot.
 - Permissions: default root/system-server write behavior; app reads via `su`.
 - Lifetime: per boot.
+
+`/data/system/vpnhide_hook_active` is the retired status-only marker. App
+startup removes it best-effort after canonical JSON migration.
 
 The canonical config is also in `/data/system`, but it is covered in section 1
 because it is the storage root for every layer.
@@ -299,7 +303,7 @@ service:
 system_server:
   HookEntry.handleLoadPackage
     -> install hooks
-    -> write /data/system/vpnhide_hook_active
+    -> write /data/system/vpnhide_lsposed_state
     -> watch canonical JSON
 
 zygote app fork:
@@ -317,7 +321,7 @@ zygote app fork:
 | Lifetime | Examples |
 |---|---|
 | In-kernel per boot | `/proc/vpnhide_ctl` state, KPM in-kernel state, iptables chains |
-| Per boot files | `/data/adb/vpnhide_kmod/load_status`, `/data/adb/vpnhide_kmod/load_dmesg`, `/data/adb/vpnhide_kpm/load_status`, `/data/system/vpnhide_hook_active` |
+| Per boot files | `/data/adb/vpnhide_kmod/load_status`, `/data/adb/vpnhide_kmod/load_dmesg`, `/data/adb/vpnhide_kpm/load_status`, `/data/system/vpnhide_lsposed_state` |
 | Per app launch | `filesDir/vpnhide_zygisk_active` |
 | Persistent root-managed | `/data/system/vpnhide_config.json`, `/data/adb/vpnhide/superkey` |
 | Module-dir derived state | `/data/adb/modules/vpnhide_zygisk/targets.txt` |

--- a/docs/storage.md
+++ b/docs/storage.md
@@ -119,12 +119,12 @@ How it reads, carefully (this runs in the bootloop-critical `system_server`):
   `packages.list` is a plain file read, hook-free.
 - **Multi-profile for free:** match `callingUid % 100000 ∈ targetAppIds`. Any
   profile's instance of a target app matches, with no per-profile enumeration.
-- **Status out:** the hook writes `/data/system/vpnhide_hook_active`
-  (`version`/`boot_id`/`broken_fields`) so the dashboard knows the Java layer is
-  alive and healthy. (Config-in and status-out are different files / opposite
-  directions — `system_server` can't expose a `/proc`-style node, so it can't
-  multiplex both on one channel the way the kmod node does.)
-- **Stats:** deferred (§5).
+- **State out:** the hook writes `/data/system/vpnhide_lsposed_state`, a single
+  protocol-shaped readback file containing `vpnhide 1 status` plus LSPosed
+  metadata (`version`/`boot_id`/`broken_fields`) and `vpnhide 1 stats` counters.
+  Config-in and state-out are still different files / opposite directions:
+  `system_server` can't expose a `/proc`-style node, so it can't multiplex write
+  config + read state on one channel the way the kmod node does.
 
 > Current code (#164) differs: LSPosed reads a *derived protocol config*
 > (`vpnhide_uids.txt`) that the native boot scripts populate. That is exactly the
@@ -252,8 +252,9 @@ single-writer / atomic-replace, and stats are never written back into it.
   zygote-inherited memfd must be created in the zygote, where our code does not run).
   So Zygisk emits **status only**; per-hook stats are a future problem, not a
   blocker for this design.
-- **LSPosed: deferred** (it *could* aggregate in `system_server`'s single process,
-  but not now). Status via `vpnhide_hook_active`.
+- **LSPosed: yes** — counters live in `system_server`, so the hook aggregates
+  cumulative-since-boot non-zero `(uid, hook_id)` cells and writes them into
+  `/data/system/vpnhide_lsposed_state` next to its `status` block.
 
 ---
 
@@ -345,7 +346,7 @@ optional.
 | `/proc/vpnhide_ctl` | kmod runtime channel (node, not a file) | per-boot, in-kernel |
 | KPM ctl0 supercall | KPM runtime channel (supercall, no file) | per-boot, in-kernel |
 | `/data/adb/modules/vpnhide_zygisk/<cfg>` | Zygisk runtime channel (derived copy) | regenerated |
-| `/data/system/vpnhide_hook_active` | LSPosed status (hook → dashboard) | per-boot |
+| `/data/system/vpnhide_lsposed_state` | LSPosed status + stats (hook → dashboard) | per-boot |
 | `/data/adb/vpnhide/superkey` | APatch superkey (optional, flag-gated) | persistent, root-only |
 
 Removed vs. the pre-redesign layout:

--- a/kmod/generated/hook_ids.h
+++ b/kmod/generated/hook_ids.h
@@ -3,22 +3,30 @@
 #define VPNHIDE_GENERATED_HOOK_IDS_H
 
 /* Global hook id space (data/hooks.toml). bit N == hook id N. */
-#define VPNHIDE_HOOK_FIB_ROUTE_SEQ_SHOW  0
-#define VPNHIDE_HOOK_IPV6_ROUTE_SEQ_SHOW 1
-#define VPNHIDE_HOOK_RTNL_FILL_IFINFO    2
-#define VPNHIDE_HOOK_INET_FILL_IFADDR    3
-#define VPNHIDE_HOOK_INET6_FILL_IFADDR   4
-#define VPNHIDE_HOOK_DEV_IOCTL           5
-#define VPNHIDE_HOOK_SOCK_IOCTL          6
-#define VPNHIDE_HOOK_FIB_DUMP_INFO       7
-#define VPNHIDE_HOOK_RT6_FILL_NODE       8
-#define VPNHIDE_HOOK_FIB_NL_FILL_RULE    9
-#define VPNHIDE_HOOK_COUNT               10
+#define VPNHIDE_HOOK_FIB_ROUTE_SEQ_SHOW            0
+#define VPNHIDE_HOOK_IPV6_ROUTE_SEQ_SHOW           1
+#define VPNHIDE_HOOK_RTNL_FILL_IFINFO              2
+#define VPNHIDE_HOOK_INET_FILL_IFADDR              3
+#define VPNHIDE_HOOK_INET6_FILL_IFADDR             4
+#define VPNHIDE_HOOK_DEV_IOCTL                     5
+#define VPNHIDE_HOOK_SOCK_IOCTL                    6
+#define VPNHIDE_HOOK_FIB_DUMP_INFO                 7
+#define VPNHIDE_HOOK_RT6_FILL_NODE                 8
+#define VPNHIDE_HOOK_FIB_NL_FILL_RULE              9
+#define VPNHIDE_HOOK_LSPOSED_LINK_PROPERTIES       10
+#define VPNHIDE_HOOK_LSPOSED_NETWORK_CAPABILITIES  11
+#define VPNHIDE_HOOK_LSPOSED_NETWORK_INFO          12
+#define VPNHIDE_HOOK_LSPOSED_NETWORK               13
+#define VPNHIDE_HOOK_LSPOSED_CONNECTIVITY_RESULT   14
+#define VPNHIDE_HOOK_LSPOSED_CONNECTIVITY_CALLBACK 15
+#define VPNHIDE_HOOK_LSPOSED_CONNECTIVITY_NETWORK  16
+#define VPNHIDE_HOOK_LSPOSED_PACKAGE_VISIBILITY    17
+#define VPNHIDE_HOOK_COUNT                         18
 
 /* Hooks owned by each backend: apply `mask & own`, ignore foreign bits. */
 #define VPNHIDE_KERNEL_HOOK_MASK 0x3ffu
 #define VPNHIDE_ZYGISK_HOOK_MASK 0x0u
-#define VPNHIDE_LSPOSED_HOOK_MASK 0x0u
+#define VPNHIDE_LSPOSED_HOOK_MASK 0x3fc00u
 
 /* status error codes (protocol §5.1). */
 #define VPNHIDE_ERR_OK                       0
@@ -48,6 +56,14 @@ static inline const char *vpnhide_hook_name(int id)
 	case 7: return "fib_dump_info";
 	case 8: return "rt6_fill_node";
 	case 9: return "fib_nl_fill_rule";
+	case 10: return "lsposed_link_properties";
+	case 11: return "lsposed_network_capabilities";
+	case 12: return "lsposed_network_info";
+	case 13: return "lsposed_network";
+	case 14: return "lsposed_connectivity_result";
+	case 15: return "lsposed_connectivity_callback";
+	case 16: return "lsposed_connectivity_network";
+	case 17: return "lsposed_package_visibility";
 	default: return "?";
 	}
 }

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DashboardData.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DashboardData.kt
@@ -4,6 +4,7 @@ import android.content.pm.PackageManager
 import android.database.sqlite.SQLiteDatabase
 import android.os.Build
 import android.os.SystemClock
+import dev.okhsunrog.vpnhide.generated.HookIds
 import java.io.File
 
 // ── Domain types — invalid states are unrepresentable ────────────────────
@@ -1119,12 +1120,18 @@ internal suspend fun loadDashboardState(
     )
     StartupTrace.mark("dashboard_kernel_done")
 
-    // lsposed hook status
-    val hookStatusRaw = shellSnapshot["hook_status"].orEmpty()
-    val hookProps = parseKeyValueLines(hookStatusRaw)
+    // lsposed runtime state
+    val lsposedStateRaw = shellSnapshot["lsposed_state"].orEmpty()
+    val lsposedStatus = Protocol.parseStatus(lsposedStateRaw)
+    val hookProps = parseLsposedStateMetadata(lsposedStateRaw)
     val hookVersion = hookProps["version"]
     val hookBootId = hookProps["boot_id"]
-    val hooksActiveThisBoot = hookBootId != null && hookBootId == currentBootId.trim()
+    val hooksActiveThisBoot =
+        lsposedStatus?.backend ==
+            HookIds.Backend.LSPOSED.id
+                .toLong() &&
+            hookBootId != null &&
+            hookBootId == currentBootId.trim()
     val lsposedTargetCount = countPackages(targetsSnapshot.lsposedTargets)
     val lsposedFramework = detectLsposedFramework(shellSnapshot)
     val lsposedConfig =
@@ -1160,7 +1167,7 @@ internal suspend fun loadDashboardState(
     VpnHideLog.i(
         TAG,
         "lsposed: $lsposed (hookBootId=$hookBootId currentBootId=${currentBootId.trim()} " +
-            "framework=$lsposedFramework hooksActive=$hooksActiveThisBoot config=$lsposedConfig)",
+            "status=$lsposedStatus framework=$lsposedFramework hooksActive=$hooksActiveThisBoot config=$lsposedConfig)",
     )
     StartupTrace.mark("dashboard_lsposed_done")
 

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DiagnosticsScreen.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DiagnosticsScreen.kt
@@ -1173,6 +1173,9 @@ private fun buildTargetsText(): String =
         appendLine("=== /proc/vpnhide_ctl (live status + stats) ===")
         appendLine(suExec("cat $PROC_CTL 2>/dev/null").second.ifEmpty { "(empty)" })
         appendLine()
+        appendLine("=== LSPosed state (live status + stats) ===")
+        appendLine(suExec("cat $LSPOSED_STATE_FILE 2>/dev/null").second.ifEmpty { "(empty)" })
+        appendLine()
         appendLine("=== canonical config ===")
         appendLine(suExec("cat $CANONICAL_CONFIG_FILE 2>/dev/null").second.ifEmpty { "(empty)" })
     }

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/HookEntry.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/HookEntry.kt
@@ -14,8 +14,8 @@ import de.robv.android.xposed.XC_MethodHook
 import de.robv.android.xposed.XposedBridge
 import de.robv.android.xposed.XposedHelpers
 import de.robv.android.xposed.callbacks.XC_LoadPackage
+import dev.okhsunrog.vpnhide.generated.HookIds
 import dev.okhsunrog.vpnhide.generated.IfaceLists
-import java.io.File
 import java.util.concurrent.atomic.AtomicBoolean
 import java.lang.reflect.Array as JavaArray
 
@@ -39,7 +39,11 @@ import java.lang.reflect.Array as JavaArray
  * by vpnhide-kmod (kernel module) or vpnhide-zygisk (in-process hooks).
  *
  * Only "System Framework" needs to be in LSPosed scope.
+ *
+ * Single Xposed entry point for system_server hook wiring; splitting the hook
+ * installer is a separate refactor from adding telemetry.
  */
+@Suppress("LargeClass")
 class HookEntry : IXposedHookLoadPackage {
     private val hookInstalled = AtomicBoolean(false)
 
@@ -85,29 +89,41 @@ class HookEntry : IXposedHookLoadPackage {
         if (hookInstalled.compareAndSet(false, true)) {
             HookLog.install()
             HookLog.i("VpnHide: system_server detected, installing Binder hooks")
-            val brokenFields = installSystemServerHooks()
-            tryHook("PackageVisibility") { PackageVisibilityHooks.install(lpparam.classLoader) }
-            tryHook("ConnectivityService") { installConnectivityServiceHook(lpparam.classLoader) }
-            writeHookStatusFile(brokenFields)
+            val hookInstall = installSystemServerHooks()
+            var installedMask = hookInstall.installedHookMask
+            if (tryHook("PackageVisibility") { PackageVisibilityHooks.install(lpparam.classLoader) }) {
+                installedMask = installedMask or hookBit(HookIds.Hook.LSPOSED_PACKAGE_VISIBILITY)
+            }
+            if (tryHook("ConnectivityService") { installConnectivityServiceHook(lpparam.classLoader) }) {
+                installedMask =
+                    installedMask or
+                    hookBit(HookIds.Hook.LSPOSED_CONNECTIVITY_RESULT) or
+                    hookBit(HookIds.Hook.LSPOSED_CONNECTIVITY_CALLBACK) or
+                    hookBit(HookIds.Hook.LSPOSED_CONNECTIVITY_NETWORK)
+            }
+            LsposedStats.setStatus(installedMask, hookInstall.brokenFields)
         }
     }
 
     private inline fun tryHook(
         name: String,
         block: () -> Unit,
-    ) {
+    ): Boolean =
         try {
             block()
+            true
         } catch (t: Throwable) {
             HookLog.e("VpnHide: $name hook failed: ${t::class.java.simpleName}: ${t.message}")
+            false
         }
-    }
 
     // ------------------------------------------------------------------
     //  Helpers
     // ------------------------------------------------------------------
 
     private fun isVpnInterfaceName(name: String): Boolean = IfaceLists.isVpnIface(name)
+
+    private fun hookBit(hook: HookIds.Hook): Int = 1 shl hook.id
 
     // Recursively sanitizes mIfaceName + mRoutes + nested mStackedLinks; the
     // length and nesting are inherent to walking that object graph by reflection.
@@ -389,10 +405,13 @@ class HookEntry : IXposedHookLoadPackage {
         }
 
         val copy = JavaArray.newInstance(componentType, values.size)
+        var modified = false
         for (i in values.indices) {
-            JavaArray.set(copy, i, sanitizedValue(values[i]))
+            val sanitized = sanitizedValue(values[i])
+            if (sanitized !== values[i]) modified = true
+            JavaArray.set(copy, i, sanitized)
         }
-        return copy
+        return if (modified) copy else values
     }
 
     private fun sanitizeMethodResult(
@@ -402,22 +421,41 @@ class HookEntry : IXposedHookLoadPackage {
         if (bypassConnectivitySanitize.get() == true) return
         if (!isTargetCallerOrUid(explicitUid)) return
         try {
-            param.result = sanitizedValue(param.result)
+            val original = param.result
+            val sanitized = sanitizedValue(original)
+            if (sanitized !== original) {
+                param.result = sanitized
+                LsposedStats.record(explicitUid ?: effectiveCallerUid(), HookIds.Hook.LSPOSED_CONNECTIVITY_RESULT)
+            }
         } catch (t: Throwable) {
             HookLog.e("VpnHide: ConnectivityService result sanitize error: ${t.message}")
         }
     }
 
     @Suppress("DEPRECATION")
-    private fun sanitizeCallbackBundle(bundle: Bundle) {
+    private fun sanitizeCallbackBundle(bundle: Bundle): Boolean {
+        var modified = false
         try {
             val nc = bundle.getParcelable(NetworkCapabilities::class.java.simpleName) as? NetworkCapabilities
-            if (nc != null) bundle.putParcelable(NetworkCapabilities::class.java.simpleName, sanitizedNetworkCapabilities(nc))
+            if (nc != null) {
+                val sanitized = sanitizedNetworkCapabilities(nc)
+                if (sanitized !== nc) {
+                    bundle.putParcelable(NetworkCapabilities::class.java.simpleName, sanitized)
+                    modified = true
+                }
+            }
             val lp = bundle.getParcelable(LinkProperties::class.java.simpleName) as? LinkProperties
-            if (lp != null) bundle.putParcelable(LinkProperties::class.java.simpleName, sanitizedLinkProperties(lp))
+            if (lp != null) {
+                val sanitized = sanitizedLinkProperties(lp)
+                if (sanitized !== lp) {
+                    bundle.putParcelable(LinkProperties::class.java.simpleName, sanitized)
+                    modified = true
+                }
+            }
         } catch (t: Throwable) {
             HookLog.e("VpnHide: callback bundle sanitize error: ${t.message}")
         }
+        return modified
     }
 
     // ==================================================================
@@ -438,11 +476,17 @@ class HookEntry : IXposedHookLoadPackage {
     // gets that on every NetworkCapabilities IPC, target or not). The
     // dashboard surfaces the broken_fields list as a red error so the
     // user can see and report the AOSP drift.
-    private fun installSystemServerHooks(): List<String> {
+    private data class HookInstallResult(
+        val brokenFields: List<String>,
+        val installedHookMask: Int,
+    )
+
+    private fun installSystemServerHooks(): HookInstallResult {
         val brokenFields = runReflectionSmokeCheck()
         if (brokenFields.isNotEmpty()) {
             HookLog.e("VpnHide: reflection smoke-check found broken keys: $brokenFields")
         }
+        var installedHookMask = 0
 
         // Match a probe key against either an exact entry in `broken` or
         // an entry with a `:type=...` suffix (wrong-typed field).
@@ -455,12 +499,16 @@ class HookEntry : IXposedHookLoadPackage {
         if (anyBroken(LP_CRITICAL_KEYS)) {
             HookLog.e("VpnHide: LP.writeToParcel hook SKIPPED — critical reflection broken")
         } else {
-            tryHook("LP.writeToParcel") { hookLPWriteToParcel() }
+            if (tryHook("LP.writeToParcel") { hookLPWriteToParcel() }) {
+                installedHookMask = installedHookMask or hookBit(HookIds.Hook.LSPOSED_LINK_PROPERTIES)
+            }
         }
 
         // NC uses public NetworkCapabilities mutators now, so private AOSP
         // field drift must not disable this hook.
-        tryHook("NC.writeToParcel") { hookNCWriteToParcel() }
+        if (tryHook("NC.writeToParcel") { hookNCWriteToParcel() }) {
+            installedHookMask = installedHookMask or hookBit(HookIds.Hook.LSPOSED_NETWORK_CAPABILITIES)
+        }
 
         // NI: every field + ctor is critical — the hook body has no
         // inner try/catch around the per-field setIntField/setBooleanField
@@ -468,12 +516,16 @@ class HookEntry : IXposedHookLoadPackage {
         if (anyBroken(NI_CRITICAL_KEYS)) {
             HookLog.e("VpnHide: NI.writeToParcel hook SKIPPED — critical reflection broken")
         } else {
-            tryHook("NI.writeToParcel") { hookNIWriteToParcel() }
+            if (tryHook("NI.writeToParcel") { hookNIWriteToParcel() }) {
+                installedHookMask = installedHookMask or hookBit(HookIds.Hook.LSPOSED_NETWORK_INFO)
+            }
         }
-        tryHook("Network.writeToParcel") { hookNetworkWriteToParcel() }
+        if (tryHook("Network.writeToParcel") { hookNetworkWriteToParcel() }) {
+            installedHookMask = installedHookMask or hookBit(HookIds.Hook.LSPOSED_NETWORK)
+        }
 
         tryHook("FileObserver") { watchCanonicalConfigFile() }
-        return brokenFields
+        return HookInstallResult(brokenFields, installedHookMask)
     }
 
     private data class FieldProbe(
@@ -523,41 +575,6 @@ class HookEntry : IXposedHookLoadPackage {
             }
         }
         return broken
-    }
-
-    /**
-     * Write a status file so the VPN Hide app can verify hooks are active.
-     * Includes boot_id to distinguish stale files from previous boots,
-     * aosp_sdk for diagnostic context in bug reports, and (only when
-     * non-empty) broken_fields listing the reflection probes that the
-     * smoke-check rejected this boot.
-     */
-    private fun writeHookStatusFile(brokenFields: List<String>) {
-        try {
-            val bootId = File("/proc/sys/kernel/random/boot_id").readText().trim()
-            val timestamp = System.currentTimeMillis() / 1000
-            val version = BuildConfig.VERSION_NAME
-            val sdk = Build.VERSION.SDK_INT
-            val sb = StringBuilder()
-            sb.append("version=").append(version).append('\n')
-            sb.append("boot_id=").append(bootId).append('\n')
-            sb.append("timestamp=").append(timestamp).append('\n')
-            sb.append("aosp_sdk=").append(sdk).append('\n')
-            if (brokenFields.isNotEmpty()) {
-                sb.append("broken_fields=").append(brokenFields.joinToString(",")).append('\n')
-            }
-            val statusFile = File(HOOK_STATUS_FILE)
-            statusFile.writeText(sb.toString())
-            // Don't expose this file to untrusted apps — anti-tamper SDKs
-            // scan /data/system/ for known marker filenames. The VPN Hide
-            // app reads it via root (`suExec("cat ...")`), see DashboardData.kt.
-            HookLog.i(
-                "VpnHide: wrote hook status file (version=$version, boot_id=$bootId, " +
-                    "sdk=$sdk, broken=${brokenFields.size})",
-            )
-        } catch (t: Throwable) {
-            HookLog.e("VpnHide: failed to write hook status: ${t.message}")
-        }
     }
 
     /**
@@ -621,6 +638,7 @@ class HookEntry : IXposedHookLoadPackage {
                             writingCopy.set(false)
                         }
                         param.result = null
+                        LsposedStats.record(callerUid, HookIds.Hook.LSPOSED_NETWORK_CAPABILITIES)
                         HookLog.i("VpnHide-NC: uid=$callerUid STRIPPED VPN")
                     } catch (t: Throwable) {
                         HookLog.e("VpnHide: NC.writeToParcel error: ${t.message}")
@@ -655,6 +673,7 @@ class HookEntry : IXposedHookLoadPackage {
                             writingCopy.set(false)
                         }
                         param.result = null
+                        LsposedStats.record(effectiveCallerUid(), HookIds.Hook.LSPOSED_NETWORK)
                         HookLog.i("VpnHide: replaced VPN Network parcel for uid=${effectiveCallerUid()}")
                     } catch (t: Throwable) {
                         HookLog.e("VpnHide: Network.writeToParcel error: ${t.message}")
@@ -702,6 +721,7 @@ class HookEntry : IXposedHookLoadPackage {
                             writingCopy.set(false)
                         }
                         param.result = null
+                        LsposedStats.record(callerUid, HookIds.Hook.LSPOSED_NETWORK_INFO)
                         HookLog.i("VpnHide-NI: uid=$callerUid STRIPPED VPN (disguised as WIFI)")
                     } catch (t: Throwable) {
                         HookLog.e("VpnHide: NI.writeToParcel error: ${t.message}")
@@ -748,6 +768,7 @@ class HookEntry : IXposedHookLoadPackage {
                             writingCopy.set(false)
                         }
                         param.result = null
+                        LsposedStats.record(callerUid, HookIds.Hook.LSPOSED_LINK_PROPERTIES)
                         HookLog.i("VpnHide-LP: uid=$callerUid STRIPPED VPN (ifname was $ifname)")
                     } catch (t: Throwable) {
                         HookLog.e("VpnHide: LP.writeToParcel error: ${t.message}")
@@ -861,10 +882,15 @@ class HookEntry : IXposedHookLoadPackage {
                         // App is specifically listening for a VPN network —
                         // suppress so it never learns one exists.
                         param.result = null
+                        LsposedStats.record(uid, HookIds.Hook.LSPOSED_CONNECTIVITY_CALLBACK)
                         HookLog.i("VpnHide-CB: uid=$uid suppressed VPN-request dispatch")
                         return
                     }
-                    (param.args.getOrNull(CALLBACK_BUNDLE_ARG_INDEX) as? Bundle)?.let { sanitizeCallbackBundle(it) }
+                    (param.args.getOrNull(CALLBACK_BUNDLE_ARG_INDEX) as? Bundle)?.let {
+                        if (sanitizeCallbackBundle(it)) {
+                            LsposedStats.record(uid, HookIds.Hook.LSPOSED_CONNECTIVITY_CALLBACK)
+                        }
+                    }
                     currentCallbackUid.set(uid)
                 }
 
@@ -956,6 +982,7 @@ class HookEntry : IXposedHookLoadPackage {
             return
         }
         param.result = replacement
+        LsposedStats.record(effectiveCallerUid(), HookIds.Hook.LSPOSED_CONNECTIVITY_NETWORK)
         HookLog.i("VpnHide: replaced active VPN Network handle for uid=${effectiveCallerUid()}")
     }
 
@@ -965,6 +992,7 @@ class HookEntry : IXposedHookLoadPackage {
         val filtered = networks.filterNot { isVpnNetwork(cs, it) }
         if (filtered.size == networks.size) return
         param.result = filtered.toTypedArray()
+        LsposedStats.record(effectiveCallerUid(), HookIds.Hook.LSPOSED_CONNECTIVITY_NETWORK)
         HookLog.i(
             "VpnHide: filtered ${networks.size - filtered.size} VPN Network handle(s) " +
                 "for uid=${effectiveCallerUid()}",
@@ -975,6 +1003,7 @@ class HookEntry : IXposedHookLoadPackage {
         val type = param.args.getOrNull(0) as? Int ?: return
         if (type != ConnectivityManager.TYPE_VPN || param.result == null) return
         param.result = null
+        LsposedStats.record(effectiveCallerUid(), HookIds.Hook.LSPOSED_CONNECTIVITY_NETWORK)
         HookLog.i("VpnHide: suppressed getNetworkForType(TYPE_VPN) for uid=${effectiveCallerUid()}")
     }
 
@@ -989,6 +1018,7 @@ class HookEntry : IXposedHookLoadPackage {
         if (param.result == null) return true
         if (!isTargetCallerOrUid()) return false
         param.result = null
+        LsposedStats.record(effectiveCallerUid(), HookIds.Hook.LSPOSED_CONNECTIVITY_RESULT)
         HookLog.i("VpnHide: suppressed getNetworkInfo(TYPE_VPN) for uid=${effectiveCallerUid()}")
         return true
     }
@@ -1053,8 +1083,6 @@ class HookEntry : IXposedHookLoadPackage {
                 "getNetworkInfoForUid" to 1,
                 "getAllNetworkInfo" to null,
             )
-        const val HOOK_STATUS_FILE = "/data/system/vpnhide_hook_active"
-
         private val FIELD_PROBES =
             listOf(
                 FieldProbe(

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/LsposedState.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/LsposedState.kt
@@ -1,0 +1,154 @@
+package dev.okhsunrog.vpnhide
+
+import android.os.Build
+import android.os.Process
+import dev.okhsunrog.vpnhide.generated.HookIds
+import java.io.File
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.atomic.AtomicLong
+
+internal const val LSPOSED_STATE_FILE = "/data/system/vpnhide_lsposed_state"
+internal const val LEGACY_HOOK_STATUS_FILE = "/data/system/vpnhide_hook_active"
+
+internal object LsposedStateMetadata {
+    const val VERSION = "version"
+    const val BOOT_ID = "boot_id"
+    const val TIMESTAMP = "timestamp"
+    const val AOSP_SDK = "aosp_sdk"
+    const val BROKEN_FIELDS = "broken_fields"
+}
+
+internal fun parseLsposedStateMetadata(raw: String): Map<String, String> =
+    raw
+        .lineSequence()
+        .map { it.trim() }
+        .filter { it.startsWith("meta ") }
+        .mapNotNull { line ->
+            val parts = line.split(' ', limit = 3)
+            val key = parts.getOrNull(1)?.takeIf { it.isNotBlank() } ?: return@mapNotNull null
+            val value = parts.getOrNull(2).orEmpty()
+            key to value
+        }.toMap()
+
+internal fun formatLsposedState(
+    status: Protocol.Status,
+    metadata: Map<String, String>,
+    stats: List<Protocol.StatEntry>,
+): String =
+    buildString {
+        append(Protocol.formatStatus(status))
+        for ((key, value) in metadata) {
+            append("meta ")
+                .append(key)
+                .append(' ')
+                .append(value)
+                .append('\n')
+        }
+        append(Protocol.formatStats(stats))
+    }
+
+internal object LsposedStats {
+    private val counts = ConcurrentHashMap<Int, ConcurrentHashMap<Int, AtomicLong>>()
+
+    @Volatile private var installedHooks: Int = 0
+
+    @Volatile private var brokenFields: List<String> = emptyList()
+
+    fun setStatus(
+        installedHookMask: Int,
+        broken: List<String>,
+    ) {
+        installedHooks = installedHookMask
+        brokenFields = broken
+        writeState()
+    }
+
+    fun record(
+        uid: Int,
+        hook: HookIds.Hook,
+    ) {
+        if (uid < Process.FIRST_APPLICATION_UID) return
+        counts
+            .computeIfAbsent(uid) { ConcurrentHashMap() }
+            .computeIfAbsent(hook.id) { AtomicLong() }
+            .incrementAndGet()
+        writeState()
+    }
+
+    @Synchronized
+    private fun writeState() {
+        try {
+            val text = buildStateText()
+            val tmp = File("$LSPOSED_STATE_FILE.tmp.${Process.myPid()}")
+            tmp.writeText(text)
+            if (!tmp.renameTo(File(LSPOSED_STATE_FILE))) {
+                tmp.delete()
+                File(LSPOSED_STATE_FILE).writeText(text)
+            }
+        } catch (t: Throwable) {
+            HookLog.e("VpnHide: failed to write LSPosed state: ${t.message}")
+        }
+    }
+
+    private fun buildStateText(): String {
+        val installed = installedHooks
+        val error =
+            if (installed == HookIds.LSPOSED_HOOK_MASK) {
+                HookIds.StatusError.OK.code
+            } else {
+                HookIds.StatusError.PARTIAL_HOOKS.code
+            }
+        val status =
+            Protocol.Status(
+                backend =
+                    HookIds.Backend.LSPOSED.id
+                        .toLong(),
+                kver = 0,
+                hooks = installed.toLong(),
+                error = error.toLong(),
+            )
+        return formatLsposedState(
+            status = status,
+            metadata = metadataSnapshot(),
+            stats = statsSnapshot(),
+        )
+    }
+
+    private fun metadataSnapshot(): Map<String, String> {
+        val meta =
+            linkedMapOf(
+                LsposedStateMetadata.VERSION to BuildConfig.VERSION_NAME,
+                LsposedStateMetadata.BOOT_ID to readBootId(),
+                LsposedStateMetadata.TIMESTAMP to (System.currentTimeMillis() / 1000).toString(),
+                LsposedStateMetadata.AOSP_SDK to Build.VERSION.SDK_INT.toString(),
+            )
+        val broken = brokenFields
+        if (broken.isNotEmpty()) {
+            meta[LsposedStateMetadata.BROKEN_FIELDS] = broken.joinToString(",")
+        }
+        return meta
+    }
+
+    private fun statsSnapshot(): List<Protocol.StatEntry> =
+        counts
+            .toSortedMap()
+            .flatMap { (uid, byHook) ->
+                byHook
+                    .toSortedMap()
+                    .mapNotNull { (hook, count) ->
+                        val value = count.get()
+                        if (value == 0L) {
+                            null
+                        } else {
+                            Protocol.StatEntry(uid.toLong(), hook.toLong(), value)
+                        }
+                    }
+            }
+
+    private fun readBootId(): String =
+        try {
+            File("/proc/sys/kernel/random/boot_id").readText().trim()
+        } catch (_: Throwable) {
+            ""
+        }
+}

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/PackageVisibilityHooks.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/PackageVisibilityHooks.kt
@@ -9,6 +9,7 @@ import android.os.Process
 import de.robv.android.xposed.XC_MethodHook
 import de.robv.android.xposed.XposedBridge
 import de.robv.android.xposed.XposedHelpers
+import dev.okhsunrog.vpnhide.generated.HookIds
 
 /**
  * Package-visibility policy — hide packages from selected callers.
@@ -173,6 +174,7 @@ internal object PackageVisibilityHooks {
                 if (removed.isEmpty()) return
 
                 param.result = newListResultLike(result, filtered) ?: return
+                LsposedStats.record(callerUid, HookIds.Hook.LSPOSED_PACKAGE_VISIBILITY)
                 HookLog.i(
                     "VpnHide/PV: $methodName uid=$callerUid filtered ${removed.size}/${original.size} " +
                         "hidden=${removed.sorted()} wrapper=${result.javaClass.simpleName}",
@@ -225,6 +227,7 @@ internal object PackageVisibilityHooks {
                 val callerUid = observerCallerUid() ?: return
                 if (pkg in loadHiddenPackages()) {
                     param.result = null
+                    LsposedStats.record(callerUid, HookIds.Hook.LSPOSED_PACKAGE_VISIBILITY)
                     HookLog.i("VpnHide/PV: $methodName uid=$callerUid hid $pkg")
                 }
             }
@@ -239,6 +242,7 @@ internal object PackageVisibilityHooks {
                 val callerUid = observerCallerUid() ?: return
                 if (pkg in loadHiddenPackages()) {
                     param.result = -1
+                    LsposedStats.record(callerUid, HookIds.Hook.LSPOSED_PACKAGE_VISIBILITY)
                     HookLog.i("VpnHide/PV: getPackageUid uid=$callerUid hid $pkg")
                 }
             }
@@ -254,6 +258,7 @@ internal object PackageVisibilityHooks {
                 val pkg = resolveInfoPackageName(ri) ?: return
                 if (pkg in loadHiddenPackages()) {
                     param.result = null
+                    LsposedStats.record(callerUid, HookIds.Hook.LSPOSED_PACKAGE_VISIBILITY)
                     HookLog.i("VpnHide/PV: $methodName uid=$callerUid hid $pkg")
                 }
             }
@@ -271,6 +276,7 @@ internal object PackageVisibilityHooks {
                 val filtered = arr.filterIsInstance<String>().filter { it !in hidden }
                 if (filtered.size == arr.size) return
                 param.result = if (filtered.isEmpty()) null else filtered.toTypedArray()
+                LsposedStats.record(callerUid, HookIds.Hook.LSPOSED_PACKAGE_VISIBILITY)
                 val requestedUid = param.args.firstOrNull()
                 val removed = arr.filterIsInstance<String>().filter { it in hidden }
                 HookLog.i(

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/RootSnapshotCache.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/RootSnapshotCache.kt
@@ -44,7 +44,7 @@ internal val REQUIRED_ROOT_SNAPSHOT_SECTIONS =
         "kmod_load_status",
         "kmod_load_dmesg",
         "kernel_release",
-        "hook_status",
+        "lsposed_state",
         "debug_logging",
         "getenforce",
         "pm_packages",
@@ -230,7 +230,7 @@ internal fun buildRootShellSnapshotCommand(includePmPackages: Boolean = true): S
     phase_runtime_status_files() {
       phase_start runtime_status_files
       emit_cmd kernel_release uname -r
-      emit_file hook_status ${HookEntry.HOOK_STATUS_FILE}
+      emit_file lsposed_state $LSPOSED_STATE_FILE
       emit_file debug_logging /data/system/vpnhide_debug_logging
       emit_cmd getenforce getenforce
       phase_end

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/StorageConfig.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/StorageConfig.kt
@@ -330,6 +330,7 @@ internal fun buildLegacyConfigCleanupCommand(): String =
                 SS_OBSERVER_UIDS_FILE,
                 "/data/system/vpnhide_uids.txt",
                 "/data/system/vpnhide_debug_logging",
+                LEGACY_HOOK_STATUS_FILE,
             ).joinToString(" "),
         "rmdir /data/adb/vpnhide_zygisk /data/adb/vpnhide_lsposed /data/adb/vpnhide_ports 2>/dev/null || true",
     ).joinToString(" ; ")

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/generated/HookIds.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/generated/HookIds.kt
@@ -38,12 +38,36 @@ internal object HookIds {
 
         // RTM_GETRULE — policy routing rules
         FIB_NL_FILL_RULE(9, "fib_nl_fill_rule", "RTM_GETRULE — policy routing rules"),
+
+        // LinkProperties parcel/result sanitization
+        LSPOSED_LINK_PROPERTIES(10, "lsposed_link_properties", "LinkProperties parcel/result sanitization"),
+
+        // NetworkCapabilities parcel/result sanitization
+        LSPOSED_NETWORK_CAPABILITIES(11, "lsposed_network_capabilities", "NetworkCapabilities parcel/result sanitization"),
+
+        // NetworkInfo parcel/result sanitization
+        LSPOSED_NETWORK_INFO(12, "lsposed_network_info", "NetworkInfo parcel/result sanitization"),
+
+        // Network handle replacement/filtering
+        LSPOSED_NETWORK(13, "lsposed_network", "Network handle replacement/filtering"),
+
+        // ConnectivityService synchronous result filtering
+        LSPOSED_CONNECTIVITY_RESULT(14, "lsposed_connectivity_result", "ConnectivityService synchronous result filtering"),
+
+        // ConnectivityService callback filtering
+        LSPOSED_CONNECTIVITY_CALLBACK(15, "lsposed_connectivity_callback", "ConnectivityService callback filtering"),
+
+        // ConnectivityService Network handle APIs
+        LSPOSED_CONNECTIVITY_NETWORK(16, "lsposed_connectivity_network", "ConnectivityService Network handle APIs"),
+
+        // PackageManager app-hiding filters
+        LSPOSED_PACKAGE_VISIBILITY(17, "lsposed_package_visibility", "PackageManager app-hiding filters"),
     }
 
     // Hooks owned by each backend: apply `mask and own`.
     const val KERNEL_HOOK_MASK = 0x3ff
     const val ZYGISK_HOOK_MASK = 0x0
-    const val LSPOSED_HOOK_MASK = 0x0
+    const val LSPOSED_HOOK_MASK = 0x3fc00
 
     /** status error codes (protocol §5.1). */
     enum class StatusError(

--- a/lsposed/app/src/test/kotlin/dev/okhsunrog/vpnhide/LsposedStateTest.kt
+++ b/lsposed/app/src/test/kotlin/dev/okhsunrog/vpnhide/LsposedStateTest.kt
@@ -1,0 +1,65 @@
+package dev.okhsunrog.vpnhide
+
+import dev.okhsunrog.vpnhide.generated.HookIds
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class LsposedStateTest {
+    @Test
+    fun `state file carries protocol status metadata and stats`() {
+        val text =
+            formatLsposedState(
+                status =
+                    Protocol.Status(
+                        backend =
+                            HookIds.Backend.LSPOSED.id
+                                .toLong(),
+                        kver = 0,
+                        hooks = HookIds.LSPOSED_HOOK_MASK.toLong(),
+                        error =
+                            HookIds.StatusError.OK.code
+                                .toLong(),
+                    ),
+                metadata =
+                    linkedMapOf(
+                        LsposedStateMetadata.VERSION to "1.2.3",
+                        LsposedStateMetadata.BOOT_ID to "boot-123",
+                    ),
+                stats =
+                    listOf(
+                        Protocol.StatEntry(
+                            uid = 10123,
+                            hookId =
+                                HookIds.Hook.LSPOSED_NETWORK_CAPABILITIES.id
+                                    .toLong(),
+                            count = 7,
+                        ),
+                    ),
+            )
+
+        assertEquals(
+            Protocol.Status(
+                backend =
+                    HookIds.Backend.LSPOSED.id
+                        .toLong(),
+                kver = 0,
+                hooks = HookIds.LSPOSED_HOOK_MASK.toLong(),
+                error =
+                    HookIds.StatusError.OK.code
+                        .toLong(),
+            ),
+            Protocol.parseStatus(text),
+        )
+        assertEquals(
+            mapOf(
+                LsposedStateMetadata.VERSION to "1.2.3",
+                LsposedStateMetadata.BOOT_ID to "boot-123",
+            ),
+            parseLsposedStateMetadata(text),
+        )
+        assertEquals(
+            "vpnhide 1 stats\n0x278b 0xb:0x7\n",
+            text.substringAfter("vpnhide 1 stats\n").let { "vpnhide 1 stats\n$it" },
+        )
+    }
+}

--- a/zygisk/src/generated/hook_ids.rs
+++ b/zygisk/src/generated/hook_ids.rs
@@ -26,14 +26,30 @@ pub enum Hook {
     Rt6FillNode = 8,
     /// RTM_GETRULE — policy routing rules
     FibNlFillRule = 9,
+    /// LinkProperties parcel/result sanitization
+    LsposedLinkProperties = 10,
+    /// NetworkCapabilities parcel/result sanitization
+    LsposedNetworkCapabilities = 11,
+    /// NetworkInfo parcel/result sanitization
+    LsposedNetworkInfo = 12,
+    /// Network handle replacement/filtering
+    LsposedNetwork = 13,
+    /// ConnectivityService synchronous result filtering
+    LsposedConnectivityResult = 14,
+    /// ConnectivityService callback filtering
+    LsposedConnectivityCallback = 15,
+    /// ConnectivityService Network handle APIs
+    LsposedConnectivityNetwork = 16,
+    /// PackageManager app-hiding filters
+    LsposedPackageVisibility = 17,
 }
 
-pub const HOOK_COUNT: u32 = 10;
+pub const HOOK_COUNT: u32 = 18;
 
 /// Hooks owned by each backend: apply `mask & own`.
 pub const KERNEL_HOOK_MASK: u32 = 0x3ff;
 pub const ZYGISK_HOOK_MASK: u32 = 0x0;
-pub const LSPOSED_HOOK_MASK: u32 = 0x0;
+pub const LSPOSED_HOOK_MASK: u32 = 0x3fc00;
 
 /// status error codes (protocol §5.1).
 #[repr(u32)]
@@ -65,7 +81,7 @@ pub enum Backend {
     Lsposed = 3,
 }
 
-pub const HOOK_NAMES: [&str; 10] = [
+pub const HOOK_NAMES: [&str; 18] = [
     "fib_route_seq_show",
     "ipv6_route_seq_show",
     "rtnl_fill_ifinfo",
@@ -76,4 +92,12 @@ pub const HOOK_NAMES: [&str; 10] = [
     "fib_dump_info",
     "rt6_fill_node",
     "fib_nl_fill_rule",
+    "lsposed_link_properties",
+    "lsposed_network_capabilities",
+    "lsposed_network_info",
+    "lsposed_network",
+    "lsposed_connectivity_result",
+    "lsposed_connectivity_callback",
+    "lsposed_connectivity_network",
+    "lsposed_package_visibility",
 ];


### PR DESCRIPTION
## Summary
- adds LSPosed Java-hook status and per-app interception stats using the shared protocol-shaped state file
- keeps the LSPosed state path aligned with native status+stats reads
- replays the LSPosed stats work on top of current `main` after the stacked PR was merged into its feature base

## Validation
- `python3 scripts/codegen-hooks.py` + generated-file diff check
- `cargo fmt --check` and `cd lsposed/native && cargo fmt --check`
- `cargo test -p vpnhide_protocol -p vpnhide_activator`
- `cd lsposed/native && cargo test`
- `cd lsposed && ./gradlew :app:ktlintCheck`
- `cd lsposed && ./gradlew :app:testDebugUnitTest :app:detekt cpdCheck`
