### PR TITLE
Pin C formatting to clang-format 18

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -147,10 +147,7 @@ jobs:
 
       # C (kernel module)
       - name: clang-format
-        run: |
-          git ls-files 'kmod/*.c' 'kmod/*.h' 'kmod/**/*.c' 'kmod/**/*.h' \
-            | grep -Ev '(^kmod/third_party/|^kmod/generated/|\.mod\.c$)' \
-            | xargs clang-format --dry-run --Werror
+        run: scripts/clang-format-c.sh --check
       - name: kmod iface-list test (host build)
         run: |
           cd kmod

--- a/docs/development.md
+++ b/docs/development.md
@@ -12,6 +12,15 @@ How to build vpnhide from source.
   rustup target add aarch64-linux-android
   cargo install cargo-ndk
   ```
+- **clang-format 18.x** — kmod C formatting is pinned because clang-format
+  versions disagree on kernel-style C casts. The repo checks this via
+  `scripts/clang-format-c.sh`. On Arch:
+  ```sh
+  sudo pacman -S clang18
+  mkdir -p ~/.local/bin
+  ln -sfn /usr/lib/llvm18/bin/clang-format ~/.local/bin/clang-format-18
+  clang-format-18 --version
+  ```
 - **`docker` or `podman`** — only for building the kernel module via DDK images. Docker is preferred when both are installed, matching CI and device-test workflows. See [kmod/BUILDING.md](../kmod/BUILDING.md).
 - **`zip`** — packaging module zips.
 - **`adb`** — installing builds on a device.
@@ -114,7 +123,7 @@ cd ../zygisk && cargo test
 cd ../lsposed/native && cargo test
 
 # C (kernel module)
-clang-format --dry-run --Werror kmod/vpnhide_kmod.c
+scripts/clang-format-c.sh --check
 # Host-side test of the generated VPN-iface matcher used by the kernel module
 gcc -O2 -Wall -Werror -o /tmp/test_iface_lists kmod/test_iface_lists.c && /tmp/test_iface_lists
 

--- a/scripts/clang-format-c.sh
+++ b/scripts/clang-format-c.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+# Run the pinned C formatter for kmod sources.
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+usage() {
+    cat >&2 <<'EOF'
+Usage: scripts/clang-format-c.sh [--check|--fix] [file...]
+
+Uses clang-format 18.x. Set CLANG_FORMAT=/path/to/clang-format to override.
+When no files are passed, formats all tracked kmod C/H files except generated
+and vendored sources.
+EOF
+}
+
+mode="check"
+case "${1:-}" in
+    --check)
+        mode="check"
+        shift
+        ;;
+    --fix)
+        mode="fix"
+        shift
+        ;;
+    -h|--help)
+        usage
+        exit 0
+        ;;
+esac
+
+find_clang_format() {
+    if [[ -n "${CLANG_FORMAT:-}" ]]; then
+        printf '%s\n' "$CLANG_FORMAT"
+        return
+    fi
+
+    local candidates=(
+        clang-format-18
+        /usr/lib/llvm18/bin/clang-format
+        /usr/bin/clang-format-18
+        clang-format
+    )
+    local candidate
+    for candidate in "${candidates[@]}"; do
+        if command -v "$candidate" >/dev/null 2>&1; then
+            command -v "$candidate"
+            return
+        fi
+        if [[ -x "$candidate" ]]; then
+            printf '%s\n' "$candidate"
+            return
+        fi
+    done
+}
+
+clang_format="$(find_clang_format || true)"
+if [[ -z "$clang_format" ]]; then
+    cat >&2 <<'EOF'
+error: clang-format 18.x not found.
+
+Install it and expose it as clang-format-18. On Arch:
+  sudo pacman -S clang18
+  mkdir -p ~/.local/bin
+  ln -sfn /usr/lib/llvm18/bin/clang-format ~/.local/bin/clang-format-18
+EOF
+    exit 127
+fi
+
+version="$("$clang_format" --version)"
+case "$version" in
+    *"version 18."*) ;;
+    *)
+        cat >&2 <<EOF
+error: expected clang-format 18.x, got:
+  $version
+
+Use CLANG_FORMAT=/path/to/clang-format-18 or install clang-format-18 in PATH.
+EOF
+        exit 2
+        ;;
+esac
+
+tmp="$(mktemp)"
+trap 'rm -f "$tmp"' EXIT
+
+if [[ "$#" -gt 0 ]]; then
+    printf '%s\n' "$@" > "$tmp"
+else
+    git ls-files 'kmod/*.c' 'kmod/*.h' 'kmod/**/*.c' 'kmod/**/*.h' \
+        | grep -Ev '(^kmod/third_party/|^kmod/generated/|\.mod\.c$)' > "$tmp"
+fi
+
+if [[ ! -s "$tmp" ]]; then
+    exit 0
+fi
+
+case "$mode" in
+    check)
+        xargs "$clang_format" --dry-run --Werror < "$tmp"
+        ;;
+    fix)
+        xargs "$clang_format" -i < "$tmp"
+        ;;
+esac


### PR DESCRIPTION
## Summary
- adds `scripts/clang-format-c.sh` as the single local/CI entry point for kmod C formatting
- requires clang-format 18.x and rejects other major versions with a clear setup hint
- updates CI and development docs to use the wrapper instead of raw `clang-format`

## Validation
- `mkdir -p ~/.local/bin && ln -sfn /usr/lib/llvm18/bin/clang-format ~/.local/bin/clang-format-18`
- `scripts/clang-format-c.sh --check`
- `CLANG_FORMAT=/usr/bin/clang-format scripts/clang-format-c.sh --check` rejects clang-format 22.x with rc=2
- `shellcheck scripts/clang-format-c.sh`
- `git diff --check`
