### PR TITLE
Add Statistics tab

### DIFF
--- a/changelog.d/added-add-a-statistics-tab-with-backend-e108.md
+++ b/changelog.d/added-add-a-statistics-tab-with-backend-e108.md
@@ -1,0 +1,9 @@
+_2026-06-29_
+
+## English
+
+Add a Statistics tab with backend interception counters.
+
+## Русский
+
+Добавлена вкладка статистики со счётчиками перехватов бэкендов.

--- a/crates/activator/src/bin/kpm.rs
+++ b/crates/activator/src/bin/kpm.rs
@@ -1,18 +1,27 @@
 fn main() {
-    let boot_wait = match vpnhide_activator::boot_wait_requested_from_env() {
-        Ok(value) => value,
-        Err(e) => {
-            eprintln!("vpnhide kpm activator failed: {e}");
-            std::process::exit(2);
-        }
-    };
-    let result = if boot_wait {
-        vpnhide_activator::activate_kpm_boot()
-    } else {
-        vpnhide_activator::activate_kpm()
-    };
-    if let Err(e) = result {
+    if let Err(e) = run() {
         eprintln!("vpnhide kpm activator failed: {e}");
         std::process::exit(1);
+    }
+}
+
+fn run() -> vpnhide_activator::Result<()> {
+    let args = std::env::args().skip(1).collect::<Vec<_>>();
+    match args.as_slice() {
+        [] => vpnhide_activator::activate_kpm(),
+        [arg] if arg == "--boot-wait" => vpnhide_activator::activate_kpm_boot(),
+        [arg] if arg == "status" => {
+            print!("{}", vpnhide_activator::read_kpm_status()?);
+            Ok(())
+        }
+        [arg] if arg == "stats" => {
+            print!("{}", vpnhide_activator::read_kpm_stats()?);
+            Ok(())
+        }
+        [arg] if arg == "state" => {
+            print!("{}", vpnhide_activator::read_kpm_state()?);
+            Ok(())
+        }
+        _ => Err("usage: activator [--boot-wait|status|stats|state]".into()),
     }
 }

--- a/crates/activator/src/lib.rs
+++ b/crates/activator/src/lib.rs
@@ -310,6 +310,26 @@ pub fn activate_kpm_boot() -> Result<()> {
     activate_kpm_with_pm_wait(PmReadyWait::Forever, false)
 }
 
+pub fn read_kpm_status() -> Result<String> {
+    read_kpm_payload("vpnhide 1 status")
+}
+
+pub fn read_kpm_stats() -> Result<String> {
+    read_kpm_payload("vpnhide 1 stats")
+}
+
+pub fn read_kpm_state() -> Result<String> {
+    let client = KpmClient::detect()?;
+    let mut out = client.ctl0_read("vpnhide 1 status")?;
+    out.push_str(&client.ctl0_read("vpnhide 1 stats")?);
+    Ok(out)
+}
+
+fn read_kpm_payload(wire: &str) -> Result<String> {
+    let client = KpmClient::detect()?;
+    client.ctl0_read(wire)
+}
+
 fn activate_kpm_with_pm_wait(wait: PmReadyWait, conflict_is_error: bool) -> Result<()> {
     if skip_kpm_for_kmod_conflict(conflict_is_error)? {
         return Ok(());
@@ -320,7 +340,7 @@ fn activate_kpm_with_pm_wait(wait: PmReadyWait, conflict_is_error: bool) -> Resu
     }
     let client = KpmClient::detect()?;
     client.ensure_loaded()?;
-    client.ctl0(&wire)
+    client.ctl0_config(&wire)
 }
 
 pub fn activate_ports() -> Result<()> {
@@ -543,10 +563,17 @@ impl KpmClient {
         }
     }
 
-    fn ctl0(&self, wire: &str) -> Result<()> {
+    fn ctl0_config(&self, wire: &str) -> Result<()> {
         match self {
-            Self::KpatchCli { path } => run_kpatch_kpm_ctl0(path, wire),
-            Self::ApatchSupercall { key, style } => apatch_kpm_ctl0(key, *style, wire),
+            Self::KpatchCli { path } => run_kpatch_kpm_ctl0_config(path, wire),
+            Self::ApatchSupercall { key, style } => apatch_kpm_ctl0_config(key, *style, wire),
+        }
+    }
+
+    fn ctl0_read(&self, wire: &str) -> Result<String> {
+        match self {
+            Self::KpatchCli { path } => run_kpatch_kpm_ctl0_read(path, wire),
+            Self::ApatchSupercall { key, style } => apatch_kpm_ctl0_read(key, *style, wire),
         }
     }
 }
@@ -577,7 +604,7 @@ fn kpatch_hello(kpatch: &Path) -> Result<()> {
     }
 }
 
-fn run_kpatch_kpm_ctl0(kpatch: &Path, wire: &str) -> Result<()> {
+fn run_kpatch_kpm_ctl0_config(kpatch: &Path, wire: &str) -> Result<()> {
     let mut cmd = Command::new(kpatch);
     cmd.args(["kpm", "ctl0", KPM_NAME, wire]);
     let out = cmd.output()?;
@@ -585,6 +612,17 @@ fn run_kpatch_kpm_ctl0(kpatch: &Path, wire: &str) -> Result<()> {
         Ok(())
     } else {
         Err(format!("kpm ctl0 failed with status {}", out.status).into())
+    }
+}
+
+fn run_kpatch_kpm_ctl0_read(kpatch: &Path, wire: &str) -> Result<String> {
+    let mut cmd = Command::new(kpatch);
+    cmd.args(["kpm", "ctl0", KPM_NAME, wire]);
+    let out = cmd.output()?;
+    if out.status.success() {
+        Ok(String::from_utf8(out.stdout)?)
+    } else {
+        Err(format!("kpm ctl0 read failed with status {}", out.status).into())
     }
 }
 
@@ -646,7 +684,23 @@ fn apatch_kpm_list(key: &str, style: ApatchCommandStyle) -> Result<String> {
     Ok(String::from_utf8_lossy(&buf[..len]).into_owned())
 }
 
-fn apatch_kpm_ctl0(key: &str, style: ApatchCommandStyle, wire: &str) -> Result<()> {
+fn apatch_kpm_ctl0_config(key: &str, style: ApatchCommandStyle, wire: &str) -> Result<()> {
+    let (rc, _) = apatch_kpm_ctl0_raw(key, style, wire)?;
+    supercall_ok(rc, "kpm ctl0")
+}
+
+fn apatch_kpm_ctl0_read(key: &str, style: ApatchCommandStyle, wire: &str) -> Result<String> {
+    let (rc, out) = apatch_kpm_ctl0_raw(key, style, wire)?;
+    supercall_ok(rc, "kpm ctl0")?;
+    let len = apatch_output_len(rc, &out);
+    Ok(String::from_utf8_lossy(&out[..len]).into_owned())
+}
+
+fn apatch_kpm_ctl0_raw(
+    key: &str,
+    style: ApatchCommandStyle,
+    wire: &str,
+) -> Result<(c_long, [u8; 4096])> {
     let key = CString::new(key)?;
     let name = CString::new(KPM_NAME)?;
     let wire = CString::new(wire)?;
@@ -662,7 +716,14 @@ fn apatch_kpm_ctl0(key: &str, style: ApatchCommandStyle, wire: &str) -> Result<(
             out.len() as c_long,
         )
     };
-    supercall_ok(rc, "kpm ctl0")
+    Ok((rc, out))
+}
+
+fn apatch_output_len(rc: c_long, out: &[u8]) -> usize {
+    if rc > 0 {
+        return usize::try_from(rc).unwrap_or(out.len()).min(out.len());
+    }
+    out.iter().position(|b| *b == 0).unwrap_or(0)
 }
 
 fn apatch_command_candidates() -> Vec<ApatchCommandStyle> {

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/MainActivity.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/MainActivity.kt
@@ -19,6 +19,7 @@ import androidx.compose.foundation.layout.*
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.automirrored.filled.List
+import androidx.compose.material.icons.filled.BarChart
 import androidx.compose.material.icons.filled.CheckCircle
 import androidx.compose.material.icons.filled.Clear
 import androidx.compose.material.icons.filled.FilterList
@@ -151,7 +152,7 @@ fun VpnHideApp(
     }
 }
 
-private enum class Tab { Dashboard, Protection, Diagnostics }
+private enum class Tab { Dashboard, Statistics, Protection, Diagnostics }
 
 private data class RefreshContext(
     val loading: Boolean,
@@ -163,6 +164,7 @@ private fun AppTopBarTitle(currentTab: Tab) {
     val tabLabel =
         when (currentTab) {
             Tab.Dashboard -> stringResource(R.string.tab_dashboard)
+            Tab.Statistics -> stringResource(R.string.tab_statistics)
             Tab.Protection -> stringResource(R.string.tab_protection)
             Tab.Diagnostics -> stringResource(R.string.tab_diagnostics)
         }
@@ -242,6 +244,7 @@ private fun MainScreen(onReady: () -> Unit = {}) {
     val appListLoading by AppListCache.loading.collectAsState()
     val targetsLoading by TargetsCache.loading.collectAsState()
     val dashboardLoading by DashboardCache.loading.collectAsState()
+    val statisticsLoading by StatisticsCache.loading.collectAsState()
     val dashboardState by DashboardCache.state.collectAsState()
     val dashboardError by DashboardCache.error.collectAsState()
     val rootSnapshot by RootSnapshotCache.snapshot.collectAsState()
@@ -379,6 +382,15 @@ private fun MainScreen(onReady: () -> Unit = {}) {
                                         )
                                     }
 
+                                    Tab.Statistics -> {
+                                        RefreshContext(
+                                            loading = statisticsLoading,
+                                            onRefresh = {
+                                                StatisticsCache.refresh(scope)
+                                            },
+                                        )
+                                    }
+
                                     Tab.Protection -> {
                                         RefreshContext(
                                             loading = appListLoading || targetsLoading,
@@ -451,7 +463,7 @@ private fun MainScreen(onReady: () -> Unit = {}) {
                                     } else {
                                         Icon(
                                             Icons.Default.Refresh,
-                                            contentDescription = stringResource(R.string.action_refresh_apps),
+                                            contentDescription = stringResource(R.string.action_refresh),
                                         )
                                     }
                                 }
@@ -492,6 +504,15 @@ private fun MainScreen(onReady: () -> Unit = {}) {
                     },
                     icon = { Icon(Icons.Default.Home, contentDescription = null) },
                     label = { Text(stringResource(R.string.tab_dashboard)) },
+                )
+                NavigationBarItem(
+                    selected = currentTab == Tab.Statistics,
+                    onClick = {
+                        tabHaptic()
+                        currentTab = Tab.Statistics
+                    },
+                    icon = { Icon(Icons.Default.BarChart, contentDescription = null) },
+                    label = { Text(stringResource(R.string.tab_statistics)) },
                 )
                 NavigationBarItem(
                     selected = currentTab == Tab.Protection,
@@ -555,6 +576,12 @@ private fun MainScreen(onReady: () -> Unit = {}) {
                     Tab.Dashboard -> {
                         DashboardScreen(
                             selfNeedsRestart = restart,
+                            modifier = Modifier.padding(innerPadding),
+                        )
+                    }
+
+                    Tab.Statistics -> {
+                        StatisticsScreen(
                             modifier = Modifier.padding(innerPadding),
                         )
                     }

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/RootSnapshotCache.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/RootSnapshotCache.kt
@@ -44,6 +44,8 @@ internal val REQUIRED_ROOT_SNAPSHOT_SECTIONS =
         "kmod_load_status",
         "kmod_load_dmesg",
         "kernel_release",
+        "kmod_state",
+        "kpm_state",
         "lsposed_state",
         "debug_logging",
         "getenforce",
@@ -230,6 +232,8 @@ internal fun buildRootShellSnapshotCommand(includePmPackages: Boolean = true): S
     phase_runtime_status_files() {
       phase_start runtime_status_files
       emit_cmd kernel_release uname -r
+      emit_eval kmod_state '[ -e $PROC_CTL ] && cat $PROC_CTL || true'
+      emit_eval kpm_state 'if [ -x $KPM_ACTIVATOR ] && [ ! -f $KPM_MODULE_DIR/disable ]; then $KPM_ACTIVATOR state; fi'
       emit_file lsposed_state $LSPOSED_STATE_FILE
       emit_file debug_logging /data/system/vpnhide_debug_logging
       emit_cmd getenforce getenforce

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/StatisticsCache.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/StatisticsCache.kt
@@ -1,0 +1,30 @@
+package dev.okhsunrog.vpnhide
+
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.withContext
+
+internal object StatisticsCache : StateCache<StatisticsState>(
+    traceName = "statistics_state",
+    logTag = "VpnHide-Statistics",
+) {
+    val state: StateFlow<StatisticsState?> get() = value
+
+    fun ensureLoaded(scope: CoroutineScope) {
+        ensure(scope)
+    }
+
+    fun refresh(scope: CoroutineScope) {
+        RootSnapshotCache.invalidate()
+        forceRefresh(scope)
+    }
+
+    override suspend fun load(force: Boolean): StatisticsState {
+        val rootSnapshot =
+            if (force) RootSnapshotCache.refresh() else RootSnapshotCache.getOrLoad()
+        return withContext(Dispatchers.IO) {
+            buildStatisticsState(rootSnapshot)
+        }
+    }
+}

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/StatisticsData.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/StatisticsData.kt
@@ -1,0 +1,162 @@
+package dev.okhsunrog.vpnhide
+
+import dev.okhsunrog.vpnhide.generated.HookIds
+
+internal data class StatisticsState(
+    val backends: List<BackendStatistics>,
+) {
+    val hasAnyData: Boolean = backends.any { it.hasData }
+    val activeBackendCount: Int = backends.count { it.hasData }
+    val totalRows: Int = backends.sumOf { it.rows.size }
+    val totalCount: ULong = backends.fold(0uL) { acc, backend -> acc + backend.totalCount }
+}
+
+internal data class BackendStatistics(
+    val backend: HookIds.Backend,
+    val status: Protocol.Status?,
+    val metadata: Map<String, String> = emptyMap(),
+    val rows: List<StatisticsRow>,
+) {
+    val hasData: Boolean = status != null || rows.isNotEmpty()
+    val totalCount: ULong = rows.fold(0uL) { acc, row -> acc + row.count.toULong() }
+    val hookedCount: Int = status?.hooks?.let { java.lang.Long.bitCount(it) } ?: 0
+}
+
+internal data class StatisticsRow(
+    val uid: Long,
+    val packageNames: List<String>,
+    val hookId: Long,
+    val hook: HookIds.Hook?,
+    val count: Long,
+)
+
+private val PROTOCOL_KINDS = setOf("config", "stats", "status")
+private val HOOKS_BY_ID = HookIds.Hook.entries.associateBy { it.id.toLong() }
+
+internal fun buildStatisticsState(snapshot: RootSnapshot): StatisticsState {
+    val uidPackages = uidPackages(snapshot.sections["pm_packages"].orEmpty())
+    val kmodRaw = snapshot.sections["kmod_state"].orEmpty()
+    val kpmRaw = snapshot.sections["kpm_state"].orEmpty()
+    val lsposedRaw = snapshot.sections["lsposed_state"].orEmpty()
+
+    return StatisticsState(
+        listOf(
+            buildBackendStatistics(
+                backend = HookIds.Backend.KMOD,
+                status = parseProtocolStatusBlock(kmodRaw),
+                stats = parseProtocolStatsBlock(kmodRaw),
+                uidPackages = uidPackages,
+            ),
+            buildBackendStatistics(
+                backend = HookIds.Backend.KPM,
+                status = parseProtocolStatusBlock(kpmRaw),
+                stats = parseProtocolStatsBlock(kpmRaw),
+                uidPackages = uidPackages,
+            ),
+            buildBackendStatistics(
+                backend = HookIds.Backend.LSPOSED,
+                status = parseProtocolStatusBlock(lsposedRaw),
+                stats = parseProtocolStatsBlock(lsposedRaw),
+                metadata = parseLsposedStateMetadata(lsposedRaw),
+                uidPackages = uidPackages,
+            ),
+        ),
+    )
+}
+
+internal fun parseProtocolStatusBlock(raw: String): Protocol.Status? =
+    extractProtocolBlock(raw, Protocol.Kind.STATUS)?.let(Protocol::parseStatus)
+
+internal fun parseProtocolStatsBlock(raw: String): List<Protocol.StatEntry> =
+    extractProtocolBlock(raw, Protocol.Kind.STATS)?.let(Protocol::parseStats).orEmpty()
+
+internal fun extractProtocolBlock(
+    raw: String,
+    kind: Protocol.Kind,
+): String? {
+    val lines = raw.split('\n').map { it.removeSuffix("\r") }
+    val start = lines.indexOfFirst { protocolKindOfLine(it) == kind }
+    if (start < 0) return null
+    val end =
+        lines
+            .drop(start + 1)
+            .indexOfFirst { protocolKindOfLine(it) != null }
+            .let { if (it < 0) lines.size else start + 1 + it }
+    return lines.subList(start, end).joinToString("\n").let { block ->
+        if (block.endsWith("\n")) block else "$block\n"
+    }
+}
+
+internal fun formatStatCount(count: ULong): String =
+    count
+        .toString()
+        .reversed()
+        .chunked(3)
+        .joinToString(",")
+        .reversed()
+
+internal fun formatStatCount(count: Long): String = formatStatCount(count.toULong())
+
+private fun buildBackendStatistics(
+    backend: HookIds.Backend,
+    status: Protocol.Status?,
+    stats: List<Protocol.StatEntry>,
+    uidPackages: Map<Long, List<String>>,
+    metadata: Map<String, String> = emptyMap(),
+): BackendStatistics =
+    BackendStatistics(
+        backend = backend,
+        status = status,
+        metadata = metadata,
+        rows = buildStatisticsRows(stats, uidPackages),
+    )
+
+private fun buildStatisticsRows(
+    stats: List<Protocol.StatEntry>,
+    uidPackages: Map<Long, List<String>>,
+): List<StatisticsRow> =
+    stats
+        .map { entry ->
+            StatisticsRow(
+                uid = entry.uid,
+                packageNames = uidPackages[entry.uid].orEmpty(),
+                hookId = entry.hookId,
+                hook = HOOKS_BY_ID[entry.hookId],
+                count = entry.count,
+            )
+        }.sortedWith(::compareStatisticsRows)
+
+private fun compareStatisticsRows(
+    left: StatisticsRow,
+    right: StatisticsRow,
+): Int {
+    val byCount = java.lang.Long.compareUnsigned(right.count, left.count)
+    if (byCount != 0) return byCount
+    val byPackage = left.packageNames.joinToString().compareTo(right.packageNames.joinToString())
+    if (byPackage != 0) return byPackage
+    return left.hookId.compareTo(right.hookId)
+}
+
+private fun uidPackages(raw: String): Map<Long, List<String>> {
+    val byUid = linkedMapOf<Long, MutableList<String>>()
+    parsePackageUidMap(raw).forEach { (pkg, uids) ->
+        uids.forEach { uid ->
+            byUid.getOrPut(uid.toLong()) { mutableListOf() } += pkg
+        }
+    }
+    return byUid.mapValues { (_, packages) -> packages.distinct().sorted() }
+}
+
+private fun protocolKindOfLine(line: String): Protocol.Kind? {
+    val trimmed = line.trim()
+    if (trimmed.isEmpty() || trimmed.startsWith("#")) return null
+    val tokens = trimmed.split(' ', '\t').filter { it.isNotEmpty() }
+    if (tokens.size < 3 || tokens[0] != "vpnhide") return null
+    if (tokens[1].toIntOrNull() == null || tokens[2] !in PROTOCOL_KINDS) return null
+    return when (tokens[2]) {
+        "config" -> Protocol.Kind.CONFIG
+        "stats" -> Protocol.Kind.STATS
+        "status" -> Protocol.Kind.STATUS
+        else -> null
+    }
+}

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/StatisticsScreen.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/StatisticsScreen.kt
@@ -1,0 +1,519 @@
+package dev.okhsunrog.vpnhide
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.BarChart
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import dev.okhsunrog.vpnhide.generated.HookIds
+import dev.okhsunrog.vpnhide.ui.components.EnhancedButton
+import dev.okhsunrog.vpnhide.ui.components.EnhancedCard
+import dev.okhsunrog.vpnhide.ui.components.GroupedCard
+import dev.okhsunrog.vpnhide.ui.theme.AppColors
+
+@Composable
+fun StatisticsScreen(modifier: Modifier = Modifier) {
+    val scope = rememberCoroutineScope()
+    val state by StatisticsCache.state.collectAsState()
+    val loadError by StatisticsCache.error.collectAsState()
+
+    LaunchedEffect(Unit) {
+        StatisticsCache.ensureLoaded(scope)
+    }
+
+    Column(
+        modifier =
+            modifier
+                .fillMaxSize()
+                .verticalScroll(rememberScrollState())
+                .padding(horizontal = 16.dp),
+    ) {
+        Spacer(Modifier.height(12.dp))
+
+        val s = state
+        val error = loadError
+        if (error != null) {
+            StatisticsLoadErrorCard(
+                previousDataVisible = s != null,
+                onRetry = { StatisticsCache.refresh(scope) },
+            )
+            Spacer(Modifier.height(12.dp))
+            if (s == null) return@Column
+        }
+
+        if (s == null) {
+            Box(Modifier.fillMaxWidth(), contentAlignment = Alignment.Center) {
+                CircularProgressIndicator()
+            }
+            return@Column
+        }
+
+        StatisticsHeroCard(s)
+        Spacer(Modifier.height(20.dp))
+
+        SectionHeader(stringResource(R.string.statistics_backends))
+        Spacer(Modifier.height(8.dp))
+        Column(verticalArrangement = Arrangement.spacedBy(3.dp)) {
+            s.backends.forEachIndexed { index, backend ->
+                BackendSummaryCard(backend, index = index, count = s.backends.size)
+            }
+        }
+
+        if (!s.hasAnyData) {
+            Spacer(Modifier.height(12.dp))
+            StatusBanner(
+                text = stringResource(R.string.statistics_no_data),
+                containerColor = StatusColors.infoContainer(),
+                contentColor = MaterialTheme.colorScheme.onSurface,
+            )
+        }
+
+        s.backends
+            .filter { it.hasData }
+            .forEach { backend ->
+                Spacer(Modifier.height(20.dp))
+                SectionHeader(backendName(backend.backend))
+                Spacer(Modifier.height(8.dp))
+                if (backend.rows.isEmpty()) {
+                    StatusBanner(
+                        text = stringResource(R.string.statistics_no_counters),
+                        containerColor = StatusColors.infoContainer(),
+                        contentColor = MaterialTheme.colorScheme.onSurface,
+                    )
+                } else {
+                    Column(verticalArrangement = Arrangement.spacedBy(3.dp)) {
+                        backend.rows.forEachIndexed { index, row ->
+                            StatisticsRowCard(row, index = index, count = backend.rows.size)
+                        }
+                    }
+                }
+            }
+
+        Spacer(Modifier.height(16.dp))
+    }
+}
+
+@Composable
+private fun StatisticsLoadErrorCard(
+    previousDataVisible: Boolean,
+    onRetry: () -> Unit,
+) {
+    EnhancedCard(
+        modifier = Modifier.fillMaxWidth(),
+        color = StatusColors.errorContainer(),
+        contentColor = MaterialTheme.colorScheme.onSurface,
+    ) {
+        Column(Modifier.padding(16.dp)) {
+            Text(
+                text = stringResource(R.string.statistics_load_failed_title),
+                style = MaterialTheme.typography.titleMedium,
+                fontWeight = FontWeight.Bold,
+                color = StatusColors.errorHeader(),
+            )
+            Spacer(Modifier.height(6.dp))
+            Text(
+                text =
+                    stringResource(
+                        if (previousDataVisible) {
+                            R.string.statistics_refresh_failed_message
+                        } else {
+                            R.string.statistics_load_failed_message
+                        },
+                    ),
+                style = MaterialTheme.typography.bodyMedium,
+            )
+            Spacer(Modifier.height(12.dp))
+            EnhancedButton(onClick = onRetry) {
+                Text(stringResource(R.string.vpn_off_retry))
+            }
+        }
+    }
+}
+
+@Composable
+private fun StatisticsHeroCard(state: StatisticsState) {
+    EnhancedCard(
+        modifier = Modifier.fillMaxWidth(),
+        shape = MaterialTheme.shapes.extraLarge,
+        color = AppColors.cardContainer,
+    ) {
+        Column(modifier = Modifier.padding(18.dp).fillMaxWidth()) {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                IconBubble(
+                    iconTint = StatusColors.infoAccent,
+                    container = StatusColors.infoContainer(),
+                )
+                Spacer(Modifier.width(16.dp))
+                Column(Modifier.weight(1f)) {
+                    Text(
+                        text = stringResource(R.string.statistics_title),
+                        style = MaterialTheme.typography.headlineSmall,
+                        fontWeight = FontWeight.Bold,
+                    )
+                    Spacer(Modifier.height(2.dp))
+                    Text(
+                        text = stringResource(R.string.statistics_subtitle),
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+            }
+            Spacer(Modifier.height(16.dp))
+            Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                    StatisticsMetric(
+                        label = stringResource(R.string.statistics_total_events),
+                        value = formatStatCount(state.totalCount),
+                        accent = StatusColors.infoAccent,
+                        modifier = Modifier.weight(1f),
+                    )
+                    StatisticsMetric(
+                        label = stringResource(R.string.statistics_active_backends),
+                        value = "${state.activeBackendCount}/${state.backends.size}",
+                        accent = if (state.hasAnyData) StatusColors.successDot else StatusColors.warningAccent,
+                        modifier = Modifier.weight(1f),
+                    )
+                }
+                Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                    StatisticsMetric(
+                        label = stringResource(R.string.statistics_counter_rows),
+                        value = state.totalRows.toString(),
+                        accent = StatusColors.successDot,
+                        modifier = Modifier.weight(1f),
+                    )
+                    StatisticsMetric(
+                        label = stringResource(R.string.statistics_hooks),
+                        value = state.backends.sumOf { it.hookedCount }.toString(),
+                        accent = StatusColors.successDot,
+                        modifier = Modifier.weight(1f),
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun IconBubble(
+    iconTint: Color,
+    container: Color,
+) {
+    Box(
+        modifier =
+            Modifier
+                .size(58.dp)
+                .clip(CircleShape)
+                .background(container),
+        contentAlignment = Alignment.Center,
+    ) {
+        Icon(
+            imageVector = Icons.Default.BarChart,
+            contentDescription = null,
+            tint = iconTint,
+            modifier = Modifier.size(31.dp),
+        )
+    }
+}
+
+@Composable
+private fun StatisticsMetric(
+    label: String,
+    value: String,
+    accent: Color,
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        modifier =
+            modifier
+                .clip(MaterialTheme.shapes.medium)
+                .background(AppColors.cardContainerStrong)
+                .padding(horizontal = 12.dp, vertical = 10.dp),
+    ) {
+        Text(
+            text = label,
+            style = MaterialTheme.typography.labelMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis,
+        )
+        Spacer(Modifier.height(4.dp))
+        Text(
+            text = value,
+            style = MaterialTheme.typography.titleMedium,
+            fontWeight = FontWeight.Bold,
+            color = accent,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis,
+        )
+    }
+}
+
+@Composable
+private fun BackendSummaryCard(
+    backend: BackendStatistics,
+    index: Int,
+    count: Int,
+) {
+    val health = backendHealth(backend)
+    val visual = backendHealthVisual(health)
+    GroupedCard(
+        index = index,
+        count = count,
+        modifier = Modifier.fillMaxWidth(),
+        color = AppColors.cardContainer,
+    ) {
+        Row(
+            modifier = Modifier.padding(16.dp).fillMaxWidth(),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            BackendBadge(
+                text = backendBadge(backend.backend),
+                accentColor = visual.accent,
+                containerColor = visual.container,
+            )
+            Spacer(Modifier.width(14.dp))
+            Column(Modifier.weight(1f)) {
+                Text(
+                    text = backendName(backend.backend),
+                    style = MaterialTheme.typography.titleSmall,
+                    fontWeight = FontWeight.Bold,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                )
+                Text(
+                    text =
+                        stringResource(
+                            R.string.statistics_backend_detail,
+                            visual.label,
+                            backend.hookedCount,
+                        ),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+            Spacer(Modifier.width(10.dp))
+            Column(horizontalAlignment = Alignment.End) {
+                Text(
+                    text = formatStatCount(backend.totalCount),
+                    style = MaterialTheme.typography.titleMedium,
+                    fontWeight = FontWeight.Bold,
+                    color = visual.accent,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                )
+                Text(
+                    text = stringResource(R.string.statistics_events),
+                    style = MaterialTheme.typography.labelSmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun StatisticsRowCard(
+    row: StatisticsRow,
+    index: Int,
+    count: Int,
+) {
+    GroupedCard(
+        index = index,
+        count = count,
+        modifier = Modifier.fillMaxWidth(),
+        color = AppColors.cardContainer,
+    ) {
+        Row(
+            modifier = Modifier.padding(14.dp).fillMaxWidth(),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Column(Modifier.weight(1f)) {
+                Text(
+                    text = rowTargetText(row),
+                    style = MaterialTheme.typography.titleSmall,
+                    fontWeight = FontWeight.Bold,
+                    maxLines = 2,
+                    overflow = TextOverflow.Ellipsis,
+                )
+                Spacer(Modifier.height(3.dp))
+                Text(
+                    text = rowHookText(row),
+                    style = MaterialTheme.typography.bodySmall,
+                    fontFamily = FontFamily.Monospace,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                )
+                row.hook?.note?.takeIf { it.isNotBlank() }?.let { note ->
+                    Text(
+                        text = note,
+                        style = MaterialTheme.typography.labelSmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
+                    )
+                }
+            }
+            Spacer(Modifier.width(12.dp))
+            Text(
+                text = formatStatCount(row.count),
+                style = MaterialTheme.typography.titleMedium,
+                fontWeight = FontWeight.Bold,
+                color = StatusColors.infoAccent,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+            )
+        }
+    }
+}
+
+@Composable
+private fun BackendBadge(
+    text: String,
+    accentColor: Color,
+    containerColor: Color,
+) {
+    Box(
+        modifier =
+            Modifier
+                .size(46.dp)
+                .clip(CircleShape)
+                .background(containerColor),
+        contentAlignment = Alignment.Center,
+    ) {
+        Text(
+            text = text,
+            style = MaterialTheme.typography.labelLarge,
+            fontWeight = FontWeight.Bold,
+            color = accentColor,
+            maxLines = 1,
+        )
+    }
+}
+
+@Composable
+private fun SectionHeader(text: String) {
+    Text(
+        text = text,
+        style = MaterialTheme.typography.titleSmall,
+        fontWeight = FontWeight.Bold,
+        color = MaterialTheme.colorScheme.primary,
+    )
+}
+
+@Composable
+private fun backendName(backend: HookIds.Backend): String =
+    stringResource(
+        when (backend) {
+            HookIds.Backend.KMOD -> R.string.dashboard_backend_kmod
+            HookIds.Backend.KPM -> R.string.dashboard_backend_kpm
+            HookIds.Backend.ZYGISK -> R.string.dashboard_backend_zygisk
+            HookIds.Backend.LSPOSED -> R.string.dashboard_backend_lsposed
+        },
+    )
+
+private fun backendBadge(backend: HookIds.Backend): String =
+    when (backend) {
+        HookIds.Backend.KMOD -> "K"
+        HookIds.Backend.KPM -> "KPM"
+        HookIds.Backend.ZYGISK -> "Z"
+        HookIds.Backend.LSPOSED -> "J"
+    }
+
+@Composable
+private fun rowTargetText(row: StatisticsRow): String =
+    row.packageNames
+        .takeIf { it.isNotEmpty() }
+        ?.joinToString(", ")
+        ?: stringResource(R.string.statistics_unknown_uid, row.uid)
+
+@Composable
+private fun rowHookText(row: StatisticsRow): String = row.hook?.hookName ?: stringResource(R.string.statistics_unknown_hook, row.hookId)
+
+private enum class BackendHealth { Ok, Partial, Error, NoData }
+
+private fun backendHealth(backend: BackendStatistics): BackendHealth {
+    val status = backend.status
+    return when {
+        status == null && backend.rows.isEmpty() -> BackendHealth.NoData
+
+        status == null -> BackendHealth.Partial
+
+        status.error ==
+            HookIds.StatusError.OK.code
+                .toLong()
+        -> BackendHealth.Ok
+
+        status.error ==
+            HookIds.StatusError.PARTIAL_HOOKS.code
+                .toLong()
+        -> BackendHealth.Partial
+
+        else -> BackendHealth.Error
+    }
+}
+
+private data class HealthVisual(
+    val label: String,
+    val accent: Color,
+    val container: Color,
+)
+
+@Composable
+private fun backendHealthVisual(health: BackendHealth): HealthVisual =
+    when (health) {
+        BackendHealth.Ok -> {
+            HealthVisual(
+                label = stringResource(R.string.statistics_status_ok),
+                accent = StatusColors.successDot,
+                container = StatusColors.successContainer(),
+            )
+        }
+
+        BackendHealth.Partial -> {
+            HealthVisual(
+                label = stringResource(R.string.statistics_status_partial),
+                accent = StatusColors.warningAccent,
+                container = StatusColors.warningContainer(),
+            )
+        }
+
+        BackendHealth.Error -> {
+            HealthVisual(
+                label = stringResource(R.string.statistics_status_error),
+                accent = StatusColors.errorAccent,
+                container = StatusColors.errorContainer(),
+            )
+        }
+
+        BackendHealth.NoData -> {
+            HealthVisual(
+                label = stringResource(R.string.statistics_status_no_data),
+                accent = StatusColors.neutralAccent,
+                container = AppColors.neutralAccentContainer,
+            )
+        }
+    }

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/StatusUi.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/StatusUi.kt
@@ -74,6 +74,7 @@ internal object StatusColors {
     val errorDot = Color(0xFFD92D4B)
     val errorAccent = Color(0xFFC9184A)
     val infoAccent = Color(0xFF2E7CF6)
+    val neutralAccent = Color(0xFF64748B)
 }
 
 /**

--- a/lsposed/app/src/main/res/values-ru/strings.xml
+++ b/lsposed/app/src/main/res/values-ru/strings.xml
@@ -4,6 +4,7 @@
 
     <!-- Navigation -->
     <string name="tab_dashboard">Обзор</string>
+    <string name="tab_statistics">Статистика</string>
     <string name="tab_protection">Защита</string>
     <string name="tab_diagnostics">Диагностика</string>
 
@@ -26,6 +27,7 @@
     <string name="selected_count">%d выбрано</string>
     <string name="btn_save">Сохранить</string>
     <string name="btn_cancel">Отмена</string>
+    <string name="action_refresh">Обновить</string>
     <string name="action_refresh_apps">Обновить список приложений</string>
     <string name="search_placeholder">Поиск приложений&#8230;</string>
     <string name="filter_system">Системные</string>
@@ -105,6 +107,29 @@
     <string name="dashboard_no_vpn">VPN не активен. Включите VPN для проверки защиты.</string>
     <string name="vpn_off_prompt">VPN не активен. Включите его и нажмите «Повторить», чтобы запустить проверку защиты. Результаты кэшируются до перезапуска VPN Hide — повторно гонять в рамках сессии не нужно.</string>
     <string name="vpn_off_retry">Повторить</string>
+
+    <!-- Statistics -->
+    <string name="statistics_title">Счётчики перехватов</string>
+    <string name="statistics_subtitle">Runtime-события от активных бэкендов</string>
+    <string name="statistics_backends">Бэкенды</string>
+    <string name="statistics_total_events">События</string>
+    <string name="statistics_active_backends">Активные бэкенды</string>
+    <string name="statistics_counter_rows">Строки счётчиков</string>
+    <string name="statistics_hooks">Хуки</string>
+    <string name="statistics_backend_detail">%1$s · хуков: %2$d</string>
+    <string name="statistics_events">события</string>
+    <string name="statistics_no_data">Runtime-статистики пока нет. Счётчики появятся после того, как защищённое приложение попадёт в установленный хук.</string>
+    <string name="statistics_no_counters">Счётчиков пока нет.</string>
+    <string name="statistics_unknown_uid">uid %1$d</string>
+    <string name="statistics_unknown_hook">неизвестный хук %1$d</string>
+    <string name="statistics_status_ok">ОК</string>
+    <string name="statistics_status_partial">Частично</string>
+    <string name="statistics_status_error">Ошибка</string>
+    <string name="statistics_status_no_data">Нет данных</string>
+    <string name="statistics_load_failed_title">Статистика недоступна</string>
+    <string name="statistics_load_failed_message">VPN Hide не смог собрать root-состояние для этой вкладки. Проверьте менеджер root, если разрешение было прервано, затем нажмите «Повторить».</string>
+    <string name="statistics_refresh_failed_message">Обновление не удалось. Показываются предыдущие данные статистики.</string>
+
     <string name="dashboard_install_recommendation_title">Рекомендация по установке</string>
     <string name="dashboard_install_recommendation_device">Ваше устройство: %1$s, ядро %2$s</string>
     <string name="dashboard_install_recommendation_kmi_note">«%1$s» в версии ядра — это GKI Kernel Module Interface, обозначающий бинарный интерфейс ядра для модулей, а не версию Android на устройстве.</string>

--- a/lsposed/app/src/main/res/values/strings.xml
+++ b/lsposed/app/src/main/res/values/strings.xml
@@ -4,6 +4,7 @@
 
     <!-- Navigation -->
     <string name="tab_dashboard">Dashboard</string>
+    <string name="tab_statistics">Statistics</string>
     <string name="tab_protection">Protection</string>
     <string name="tab_diagnostics">Diagnostics</string>
 
@@ -28,6 +29,7 @@
     <string name="selected_count">%d selected</string>
     <string name="btn_save">Save</string>
     <string name="btn_cancel">Cancel</string>
+    <string name="action_refresh">Refresh</string>
     <string name="action_refresh_apps">Refresh app list</string>
     <string name="search_placeholder">Search apps&#8230;</string>
     <string name="filter_system">System</string>
@@ -141,6 +143,29 @@
     <string name="dashboard_no_vpn">No active VPN. Turn on VPN to check protection status.</string>
     <string name="vpn_off_prompt">No active VPN. Turn it on, then tap Retry to run the protection checks. Results are cached until VPN Hide is restarted — no need to re-run later in the same session.</string>
     <string name="vpn_off_retry">Retry</string>
+
+    <!-- Statistics -->
+    <string name="statistics_title">Interception counters</string>
+    <string name="statistics_subtitle">Runtime events reported by active backends</string>
+    <string name="statistics_backends">Backends</string>
+    <string name="statistics_total_events">Events</string>
+    <string name="statistics_active_backends">Active backends</string>
+    <string name="statistics_counter_rows">Counter rows</string>
+    <string name="statistics_hooks">Hooks</string>
+    <string name="statistics_backend_detail">%1$s · hooks: %2$d</string>
+    <string name="statistics_events">events</string>
+    <string name="statistics_no_data">No runtime statistics yet. Counters appear after a protected app hits an installed hook.</string>
+    <string name="statistics_no_counters">No counters yet.</string>
+    <string name="statistics_unknown_uid">uid %1$d</string>
+    <string name="statistics_unknown_hook">unknown hook %1$d</string>
+    <string name="statistics_status_ok">OK</string>
+    <string name="statistics_status_partial">Partial</string>
+    <string name="statistics_status_error">Error</string>
+    <string name="statistics_status_no_data">No data</string>
+    <string name="statistics_load_failed_title">Statistics unavailable</string>
+    <string name="statistics_load_failed_message">VPN Hide could not collect the root state needed for this tab. Check your root manager if permission was interrupted, then tap Retry.</string>
+    <string name="statistics_refresh_failed_message">Refresh failed. Showing the previous statistics data.</string>
+
     <string name="dashboard_install_recommendation_title">Installation recommendation</string>
     <string name="dashboard_install_recommendation_device">Your device: %1$s, kernel %2$s</string>
     <string name="dashboard_install_recommendation_kmi_note">\"%1$s\" in the kernel version is the GKI Kernel Module Interface tag — it identifies the kernel\'s binary interface to modules, not your Android OS release.</string>

--- a/lsposed/app/src/test/kotlin/dev/okhsunrog/vpnhide/RootSnapshotCacheTest.kt
+++ b/lsposed/app/src/test/kotlin/dev/okhsunrog/vpnhide/RootSnapshotCacheTest.kt
@@ -74,6 +74,8 @@ class RootSnapshotCacheTest {
         assertTrue(command.contains("pm list packages -U --user all"))
         assertTrue(command.contains("grep -H . /sys/class/net/*/operstate"))
         assertTrue(command.contains("[ -s $SUPERKEY_FILE ] && echo 1 || echo 0"))
+        assertTrue(command.contains("cat $PROC_CTL"))
+        assertTrue(command.contains("$KPM_ACTIVATOR state"))
         assertTrue(command.contains("probe_ok=1"))
         assertTrue(command.contains("iptables -C OUTPUT -j vpnhide_out"))
         assertTrue(command.contains("ip6tables -C OUTPUT -j vpnhide_out6"))

--- a/lsposed/app/src/test/kotlin/dev/okhsunrog/vpnhide/StatisticsDataTest.kt
+++ b/lsposed/app/src/test/kotlin/dev/okhsunrog/vpnhide/StatisticsDataTest.kt
@@ -1,0 +1,128 @@
+package dev.okhsunrog.vpnhide
+
+import dev.okhsunrog.vpnhide.generated.HookIds
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class StatisticsDataTest {
+    @Test
+    fun `extracts status and stats blocks from combined runtime state`() {
+        val raw =
+            """
+            # vpnhide v1 readback
+            vpnhide 1 status
+            backend 0x3
+            kver 0x0
+            hooks 0x3fc00
+            error 0x0
+            meta version 1.2.3
+            vpnhide 1 stats
+            0x278b 0xb:0x7
+            """.trimIndent()
+
+        assertEquals(
+            Protocol.Status(
+                backend =
+                    HookIds.Backend.LSPOSED.id
+                        .toLong(),
+                kver = 0,
+                hooks = HookIds.LSPOSED_HOOK_MASK.toLong(),
+                error = 0,
+            ),
+            parseProtocolStatusBlock(raw),
+        )
+        assertEquals(
+            listOf(
+                Protocol.StatEntry(
+                    uid = 10123,
+                    hookId =
+                        HookIds.Hook.LSPOSED_NETWORK_CAPABILITIES.id
+                            .toLong(),
+                    count = 7,
+                ),
+            ),
+            parseProtocolStatsBlock(raw),
+        )
+        assertNull(extractProtocolBlock("not protocol\n", Protocol.Kind.STATS))
+    }
+
+    @Test
+    fun `builds backend rows with uid package names and hook registry data`() {
+        val state = buildStatisticsState(statisticsFixtureSnapshot())
+
+        val kmod = state.backends.single { it.backend == HookIds.Backend.KMOD }
+        assertEquals(2, kmod.rows.size)
+        assertEquals(3uL, kmod.totalCount)
+        assertEquals("com.example.one", kmod.rows[0].packageNames.single())
+        assertEquals(HookIds.Hook.SOCK_IOCTL, kmod.rows[0].hook)
+        assertEquals(99L, kmod.rows[1].hookId)
+        assertNull(kmod.rows[1].hook)
+
+        val kpm = state.backends.single { it.backend == HookIds.Backend.KPM }
+        assertEquals(
+            HookIds.Backend.KPM.id
+                .toLong(),
+            kpm.status?.backend,
+        )
+        assertEquals(
+            "com.example.two",
+            kpm.rows
+                .single()
+                .packageNames
+                .single(),
+        )
+
+        val lsposed = state.backends.single { it.backend == HookIds.Backend.LSPOSED }
+        assertEquals("1.2.3", lsposed.metadata["version"])
+        assertEquals(HookIds.Hook.LSPOSED_NETWORK_CAPABILITIES, lsposed.rows.single().hook)
+    }
+
+    @Test
+    fun `formats unsigned counters with grouping`() {
+        assertEquals("0", formatStatCount(0uL))
+        assertEquals("12,345", formatStatCount(12_345uL))
+        assertEquals("18,446,744,073,709,551,615", formatStatCount(-1L))
+    }
+
+    private fun statisticsFixtureSnapshot(): RootSnapshot =
+        RootSnapshot(
+            mapOf(
+                "pm_packages" to
+                    "package:com.example.one uid:10123\n" +
+                    "package:com.example.two uid:10234,1010234\n",
+                "kmod_state" to
+                    """
+                    # folded kmod read
+                    vpnhide 1 status
+                    backend 0x0
+                    kver 0x6019d
+                    hooks 0x3ff
+                    error 0x0
+                    vpnhide 1 stats
+                    0x278b 0x6:0x2 0x63:0x1
+                    """.trimIndent(),
+                "kpm_state" to
+                    """
+                    vpnhide 1 status
+                    backend 0x1
+                    kver 0x6019d
+                    hooks 0x3ff
+                    error 0x0
+                    vpnhide 1 stats
+                    0x27fa 0x0:0x5
+                    """.trimIndent(),
+                "lsposed_state" to
+                    """
+                    vpnhide 1 status
+                    backend 0x3
+                    kver 0x0
+                    hooks 0x3fc00
+                    error 0x0
+                    meta version 1.2.3
+                    vpnhide 1 stats
+                    0x278b 0xb:0x7
+                    """.trimIndent(),
+            ),
+        )
+}


### PR DESCRIPTION
## Summary
- add a Statistics tab after Dashboard for backend interception counters
- read kmod, KPM, and LSPosed runtime state through the shared root snapshot
- add KPM activator read subcommands for status, stats, and combined state
- map counter rows to package UIDs and generated hook registry metadata

## Validation
- cd lsposed && ./gradlew :app:ktlintCheck :app:testDebugUnitTest :app:detekt cpdCheck
- cargo fmt --check && cargo test -p vpnhide_activator -p vpnhide_protocol
- cd lsposed && ./gradlew :app:assembleRelease