### PR TITLE
Improve diagnostics, hook controls, and Protection sorting

### DIFF
--- a/changelog.d/added-add-configurable-protection-list-sorting-with-18fb.md
+++ b/changelog.d/added-add-configurable-protection-list-sorting-with-18fb.md
@@ -1,0 +1,9 @@
+_2026-06-29_
+
+## English
+
+Add configurable Protection list sorting with configured apps first by default.
+
+## Русский
+
+Добавлена настраиваемая сортировка списка защиты: настроенные приложения теперь по умолчанию показываются первыми.

--- a/changelog.d/added-add-detailed-diagnostics-separate-debug-settings-6466.md
+++ b/changelog.d/added-add-detailed-diagnostics-separate-debug-settings-6466.md
@@ -1,0 +1,9 @@
+_2026-06-29_
+
+## English
+
+Add detailed diagnostics, separate debug settings, per-app Java hook selection, and full role labels.
+
+## Русский
+
+Добавлены подробная диагностика, отдельные настройки отладки, выбор Java-хуков по приложениям и полные названия ролей.

--- a/changelog.d/changed-improve-protection-help-formatting-and-show-b8d7.md
+++ b/changelog.d/changed-improve-protection-help-formatting-and-show-b8d7.md
@@ -1,0 +1,9 @@
+_2026-06-29_
+
+## English
+
+Improve Protection help formatting and show the banking-app warning only when Zygisk is the active native backend.
+
+## Русский
+
+Улучшено оформление справки на экране защиты, а предупреждение про банковские приложения теперь показывается только когда активный нативный бэкенд — Zygisk.

--- a/changelog.d/changed-move-diagnostics-into-settings-make-dashboard-1d7a.md
+++ b/changelog.d/changed-move-diagnostics-into-settings-make-dashboard-1d7a.md
@@ -1,0 +1,9 @@
+_2026-06-29_
+
+## English
+
+Move Diagnostics into Settings, make Dashboard wait for the full protection check set, and show an in-app loading state instead of holding the splash screen.
+
+## Русский
+
+Перенесена диагностика в настройки; обзор теперь ждёт полный набор проверок защиты, а при запуске показывается загрузка внутри приложения вместо удержания splash-экрана.

--- a/changelog.d/fixed-show-only-the-active-native-backend-d070.md
+++ b/changelog.d/fixed-show-only-the-active-native-backend-d070.md
@@ -1,0 +1,9 @@
+_2026-06-29_
+
+## English
+
+Show only the active native backend on the Statistics screen instead of rendering inactive kmod/KPM cards.
+
+## Русский
+
+На экране статистики теперь показывается только активный нативный бэкенд, без карточек неактивных kmod/KPM.

--- a/docs/state.md
+++ b/docs/state.md
@@ -199,7 +199,10 @@ activator write, but it is derived state, not user storage.
 The LSPosed hooks read canonical JSON directly in `system_server` and resolve
 package names to appIds through `/data/system/packages.list`, never through
 PackageManager. Caller matching uses `callingUid % 100000`, so all Android user
-profiles for the same appId are covered.
+profiles for the same appId are covered. `java: true` enables every LSPosed VPN
+sanitizer for that app; `java: ["hook_name", ...]` enables only the named
+LSPosed Java hooks for the app. App-hiding package visibility is controlled by
+`appHiding`, not by the Java VPN hook list.
 
 Inotify watches `/data/system/vpnhide_config.json`; package reinstall UID/appId
 changes are picked up by a periodic fingerprint of `/data/system/packages.list`.

--- a/docs/state.md
+++ b/docs/state.md
@@ -253,7 +253,7 @@ the app when Vector is active.
 
 - Format: `key=value`: `version`, `boot_id`, `pid`, `timestamp`.
 - Writer: Zygisk module when VPN Hide itself is forked under hooks.
-- Reader: app dashboard/startup cleanup.
+- Reader: app root snapshot/dashboard/startup cleanup.
 - Lifetime: per app launch, stale records removed when boot_id changes.
 
 ### `cacheDir`

--- a/docs/storage.md
+++ b/docs/storage.md
@@ -70,7 +70,7 @@ Shape (illustrative):
   "debug": false,
   "apps": {
     "com.example.bank":  { "java": true, "native": true,  "appHiding": false, "ports": false },
-    "org.example.proxy": { "java": true, "native": true,  "appHiding": true,  "ports": true }
+    "org.example.proxy": { "java": ["lsposed_network_capabilities"], "native": true, "appHiding": true, "ports": true }
   },
   "settings": {
     "rememberSuperkey": false
@@ -78,12 +78,16 @@ Shape (illustrative):
 }
 ```
 
-Per-hook granularity ("раздельное управление хуками"): the coarse `"native": true`
-is the common case (enable every native hook for the app). When the UI exposes
-per-hook control, `native` grows into an explicit hook list, e.g.
-`"native": ["fib_route_seq_show", "sock_ioctl"]`; the activator maps that to the
-protocol `hookmask` bits. An absent/`true` value means "all native hooks". The JSON
-is the *desired* selection; the wire carries the resolved `hookmask`.
+Per-hook granularity ("раздельное управление хуками"): the coarse `"java": true`
+or `"native": true` is the common case (enable every hook in that role for the
+app). When the UI exposes per-hook control, the role grows into an explicit hook
+list, e.g. `"java": ["lsposed_network_capabilities"]` or
+`"native": ["fib_route_seq_show", "sock_ioctl"]`. The native activator maps the
+native list to protocol `hookmask` bits. LSPosed reads the Java list directly in
+`system_server`; app-hiding package visibility is still controlled by
+`appHiding`, not by the Java VPN hook list. An absent/`true` value means "all
+hooks for this role". The JSON is the *desired* selection; the native wire
+carries the resolved `hookmask`.
 
 The `rememberSuperkey` boolean lives here (it is a preference, not a secret). The
 superkey itself does **not** (§6).

--- a/kmod/build.py
+++ b/kmod/build.py
@@ -242,6 +242,7 @@ def find_runtime() -> tuple[str, bool]:
 def container_build_one(runtime: str, is_podman: bool, repo_root: Path, kmi: str) -> None:
     image = f"ghcr.io/ylarod/ddk-min:{kmi}-{DDK_IMAGE_TAG}"
     mount_spec = f"{repo_root}:/work"
+    build_version = get_build_version(repo_root)
     cmd = [runtime, "run", "--rm"]
     if is_podman:
         # Rootless podman + Fedora SELinux: keep host UID inside so the
@@ -250,6 +251,8 @@ def container_build_one(runtime: str, is_podman: bool, repo_root: Path, kmi: str
         cmd += ["--userns=keep-id"]
         mount_spec += ":Z"
     cmd += [
+        "-e",
+        f"VPNHIDE_BUILD_VERSION={build_version}",
         "-v",
         mount_spec,
         "-w",

--- a/lsposed/app/build.gradle.kts
+++ b/lsposed/app/build.gradle.kts
@@ -176,9 +176,6 @@ dependencies {
     // Xposed API — compileOnly so it's not bundled into the APK.
     compileOnly("de.robv.android.xposed:api:82")
 
-    // Android 12 SplashScreen API, backported to API 23+.
-    implementation("androidx.core:core-splashscreen:1.2.0")
-
     // Compose UI
     implementation(libs.core.ktx)
     implementation(libs.activity.compose)

--- a/lsposed/app/src/main/AndroidManifest.xml
+++ b/lsposed/app/src/main/AndroidManifest.xml
@@ -10,7 +10,7 @@
     <application
         android:label="@string/app_name"
         android:icon="@mipmap/ic_launcher"
-        android:theme="@style/Theme.VpnHide.Splash"
+        android:theme="@style/Theme.VpnHide"
         android:allowBackup="false"
         tools:ignore="GoogleAppIndexingWarning">
 

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/AppPickerData.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/AppPickerData.kt
@@ -43,6 +43,7 @@ internal fun resolveAutoHiddenPackages(
 internal data class AppRoleSelection(
     val packageName: String,
     val java: Boolean = false,
+    val javaHooks: List<String>? = null,
     val native: Boolean = false,
     val nativeHooks: List<String>? = null,
     val appHiding: Boolean = false,
@@ -50,6 +51,11 @@ internal data class AppRoleSelection(
 )
 
 internal fun resolveNativeHookSelection(
+    hookNames: List<String>,
+    selectedHookNames: Set<String>,
+): List<String>? = resolveHookSelection(hookNames, selectedHookNames)
+
+internal fun resolveHookSelection(
     hookNames: List<String>,
     selectedHookNames: Set<String>,
 ): List<String>? {
@@ -78,6 +84,7 @@ internal fun buildCanonicalConfigForAppPickerSave(
 
     val javaPkgs = preserved { it.java } + selections.selectedPkgs { it.java } + selfPkg
     val nativePkgs = preserved { it.native.enabled } + selections.selectedPkgs { it.native } + selfPkg
+    val selectedJavaHooks = selections.selectedJavaHooks()
     val selectedNativeRoles = selections.selectedNativeRoles()
     val observerPkgs = preserved { it.appHiding } + selections.selectedPkgs { it.appHiding }
     val portsPkgs = preserved { it.ports } + selections.selectedPkgs { it.ports }
@@ -89,7 +96,7 @@ internal fun buildCanonicalConfigForAppPickerSave(
             selfPkg = selfPkg,
         )
 
-    val canonical =
+    val canonicalWithJavaHooks =
         buildCanonicalConfig(
             debug = debug,
             javaPkgs = javaPkgs,
@@ -98,7 +105,8 @@ internal fun buildCanonicalConfigForAppPickerSave(
             observerPkgs = observerPkgs,
             portsPkgs = portsPkgs,
             existing = base,
-        ).withNativeRoles(selectedNativeRoles)
+        ).withJavaHooks(selectedJavaHooks)
+    val canonical = canonicalWithJavaHooks.withNativeRoles(selectedNativeRoles)
     return applyAutoHiddenPackages(
         config = canonical,
         selfPkg = selfPkg,
@@ -183,6 +191,22 @@ private fun Collection<AppRoleSelection>.selectedNativeRoles(): Map<String, Nati
             val hooks = selection.nativeHooks?.takeIf { it.isNotEmpty() }
             selection.packageName to (hooks?.let { NativeRole(enabled = true, hooks = it) } ?: NativeRole.All)
         }
+
+private fun Collection<AppRoleSelection>.selectedJavaHooks(): Map<String, List<String>?> =
+    filter { it.java }
+        .associate { selection ->
+            selection.packageName to selection.javaHooks?.takeIf { it.isNotEmpty() }
+        }
+
+private fun CanonicalConfig.withJavaHooks(hooks: Map<String, List<String>?>): CanonicalConfig {
+    if (hooks.isEmpty()) return this
+    val updated =
+        apps
+            .mapValues { (pkg, app) ->
+                if (pkg in hooks) app.copy(javaHooks = hooks[pkg]) else app
+            }.toSortedMap()
+    return copy(apps = updated)
+}
 
 private fun CanonicalConfig.withNativeRoles(roles: Map<String, NativeRole>): CanonicalConfig {
     if (roles.isEmpty()) return this

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/AppPickerScreen.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/AppPickerScreen.kt
@@ -3,6 +3,7 @@ package dev.okhsunrog.vpnhide
 import android.graphics.drawable.Drawable
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -11,13 +12,14 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Tune
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Checkbox
 import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
@@ -25,17 +27,20 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import dev.okhsunrog.vpnhide.generated.HookIds
+import dev.okhsunrog.vpnhide.settings.LocalSettingsState
 
 /**
  * One row per app across every protection role. The three old tabs (Tun /
  * App-hiding / Ports) are merged into this single list so a target is
  * configured once, in one place, and saved once. Roles:
  *
- *  - [java]      "J" — LSPosed (the always-on Java layer)
+ *  - [java]      "J" — LSPosed (the Java layer)
  *  - [native]    "N" — the one active native backend (kmod / KPM / Zygisk, §1.5);
  *                       written to every installed native backend, only the
  *                       active one acts.
@@ -50,6 +55,7 @@ data class AppEntry(
     override val isSystem: Boolean,
     override val userIds: List<Int> = emptyList(),
     val java: Boolean = false,
+    val javaHooks: List<String>? = null,
     val native: Boolean = false,
     val nativeHooks: List<String>? = null,
     val appHiding: Boolean = false,
@@ -107,14 +113,16 @@ fun AppPickerScreen(
                 apps
                     .filter { it.packageName != selfPkg }
                     .map { app ->
-                        val nativeRole = baseCanonical.apps[app.packageName]?.native
+                        val canonicalApp = baseCanonical.apps[app.packageName]
+                        val nativeRole = canonicalApp?.native
                         AppEntry(
                             packageName = app.packageName,
                             label = app.label,
                             icon = app.icon,
                             isSystem = app.isSystem,
                             userIds = app.userIds,
-                            java = app.packageName in t.lsposedTargets,
+                            java = canonicalApp?.java ?: (app.packageName in t.lsposedTargets),
+                            javaHooks = canonicalApp?.takeIf { it.java }?.javaHooks?.takeIf { it.isNotEmpty() },
                             native = app.packageName in nativeTargets,
                             nativeHooks = nativeRole?.hooks?.takeIf { it.isNotEmpty() },
                             appHiding = app.packageName in observers,
@@ -148,11 +156,19 @@ fun AppPickerScreen(
             onToggle = { layer ->
                 onChange(
                     when (layer) {
-                        Layer.JAVA -> app.copy(java = !app.java)
+                        Layer.JAVA -> app.copy(java = !app.java, javaHooks = null)
                         Layer.NATIVE -> app.copy(native = !app.native, nativeHooks = null)
                         Layer.APP_HIDING -> app.copy(appHiding = !app.appHiding)
                         Layer.PORTS -> app.copy(ports = !app.ports)
                     },
+                )
+            },
+            onJavaHooksChange = { hooks ->
+                onChange(
+                    app.copy(
+                        java = hooks == null || hooks.isNotEmpty(),
+                        javaHooks = hooks?.takeIf { it.isNotEmpty() },
+                    ),
                 )
             },
             onNativeHooksChange = { hooks ->
@@ -168,6 +184,7 @@ fun AppPickerScreen(
                 onChange(
                     app.copy(
                         java = newState,
+                        javaHooks = null,
                         native = if (targets.anyNativeInstalled) newState else false,
                         nativeHooks = null,
                         appHiding = newState,
@@ -213,6 +230,7 @@ private fun AppEntry.toRoleSelection(): AppRoleSelection =
     AppRoleSelection(
         packageName = packageName,
         java = java,
+        javaHooks = javaHooks,
         native = native,
         nativeHooks = nativeHooks,
         appHiding = appHiding,
@@ -233,10 +251,13 @@ private fun AppRow(
     anyNativeInstalled: Boolean,
     portsInstalled: Boolean,
     onToggle: (Layer) -> Unit,
+    onJavaHooksChange: (List<String>?) -> Unit,
     onNativeHooksChange: (List<String>?) -> Unit,
     onToggleAll: () -> Unit,
 ) {
-    var hookDialogOpen by remember { mutableStateOf(false) }
+    var javaHookDialogOpen by remember { mutableStateOf(false) }
+    var nativeHookDialogOpen by remember { mutableStateOf(false) }
+    val fullRoleLabels = LocalSettingsState.current.fullProtectionRoleLabels
     TargetRowShell(
         label = app.label,
         packageName = app.packageName,
@@ -245,61 +266,156 @@ private fun AppRow(
         userNames = userNames,
         modifier = Modifier.clickable(onClick = onToggleAll),
     ) {
-        TargetChip(stringResource(R.string.chip_java), app.java) { onToggle(Layer.JAVA) }
+        HookTargetChip(
+            label =
+                roleLabel(
+                    compact = stringResource(R.string.chip_java),
+                    full = stringResource(R.string.chip_java_full),
+                    partial = app.javaHooks != null,
+                    fullLabels = fullRoleLabels,
+                ),
+            enabled = app.java,
+            onToggle = { onToggle(Layer.JAVA) },
+            onConfigure = { javaHookDialogOpen = true },
+            contentDescription = stringResource(R.string.java_hooks_title),
+        )
         if (anyNativeInstalled) {
-            TargetChip(
-                if (app.nativeHooks == null) {
-                    stringResource(R.string.chip_native)
-                } else {
-                    stringResource(R.string.chip_native_partial)
-                },
-                app.native,
-            ) { onToggle(Layer.NATIVE) }
-            if (app.native) {
-                IconButton(
-                    onClick = { hookDialogOpen = true },
-                    modifier = Modifier.size(30.dp),
-                ) {
-                    Icon(
-                        imageVector = Icons.Default.Tune,
-                        contentDescription = stringResource(R.string.native_hooks_title),
-                        modifier = Modifier.size(18.dp),
-                    )
-                }
-            }
+            HookTargetChip(
+                label =
+                    roleLabel(
+                        compact = stringResource(R.string.chip_native),
+                        full = stringResource(R.string.chip_native_full),
+                        partial = app.nativeHooks != null,
+                        fullLabels = fullRoleLabels,
+                    ),
+                enabled = app.native,
+                onToggle = { onToggle(Layer.NATIVE) },
+                onConfigure = { nativeHookDialogOpen = true },
+                contentDescription = stringResource(R.string.native_hooks_title),
+            )
         }
-        TargetChip(stringResource(R.string.chip_app_hiding), app.appHiding) { onToggle(Layer.APP_HIDING) }
+        TargetChip(
+            label =
+                if (fullRoleLabels) {
+                    stringResource(R.string.chip_app_hiding_full)
+                } else {
+                    stringResource(R.string.chip_app_hiding)
+                },
+            enabled = app.appHiding,
+        ) {
+            onToggle(Layer.APP_HIDING)
+        }
         if (portsInstalled) {
-            TargetChip(stringResource(R.string.chip_ports), app.ports) { onToggle(Layer.PORTS) }
+            TargetChip(
+                label =
+                    if (fullRoleLabels) {
+                        stringResource(R.string.chip_ports_full)
+                    } else {
+                        stringResource(R.string.chip_ports)
+                    },
+                enabled = app.ports,
+            ) {
+                onToggle(Layer.PORTS)
+            }
         }
     }
 
-    if (hookDialogOpen) {
-        NativeHooksDialog(
+    if (javaHookDialogOpen) {
+        HooksDialog(
             app = app,
-            onDismiss = { hookDialogOpen = false },
+            title = stringResource(R.string.java_hooks_title),
+            hookEntries = LsposedJavaHookEntries,
+            selectedHooks = app.javaHooks,
+            onDismiss = { javaHookDialogOpen = false },
+            onSave = { hooks ->
+                onJavaHooksChange(hooks)
+                javaHookDialogOpen = false
+            },
+        )
+    }
+
+    if (nativeHookDialogOpen) {
+        HooksDialog(
+            app = app,
+            title = stringResource(R.string.native_hooks_title),
+            hookEntries = NativeHookEntries,
+            selectedHooks = app.nativeHooks,
+            onDismiss = { nativeHookDialogOpen = false },
             onSave = { hooks ->
                 onNativeHooksChange(hooks)
-                hookDialogOpen = false
+                nativeHookDialogOpen = false
             },
         )
     }
 }
 
+private fun roleLabel(
+    compact: String,
+    full: String,
+    partial: Boolean,
+    fullLabels: Boolean,
+): String = (if (fullLabels) full else compact) + if (partial) "*" else ""
+
 @Composable
-private fun NativeHooksDialog(
+private fun HookTargetChip(
+    label: String,
+    enabled: Boolean,
+    onToggle: () -> Unit,
+    onConfigure: () -> Unit,
+    contentDescription: String,
+) {
+    val containerColor = if (enabled) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.surfaceVariant
+    val contentColor = if (enabled) MaterialTheme.colorScheme.onPrimary else MaterialTheme.colorScheme.onSurfaceVariant
+    Surface(
+        shape = RoundedCornerShape(4.dp),
+        color = containerColor,
+    ) {
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            Text(
+                text = label,
+                style = MaterialTheme.typography.labelSmall,
+                fontWeight = FontWeight.Bold,
+                color = contentColor,
+                modifier =
+                    Modifier
+                        .clickable(onClick = onToggle)
+                        .padding(start = 8.dp, top = 4.dp, end = 6.dp, bottom = 4.dp),
+            )
+            Box(
+                modifier =
+                    Modifier
+                        .clickable(onClick = onConfigure)
+                        .padding(start = 4.dp, top = 3.dp, end = 7.dp, bottom = 3.dp),
+                contentAlignment = Alignment.Center,
+            ) {
+                Icon(
+                    imageVector = Icons.Default.Tune,
+                    contentDescription = contentDescription,
+                    tint = contentColor,
+                    modifier = Modifier.size(14.dp),
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun HooksDialog(
     app: AppEntry,
+    title: String,
+    hookEntries: List<HookIds.Hook>,
+    selectedHooks: List<String>?,
     onDismiss: () -> Unit,
     onSave: (List<String>?) -> Unit,
 ) {
-    val hookNames = remember { HookIds.Hook.entries.map { it.hookName } }
-    var selected by remember(app.packageName, app.nativeHooks) {
-        mutableStateOf(app.nativeHooks?.toSet() ?: hookNames.toSet())
+    val hookNames = remember(hookEntries) { hookEntries.map { it.hookName } }
+    var selected by remember(app.packageName, selectedHooks, hookNames) {
+        mutableStateOf(selectedHooks?.toSet() ?: hookNames.toSet())
     }
 
     AlertDialog(
         onDismissRequest = onDismiss,
-        title = { Text(stringResource(R.string.native_hooks_title)) },
+        title = { Text(title) },
         text = {
             Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
                 Text(
@@ -312,9 +428,9 @@ private fun NativeHooksDialog(
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                 )
                 LazyColumn(modifier = Modifier.heightIn(max = 420.dp)) {
-                    items(HookIds.Hook.entries, key = { it.hookName }) { hook ->
+                    items(hookEntries, key = { it.hookName }) { hook ->
                         val checked = hook.hookName in selected
-                        NativeHookRow(
+                        HookRow(
                             hook = hook,
                             checked = checked,
                             onCheckedChange = { enabled ->
@@ -333,7 +449,7 @@ private fun NativeHooksDialog(
         confirmButton = {
             TextButton(
                 onClick = {
-                    onSave(resolveNativeHookSelection(hookNames, selected))
+                    onSave(resolveHookSelection(hookNames, selected))
                 },
             ) {
                 Text(stringResource(R.string.btn_save))
@@ -348,7 +464,7 @@ private fun NativeHooksDialog(
 }
 
 @Composable
-private fun NativeHookRow(
+private fun HookRow(
     hook: HookIds.Hook,
     checked: Boolean,
     onCheckedChange: (Boolean) -> Unit,

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/AppPickerScreen.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/AppPickerScreen.kt
@@ -79,16 +79,20 @@ data class AppEntry(
 internal enum class Layer { JAVA, NATIVE, APP_HIDING, PORTS }
 
 @Composable
-fun AppPickerScreen(
+internal fun AppPickerScreen(
     searchQuery: String,
     showSystem: Boolean,
     showRussianOnly: Boolean,
+    showConfiguredOnly: Boolean,
+    sortMode: TargetListSortMode,
     modifier: Modifier = Modifier,
 ) {
     TargetPickerScreen(
         searchQuery = searchQuery,
         showSystem = showSystem,
         showRussianOnly = showRussianOnly,
+        showConfiguredOnly = showConfiguredOnly,
+        sortMode = sortMode,
         modifier = modifier,
         helpPrefKey = "apps_unified",
         helpTitle = stringResource(R.string.apps_help_title),

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/AppPickerScreen.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/AppPickerScreen.kt
@@ -1,20 +1,28 @@
 package dev.okhsunrog.vpnhide
 
 import android.graphics.drawable.Drawable
+import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Layers
+import androidx.compose.material.icons.filled.TextFields
 import androidx.compose.material.icons.filled.Tune
+import androidx.compose.material.icons.filled.VisibilityOff
+import androidx.compose.material.icons.filled.VpnKey
+import androidx.compose.material.icons.filled.Warning
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Checkbox
 import androidx.compose.material3.Icon
@@ -29,6 +37,8 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
@@ -82,22 +92,7 @@ fun AppPickerScreen(
         modifier = modifier,
         helpPrefKey = "apps_unified",
         helpTitle = stringResource(R.string.apps_help_title),
-        help = {
-            Text(
-                text = stringResource(R.string.apps_hint_roles),
-                style = MaterialTheme.typography.bodyMedium,
-            )
-            Text(
-                text = stringResource(R.string.apps_hint_restart_target),
-                style = MaterialTheme.typography.bodyMedium,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
-            )
-            Text(
-                text = stringResource(R.string.apps_hint_zygisk),
-                style = MaterialTheme.typography.bodyMedium,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
-            )
-        },
+        help = { targets -> AppsHelpContent(targets) },
         merge = { apps, t, selfPkg ->
             val nativeTargets = t.nativeTargets
             val observers = t.observerNames
@@ -193,6 +188,135 @@ fun AppPickerScreen(
                 )
             },
         )
+    }
+}
+
+@Composable
+private fun AppsHelpContent(targets: TargetsSnapshot) {
+    val fullRoleLabels = LocalSettingsState.current.fullProtectionRoleLabels
+    val primary = MaterialTheme.colorScheme.primary
+    val secondary = MaterialTheme.colorScheme.secondary
+    val tertiary = MaterialTheme.colorScheme.tertiary
+    val error = MaterialTheme.colorScheme.error
+
+    Column(verticalArrangement = Arrangement.spacedBy(10.dp)) {
+        HelpInfoBlock(
+            title =
+                roleHelpLabel(
+                    compact = stringResource(R.string.chip_java),
+                    full = stringResource(R.string.chip_java_full),
+                    fullLabels = fullRoleLabels,
+                ),
+            body = stringResource(R.string.apps_help_role_java_body),
+            icon = Icons.Default.TextFields,
+            color = primary,
+        )
+        HelpInfoBlock(
+            title =
+                roleHelpLabel(
+                    compact = stringResource(R.string.chip_native),
+                    full = stringResource(R.string.chip_native_full),
+                    fullLabels = fullRoleLabels,
+                ),
+            body = stringResource(R.string.apps_help_role_native_body),
+            icon = Icons.Default.VpnKey,
+            color = secondary,
+        )
+        HelpInfoBlock(
+            title =
+                roleHelpLabel(
+                    compact = stringResource(R.string.chip_app_hiding),
+                    full = stringResource(R.string.chip_app_hiding_full),
+                    fullLabels = fullRoleLabels,
+                ),
+            body = stringResource(R.string.apps_help_role_apps_body),
+            icon = Icons.Default.VisibilityOff,
+            color = tertiary,
+        )
+        HelpInfoBlock(
+            title =
+                roleHelpLabel(
+                    compact = stringResource(R.string.chip_ports),
+                    full = stringResource(R.string.chip_ports_full),
+                    fullLabels = fullRoleLabels,
+                ),
+            body = stringResource(R.string.apps_help_role_ports_body),
+            icon = Icons.Default.Layers,
+            color = primary,
+        )
+        HelpInfoBlock(
+            title = stringResource(R.string.apps_help_hook_settings_title),
+            body = stringResource(R.string.apps_help_hook_settings_body),
+            icon = Icons.Default.Tune,
+            color = secondary,
+        )
+        HelpInfoBlock(
+            title = stringResource(R.string.apps_help_apps_hiding_title),
+            body = stringResource(R.string.apps_help_apps_hiding_body),
+            icon = Icons.Default.VisibilityOff,
+            color = tertiary,
+        )
+        HelpInfoBlock(
+            title = stringResource(R.string.apps_help_apply_title),
+            body = stringResource(R.string.apps_help_apply_body),
+            icon = Icons.Default.Layers,
+            color = primary,
+        )
+        if (targets.activeNativeBackendId == NativeBackendId.Zygisk) {
+            HelpInfoBlock(
+                title = stringResource(R.string.apps_help_zygisk_warning_title),
+                body = stringResource(R.string.apps_help_zygisk_warning_body),
+                icon = Icons.Default.Warning,
+                color = error,
+            )
+        }
+    }
+}
+
+private fun roleHelpLabel(
+    compact: String,
+    full: String,
+    fullLabels: Boolean,
+): String = if (fullLabels) "$full ($compact)" else "$compact ($full)"
+
+@Composable
+private fun HelpInfoBlock(
+    title: String,
+    body: String,
+    icon: ImageVector,
+    color: Color,
+) {
+    Surface(
+        modifier = Modifier.fillMaxWidth(),
+        shape = RoundedCornerShape(6.dp),
+        color = color.copy(alpha = 0.08f),
+        border = BorderStroke(1.dp, color.copy(alpha = 0.42f)),
+    ) {
+        Row(
+            modifier = Modifier.padding(12.dp),
+            verticalAlignment = Alignment.Top,
+        ) {
+            Icon(
+                imageVector = icon,
+                contentDescription = null,
+                tint = color,
+                modifier = Modifier.size(18.dp),
+            )
+            Spacer(Modifier.width(10.dp))
+            Column(verticalArrangement = Arrangement.spacedBy(3.dp)) {
+                Text(
+                    text = title,
+                    style = MaterialTheme.typography.titleSmall,
+                    fontWeight = FontWeight.Bold,
+                    color = MaterialTheme.colorScheme.onSurface,
+                )
+                Text(
+                    text = body,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+        }
     }
 }
 

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/ConfigChannels.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/ConfigChannels.kt
@@ -9,9 +9,9 @@ import dev.okhsunrog.vpnhide.generated.HookIds
  * canonical JSON, then runs the installed native module's activator.
  */
 internal object ConfigChannels {
-    // The hookmask written for every target: the full kernel hook mask. Kernel
-    // backends gate per-hook on it; zygisk/lsposed own no registry bits yet, so
-    // they act on target *presence* and ignore it (protocol §6 note).
+    // The hookmask written for legacy native config snapshots. The canonical
+    // JSON stores per-app native hook lists; installed native activators fold
+    // those into this protocol mask.
     private val FULL_MASK = HookIds.KERNEL_HOOK_MASK.toLong()
 
     /** A `vpnhide 1 config` snapshot for [uids] with [debug] folded in (§4.3). */

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DashboardData.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DashboardData.kt
@@ -1055,13 +1055,7 @@ internal suspend fun loadDashboardState(
     val currentBootId = shellSnapshot["current_boot_id"].orEmpty()
     val nativeTargetCount = countPackages(targetsSnapshot.nativeTargets)
     val kmodRaw = detectKmodModule(shellSnapshot, selfPkg).withTargetCount(nativeTargetCount)
-    val zygiskStatusRaw =
-        try {
-            File(context.filesDir, ZYGISK_STATUS_FILE_NAME).takeIf { it.isFile }?.readText().orEmpty()
-        } catch (e: Exception) {
-            VpnHideLog.w(TAG, "failed to read zygisk status heartbeat: ${e.message}")
-            ""
-        }
+    val zygiskStatusRaw = shellSnapshot["zygisk_status"].orEmpty()
     val zygisk = detectZygiskModule(shellSnapshot, zygiskStatusRaw, selfPkg, currentBootId).withTargetCount(nativeTargetCount)
     val kpm = detectKpmModule(shellSnapshot, selfPkg, currentBootId).withTargetCount(nativeTargetCount)
     val ports = detectPortsModule(shellSnapshot, selfPkg).withTargetCount(countPackages(targetsSnapshot.portsObservers))

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DashboardData.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DashboardData.kt
@@ -1299,7 +1299,7 @@ internal suspend fun loadDashboardState(
 
     // W3: user has debug logging turned on — VPN Hide is writing verbose lines
     // to logcat that a forensic reader with root can see. The flag file is
-    // written by the Settings → Diagnostics → Debug logging toggle; absent file ⇒
+    // written by the Settings → Debugging → Debug logging toggle; absent file ⇒
     // default off ⇒ no warning.
     val debugEnabled =
         targetsSnapshot.canonicalConfig?.debug

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DashboardData.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DashboardData.kt
@@ -1299,7 +1299,7 @@ internal suspend fun loadDashboardState(
 
     // W3: user has debug logging turned on — VPN Hide is writing verbose lines
     // to logcat that a forensic reader with root can see. The flag file is
-    // written by the Diagnostics → Debug logging toggle; absent file ⇒
+    // written by the Settings → Diagnostics → Debug logging toggle; absent file ⇒
     // default off ⇒ no warning.
     val debugEnabled =
         targetsSnapshot.canonicalConfig?.debug
@@ -1356,19 +1356,19 @@ internal suspend fun loadDashboardState(
 
             else -> {
                 // Single source of truth: reuse the cached check run instead of
-                // probing again here. Wait only for the fast core phase — the
-                // slow Diagnostics-only probes don't feed this summary.
-                val core = DiagnosticsCache.awaitCoreResults(context)
-                if (core == null) {
+                // probing again here. Dashboard waits for the full Diagnostics
+                // result so its "OK" state means every protection probe passed.
+                val checks = DiagnosticsCache.awaitFullResults(context)
+                if (checks == null) {
                     // No active VPN per the check run (or it failed) — nothing to
                     // summarize; fall back to the same retry path as no-VPN.
                     ProtectionCheck.NoVpn
                 } else {
                     val native =
-                        if (hasNative) core.native.toNativeResult() else NativeResult.NoModule
+                        if (hasNative) checks.nativeAll.toNativeResult() else NativeResult.NoModule
                     val java =
                         if (lsposed is LsposedState.Active) {
-                            core.coreJava.toJavaResult()
+                            checks.java.toJavaResult()
                         } else {
                             JavaResult.HooksInactive
                         }

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DashboardScreen.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DashboardScreen.kt
@@ -2,6 +2,11 @@ package dev.okhsunrog.vpnhide
 
 import android.content.Intent
 import android.net.Uri
+import androidx.compose.animation.core.RepeatMode
+import androidx.compose.animation.core.animateFloat
+import androidx.compose.animation.core.infiniteRepeatable
+import androidx.compose.animation.core.rememberInfiniteTransition
+import androidx.compose.animation.core.tween
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.layout.Box
@@ -20,6 +25,7 @@ import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
@@ -81,6 +87,11 @@ fun DashboardScreen(
         )
     }
 
+    if (state == null && loadError == null) {
+        DashboardLoadingState(modifier = modifier)
+        return
+    }
+
     Column(
         modifier =
             modifier
@@ -124,22 +135,16 @@ fun DashboardScreen(
             Spacer(Modifier.height(12.dp))
             if (s == null) return@Column
         }
-
-        if (s == null) {
-            Box(Modifier.fillMaxWidth(), contentAlignment = Alignment.Center) {
-                CircularProgressIndicator()
-            }
-            return@Column
-        }
+        val loadedState = s ?: return@Column
 
         // Issues split by severity — computed up front so the hero card can
         // summarize them. Errors = user attention, warnings = working-but-
         // suboptimal. Their banner sections render further down.
-        val errors = s.issues.filter { it.severity == IssueSeverity.ERROR }
-        val warnings = s.issues.filter { it.severity == IssueSeverity.WARNING }
+        val errors = loadedState.issues.filter { it.severity == IssueSeverity.ERROR }
+        val warnings = loadedState.issues.filter { it.severity == IssueSeverity.WARNING }
 
         // Hero: the whole setup's health at a glance.
-        DashboardHeroCard(state = s, errorCount = errors.size, warningCount = warnings.size)
+        DashboardHeroCard(state = loadedState, errorCount = errors.size, warningCount = warnings.size)
         Spacer(Modifier.height(20.dp))
 
         // Module status cards — one grouped block (byIndex corners).
@@ -149,11 +154,11 @@ fun DashboardScreen(
         // active native backend (kmod / KPM / Zygisk, §1.5), then the separate
         // ports feature.
         Column(verticalArrangement = Arrangement.spacedBy(3.dp)) {
-            JavaBackendCard(s.lsposed, index = 0, count = 3)
-            NativeBackendCard(s.nativeBackend, selfNeedsRestart, index = 1, count = 3)
-            ModuleCard(stringResource(R.string.dashboard_ports), "P", s.ports, index = 2, count = 3)
+            JavaBackendCard(loadedState.lsposed, index = 0, count = 3)
+            NativeBackendCard(loadedState.nativeBackend, selfNeedsRestart, index = 1, count = 3)
+            ModuleCard(stringResource(R.string.dashboard_ports), "P", loadedState.ports, index = 2, count = 3)
         }
-        s.nativeInstallRecommendation?.let { recommendation ->
+        loadedState.nativeInstallRecommendation?.let { recommendation ->
             Spacer(Modifier.height(8.dp))
             NativeInstallRecommendationCard(recommendation)
         }
@@ -167,7 +172,7 @@ fun DashboardScreen(
         SectionHeader(stringResource(R.string.dashboard_protection))
         Spacer(Modifier.height(8.dp))
 
-        when (val p = s.protection) {
+        when (val p = loadedState.protection) {
             is ProtectionCheck.NoVpn -> {
                 VpnOffPrompt(
                     onRetry = {
@@ -230,6 +235,175 @@ fun DashboardScreen(
 }
 
 // ── UI Components ────────────────────────────────────────────────────────
+
+@Composable
+internal fun DashboardLoadingState(modifier: Modifier = Modifier) {
+    val animations = LocalSettingsState.current.animationsEnabled
+    val alpha =
+        if (animations) {
+            val transition = rememberInfiniteTransition(label = "dashboardLoading")
+            val pulseAlpha by
+                transition.animateFloat(
+                    initialValue = 0.42f,
+                    targetValue = 0.88f,
+                    animationSpec =
+                        infiniteRepeatable(
+                            animation = tween(durationMillis = 900),
+                            repeatMode = RepeatMode.Reverse,
+                        ),
+                    label = "dashboardLoadingAlpha",
+                )
+            pulseAlpha
+        } else {
+            0.72f
+        }
+
+    Column(
+        modifier =
+            modifier
+                .fillMaxSize()
+                .verticalScroll(rememberScrollState())
+                .padding(horizontal = 16.dp),
+    ) {
+        Spacer(Modifier.height(12.dp))
+        EnhancedCard(
+            modifier = Modifier.fillMaxWidth(),
+            shape = MaterialTheme.shapes.extraLarge,
+            color = AppColors.cardContainer,
+        ) {
+            Column(modifier = Modifier.padding(18.dp).fillMaxWidth()) {
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    LoadingBlock(
+                        modifier = Modifier.size(58.dp).clip(CircleShape),
+                        alpha = alpha,
+                    )
+                    Spacer(Modifier.width(16.dp))
+                    Column(Modifier.weight(1f)) {
+                        LoadingBlock(
+                            modifier = Modifier.fillMaxWidth(0.56f).height(24.dp),
+                            alpha = alpha,
+                        )
+                        Spacer(Modifier.height(8.dp))
+                        LoadingBlock(
+                            modifier = Modifier.fillMaxWidth(0.82f).height(14.dp),
+                            alpha = alpha,
+                        )
+                    }
+                }
+                Spacer(Modifier.height(18.dp))
+                LinearProgressIndicator(modifier = Modifier.fillMaxWidth())
+                Spacer(Modifier.height(18.dp))
+                Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                    LoadingMetric(alpha = alpha, modifier = Modifier.weight(1f))
+                    LoadingMetric(alpha = alpha, modifier = Modifier.weight(1f))
+                }
+                Spacer(Modifier.height(8.dp))
+                Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                    LoadingMetric(alpha = alpha, modifier = Modifier.weight(1f))
+                    LoadingMetric(alpha = alpha, modifier = Modifier.weight(1f))
+                }
+            }
+        }
+
+        Spacer(Modifier.height(20.dp))
+        LoadingSection(alpha = alpha, rows = 3)
+        Spacer(Modifier.height(20.dp))
+        LoadingSection(alpha = alpha, rows = 2)
+        Spacer(Modifier.height(16.dp))
+    }
+}
+
+@Composable
+private fun LoadingMetric(
+    alpha: Float,
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        modifier =
+            modifier
+                .clip(MaterialTheme.shapes.medium)
+                .background(AppColors.cardContainerStrong)
+                .padding(horizontal = 12.dp, vertical = 10.dp),
+    ) {
+        LoadingBlock(
+            modifier = Modifier.fillMaxWidth(0.68f).height(12.dp),
+            alpha = alpha,
+        )
+        Spacer(Modifier.height(8.dp))
+        LoadingBlock(
+            modifier = Modifier.fillMaxWidth(0.42f).height(18.dp),
+            alpha = alpha,
+        )
+    }
+}
+
+@Composable
+private fun LoadingSection(
+    alpha: Float,
+    rows: Int,
+) {
+    LoadingBlock(
+        modifier = Modifier.fillMaxWidth(0.42f).height(18.dp),
+        alpha = alpha,
+    )
+    Spacer(Modifier.height(8.dp))
+    Column(verticalArrangement = Arrangement.spacedBy(3.dp)) {
+        repeat(rows) { index ->
+            LoadingRow(index = index, count = rows, alpha = alpha)
+        }
+    }
+}
+
+@Composable
+private fun LoadingRow(
+    index: Int,
+    count: Int,
+    alpha: Float,
+) {
+    Row(
+        modifier =
+            Modifier
+                .fillMaxWidth()
+                .clip(MaterialTheme.shapes.medium)
+                .background(AppColors.cardContainer)
+                .padding(horizontal = 16.dp, vertical = 14.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        LoadingBlock(
+            modifier = Modifier.size(40.dp),
+            alpha = alpha,
+        )
+        Spacer(Modifier.width(16.dp))
+        Column(Modifier.weight(1f)) {
+            LoadingBlock(
+                modifier = Modifier.fillMaxWidth(if (index == count - 1) 0.48f else 0.62f).height(16.dp),
+                alpha = alpha,
+            )
+            Spacer(Modifier.height(8.dp))
+            LoadingBlock(
+                modifier = Modifier.fillMaxWidth(if (index == 0) 0.78f else 0.68f).height(12.dp),
+                alpha = alpha,
+            )
+        }
+    }
+}
+
+@Composable
+private fun LoadingBlock(
+    alpha: Float,
+    modifier: Modifier = Modifier,
+) {
+    Box(
+        modifier =
+            modifier
+                .clip(MaterialTheme.shapes.medium)
+                .alpha(alpha)
+                .background(MaterialTheme.colorScheme.primary.copy(alpha = 0.18f)),
+    )
+}
 
 /** A bold section title. Pass [color] for the colored issue/warning headers. */
 @Composable

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DiagnosticsCache.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DiagnosticsCache.kt
@@ -29,12 +29,13 @@ import kotlinx.coroutines.withContext
  * - [State.Running] — a run is in flight.
  * - [State.VpnOff] — last run aborted because no active VPN was
  *   detected. User gets a "turn on VPN, then retry" banner.
- * - [State.Ready] — results captured; exposed to both the Dashboard
- *   protection panel and the Diagnostics screen.
+ * - [State.Ready] — at least the fast phase is captured; [State.Ready.complete]
+ *   flips to true when the slow Java probes have filled in too. Dashboard waits
+ *   for the complete result, while Diagnostics can show the fast result first.
  *
- * Once [State.Ready] is reached, [run] becomes a no-op — results don't
- * change mid-process. The only path back to "please retry" is killing the
- * process (a new launch starts with a fresh cache).
+ * Once a complete [State.Ready] is reached, [run] becomes a no-op — results
+ * don't change mid-process. The only path back to "please retry" is killing
+ * the process (a new launch starts with a fresh cache).
  */
 internal object DiagnosticsCache {
     sealed interface State {
@@ -47,8 +48,8 @@ internal object DiagnosticsCache {
         data class Ready(
             val results: CheckResults,
             // false after the fast core phase (native + VPN-presence Java) —
-            // enough for the Dashboard summary; true once the slow Diagnostics-
-            // only probes (push callback etc.) have filled in too.
+            // enough for early Diagnostics UI; true once the slow Java probes
+            // (push callback etc.) have filled in too.
             val complete: Boolean,
         ) : State
     }
@@ -70,9 +71,10 @@ internal object DiagnosticsCache {
         scope: CoroutineScope,
         context: Context,
     ) {
-        when (_state.value) {
+        val current = _state.value
+        when (current) {
             is State.Ready -> {
-                return
+                if (current.complete) return
             }
 
             State.Running -> {
@@ -95,15 +97,14 @@ internal object DiagnosticsCache {
     ) = run(scope, context)
 
     /**
-     * Suspend until the fast core phase is available, returning its results
-     * (native + VPN-presence Java) — the Dashboard protection summary's source.
-     * Returns null if there's no active VPN (or the run failed): nothing to
-     * summarize. Ensures a run is in flight, so it's safe to call standalone.
-     * Does not wait for the slow Diagnostics-only phase.
+     * Suspend until the full Diagnostics result is available. Dashboard uses
+     * this path so the top-level "OK" state is backed by every protection
+     * probe shown in Settings → Diagnostics, including the slow push-callback
+     * and route/proxy Java checks.
      */
-    suspend fun awaitCoreResults(context: Context): CheckResults? {
+    suspend fun awaitFullResults(context: Context): CheckResults? {
         run(cacheScope, context)
-        val terminal = state.first { it is State.Ready || it is State.VpnOff }
+        val terminal = state.first { it is State.VpnOff || (it is State.Ready && it.complete) }
         return (terminal as? State.Ready)?.results
     }
 
@@ -119,13 +120,13 @@ internal object DiagnosticsCache {
             }
             val cm = appContext.getSystemService(ConnectivityManager::class.java)
             // Phase 1 (fast): native + VPN-presence Java probes. Publish
-            // immediately so the Dashboard summary can render without waiting
-            // for the slow phase below.
+            // immediately so Settings → Diagnostics can show progress without
+            // waiting for the slow phase below.
             val core = withContext(Dispatchers.IO) { runCoreChecks(cm, appContext) }
             _state.value = State.Ready(core, complete = false)
             StartupTrace.mark("diagnostics_cache_core_done")
-            // Phase 2 (slow): Diagnostics-only Java probes, incl. the push
-            // callback that blocks for up to 3s.
+            // Phase 2 (slow): remaining Java probes, incl. the push callback
+            // that blocks for up to 3s. Dashboard waits for this full result.
             val extraJava = withContext(Dispatchers.IO) { runExtraJavaChecks(cm, appContext) }
             _state.value = State.Ready(core.copy(extraJava = extraJava), complete = true)
             StartupTrace.mark("diagnostics_cache_done")

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DiagnosticsCache.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DiagnosticsCache.kt
@@ -99,7 +99,7 @@ internal object DiagnosticsCache {
     /**
      * Suspend until the full Diagnostics result is available. Dashboard uses
      * this path so the top-level "OK" state is backed by every protection
-     * probe shown in Settings → Diagnostics, including the slow push-callback
+     * probe shown in Settings → Detailed diagnostics, including the slow push-callback
      * and route/proxy Java checks.
      */
     suspend fun awaitFullResults(context: Context): CheckResults? {
@@ -120,7 +120,7 @@ internal object DiagnosticsCache {
             }
             val cm = appContext.getSystemService(ConnectivityManager::class.java)
             // Phase 1 (fast): native + VPN-presence Java probes. Publish
-            // immediately so Settings → Diagnostics can show progress without
+            // immediately so Settings → Detailed diagnostics can show progress without
             // waiting for the slow phase below.
             val core = withContext(Dispatchers.IO) { runCoreChecks(cm, appContext) }
             _state.value = State.Ready(core, complete = false)

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DiagnosticsScreen.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DiagnosticsScreen.kt
@@ -57,17 +57,16 @@ data class CheckResult(
 )
 
 internal data class CheckResults(
-    // UniFFI native probes — the Dashboard "Native level" summary rolls up
-    // exactly this group.
+    // UniFFI native probes from the fast phase.
     val native: List<CheckResult>,
     // Java-implemented native-level probes (NetworkInterface enum, /proc/net/route)
-    // — shown under "Native level" on Diagnostics, not part of any summary.
+    // — shown under "Native level" and included in Dashboard once the full
+    // diagnostics result is ready.
     val nativeExtra: List<CheckResult> = emptyList(),
-    // VPN-presence probes — the Dashboard "Java API level" summary rolls up
-    // exactly this group.
+    // VPN-presence probes from the fast phase.
     val coreJava: List<CheckResult> = emptyList(),
-    // Diagnostics-only Java probes (active-network, push callback, routes, proxy)
-    // — the slow push-callback check lives here, so it runs in a second phase.
+    // Remaining Java probes (active-network, push callback, routes, proxy) —
+    // the slow push-callback check lives here, so it runs in a second phase.
     val extraJava: List<CheckResult> = emptyList(),
 ) {
     val nativeAll get() = native + nativeExtra
@@ -543,12 +542,11 @@ private fun CheckCard(
 // ==========================================================================
 
 /**
- * The checks split into two phases so the Dashboard can show its protection
- * summary without waiting for the slow probes. [runCoreChecks] runs everything
- * the Dashboard summary needs (UniFFI native + the VPN-presence Java probes)
- * plus the cheap native-extra probes; [runExtraJavaChecks] runs the
- * Diagnostics-only Java probes, including the push-callback probe that blocks
- * for up to 3s. DiagnosticsCache publishes after each phase.
+ * The checks split into two phases so Settings → Diagnostics can show progress
+ * before the slow probes finish. [runCoreChecks] runs the fast native and
+ * VPN-presence Java probes; [runExtraJavaChecks] runs the remaining Java probes,
+ * including the push-callback probe that blocks for up to 3s. Dashboard waits
+ * for the complete DiagnosticsCache result before summarizing protection.
  */
 internal fun runCoreChecks(
     cm: ConnectivityManager,
@@ -610,7 +608,7 @@ private fun List<CheckResult>.logged(): List<CheckResult> =
 
 /** Run both phases and return the complete results. Used where blocking on the
  * slow probes is fine (debug export); the live cache runs the phased builders
- * directly so the Dashboard summary needn't wait for the slow phase. */
+ * directly so Settings → Diagnostics can show the fast phase first. */
 internal fun runAllChecks(
     cm: ConnectivityManager,
     context: android.content.Context,

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DiagnosticsScreen.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DiagnosticsScreen.kt
@@ -97,12 +97,9 @@ fun DiagnosticsScreen(
     modifier: Modifier = Modifier,
 ) {
     val context = LocalContext.current
-    val cm = context.getSystemService(ConnectivityManager::class.java)
     val scope = rememberCoroutineScope()
 
     val diagState by DiagnosticsCache.state.collectAsState()
-    var exporting by remember { mutableStateOf(false) }
-    var debugZipFile by remember { mutableStateOf<File?>(null) }
     val summaryFmt = stringResource(R.string.summary_format)
 
     // Kick off the diagnostics run once per process. If selfNeedsRestart
@@ -114,18 +111,6 @@ fun DiagnosticsScreen(
             DiagnosticsCache.run(scope, context)
         }
     }
-
-    val saveLauncher =
-        rememberLauncherForActivityResult(
-            ActivityResultContracts.CreateDocument("application/zip"),
-        ) { uri: Uri? ->
-            val zip = debugZipFile ?: return@rememberLauncherForActivityResult
-            if (uri != null) {
-                context.contentResolver.openOutputStream(uri)?.use { out ->
-                    zip.inputStream().use { it.copyTo(out) }
-                }
-            }
-        }
 
     val results = (diagState as? DiagnosticsCache.State.Ready)?.results
     // Native probes that couldn't run (ECONNREFUSED from socket()) are
@@ -148,10 +133,6 @@ fun DiagnosticsScreen(
     ) {
         Spacer(Modifier.height(8.dp))
 
-        // Protection check section — its content depends on cache state,
-        // but the bottom debug-tools section always renders below so
-        // users can collect logs / toggle verbose logging even when
-        // VPN is off or a run is in flight.
         when {
             selfNeedsRestart -> {
                 StatusBanner(
@@ -230,7 +211,35 @@ fun DiagnosticsScreen(
         }
 
         Spacer(Modifier.height(16.dp))
+    }
+}
 
+@Composable
+fun DebugToolsSection(
+    selfNeedsRestart: Boolean?,
+    modifier: Modifier = Modifier,
+) {
+    val context = LocalContext.current
+    val cm = context.getSystemService(ConnectivityManager::class.java)
+    val scope = rememberCoroutineScope()
+    var exporting by remember { mutableStateOf(false) }
+    var debugZipFile by remember { mutableStateOf<File?>(null) }
+
+    val saveLauncher =
+        rememberLauncherForActivityResult(
+            ActivityResultContracts.CreateDocument("application/zip"),
+        ) { uri: Uri? ->
+            val zip = debugZipFile ?: return@rememberLauncherForActivityResult
+            if (uri != null) {
+                context.contentResolver.openOutputStream(uri)?.use { out ->
+                    zip.inputStream().use { it.copyTo(out) }
+                }
+            }
+        }
+
+    Column(
+        modifier = modifier.fillMaxWidth(),
+    ) {
         DebugLoggingCard()
 
         Spacer(Modifier.height(16.dp))
@@ -240,16 +249,18 @@ fun DiagnosticsScreen(
         Spacer(Modifier.height(16.dp))
 
         // Collect button
-        if (debugZipFile == null) {
+        val zip = debugZipFile
+        if (zip == null) {
             EnhancedButton(
                 onClick = {
+                    val restartState = selfNeedsRestart ?: return@EnhancedButton
                     exporting = true
                     scope.launch {
-                        debugZipFile = exportDebugZip(cm, context, selfNeedsRestart)
+                        debugZipFile = exportDebugZip(cm, context, restartState)
                         exporting = false
                     }
                 },
-                enabled = !exporting,
+                enabled = !exporting && selfNeedsRestart != null,
                 modifier = Modifier.fillMaxWidth(),
             ) {
                 if (exporting) {
@@ -273,12 +284,10 @@ fun DiagnosticsScreen(
                 saveLabel = stringResource(R.string.btn_save_debug),
                 shareLabel = stringResource(R.string.btn_share_debug),
                 sharePrimary = true,
-                onSave = { saveLauncher.launch(debugZipFile!!.name) },
-                onShare = { shareFileViaProvider(context, debugZipFile!!, "application/zip") },
+                onSave = { saveLauncher.launch(zip.name) },
+                onShare = { shareFileViaProvider(context, zip, "application/zip") },
             )
         }
-
-        Spacer(Modifier.height(16.dp))
     }
 }
 
@@ -406,14 +415,13 @@ private fun LogcatRecordCard() {
 
                 is LogcatRecorder.State.Stopped -> {
                     val last = s.lastFile
-                    val hasLast = last != null && last.exists()
-                    if (hasLast) {
+                    if (last != null && last.exists()) {
                         Text(
                             text =
                                 stringResource(
                                     R.string.logcat_last_recording,
                                     formatElapsed(s.lastDurationMs / 1000),
-                                    formatSize(last!!.length()),
+                                    formatSize(last.length()),
                                 ),
                             style = MaterialTheme.typography.bodySmall,
                             color = MaterialTheme.colorScheme.onSurfaceVariant,
@@ -542,7 +550,7 @@ private fun CheckCard(
 // ==========================================================================
 
 /**
- * The checks split into two phases so Settings → Diagnostics can show progress
+ * The checks split into two phases so Settings → Detailed diagnostics can show progress
  * before the slow probes finish. [runCoreChecks] runs the fast native and
  * VPN-presence Java probes; [runExtraJavaChecks] runs the remaining Java probes,
  * including the push-callback probe that blocks for up to 3s. Dashboard waits
@@ -608,7 +616,7 @@ private fun List<CheckResult>.logged(): List<CheckResult> =
 
 /** Run both phases and return the complete results. Used where blocking on the
  * slow probes is fine (debug export); the live cache runs the phased builders
- * directly so Settings → Diagnostics can show the fast phase first. */
+ * directly so Settings → Detailed diagnostics can show the fast phase first. */
 internal fun runAllChecks(
     cm: ConnectivityManager,
     context: android.content.Context,
@@ -951,14 +959,14 @@ private fun checkProcNetRouteJava(name: String): CheckResult =
         val allLines = mutableListOf<String>()
         val vpnLines = mutableListOf<String>()
         BufferedReader(InputStreamReader(java.io.FileInputStream("/proc/net/route"))).use { br ->
-            var line: String?
-            while (br.readLine().also { line = it } != null) {
-                allLines.add(line!!)
+            while (true) {
+                val line = br.readLine() ?: break
+                allLines.add(line)
                 // /proc/net/route is whitespace-separated; check
                 // each token instead of just startsWith on the raw
                 // line so we don't match e.g. an IP-as-hex by chance.
-                if (line!!.split(Regex("\\s+")).any(IfaceLists::isVpnIface)) {
-                    vpnLines.add(line!!.take(60))
+                if (line.split(Regex("\\s+")).any(IfaceLists::isVpnIface)) {
+                    vpnLines.add(line.take(60))
                 }
             }
         }

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/HookEntry.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/HookEntry.kt
@@ -67,9 +67,12 @@ class HookEntry : IXposedHookLoadPackage {
         return if (uid == SYSTEM_UID) currentCallbackUid.get() ?: uid else uid
     }
 
-    private fun isTargetCallerOrUid(uid: Int? = null): Boolean =
-        SystemServerConfigCache.isTargetUid(effectiveCallerUid()) ||
-            (uid != null && SystemServerConfigCache.isTargetUid(uid))
+    private fun isTargetCallerOrUid(
+        hook: HookIds.Hook,
+        uid: Int? = null,
+    ): Boolean =
+        SystemServerConfigCache.isHookEnabledForUid(effectiveCallerUid(), hook) ||
+            (uid != null && SystemServerConfigCache.isHookEnabledForUid(uid, hook))
 
     private fun rememberConnectivityService(instance: Any?) {
         if (instance != null) connectivityServiceInstance = instance
@@ -419,7 +422,7 @@ class HookEntry : IXposedHookLoadPackage {
         explicitUid: Int? = null,
     ) {
         if (bypassConnectivitySanitize.get() == true) return
-        if (!isTargetCallerOrUid(explicitUid)) return
+        if (!isTargetCallerOrUid(HookIds.Hook.LSPOSED_CONNECTIVITY_RESULT, explicitUid)) return
         try {
             val original = param.result
             val sanitized = sanitizedValue(original)
@@ -464,7 +467,10 @@ class HookEntry : IXposedHookLoadPackage {
 
     @Volatile private var canonicalConfigFileObserver: android.os.FileObserver? = null
 
-    private fun isTargetUid(uid: Int): Boolean = SystemServerConfigCache.isTargetUid(uid)
+    private fun isTargetUid(
+        uid: Int,
+        hook: HookIds.Hook,
+    ): Boolean = SystemServerConfigCache.isHookEnabledForUid(uid, hook)
 
     // Smoke-check at install time: every private AOSP field/ctor we touch
     // by reflection in the writeToParcel hooks. Returns the keys that
@@ -612,7 +618,7 @@ class HookEntry : IXposedHookLoadPackage {
                 override fun beforeHookedMethod(param: MethodHookParam) {
                     if (writingCopy.get() == true) return
                     val callerUid = effectiveCallerUid()
-                    val isTarget = isTargetUid(callerUid)
+                    val isTarget = isTargetUid(callerUid, HookIds.Hook.LSPOSED_NETWORK_CAPABILITIES)
                     val nc = param.thisObject as NetworkCapabilities
                     val hasVpn = nc.hasTransport(NetworkCapabilities.TRANSPORT_VPN)
                     // Per-request diagnostic line. Gated by the debug-logging
@@ -658,7 +664,7 @@ class HookEntry : IXposedHookLoadPackage {
             Integer.TYPE,
             object : XC_MethodHook() {
                 override fun beforeHookedMethod(param: MethodHookParam) {
-                    if (writingCopy.get() == true || !isTargetCallerOrUid()) return
+                    if (writingCopy.get() == true || !isTargetCallerOrUid(HookIds.Hook.LSPOSED_NETWORK)) return
                     val cs = connectivityServiceInstance ?: return
                     val network = param.thisObject as Network
                     try {
@@ -700,7 +706,7 @@ class HookEntry : IXposedHookLoadPackage {
                 override fun beforeHookedMethod(param: MethodHookParam) {
                     if (writingCopy.get() == true) return
                     val callerUid = effectiveCallerUid()
-                    val isTarget = isTargetUid(callerUid)
+                    val isTarget = isTargetUid(callerUid, HookIds.Hook.LSPOSED_NETWORK_INFO)
                     val ni = param.thisObject as NetworkInfo
                     val type = XposedHelpers.getIntField(ni, "mNetworkType")
                     val isVpn = type == ConnectivityManager.TYPE_VPN
@@ -748,7 +754,7 @@ class HookEntry : IXposedHookLoadPackage {
                 override fun beforeHookedMethod(param: MethodHookParam) {
                     if (writingCopy.get() == true) return
                     val callerUid = effectiveCallerUid()
-                    val isTarget = isTargetUid(callerUid)
+                    val isTarget = isTargetUid(callerUid, HookIds.Hook.LSPOSED_LINK_PROPERTIES)
                     val lp = param.thisObject as LinkProperties
                     val ifname = XposedHelpers.getObjectField(lp, "mIfaceName") as? String
                     HookLog.i("VpnHide-LP: uid=$callerUid target=$isTarget ifname=$ifname")
@@ -875,7 +881,7 @@ class HookEntry : IXposedHookLoadPackage {
                     val nri = param.args.firstOrNull() ?: return
                     rememberConnectivityService(param.thisObject)
                     val uid = extractRecipientUid(nri)
-                    if (uid < 0 || !isTargetUid(uid)) return
+                    if (uid < 0 || !isTargetUid(uid, HookIds.Hook.LSPOSED_CONNECTIVITY_CALLBACK)) return
 
                     val request = extractNetworkRequest(nri)
                     if (request != null && request.hasTransport(NetworkCapabilities.TRANSPORT_VPN)) {
@@ -957,7 +963,7 @@ class HookEntry : IXposedHookLoadPackage {
                     override fun afterHookedMethod(param: MethodHookParam) {
                         rememberConnectivityService(param.thisObject)
                         if (bypassConnectivitySanitize.get() == true) return
-                        if (!isTargetCallerOrUid()) return
+                        if (!isTargetCallerOrUid(HookIds.Hook.LSPOSED_CONNECTIVITY_NETWORK)) return
                         sanitizer(param)
                     }
                 },
@@ -1016,7 +1022,7 @@ class HookEntry : IXposedHookLoadPackage {
         val type = param.args.getOrNull(0) as? Int ?: return false
         if (type != ConnectivityManager.TYPE_VPN) return false
         if (param.result == null) return true
-        if (!isTargetCallerOrUid()) return false
+        if (!isTargetCallerOrUid(HookIds.Hook.LSPOSED_CONNECTIVITY_RESULT)) return false
         param.result = null
         LsposedStats.record(effectiveCallerUid(), HookIds.Hook.LSPOSED_CONNECTIVITY_RESULT)
         HookLog.i("VpnHide: suppressed getNetworkInfo(TYPE_VPN) for uid=${effectiveCallerUid()}")

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/HookLog.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/HookLog.kt
@@ -12,7 +12,7 @@ import de.robv.android.xposed.XposedBridge
  * Source of truth is the canonical JSON config. We read it on [install] and via an
  * inotify watcher so a flip takes effect without restarting system_server.
  *
- * The logcat sink makes Settings → Diagnostics → Debug logging visible through
+ * The logcat sink makes Settings → Debugging → Debug logging visible through
  * ordinary bug-report captures. The Xposed sink is kept for framework UIs /
  * files that expose `XposedBridge.log` separately.
  *

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/HookLog.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/HookLog.kt
@@ -12,9 +12,9 @@ import de.robv.android.xposed.XposedBridge
  * Source of truth is the canonical JSON config. We read it on [install] and via an
  * inotify watcher so a flip takes effect without restarting system_server.
  *
- * The logcat sink makes Diagnostics → Debug logging visible through ordinary
- * bug-report captures. The Xposed sink is kept for framework UIs / files that
- * expose `XposedBridge.log` separately.
+ * The logcat sink makes Settings → Diagnostics → Debug logging visible through
+ * ordinary bug-report captures. The Xposed sink is kept for framework UIs /
+ * files that expose `XposedBridge.log` separately.
  *
  * Only per-request / hot-path logs should go through [i]. Hook install failures
  * and other one-time errors use [e], which always prints — losing those would

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/MainActivity.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/MainActivity.kt
@@ -3,7 +3,6 @@ package dev.okhsunrog.vpnhide
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.BackHandler
-import androidx.activity.compose.ReportDrawnWhen
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
 import androidx.compose.animation.AnimatedContent
@@ -20,7 +19,6 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.automirrored.filled.List
 import androidx.compose.material.icons.filled.BarChart
-import androidx.compose.material.icons.filled.CheckCircle
 import androidx.compose.material.icons.filled.Clear
 import androidx.compose.material.icons.filled.FilterList
 import androidx.compose.material.icons.filled.Home
@@ -37,11 +35,9 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
-import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
 import androidx.lifecycle.compose.LocalLifecycleOwner
-import androidx.lifecycle.lifecycleScope
 import dev.okhsunrog.vpnhide.settings.AppSettings
 import dev.okhsunrog.vpnhide.settings.LocalSettingsInteractor
 import dev.okhsunrog.vpnhide.settings.LocalSettingsState
@@ -57,37 +53,17 @@ import dev.okhsunrog.vpnhide.ui.theme.VpnHideTheme
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
-import java.util.concurrent.atomic.AtomicBoolean
 
 class MainActivity : ComponentActivity() {
-    private val splashReady = AtomicBoolean(false)
-
     override fun onCreate(savedInstanceState: Bundle?) {
         StartupTrace.mark("activity_on_create")
-        installSplashScreen().setKeepOnScreenCondition { !splashReady.get() }
         enableEdgeToEdge()
         super.onCreate(savedInstanceState)
         // Load the user's debug-logging preference before anything else
         // runs so the first suExec + Dashboard reload honor it.
         VpnHideLog.init(applicationContext)
         setContent {
-            VpnHideApp(
-                onDashboardReady = {
-                    if (splashReady.compareAndSet(false, true)) {
-                        StartupTrace.dashboardReady()
-                        // Re-propagate the persisted flag to the on-disk sinks as a
-                        // safety-net, but keep it off the cold-start critical path.
-                        lifecycleScope.launch(Dispatchers.IO) {
-                            applyDebugLoggingRuntime(VpnHideLog.enabled)
-                        }
-                    }
-                },
-                onRootDeniedReady = {
-                    if (splashReady.compareAndSet(false, true)) {
-                        StartupTrace.rootDeniedReady()
-                    }
-                },
-            )
+            VpnHideApp()
         }
     }
 }
@@ -105,10 +81,7 @@ private fun checkRootAccess(): Boolean {
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun VpnHideApp(
-    onDashboardReady: () -> Unit = {},
-    onRootDeniedReady: () -> Unit = {},
-) {
+fun VpnHideApp() {
     val context = LocalContext.current
     val settingsRepository = remember(context) { SettingsRepository(context.applicationContext) }
     val settings by settingsRepository.settings.collectAsState(initial = AppSettings())
@@ -134,25 +107,24 @@ fun VpnHideApp(
             }
 
             when (rootState) {
-                // splash holds until root check completes
                 null -> {
+                    StartupLoadingScreen()
                 }
 
                 RootState.Denied -> {
-                    // Drop splash — RootDeniedScreen has no async prerequisites.
-                    LaunchedEffect(Unit) { onRootDeniedReady() }
+                    LaunchedEffect(Unit) { StartupTrace.rootDeniedReady() }
                     RootDeniedScreen()
                 }
 
                 RootState.Granted -> {
-                    MainScreen(onReady = onDashboardReady)
+                    MainScreen()
                 }
             }
         }
     }
 }
 
-private enum class Tab { Dashboard, Statistics, Protection, Diagnostics }
+private enum class Tab { Dashboard, Statistics, Protection }
 
 private data class RefreshContext(
     val loading: Boolean,
@@ -166,7 +138,6 @@ private fun AppTopBarTitle(currentTab: Tab) {
             Tab.Dashboard -> stringResource(R.string.tab_dashboard)
             Tab.Statistics -> stringResource(R.string.tab_statistics)
             Tab.Protection -> stringResource(R.string.tab_protection)
-            Tab.Diagnostics -> stringResource(R.string.tab_diagnostics)
         }
     Row(verticalAlignment = Alignment.CenterVertically) {
         Icon(
@@ -228,7 +199,7 @@ private fun TopBarActionButton(
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-private fun MainScreen(onReady: () -> Unit = {}) {
+private fun MainScreen() {
     val context = LocalContext.current
     val scope = rememberCoroutineScope()
     val appContext = context.applicationContext
@@ -263,7 +234,8 @@ private fun MainScreen(onReady: () -> Unit = {}) {
     // is resolved. Keep that preparation first: it migrates/updates canonical
     // config and determines whether this app process needs a restart, so Dashboard
     // must not derive protection state from a stale answer. Protection still
-    // prewarms during splash, but without racing the self-target root shell.
+    // prewarms before a normal tab switch, but without racing the self-target
+    // root shell.
     LaunchedEffect(selfNeedsRestart) {
         val r = selfNeedsRestart ?: return@LaunchedEffect
         startupCoordinator.ensureInitialCaches(scope, r)
@@ -278,18 +250,20 @@ private fun MainScreen(onReady: () -> Unit = {}) {
         startupCoordinator.ensureProtectionCacheAfterRootSnapshot(scope, selfNeedsRestart, rootSnapshot)
     }
 
-    // Hold the splash screen until the first Dashboard frame can render
-    // with real content. Without this, the user sees splash → brief
-    // selfNeedsRestart-null spinner → brief Dashboard state-null spinner
-    // → content, with each spinner swap being visible flicker.
+    // Mark startup readiness once the main shell has shown either usable
+    // dashboard data or a terminal load error. Users see the dashboard loading
+    // state in place while this happens.
     val uiReady = startupCoordinator.isUiReady(dashboardState, dashboardError)
-    var fullyDrawnReady by remember { mutableStateOf(false) }
-    ReportDrawnWhen { fullyDrawnReady }
+    var startupTraceMarked by remember { mutableStateOf(false) }
     LaunchedEffect(uiReady) {
-        if (uiReady) {
-            withFrameNanos { }
-            fullyDrawnReady = true
-            onReady()
+        if (uiReady && !startupTraceMarked) {
+            startupTraceMarked = true
+            StartupTrace.dashboardReady()
+            scope.launch(Dispatchers.IO) {
+                // Re-propagate the persisted flag to the on-disk sinks as a
+                // safety-net, but keep it off the cold-start critical path.
+                applyDebugLoggingRuntime(VpnHideLog.enabled)
+            }
         }
     }
 
@@ -318,7 +292,10 @@ private fun MainScreen(onReady: () -> Unit = {}) {
     var showSettings by remember { mutableStateOf(false) }
     if (showSettings) {
         BackHandler { showSettings = false }
-        SettingsScreen(onBack = { showSettings = false })
+        SettingsScreen(
+            selfNeedsRestart = selfNeedsRestart,
+            onBack = { showSettings = false },
+        )
         return
     }
 
@@ -368,9 +345,7 @@ private fun MainScreen(onReady: () -> Unit = {}) {
                         ) {
                             // Refresh is contextual: Protection refreshes
                             // the app list, Dashboard refreshes the dashboard
-                            // state + update check. Diagnostics has its own
-                            // run buttons per-check, no top-bar refresh. Keep
-                            // it immediately before Settings when present.
+                            // state + update check.
                             val refreshContext =
                                 when (currentTab) {
                                     Tab.Dashboard -> {
@@ -398,10 +373,6 @@ private fun MainScreen(onReady: () -> Unit = {}) {
                                                 startupCoordinator.refreshProtection(scope)
                                             },
                                         )
-                                    }
-
-                                    Tab.Diagnostics -> {
-                                        null
                                     }
                                 }
                             if (currentTab == Tab.Protection) {
@@ -449,23 +420,21 @@ private fun MainScreen(onReady: () -> Unit = {}) {
                                     }
                                 }
                             }
-                            refreshContext?.let { rc ->
-                                TopBarActionButton(
-                                    onClick = rc.onRefresh,
-                                    enabled = !rc.loading,
-                                ) {
-                                    if (rc.loading) {
-                                        CircularProgressIndicator(
-                                            modifier = Modifier.size(20.dp),
-                                            strokeWidth = 2.dp,
-                                            color = MaterialTheme.colorScheme.onSurfaceVariant,
-                                        )
-                                    } else {
-                                        Icon(
-                                            Icons.Default.Refresh,
-                                            contentDescription = stringResource(R.string.action_refresh),
-                                        )
-                                    }
+                            TopBarActionButton(
+                                onClick = refreshContext.onRefresh,
+                                enabled = !refreshContext.loading,
+                            ) {
+                                if (refreshContext.loading) {
+                                    CircularProgressIndicator(
+                                        modifier = Modifier.size(20.dp),
+                                        strokeWidth = 2.dp,
+                                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                    )
+                                } else {
+                                    Icon(
+                                        Icons.Default.Refresh,
+                                        contentDescription = stringResource(R.string.action_refresh),
+                                    )
                                 }
                             }
                             TopBarActionButton(
@@ -523,15 +492,6 @@ private fun MainScreen(onReady: () -> Unit = {}) {
                     icon = { Icon(Icons.AutoMirrored.Filled.List, contentDescription = null) },
                     label = { Text(stringResource(R.string.tab_protection)) },
                 )
-                NavigationBarItem(
-                    selected = currentTab == Tab.Diagnostics,
-                    onClick = {
-                        tabHaptic()
-                        currentTab = Tab.Diagnostics
-                    },
-                    icon = { Icon(Icons.Default.CheckCircle, contentDescription = null) },
-                    label = { Text(stringResource(R.string.tab_diagnostics)) },
-                )
             }
         },
     ) { innerPadding ->
@@ -543,12 +503,7 @@ private fun MainScreen(onReady: () -> Unit = {}) {
                 onRetry = { startupCoordinator.retrySelfTargets(scope) },
             )
         } else if (restart == null) {
-            Box(
-                modifier = Modifier.fillMaxSize().padding(innerPadding),
-                contentAlignment = Alignment.Center,
-            ) {
-                CircularProgressIndicator()
-            }
+            DashboardLoadingState(modifier = Modifier.padding(innerPadding))
         } else {
             AnimatedContent(
                 targetState = currentTab,
@@ -594,16 +549,30 @@ private fun MainScreen(onReady: () -> Unit = {}) {
                             modifier = Modifier.padding(innerPadding),
                         )
                     }
-
-                    Tab.Diagnostics -> {
-                        DiagnosticsScreen(
-                            selfNeedsRestart = restart,
-                            modifier = Modifier.padding(innerPadding),
-                        )
-                    }
                 }
             }
         }
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun StartupLoadingScreen() {
+    Scaffold(
+        containerColor = AppColors.screenBackground,
+        topBar = {
+            LargeTopAppBar(
+                title = { AppTopBarTitle(Tab.Dashboard) },
+                colors =
+                    TopAppBarDefaults.topAppBarColors(
+                        containerColor = AppColors.topBarContainer,
+                        scrolledContainerColor = AppColors.topBarScrolledContainer,
+                        titleContentColor = MaterialTheme.colorScheme.onSurface,
+                    ),
+            )
+        },
+    ) { innerPadding ->
+        DashboardLoadingState(modifier = Modifier.padding(innerPadding))
     }
 }
 

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/MainActivity.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/MainActivity.kt
@@ -211,6 +211,8 @@ private fun MainScreen() {
     var searchActive by remember { mutableStateOf(false) }
     var showSystem by remember { mutableStateOf(false) }
     var showRussianOnly by remember { mutableStateOf(false) }
+    var showConfiguredOnly by remember { mutableStateOf(false) }
+    var targetSortMode by remember { mutableStateOf(TargetListSortMode.ConfiguredFirst) }
     var showFilterMenu by remember { mutableStateOf(false) }
     val appListLoading by AppListCache.loading.collectAsState()
     val targetsLoading by TargetsCache.loading.collectAsState()
@@ -383,7 +385,11 @@ private fun MainScreen() {
                                     )
                                 }
                                 Box {
-                                    val anyFilterActive = showSystem || showRussianOnly
+                                    val anyFilterActive =
+                                        showSystem ||
+                                            showRussianOnly ||
+                                            showConfiguredOnly ||
+                                            targetSortMode != TargetListSortMode.ConfiguredFirst
                                     TopBarActionButton(
                                         onClick = { showFilterMenu = true },
                                         active = anyFilterActive,
@@ -414,6 +420,37 @@ private fun MainScreen() {
                                                 Checkbox(
                                                     checked = showRussianOnly,
                                                     onCheckedChange = null,
+                                                )
+                                            },
+                                        )
+                                        DropdownMenuItem(
+                                            text = { Text(stringResource(R.string.filter_configured_only)) },
+                                            onClick = { showConfiguredOnly = !showConfiguredOnly },
+                                            leadingIcon = {
+                                                Checkbox(
+                                                    checked = showConfiguredOnly,
+                                                    onCheckedChange = null,
+                                                )
+                                            },
+                                        )
+                                        HorizontalDivider()
+                                        DropdownMenuItem(
+                                            text = { Text(stringResource(R.string.sort_configured_first)) },
+                                            onClick = { targetSortMode = TargetListSortMode.ConfiguredFirst },
+                                            leadingIcon = {
+                                                RadioButton(
+                                                    selected = targetSortMode == TargetListSortMode.ConfiguredFirst,
+                                                    onClick = null,
+                                                )
+                                            },
+                                        )
+                                        DropdownMenuItem(
+                                            text = { Text(stringResource(R.string.sort_alphabetical)) },
+                                            onClick = { targetSortMode = TargetListSortMode.Alphabetical },
+                                            leadingIcon = {
+                                                RadioButton(
+                                                    selected = targetSortMode == TargetListSortMode.Alphabetical,
+                                                    onClick = null,
                                                 )
                                             },
                                         )
@@ -546,6 +583,8 @@ private fun MainScreen() {
                             searchQuery = searchQuery,
                             showSystem = showSystem,
                             showRussianOnly = showRussianOnly,
+                            showConfiguredOnly = showConfiguredOnly,
+                            sortMode = targetSortMode,
                             modifier = Modifier.padding(innerPadding),
                         )
                     }

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/ProtectionScreen.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/ProtectionScreen.kt
@@ -10,16 +10,20 @@ import androidx.compose.ui.Modifier
  * every backend at once.
  */
 @Composable
-fun ProtectionScreen(
+internal fun ProtectionScreen(
     searchQuery: String,
     showSystem: Boolean,
     showRussianOnly: Boolean,
+    showConfiguredOnly: Boolean,
+    sortMode: TargetListSortMode,
     modifier: Modifier = Modifier,
 ) {
     AppPickerScreen(
         searchQuery = searchQuery,
         showSystem = showSystem,
         showRussianOnly = showRussianOnly,
+        showConfiguredOnly = showConfiguredOnly,
+        sortMode = sortMode,
         modifier = modifier,
     )
 }

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/ProtectionScreen.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/ProtectionScreen.kt
@@ -6,7 +6,7 @@ import androidx.compose.ui.Modifier
 /**
  * The Protection tab. Formerly a segmented Tun / App-hiding / Ports switcher;
  * those three pickers are now one unified list ([AppPickerScreen]) where each
- * app row carries all four role chips (J / N / A / P) and a single Save writes
+ * app row carries all four role chips (J / N / A / P, optionally full labels) and a single Save writes
  * every backend at once.
  */
 @Composable

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/RootSnapshotCache.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/RootSnapshotCache.kt
@@ -43,6 +43,7 @@ internal val REQUIRED_ROOT_SNAPSHOT_SECTIONS =
         "current_boot_id",
         "kmod_load_status",
         "kmod_load_dmesg",
+        "zygisk_status",
         "kernel_release",
         "kmod_state",
         "kpm_state",
@@ -226,6 +227,7 @@ internal fun buildRootShellSnapshotCommand(includePmPackages: Boolean = true): S
       emit_file current_boot_id /proc/sys/kernel/random/boot_id
       emit_file kmod_load_status $KMOD_LOAD_STATUS_FILE
       emit_file kmod_load_dmesg $KMOD_LOAD_DMESG_FILE
+      emit_file zygisk_status $ZYGISK_STATUS_FILE
       emit_file kpm_load_status $KPM_LOAD_STATUS_FILE
       phase_end
     }

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/SettingsScreen.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/SettingsScreen.kt
@@ -193,7 +193,7 @@ fun SettingsScreen(
                 )
             }
 
-            // ── Interaction ── grouped block of two rows.
+            // ── Interaction ── grouped block of three rows.
             Column(verticalArrangement = Arrangement.spacedBy(3.dp)) {
                 SettingsSectionHeader(stringResource(R.string.settings_interaction))
                 PreferenceRowSwitch(
@@ -201,7 +201,7 @@ fun SettingsScreen(
                     subtitle = stringResource(R.string.settings_haptics_sub),
                     icon = Icons.Default.Vibration,
                     index = 0,
-                    count = 2,
+                    count = 3,
                     checked = settings.hapticsEnabled,
                     onCheckedChange = interactor::setHapticsEnabled,
                 )
@@ -210,14 +210,24 @@ fun SettingsScreen(
                     subtitle = stringResource(R.string.settings_animations_sub),
                     icon = Icons.Default.Animation,
                     index = 1,
-                    count = 2,
+                    count = 3,
                     checked = settings.animationsEnabled,
                     onCheckedChange = interactor::setAnimationsEnabled,
+                )
+                PreferenceRowSwitch(
+                    title = stringResource(R.string.settings_full_role_labels),
+                    subtitle = stringResource(R.string.settings_full_role_labels_sub),
+                    icon = Icons.Default.TextFields,
+                    index = 2,
+                    count = 3,
+                    checked = settings.fullProtectionRoleLabels,
+                    onCheckedChange = interactor::setFullProtectionRoleLabels,
                 )
             }
 
             AutoHideSettingsSection()
             DiagnosticsSettingsSection(onOpen = { diagnosticsOpen = true })
+            DebugToolsSettingsSection(selfNeedsRestart = selfNeedsRestart)
             ConfigBackupSection()
             SuperkeySettingsSection()
         }
@@ -235,7 +245,7 @@ private fun DiagnosticsSettingsScreen(
         containerColor = AppColors.screenBackground,
         topBar = {
             TopAppBar(
-                title = { Text(stringResource(R.string.tab_diagnostics)) },
+                title = { Text(stringResource(R.string.settings_diagnostics_title)) },
                 navigationIcon = {
                     IconButton(onClick = onBack) {
                         Icon(
@@ -266,6 +276,14 @@ private fun DiagnosticsSettingsScreen(
                 modifier = Modifier.padding(padding),
             )
         }
+    }
+}
+
+@Composable
+private fun DebugToolsSettingsSection(selfNeedsRestart: Boolean?) {
+    Column(verticalArrangement = Arrangement.spacedBy(3.dp)) {
+        SettingsSectionHeader(stringResource(R.string.settings_debug_section))
+        DebugToolsSection(selfNeedsRestart = selfNeedsRestart)
     }
 }
 

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/SettingsScreen.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/SettingsScreen.kt
@@ -1,10 +1,12 @@
 package dev.okhsunrog.vpnhide
 
 import android.net.Uri
+import androidx.activity.compose.BackHandler
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -22,6 +24,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Animation
 import androidx.compose.material.icons.filled.BrightnessMedium
+import androidx.compose.material.icons.filled.CheckCircle
 import androidx.compose.material.icons.filled.DarkMode
 import androidx.compose.material.icons.filled.FileDownload
 import androidx.compose.material.icons.filled.FileUpload
@@ -77,9 +80,21 @@ import java.nio.charset.StandardCharsets
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun SettingsScreen(onBack: () -> Unit) {
+fun SettingsScreen(
+    selfNeedsRestart: Boolean?,
+    onBack: () -> Unit,
+) {
     val settings = LocalSettingsState.current
     val interactor = LocalSettingsInteractor.current
+    var diagnosticsOpen by remember { mutableStateOf(false) }
+
+    if (diagnosticsOpen) {
+        DiagnosticsSettingsScreen(
+            selfNeedsRestart = selfNeedsRestart,
+            onBack = { diagnosticsOpen = false },
+        )
+        return
+    }
 
     Scaffold(
         containerColor = AppColors.screenBackground,
@@ -202,9 +217,68 @@ fun SettingsScreen(onBack: () -> Unit) {
             }
 
             AutoHideSettingsSection()
+            DiagnosticsSettingsSection(onOpen = { diagnosticsOpen = true })
             ConfigBackupSection()
             SuperkeySettingsSection()
         }
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun DiagnosticsSettingsScreen(
+    selfNeedsRestart: Boolean?,
+    onBack: () -> Unit,
+) {
+    BackHandler(onBack = onBack)
+    Scaffold(
+        containerColor = AppColors.screenBackground,
+        topBar = {
+            TopAppBar(
+                title = { Text(stringResource(R.string.tab_diagnostics)) },
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(
+                            Icons.AutoMirrored.Filled.ArrowBack,
+                            contentDescription = stringResource(R.string.action_back),
+                        )
+                    }
+                },
+                colors =
+                    TopAppBarDefaults.topAppBarColors(
+                        containerColor = AppColors.topBarContainer,
+                        titleContentColor = MaterialTheme.colorScheme.onSurface,
+                        navigationIconContentColor = MaterialTheme.colorScheme.onSurfaceVariant,
+                    ),
+            )
+        },
+    ) { padding ->
+        if (selfNeedsRestart == null) {
+            Box(
+                modifier = Modifier.fillMaxSize().padding(padding),
+                contentAlignment = Alignment.Center,
+            ) {
+                CircularProgressIndicator()
+            }
+        } else {
+            DiagnosticsScreen(
+                selfNeedsRestart = selfNeedsRestart,
+                modifier = Modifier.padding(padding),
+            )
+        }
+    }
+}
+
+@Composable
+private fun DiagnosticsSettingsSection(onOpen: () -> Unit) {
+    Column(verticalArrangement = Arrangement.spacedBy(3.dp)) {
+        SettingsSectionHeader(stringResource(R.string.settings_diagnostics_section))
+        PreferenceRow(
+            title = stringResource(R.string.settings_diagnostics_title),
+            subtitle = stringResource(R.string.settings_diagnostics_sub),
+            icon = Icons.Default.CheckCircle,
+            onClick = onOpen,
+        )
     }
 }
 

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/ShellUtils.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/ShellUtils.kt
@@ -31,7 +31,9 @@ internal const val KMOD_MODULE_DIR = "/data/adb/modules/vpnhide_kmod"
 internal const val KMOD_LOAD_STATUS_FILE = "/data/adb/vpnhide_kmod/load_status"
 internal const val KMOD_LOAD_DMESG_FILE = "/data/adb/vpnhide_kmod/load_dmesg"
 internal const val ZYGISK_MODULE_DIR = "/data/adb/modules/vpnhide_zygisk"
+internal const val APP_PACKAGE_NAME = "dev.okhsunrog.vpnhide"
 internal const val ZYGISK_STATUS_FILE_NAME = "vpnhide_zygisk_active"
+internal const val ZYGISK_STATUS_FILE = "/data/user/0/dev.okhsunrog.vpnhide/files/vpnhide_zygisk_active"
 
 // KPM (KernelPatch Module) backend — the third native backend. The KPM has no
 // /proc node; its runtime channel is the kpatch ctl0 supercall, so the app reads

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/ShellUtils.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/ShellUtils.kt
@@ -315,7 +315,11 @@ private fun buildCanonicalSelfUpdate(
         targets.canonicalConfig
             ?: buildCanonicalConfigFromTargetsSnapshot(targets, debug = legacyDebug)
     val previousSelf = baseCanonical.apps[selfPkg]
-    val selfNeedsRestart = previousSelf == null || !previousSelf.java || !previousSelf.native.enabled
+    val selfNeedsRestart =
+        previousSelf == null ||
+            !previousSelf.java ||
+            previousSelf.javaHooks != null ||
+            previousSelf.native != NativeRole.All
     val updatedCanonical = canonicalConfigWithSelfTarget(baseCanonical, selfPkg)
     return CanonicalSelfUpdate(
         canonical = updatedCanonical,

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/StatisticsData.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/StatisticsData.kt
@@ -38,8 +38,7 @@ internal fun buildStatisticsState(snapshot: RootSnapshot): StatisticsState {
     val kmodRaw = snapshot.sections["kmod_state"].orEmpty()
     val kpmRaw = snapshot.sections["kpm_state"].orEmpty()
     val lsposedRaw = snapshot.sections["lsposed_state"].orEmpty()
-
-    return StatisticsState(
+    val nativeBackends =
         listOf(
             buildBackendStatistics(
                 backend = HookIds.Backend.KMOD,
@@ -53,14 +52,18 @@ internal fun buildStatisticsState(snapshot: RootSnapshot): StatisticsState {
                 stats = parseProtocolStatsBlock(kpmRaw),
                 uidPackages = uidPackages,
             ),
-            buildBackendStatistics(
-                backend = HookIds.Backend.LSPOSED,
-                status = parseProtocolStatusBlock(lsposedRaw),
-                stats = parseProtocolStatsBlock(lsposedRaw),
-                metadata = parseLsposedStateMetadata(lsposedRaw),
-                uidPackages = uidPackages,
-            ),
-        ),
+        )
+    val lsposed =
+        buildBackendStatistics(
+            backend = HookIds.Backend.LSPOSED,
+            status = parseProtocolStatusBlock(lsposedRaw),
+            stats = parseProtocolStatsBlock(lsposedRaw),
+            metadata = parseLsposedStateMetadata(lsposedRaw),
+            uidPackages = uidPackages,
+        )
+
+    return StatisticsState(
+        listOfNotNull(selectActiveNativeStatisticsBackend(nativeBackends), lsposed),
     )
 }
 
@@ -110,6 +113,23 @@ private fun buildBackendStatistics(
         metadata = metadata,
         rows = buildStatisticsRows(stats, uidPackages),
     )
+
+private val ACTIVE_NATIVE_STATUS_ERRORS =
+    setOf(
+        HookIds.StatusError.OK.code
+            .toLong(),
+        HookIds.StatusError.PARTIAL_HOOKS.code
+            .toLong(),
+    )
+
+private fun selectActiveNativeStatisticsBackend(backends: List<BackendStatistics>): BackendStatistics? =
+    backends.firstOrNull(BackendStatistics::isActiveNativeStatisticsBackend)
+
+private fun BackendStatistics.isActiveNativeStatisticsBackend(): Boolean {
+    if (rows.isNotEmpty()) return true
+    val status = status ?: return false
+    return status.backend == backend.id.toLong() && status.error in ACTIVE_NATIVE_STATUS_ERRORS
+}
 
 private fun buildStatisticsRows(
     stats: List<Protocol.StatEntry>,

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/StorageConfig.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/StorageConfig.kt
@@ -1,5 +1,6 @@
 package dev.okhsunrog.vpnhide
 
+import dev.okhsunrog.vpnhide.generated.HookIds
 import org.json.JSONArray
 import org.json.JSONObject
 
@@ -22,6 +23,7 @@ internal data class CanonicalSettings(
 
 internal data class CanonicalApp(
     val java: Boolean = false,
+    val javaHooks: List<String>? = null,
     val native: NativeRole = NativeRole.Disabled,
     val appHiding: Boolean = false,
     val ports: Boolean = false,
@@ -40,6 +42,34 @@ internal data class NativeRole(
         val All = NativeRole(enabled = true)
     }
 }
+
+private data class ParsedHookRole(
+    val enabled: Boolean,
+    val hooks: List<String>? = null,
+)
+
+internal val NativeHookEntries: List<HookIds.Hook> =
+    HookIds.Hook.entries.filter { hookBit(it) and HookIds.KERNEL_HOOK_MASK.toLong() != 0L }
+
+internal val LsposedJavaHookEntries: List<HookIds.Hook> =
+    HookIds.Hook.entries.filter {
+        hookBit(it) and HookIds.LSPOSED_HOOK_MASK.toLong() != 0L &&
+            it != HookIds.Hook.LSPOSED_PACKAGE_VISIBILITY
+    }
+
+internal fun hookSelectionMask(
+    enabled: Boolean,
+    hooks: List<String>?,
+    entries: List<HookIds.Hook>,
+): Long {
+    if (!enabled) return 0L
+    val allMask = entries.fold(0L) { acc, hook -> acc or hookBit(hook) }
+    if (hooks == null) return allMask
+    val allowedByName = entries.associateBy { it.hookName }
+    return hooks.fold(0L) { acc, name -> acc or (allowedByName[name]?.let(::hookBit) ?: 0L) }
+}
+
+private fun hookBit(hook: HookIds.Hook): Long = 1L shl hook.id
 
 internal fun parseCanonicalConfig(raw: String): CanonicalConfig? {
     if (raw.isBlank()) return null
@@ -77,8 +107,10 @@ internal fun parseCanonicalConfig(raw: String): CanonicalConfig? {
 
 private fun parseCanonicalApp(obj: JSONObject?): CanonicalApp {
     if (obj == null) return CanonicalApp()
+    val java = parseHookRole(obj.opt("java"))
     return CanonicalApp(
-        java = obj.optBoolean("java", false),
+        java = java.enabled,
+        javaHooks = java.hooks,
         native = parseNativeRole(obj.opt("native")),
         appHiding = obj.optBoolean("appHiding", false),
         ports = obj.optBoolean("ports", false),
@@ -87,20 +119,25 @@ private fun parseCanonicalApp(obj: JSONObject?): CanonicalApp {
 }
 
 private fun parseNativeRole(value: Any?): NativeRole =
+    parseHookRole(value).let { role ->
+        if (role.enabled) NativeRole(enabled = true, hooks = role.hooks) else NativeRole.Disabled
+    }
+
+private fun parseHookRole(value: Any?): ParsedHookRole =
     when (value) {
         is Boolean -> {
-            if (value) NativeRole.All else NativeRole.Disabled
+            if (value) ParsedHookRole(enabled = true) else ParsedHookRole(enabled = false)
         }
 
         is JSONArray -> {
             val hooks =
                 (0 until value.length())
                     .mapNotNull { idx -> value.optString(idx).takeIf { it.isNotBlank() } }
-            if (hooks.isEmpty()) NativeRole.Disabled else NativeRole(enabled = true, hooks = hooks)
+            if (hooks.isEmpty()) ParsedHookRole(enabled = false) else ParsedHookRole(enabled = true, hooks = hooks)
         }
 
         else -> {
-            NativeRole.Disabled
+            ParsedHookRole(enabled = false)
         }
     }
 
@@ -127,9 +164,11 @@ internal fun buildCanonicalConfig(
     val apps =
         packages
             .associateWith { pkg ->
+                val previous = existing?.apps?.get(pkg)
                 val previousNative = existing?.apps?.get(pkg)?.native
                 CanonicalApp(
                     java = pkg in java,
+                    javaHooks = previous?.javaHooks?.takeIf { pkg in java && previous.java },
                     native = if (pkg in native) previousNative?.takeIf { it.enabled } ?: NativeRole.All else NativeRole.Disabled,
                     appHiding = pkg in observers,
                     ports = pkg in ports,
@@ -166,7 +205,8 @@ internal fun canonicalConfigWithSelfTarget(
     val updated =
         current.copy(
             java = true,
-            native = current.native.takeIf { it.enabled } ?: NativeRole.All,
+            javaHooks = null,
+            native = NativeRole.All,
             hidden = true,
         )
     if (updated == current && config.apps.containsKey(selfPkg)) return config
@@ -227,7 +267,7 @@ internal fun canonicalConfigJson(config: CanonicalConfig): String =
 private fun StringBuilder.appendCanonicalApp(app: CanonicalApp) {
     append("{ ")
     append("\"java\": ")
-    append(app.java)
+    appendHookRole(app.java, app.javaHooks)
     append(", \"native\": ")
     appendNativeRole(app.native)
     append(", \"appHiding\": ")
@@ -241,24 +281,27 @@ private fun StringBuilder.appendCanonicalApp(app: CanonicalApp) {
 }
 
 private fun StringBuilder.appendNativeRole(native: NativeRole) {
+    appendHookRole(native.enabled, native.hooks)
+}
+
+private fun StringBuilder.appendHookRole(
+    enabled: Boolean,
+    hooks: List<String>?,
+) {
     when {
-        !native.enabled -> {
-            append("false")
-        }
-
-        native.hooks == null -> {
-            append("true")
-        }
-
-        else -> {
-            append('[')
-            native.hooks.forEachIndexed { index, hook ->
-                if (index != 0) append(", ")
-                appendJsonString(hook)
-            }
-            append(']')
-        }
+        !enabled -> append("false")
+        hooks == null -> append("true")
+        else -> appendStringArray(hooks)
     }
+}
+
+private fun StringBuilder.appendStringArray(values: List<String>) {
+    append('[')
+    values.forEachIndexed { index, value ->
+        if (index != 0) append(", ")
+        appendJsonString(value)
+    }
+    append(']')
 }
 
 private fun StringBuilder.appendJsonString(value: String) {

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/SystemServerConfigCache.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/SystemServerConfigCache.kt
@@ -1,14 +1,18 @@
 package dev.okhsunrog.vpnhide
 
 import android.os.SystemClock
+import dev.okhsunrog.vpnhide.generated.HookIds
 import java.io.File
 
 internal data class SystemServerConfig(
-    val javaTargetAppIds: Set<Int> = emptySet(),
+    val javaTargetHookMasksByAppId: Map<Int, Long> = emptyMap(),
     val observerAppIds: Set<Int> = emptySet(),
     val hiddenPackages: Set<String> = emptySet(),
     val debug: Boolean = false,
-)
+) {
+    val javaTargetAppIds: Set<Int>
+        get() = javaTargetHookMasksByAppId.keys
+}
 
 /**
  * Canonical config reader for hooks running inside system_server.
@@ -83,6 +87,16 @@ internal object SystemServerConfigCache {
         return load().javaTargetAppIds.contains(appId(uid))
     }
 
+    fun isHookEnabledForUid(
+        uid: Int,
+        hook: HookIds.Hook,
+    ): Boolean {
+        if (uid < android.os.Process.FIRST_APPLICATION_UID) return false
+        return load().javaTargetHookMasksByAppId[appId(uid)]?.let { mask ->
+            mask and (1L shl hook.id) != 0L
+        } == true
+    }
+
     fun appId(uid: Int): Int = uid % USER_ID_MODULO
 
     private fun Cache.withNextCheck(now: Long): Cache = copy(nextStatCheckUptimeMs = nextStatCheck(now))
@@ -95,11 +109,18 @@ internal object SystemServerConfigCache {
                 parseCanonicalConfig(configFile.takeIf(File::isFile)?.readText().orEmpty())
                     ?: return SystemServerConfig()
             val packageAppIds = parsePackagesListAppIds(packagesListFile.takeIf(File::isFile)?.readText().orEmpty())
-            val javaTargets =
+            val javaTargetHookMasks =
                 canonical.apps
-                    .filterValues { it.java }
-                    .keys
-                    .resolveAppIds(packageAppIds)
+                    .mapNotNull { (pkg, app) ->
+                        val appId = packageAppIds[pkg] ?: return@mapNotNull null
+                        val mask =
+                            hookSelectionMask(
+                                enabled = app.java,
+                                hooks = app.javaHooks,
+                                entries = LsposedJavaHookEntries,
+                            )
+                        if (mask == 0L) null else appId to mask
+                    }.toMap()
             val observers =
                 canonical.apps
                     .filterValues { it.appHiding }
@@ -107,7 +128,7 @@ internal object SystemServerConfigCache {
                     .resolveAppIds(packageAppIds)
             val hidden = canonical.apps.filterValues { it.hidden }.keys
             SystemServerConfig(
-                javaTargetAppIds = javaTargets,
+                javaTargetHookMasksByAppId = javaTargetHookMasks,
                 observerAppIds = observers,
                 hiddenPackages = hidden,
                 debug = canonical.debug,

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/TargetPickerData.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/TargetPickerData.kt
@@ -1,0 +1,102 @@
+package dev.okhsunrog.vpnhide
+
+internal enum class TargetListSortMode {
+    ConfiguredFirst,
+    Alphabetical,
+}
+
+internal enum class TargetListGroup {
+    Configured,
+    OtherApps,
+}
+
+internal data class TargetListSection<T : TargetEntry>(
+    val group: TargetListGroup?,
+    val entries: List<T>,
+)
+
+internal fun <T : TargetEntry> visibleTargetEntries(
+    entries: List<T>,
+    searchQuery: String,
+    showSystem: Boolean,
+    showRussianOnly: Boolean,
+    showConfiguredOnly: Boolean,
+    sortMode: TargetListSortMode,
+): List<T> {
+    val query = searchQuery.trim().lowercase()
+    return entries
+        .filter { app ->
+            (showSystem || !app.isSystem || app.anySelected) &&
+                (!showRussianOnly || isRussianApp(app.packageName, app.label)) &&
+                (!showConfiguredOnly || app.anySelected) &&
+                (
+                    query.isEmpty() ||
+                        app.label.lowercase().contains(query) ||
+                        app.packageName.lowercase().contains(query)
+                )
+        }.sortedWith(targetEntryComparator(sortMode))
+}
+
+internal fun <T : TargetEntry> targetListSections(
+    entries: List<T>,
+    sortMode: TargetListSortMode,
+): List<TargetListSection<T>> {
+    if (sortMode == TargetListSortMode.Alphabetical) {
+        return listOf(TargetListSection(group = null, entries = entries))
+    }
+
+    return listOf(
+        TargetListSection(
+            group = TargetListGroup.Configured,
+            entries = entries.filter { it.anySelected },
+        ),
+        TargetListSection(
+            group = TargetListGroup.OtherApps,
+            entries = entries.filterNot { it.anySelected },
+        ),
+    ).filter { it.entries.isNotEmpty() }
+}
+
+internal fun <T : TargetEntry> targetListIndexLabels(
+    sections: List<TargetListSection<T>>,
+    hasHelpItem: Boolean,
+): List<String?> =
+    buildList {
+        if (hasHelpItem) add(null)
+        sections.forEach { section ->
+            if (section.group != null) add(null)
+            section.entries.forEach { add(it.label) }
+        }
+    }
+
+internal fun firstVisibleTargetLabel(
+    indexLabels: List<String?>,
+    firstVisibleItemIndex: Int,
+): String {
+    indexLabels
+        .drop(firstVisibleItemIndex.coerceAtLeast(0))
+        .firstOrNull { it != null }
+        ?.let { return it.firstOrNull()?.uppercase() ?: "" }
+
+    return indexLabels
+        .take(firstVisibleItemIndex.coerceAtMost(indexLabels.size))
+        .lastOrNull { it != null }
+        ?.firstOrNull()
+        ?.uppercase() ?: ""
+}
+
+private fun <T : TargetEntry> targetEntryComparator(sortMode: TargetListSortMode): Comparator<T> =
+    when (sortMode) {
+        TargetListSortMode.ConfiguredFirst -> {
+            compareBy<T> { if (it.anySelected) 0 else 1 }
+                .then(labelComparator())
+        }
+
+        TargetListSortMode.Alphabetical -> {
+            labelComparator()
+        }
+    }
+
+private fun <T : TargetEntry> labelComparator(): Comparator<T> =
+    compareBy<T, String>(String.CASE_INSENSITIVE_ORDER) { it.label }
+        .thenBy { it.packageName }

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/TargetPickerScaffold.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/TargetPickerScaffold.kt
@@ -129,7 +129,7 @@ internal fun <T : TargetEntry> TargetPickerScreen(
     modifier: Modifier,
     helpPrefKey: String,
     helpTitle: String,
-    help: @Composable () -> Unit,
+    help: @Composable (TargetsSnapshot) -> Unit,
     merge: (apps: List<AppSummary>, targets: TargetsSnapshot, selfPkg: String) -> MergeResult<T>,
     countText: (entries: List<T>, resources: Resources) -> String,
     buildSaveCommand: (entries: List<T>, ctx: SaveContext) -> String,
@@ -238,10 +238,12 @@ internal fun <T : TargetEntry> TargetPickerScreen(
                     state = listState,
                     modifier = Modifier.fillMaxSize(),
                 ) {
-                    item {
-                        Box(modifier = Modifier.padding(horizontal = 12.dp, vertical = 8.dp)) {
-                            HelpAccordion(prefKey = helpPrefKey, title = helpTitle) {
-                                help()
+                    if (currentTargets != null) {
+                        item {
+                            Box(modifier = Modifier.padding(horizontal = 12.dp, vertical = 8.dp)) {
+                                HelpAccordion(prefKey = helpPrefKey, title = helpTitle) {
+                                    help(currentTargets)
+                                }
                             }
                         }
                     }

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/TargetPickerScaffold.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/TargetPickerScaffold.kt
@@ -11,8 +11,9 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxScope
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.RowScope
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.defaultMinSize
 import androidx.compose.foundation.layout.fillMaxHeight
@@ -407,6 +408,7 @@ internal fun BoxScope.AppListScrollbar(
  * package name, and a chip strip. The per-screen `chips` slot and the
  * row-level click behaviour (passed via [modifier]) are all that differ.
  */
+@OptIn(ExperimentalLayoutApi::class)
 @Composable
 internal fun TargetRowShell(
     label: String,
@@ -415,7 +417,7 @@ internal fun TargetRowShell(
     userIds: List<Int>,
     userNames: Map<Int, String>,
     modifier: Modifier = Modifier,
-    chips: @Composable RowScope.() -> Unit,
+    chips: @Composable () -> Unit,
 ) {
     Row(
         modifier =
@@ -446,7 +448,10 @@ internal fun TargetRowShell(
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
             )
             Spacer(Modifier.height(4.dp))
-            Row(horizontalArrangement = Arrangement.spacedBy(6.dp)) {
+            FlowRow(
+                horizontalArrangement = Arrangement.spacedBy(6.dp),
+                verticalArrangement = Arrangement.spacedBy(6.dp),
+            ) {
                 chips()
             }
         }

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/TargetPickerScaffold.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/TargetPickerScaffold.kt
@@ -106,7 +106,7 @@ internal data class SaveContext(
 /**
  * Shared scaffold for the three Protection picker screens. Owns all the
  * machinery they had copy-pasted: the cached-apps / targets subscription,
- * the dirty-guarded merge, search+system+russian filtering, the alphabetical
+ * the dirty-guarded merge, search/system/Russian/configured filtering, the alphabetical
  * fast-scrollbar, the bottom save bar, the snackbar, and the save lifecycle
  * (including the exit-code → message mapping). Screens supply only what is
  * genuinely screen-specific via the parameters below.
@@ -126,6 +126,8 @@ internal fun <T : TargetEntry> TargetPickerScreen(
     searchQuery: String,
     showSystem: Boolean,
     showRussianOnly: Boolean,
+    showConfiguredOnly: Boolean,
+    sortMode: TargetListSortMode,
     modifier: Modifier,
     helpPrefKey: String,
     helpTitle: String,
@@ -207,15 +209,18 @@ internal fun <T : TargetEntry> TargetPickerScreen(
         }
     }
 
-    val filteredApps =
-        remember(allApps, searchQuery, showSystem, showRussianOnly) {
-            val q = searchQuery.trim().lowercase()
-            allApps.filter { app ->
-                (showSystem || !app.isSystem || app.anySelected) &&
-                    (!showRussianOnly || isRussianApp(app.packageName, app.label)) &&
-                    (q.isEmpty() || app.label.lowercase().contains(q) || app.packageName.lowercase().contains(q))
-            }
+    val visibleApps =
+        remember(allApps, searchQuery, showSystem, showRussianOnly, showConfiguredOnly, sortMode) {
+            visibleTargetEntries(
+                entries = allApps,
+                searchQuery = searchQuery,
+                showSystem = showSystem,
+                showRussianOnly = showRussianOnly,
+                showConfiguredOnly = showConfiguredOnly,
+                sortMode = sortMode,
+            )
         }
+    val visibleSections = remember(visibleApps, sortMode) { targetListSections(visibleApps, sortMode) }
 
     val onChange: (T) -> Unit = { updated ->
         allApps = allApps.map { if (it.packageName == updated.packageName) updated else it }
@@ -233,13 +238,17 @@ internal fun <T : TargetEntry> TargetPickerScreen(
         } else {
             val listState = rememberLazyListState()
             val currentTargets = targets
+            val indexLabels =
+                remember(visibleSections, currentTargets) {
+                    targetListIndexLabels(visibleSections, hasHelpItem = currentTargets != null)
+                }
             Box(modifier = Modifier.weight(1f)) {
                 LazyColumn(
                     state = listState,
                     modifier = Modifier.fillMaxSize(),
                 ) {
                     if (currentTargets != null) {
-                        item {
+                        item(key = "help") {
                             Box(modifier = Modifier.padding(horizontal = 12.dp, vertical = 8.dp)) {
                                 HelpAccordion(prefKey = helpPrefKey, title = helpTitle) {
                                     help(currentTargets)
@@ -247,20 +256,23 @@ internal fun <T : TargetEntry> TargetPickerScreen(
                             }
                         }
                     }
-                    items(filteredApps, key = { it.packageName }) { app ->
-                        if (currentTargets != null) {
-                            row(app, userNames, currentTargets, onChange)
+                    visibleSections.forEach { section ->
+                        section.group?.let { group ->
+                            item(key = "group_${group.name}") {
+                                TargetGroupHeader(group = group, count = section.entries.size)
+                            }
+                        }
+                        items(section.entries, key = { it.packageName }) { app ->
+                            if (currentTargets != null) {
+                                row(app, userNames, currentTargets, onChange)
+                            }
                         }
                     }
                 }
                 AppListScrollbar(
                     listState = listState,
                     firstVisibleLabel = {
-                        filteredApps
-                            .getOrNull(listState.firstVisibleItemIndex)
-                            ?.label
-                            ?.firstOrNull()
-                            ?.uppercase() ?: ""
+                        firstVisibleTargetLabel(indexLabels, listState.firstVisibleItemIndex)
                     },
                 )
             }
@@ -333,6 +345,28 @@ internal fun <T : TargetEntry> TargetPickerScreen(
             saving = false
         }
     }
+}
+
+@Composable
+private fun TargetGroupHeader(
+    group: TargetListGroup,
+    count: Int,
+) {
+    val title =
+        when (group) {
+            TargetListGroup.Configured -> stringResource(R.string.target_group_configured)
+            TargetListGroup.OtherApps -> stringResource(R.string.target_group_other_apps)
+        }
+    Text(
+        text = stringResource(R.string.target_group_header, title, count),
+        style = MaterialTheme.typography.labelLarge,
+        color = MaterialTheme.colorScheme.primary,
+        fontWeight = FontWeight.SemiBold,
+        modifier =
+            Modifier
+                .fillMaxWidth()
+                .padding(start = 16.dp, top = 14.dp, end = 16.dp, bottom = 6.dp),
+    )
 }
 
 /**

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/TargetsCache.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/TargetsCache.kt
@@ -36,6 +36,7 @@ internal data class TargetsSnapshot(
     val uidToPkg: Map<Int, String>,
     val canonicalConfig: CanonicalConfig?,
     val apatchSuperkeySaved: Boolean = false,
+    val activeNativeBackendId: NativeBackendId? = null,
 ) {
     /** True if any native backend is installed (kmod / KPM / Zygisk). The
      * picker's "N" toggle is meaningful only when at least one is present. */
@@ -122,6 +123,7 @@ internal fun parseTargetsSnapshot(rootSnapshot: RootSnapshot): TargetsSnapshot {
     }
 
     fun uidsFor(pkgs: Set<String>): Set<Int> = pkgs.flatMap { pkgToUids[it].orEmpty() }.toSet()
+    val activeNativeBackendId = detectActiveNativeBackend(sections)
 
     if (canonical != null) {
         val javaTargets = canonical.apps.filterValues { it.java }.keys
@@ -144,6 +146,7 @@ internal fun parseTargetsSnapshot(rootSnapshot: RootSnapshot): TargetsSnapshot {
             uidToPkg = uidToPkg,
             canonicalConfig = canonical,
             apatchSuperkeySaved = sections["superkey_saved"]?.trim() == "1",
+            activeNativeBackendId = activeNativeBackendId,
         )
     }
 
@@ -164,5 +167,23 @@ internal fun parseTargetsSnapshot(rootSnapshot: RootSnapshot): TargetsSnapshot {
         uidToPkg = uidToPkg,
         canonicalConfig = null,
         apatchSuperkeySaved = sections["superkey_saved"]?.trim() == "1",
+        activeNativeBackendId = activeNativeBackendId,
     )
+}
+
+private fun detectActiveNativeBackend(sections: Map<String, String>): NativeBackendId? {
+    val currentBootId = sections["current_boot_id"].orEmpty()
+    val ordered =
+        listOf(
+            NativeBackendId.Kmod to detectKmodModule(sections, APP_PACKAGE_NAME),
+            NativeBackendId.Kpm to detectKpmModule(sections, APP_PACKAGE_NAME, currentBootId),
+            NativeBackendId.Zygisk to
+                detectZygiskModule(
+                    sections = sections,
+                    zygiskStatusRaw = sections["zygisk_status"].orEmpty(),
+                    selfPkg = APP_PACKAGE_NAME,
+                    currentBootId = currentBootId,
+                ),
+        )
+    return ordered.firstOrNull { moduleActive(it.second) }?.first
 }

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/settings/AppSettings.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/settings/AppSettings.kt
@@ -43,6 +43,8 @@ data class AppSettings(
     val animationsEnabled: Boolean = true,
     /** Subtle haptic feedback on taps/toggles. */
     val hapticsEnabled: Boolean = true,
+    /** Use full role labels in the unified Protection picker instead of single-letter chips. */
+    val fullProtectionRoleLabels: Boolean = false,
     /** Whether the user has opened Settings at least once (gates the gear hint). */
     val settingsHintSeen: Boolean = false,
 ) {

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/settings/SettingsInteractor.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/settings/SettingsInteractor.kt
@@ -38,6 +38,8 @@ interface SettingsInteractor {
 
     fun setHapticsEnabled(value: Boolean)
 
+    fun setFullProtectionRoleLabels(value: Boolean)
+
     fun setSettingsHintSeen(value: Boolean)
 }
 
@@ -66,6 +68,8 @@ class RepositorySettingsInteractor(
     override fun setAnimationsEnabled(value: Boolean) = launch { repository.setAnimationsEnabled(value) }
 
     override fun setHapticsEnabled(value: Boolean) = launch { repository.setHapticsEnabled(value) }
+
+    override fun setFullProtectionRoleLabels(value: Boolean) = launch { repository.setFullProtectionRoleLabels(value) }
 
     override fun setSettingsHintSeen(value: Boolean) = launch { repository.setSettingsHintSeen(value) }
 

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/settings/SettingsRepository.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/settings/SettingsRepository.kt
@@ -34,6 +34,7 @@ class SettingsRepository(
         val CONTAINER_SHADOWS = booleanPreferencesKey("container_shadows")
         val ANIMATIONS = booleanPreferencesKey("animations_enabled")
         val HAPTICS = booleanPreferencesKey("haptics_enabled")
+        val FULL_PROTECTION_ROLE_LABELS = booleanPreferencesKey("full_protection_role_labels")
         val SETTINGS_HINT_SEEN = booleanPreferencesKey("settings_hint_seen")
     }
 
@@ -50,6 +51,8 @@ class SettingsRepository(
                 drawContainerShadows = p[Keys.CONTAINER_SHADOWS] ?: defaults.drawContainerShadows,
                 animationsEnabled = p[Keys.ANIMATIONS] ?: defaults.animationsEnabled,
                 hapticsEnabled = p[Keys.HAPTICS] ?: defaults.hapticsEnabled,
+                fullProtectionRoleLabels =
+                    p[Keys.FULL_PROTECTION_ROLE_LABELS] ?: defaults.fullProtectionRoleLabels,
                 settingsHintSeen = p[Keys.SETTINGS_HINT_SEEN] ?: defaults.settingsHintSeen,
             )
         }
@@ -71,6 +74,8 @@ class SettingsRepository(
     suspend fun setAnimationsEnabled(value: Boolean) = edit { it[Keys.ANIMATIONS] = value }
 
     suspend fun setHapticsEnabled(value: Boolean) = edit { it[Keys.HAPTICS] = value }
+
+    suspend fun setFullProtectionRoleLabels(value: Boolean) = edit { it[Keys.FULL_PROTECTION_ROLE_LABELS] = value }
 
     suspend fun setSettingsHintSeen(value: Boolean) = edit { it[Keys.SETTINGS_HINT_SEEN] = value }
 

--- a/lsposed/app/src/main/res/values-ru/strings.xml
+++ b/lsposed/app/src/main/res/values-ru/strings.xml
@@ -34,6 +34,7 @@
     <string name="filter_show_system">Показать системные приложения</string>
     <string name="filter_russian_only">Только российские</string>
     <string name="apps_help_title">Как это работает</string>
+    <string name="java_hooks_title">Java-хуки</string>
     <string name="native_hooks_title">Нативные хуки</string>
     <string name="apps_hint_roles">Нажмите чип, чтобы переключить роль для приложения, или нажмите на строку — переключатся все сразу. J = LSPosed (скрытие на уровне Java). N = нативный бэкенд (скрытие на уровне ядра через kmod/KPM или Zygisk). A = скрытие приложений (это приложение видит очищенный список пакетов). P = блокировать этому приложению доступ к localhost-портам. N и P показываются только когда установлен нативный бэкенд / модуль портов.</string>
     <string name="apps_hint_restart_target">После Save: J (LSPosed) и нативный бэкенд на уровне ядра (kmod/KPM) применяются к цели мгновенно — рестарт не нужен. Если ваш нативный бэкенд — Zygisk, или вы изменили P (порты), целевое приложение нужно force-stop\'нуть и открыть заново, чтобы изменение для него вступило в силу.</string>
@@ -142,7 +143,7 @@
     <string name="dashboard_issue_kmod_capable_but_zygisk">Ваше ядро поддерживает модуль ядра — он работает в пространстве ядра и невидим для анти-тампер проверок. Zygisk тоже работает, но его хуки обнаруживаются банковскими и платёжными приложениями, так что Z для них придётся вручную держать выключенным. Установите %1$s и удалите Zygisk-модуль.</string>
     <string name="dashboard_issue_native_conflict_kernel">Модуль ядра (.ko) и KPM установлены одновременно. Они хукают одни и те же функции ядра, и работа обоих может намертво подвесить устройство. Оставьте только один — удалите либо модуль ядра, либо KPM.</string>
     <string name="dashboard_issue_multiple_native">Установлено больше одного нативного бэкенда. Активным может быть только один (приоритет: модуль ядра, затем KPM, затем Zygisk), остальные простаивают. Удалите неиспользуемые, чтобы не захламлять систему.</string>
-    <string name="dashboard_issue_debug_logging_on">Отладочные логи включены. VPN Hide пишет подробные строки в logcat, которые может прочитать любой с root-доступом. Выключите переключатель в Настройки → Диагностика после сбора багрепорта.</string>
+    <string name="dashboard_issue_debug_logging_on">Отладочные логи включены. VPN Hide пишет подробные строки в logcat, которые может прочитать любой с root-доступом. Выключите переключатель в Настройки → Отладка после сбора багрепорта.</string>
     <string name="dashboard_issue_selinux_permissive">SELinux в режиме Permissive. Шесть векторов детекции, которые VPN Hide рассчитывает на блокировку ядром (RTM_GETROUTE, /proc/net/{tcp,udp,dev,fib_trie}, /sys/class/net), стали доступны целевым приложениям. Выполните `setenforce 1` и разберитесь, что его переключило.</string>
     <string name="dashboard_issue_self_multi_profile">VPN Hide установлен в %1$d профилях. Значимая копия — в основном профиле: LSPosed хукает system_server, а он запущен только в основном профиле; picker там уже видит приложения из всех профилей и применяет фильтры ко всем. Копии в дополнительных профилях избыточны и конкурируют за Save в общий конфиг. Удалите VPN Hide из рабочего профиля / Second Space / других дополнительных профилей.</string>
     <string name="dashboard_issue_no_native">Нативный модуль не установлен. Установите kmod или zygisk для полной защиты.</string>
@@ -174,7 +175,7 @@
     <string name="dashboard_issue_kmod_wrong_variant">Неправильный вариант модуля ядра: установлен %1$s, вашему ядру нужен %2$s. Удалите текущий kmod и установите %3$s из последнего релиза.</string>
     <string name="dashboard_issue_kmod_unknown_variant">Модуль ядра установлен, но не загружается, и в zip не указано, под какой GKI-вариант он собран. Переустановите %1$s из последнего релиза, чтобы убедиться, что он подходит вашему ядру.</string>
     <string name="dashboard_issue_kmod_ambiguous_try_alternative">Модуль ядра %1$s не загрузился при текущей загрузке. GKI-ветку вашего ядра не удаётся определить из uname -r — установите %2$s вместо него.</string>
-    <string name="dashboard_issue_kmod_load_failed">Модуль ядра не загрузился. Ошибка insmod: %1$s. Чтобы приложить полный вывод insmod к багрепорту, нажмите Настройки → Диагностика → Собрать отладочный лог.</string>
+    <string name="dashboard_issue_kmod_load_failed">Модуль ядра не загрузился. Ошибка insmod: %1$s. Чтобы приложить полный вывод insmod к багрепорту, нажмите Настройки → Отладка → Собрать отладочный лог.</string>
     <string name="dashboard_issue_kmod_signature_enforced">Ваше ядро требует подписанные модули, поэтому неподписанный модуль ядра не загружается (insmod вернул EKEYREJECTED — \"Key was rejected by service\"). Magisk это не отключает. Перейдите на KernelSU Next в режиме GKI — он снимает проверку подписи, и kmod загрузится. На GKI-ядрах правильный инструмент — именно модуль ядра; не откатывайтесь на Zygisk: его хуки в процессе легко детектят банковские и антифрод-приложения.</string>
     <string name="dashboard_issue_kmod_not_supported_kernel">Для вашего ядра (%1$s) нет подходящего варианта vpnhide-kmod. Удалите модуль kmod и установите вместо него %2$s.</string>
     <string name="dashboard_issue_kprobes_missing">Ваше ядро собрано без CONFIG_KRETPROBES. Модуль ядра VPN Hide не может работать на таком ядре. Удалите kmod и используйте vpnhide-zygisk.zip.</string>
@@ -239,9 +240,12 @@
     <string name="settings_haptics_sub">Вибрация при нажатиях и переключениях</string>
     <string name="settings_animations">Анимации</string>
     <string name="settings_animations_sub">Пружинные переходы и морфинг форм</string>
+    <string name="settings_full_role_labels">Полные названия ролей</string>
+    <string name="settings_full_role_labels_sub">Показывать Java / Native / Apps / Ports вместо J / N / A / P</string>
     <string name="settings_diagnostics_section">Диагностика</string>
-    <string name="settings_diagnostics_title">Проверки защиты и отладочные логи</string>
-    <string name="settings_diagnostics_sub">Подробные проверки, запись logcat и сбор архива для багрепорта</string>
+    <string name="settings_diagnostics_title">Подробная диагностика</string>
+    <string name="settings_diagnostics_sub">Полный набор проверок защиты</string>
+    <string name="settings_debug_section">Отладка</string>
     <string name="settings_config_section">Конфигурация</string>
     <string name="settings_config_backup_title">Резервная копия конфига</string>
     <string name="settings_config_backup_sub">Сохранить или восстановить канонический JSON-конфиг</string>

--- a/lsposed/app/src/main/res/values-ru/strings.xml
+++ b/lsposed/app/src/main/res/values-ru/strings.xml
@@ -142,7 +142,7 @@
     <string name="dashboard_issue_kmod_capable_but_zygisk">Ваше ядро поддерживает модуль ядра — он работает в пространстве ядра и невидим для анти-тампер проверок. Zygisk тоже работает, но его хуки обнаруживаются банковскими и платёжными приложениями, так что Z для них придётся вручную держать выключенным. Установите %1$s и удалите Zygisk-модуль.</string>
     <string name="dashboard_issue_native_conflict_kernel">Модуль ядра (.ko) и KPM установлены одновременно. Они хукают одни и те же функции ядра, и работа обоих может намертво подвесить устройство. Оставьте только один — удалите либо модуль ядра, либо KPM.</string>
     <string name="dashboard_issue_multiple_native">Установлено больше одного нативного бэкенда. Активным может быть только один (приоритет: модуль ядра, затем KPM, затем Zygisk), остальные простаивают. Удалите неиспользуемые, чтобы не захламлять систему.</string>
-    <string name="dashboard_issue_debug_logging_on">Отладочные логи включены. VPN Hide пишет подробные строки в logcat, которые может прочитать любой с root-доступом. Выключите переключатель в Диагностике после сбора багрепорта.</string>
+    <string name="dashboard_issue_debug_logging_on">Отладочные логи включены. VPN Hide пишет подробные строки в logcat, которые может прочитать любой с root-доступом. Выключите переключатель в Настройки → Диагностика после сбора багрепорта.</string>
     <string name="dashboard_issue_selinux_permissive">SELinux в режиме Permissive. Шесть векторов детекции, которые VPN Hide рассчитывает на блокировку ядром (RTM_GETROUTE, /proc/net/{tcp,udp,dev,fib_trie}, /sys/class/net), стали доступны целевым приложениям. Выполните `setenforce 1` и разберитесь, что его переключило.</string>
     <string name="dashboard_issue_self_multi_profile">VPN Hide установлен в %1$d профилях. Значимая копия — в основном профиле: LSPosed хукает system_server, а он запущен только в основном профиле; picker там уже видит приложения из всех профилей и применяет фильтры ко всем. Копии в дополнительных профилях избыточны и конкурируют за Save в общий конфиг. Удалите VPN Hide из рабочего профиля / Second Space / других дополнительных профилей.</string>
     <string name="dashboard_issue_no_native">Нативный модуль не установлен. Установите kmod или zygisk для полной защиты.</string>
@@ -174,7 +174,7 @@
     <string name="dashboard_issue_kmod_wrong_variant">Неправильный вариант модуля ядра: установлен %1$s, вашему ядру нужен %2$s. Удалите текущий kmod и установите %3$s из последнего релиза.</string>
     <string name="dashboard_issue_kmod_unknown_variant">Модуль ядра установлен, но не загружается, и в zip не указано, под какой GKI-вариант он собран. Переустановите %1$s из последнего релиза, чтобы убедиться, что он подходит вашему ядру.</string>
     <string name="dashboard_issue_kmod_ambiguous_try_alternative">Модуль ядра %1$s не загрузился при текущей загрузке. GKI-ветку вашего ядра не удаётся определить из uname -r — установите %2$s вместо него.</string>
-    <string name="dashboard_issue_kmod_load_failed">Модуль ядра не загрузился. Ошибка insmod: %1$s. Чтобы приложить полный вывод insmod к багрепорту, нажмите Диагностика → Собрать отладочный лог.</string>
+    <string name="dashboard_issue_kmod_load_failed">Модуль ядра не загрузился. Ошибка insmod: %1$s. Чтобы приложить полный вывод insmod к багрепорту, нажмите Настройки → Диагностика → Собрать отладочный лог.</string>
     <string name="dashboard_issue_kmod_signature_enforced">Ваше ядро требует подписанные модули, поэтому неподписанный модуль ядра не загружается (insmod вернул EKEYREJECTED — \"Key was rejected by service\"). Magisk это не отключает. Перейдите на KernelSU Next в режиме GKI — он снимает проверку подписи, и kmod загрузится. На GKI-ядрах правильный инструмент — именно модуль ядра; не откатывайтесь на Zygisk: его хуки в процессе легко детектят банковские и антифрод-приложения.</string>
     <string name="dashboard_issue_kmod_not_supported_kernel">Для вашего ядра (%1$s) нет подходящего варианта vpnhide-kmod. Удалите модуль kmod и установите вместо него %2$s.</string>
     <string name="dashboard_issue_kprobes_missing">Ваше ядро собрано без CONFIG_KRETPROBES. Модуль ядра VPN Hide не может работать на таком ядре. Удалите kmod и используйте vpnhide-zygisk.zip.</string>
@@ -239,6 +239,9 @@
     <string name="settings_haptics_sub">Вибрация при нажатиях и переключениях</string>
     <string name="settings_animations">Анимации</string>
     <string name="settings_animations_sub">Пружинные переходы и морфинг форм</string>
+    <string name="settings_diagnostics_section">Диагностика</string>
+    <string name="settings_diagnostics_title">Проверки защиты и отладочные логи</string>
+    <string name="settings_diagnostics_sub">Подробные проверки, запись logcat и сбор архива для багрепорта</string>
     <string name="settings_config_section">Конфигурация</string>
     <string name="settings_config_backup_title">Резервная копия конфига</string>
     <string name="settings_config_backup_sub">Сохранить или восстановить канонический JSON-конфиг</string>

--- a/lsposed/app/src/main/res/values-ru/strings.xml
+++ b/lsposed/app/src/main/res/values-ru/strings.xml
@@ -36,9 +36,18 @@
     <string name="apps_help_title">Как это работает</string>
     <string name="java_hooks_title">Java-хуки</string>
     <string name="native_hooks_title">Нативные хуки</string>
-    <string name="apps_hint_roles">Нажмите чип, чтобы переключить роль для приложения, или нажмите на строку — переключатся все сразу. J = LSPosed (скрытие на уровне Java). N = нативный бэкенд (скрытие на уровне ядра через kmod/KPM или Zygisk). A = скрытие приложений (это приложение видит очищенный список пакетов). P = блокировать этому приложению доступ к localhost-портам. N и P показываются только когда установлен нативный бэкенд / модуль портов.</string>
-    <string name="apps_hint_restart_target">После Save: J (LSPosed) и нативный бэкенд на уровне ядра (kmod/KPM) применяются к цели мгновенно — рестарт не нужен. Если ваш нативный бэкенд — Zygisk, или вы изменили P (порты), целевое приложение нужно force-stop\'нуть и открыть заново, чтобы изменение для него вступило в силу.</string>
-    <string name="apps_hint_zygisk">Если ваш нативный бэкенд — Zygisk, банковские и платёжные приложения могут обнаружить его внутрипроцессные хуки и крашиться при включённом N — держите N выключенным для таких приложений и полагайтесь на J (LSPosed). Бэкенды kmod и KPM работают в пространстве ядра и невидимы для таких проверок.</string>
+    <string name="apps_help_role_java_body">LSPosed скрывает VPN-сигналы в Java API Android: NetworkCapabilities, NetworkInfo, LinkProperties и NetworkInterface.</string>
+    <string name="apps_help_role_native_body">Активный нативный бэкенд скрывает VPN-сигналы, видимые через kernel/libc-проверки. VPN Hide пишет один native-выбор во все установленные нативные бэкенды; работает только активный.</string>
+    <string name="apps_help_role_apps_body">Режим observer для скрытия приложений. Это приложение получает очищенный вид PackageManager и не может перечислить, resolve\'нуть или query\'нуть пакеты, которые VPN Hide пометил скрытыми.</string>
+    <string name="apps_help_role_ports_body">Режим observer для портов. Модуль портов делает localhost-проверки VPN/прокси-демонов похожими на закрытые порты для этого приложения. Роль появляется только когда установлен модуль портов.</string>
+    <string name="apps_help_hook_settings_title">Настройки хуков</string>
+    <string name="apps_help_hook_settings_body">Для Java и Native нажмите край комбинированного чипа с иконкой настроек, чтобы выбрать точные хуки для этого приложения. Чип со звёздочкой * означает, что включена только часть бэкенда.</string>
+    <string name="apps_help_apps_hiding_title">Скрытие приложений</string>
+    <string name="apps_help_apps_hiding_body">VPN Hide автоматически находит пакеты, которые нужно скрывать от observer\'ов: приложения с VPN-сервисом и опционально эвристика по имени. Ручной выбор скрытых пакетов находится в Настройки → Расширенная защита. Системные вызовы исключены, чтобы Android мог продолжать устанавливать и запускать приложения.</string>
+    <string name="apps_help_apply_title">Применение изменений</string>
+    <string name="apps_help_apply_body">После Save Java и нативные бэкенды уровня ядра (kmod/KPM) применяются сразу. Zygisk-хуки и правила портов подхватываются целевым приложением после force-stop и повторного открытия.</string>
+    <string name="apps_help_zygisk_warning_title">Zygisk и банковские приложения</string>
+    <string name="apps_help_zygisk_warning_body">Zygisk-хуки работают внутри процесса целевого приложения. Банковские и платёжные приложения могут это обнаружить при включённом Native; для таких приложений оставьте Native выключенным и по возможности используйте Java.</string>
 
     <!-- App hiding -->
     <string name="hiding_help_title">Как работает скрытие приложений</string>

--- a/lsposed/app/src/main/res/values-ru/strings.xml
+++ b/lsposed/app/src/main/res/values-ru/strings.xml
@@ -33,6 +33,12 @@
     <string name="filter_system">Системные</string>
     <string name="filter_show_system">Показать системные приложения</string>
     <string name="filter_russian_only">Только российские</string>
+    <string name="filter_configured_only">Только настроенные</string>
+    <string name="sort_configured_first">Сначала настроенные</string>
+    <string name="sort_alphabetical">По алфавиту</string>
+    <string name="target_group_configured">Настроенные</string>
+    <string name="target_group_other_apps">Остальные приложения</string>
+    <string name="target_group_header">%1$s · %2$d</string>
     <string name="apps_help_title">Как это работает</string>
     <string name="java_hooks_title">Java-хуки</string>
     <string name="native_hooks_title">Нативные хуки</string>

--- a/lsposed/app/src/main/res/values/colors.xml
+++ b/lsposed/app/src/main/res/values/colors.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<resources>
-    <color name="splash_background">#181D1F</color>
-</resources>

--- a/lsposed/app/src/main/res/values/strings.xml
+++ b/lsposed/app/src/main/res/values/strings.xml
@@ -46,9 +46,18 @@
     <string name="chip_ports_full" translatable="false">Ports</string>
     <string name="java_hooks_title">Java hooks</string>
     <string name="native_hooks_title">Native hooks</string>
-    <string name="apps_hint_roles">Tap a chip to toggle that role for an app, or tap the row to toggle all of them. J = LSPosed (Java-level hiding). N = the native backend (kernel-level hiding via kmod/KPM, or Zygisk). A = app hiding (this app sees a sanitized package list). P = block this app from reaching localhost ports. N and P only appear when a native backend / the ports module is installed.</string>
-    <string name="apps_hint_restart_target">After Save: J (LSPosed) and a kernel native backend (kmod/KPM) apply to the target immediately — no restart needed. If your native backend is Zygisk, or you changed P (ports), the target app must be force-stopped and reopened for the change to take effect for it.</string>
-    <string name="apps_hint_zygisk">If your native backend is Zygisk, banking and payment apps can detect its in-process hooks and crash when N is on for them — leave N off for such apps and rely on J (LSPosed). The kmod and KPM native backends hook in kernel space and are invisible to those checks.</string>
+    <string name="apps_help_role_java_body">LSPosed hides VPN signals exposed through Android Java APIs such as NetworkCapabilities, NetworkInfo, LinkProperties, and NetworkInterface.</string>
+    <string name="apps_help_role_native_body">The active native backend hides VPN signals visible through kernel or libc probes. VPN Hide writes one native selection to every installed native backend; only the active backend acts.</string>
+    <string name="apps_help_role_apps_body">App-hiding observer mode. This app receives a sanitized package-manager view and cannot list, resolve, or query packages that VPN Hide marks as hidden.</string>
+    <string name="apps_help_role_ports_body">Ports observer mode. The ports module makes localhost VPN/proxy daemon probes look like closed ports for this app. This role appears only when the ports module is installed.</string>
+    <string name="apps_help_hook_settings_title">Per-hook settings</string>
+    <string name="apps_help_hook_settings_body">For Java and Native, tap the settings edge of the combined chip to choose exact hooks for this app. A chip marked with * means only part of that backend is enabled.</string>
+    <string name="apps_help_apps_hiding_title">Apps hiding</string>
+    <string name="apps_help_apps_hiding_body">VPN Hide auto-detects packages that should be hidden from observers, including apps declaring a VPN service and optional name heuristics. Manual hidden-package choices live in Settings → Advanced protection. System callers stay exempt so Android can keep installing and launching apps.</string>
+    <string name="apps_help_apply_title">Applying changes</string>
+    <string name="apps_help_apply_body">After Save, Java and kernel native backends (kmod/KPM) apply immediately. Zygisk native hooks and ports rules are picked up by a target app after force-stop and reopen.</string>
+    <string name="apps_help_zygisk_warning_title">Zygisk and banking apps</string>
+    <string name="apps_help_zygisk_warning_body">Zygisk hooks run inside the target process. Banking and payment apps may detect that when Native is enabled for them; leave Native off for those apps and rely on Java where possible.</string>
 
     <!-- App hiding -->
     <string name="hiding_chip_hidden" translatable="false">H</string>

--- a/lsposed/app/src/main/res/values/strings.xml
+++ b/lsposed/app/src/main/res/values/strings.xml
@@ -35,6 +35,12 @@
     <string name="filter_system">System</string>
     <string name="filter_show_system">Show system apps</string>
     <string name="filter_russian_only">Russian apps only</string>
+    <string name="filter_configured_only">Configured only</string>
+    <string name="sort_configured_first">Configured first</string>
+    <string name="sort_alphabetical">Alphabetical</string>
+    <string name="target_group_configured">Configured</string>
+    <string name="target_group_other_apps">Other apps</string>
+    <string name="target_group_header">%1$s · %2$d</string>
     <string name="apps_help_title">How it works</string>
     <string name="chip_java" translatable="false">J</string>
     <string name="chip_native" translatable="false">N</string>

--- a/lsposed/app/src/main/res/values/strings.xml
+++ b/lsposed/app/src/main/res/values/strings.xml
@@ -178,7 +178,7 @@
     <string name="dashboard_issue_kmod_capable_but_zygisk">Your kernel supports the kernel module — it hooks in kernel space and is invisible to anti-tamper checks. Zygisk works too, but its hooks can be detected by banking and payment apps, so you\'d have to keep Z off for those apps individually. Install %1$s and uninstall the Zygisk module for cleaner coverage.</string>
     <string name="dashboard_issue_native_conflict_kernel">The kernel module (.ko) and the KPM are both installed. They hook the same kernel functions, and having both active can hard-freeze the device. Keep only one — uninstall either the kernel module or the KPM.</string>
     <string name="dashboard_issue_multiple_native">More than one native backend is installed. Only one can be active at a time (priority: kernel module, then KPM, then Zygisk); the others sit idle. Uninstall the ones you don\'t use to keep things clean.</string>
-    <string name="dashboard_issue_debug_logging_on">Debug logging is enabled. VPN Hide is writing verbose lines to logcat that anyone with root can read. Turn it off in Diagnostics after you\'ve finished collecting a bug report.</string>
+    <string name="dashboard_issue_debug_logging_on">Debug logging is enabled. VPN Hide is writing verbose lines to logcat that anyone with root can read. Turn it off in Settings → Diagnostics after you\'ve finished collecting a bug report.</string>
     <string name="dashboard_issue_selinux_permissive">SELinux is Permissive. Six detection vectors VPN Hide relies on the kernel to block (RTM_GETROUTE, /proc/net/{tcp,udp,dev,fib_trie}, /sys/class/net) are reachable to target apps. Run `setenforce 1` and investigate what disabled it.</string>
     <string name="dashboard_issue_self_multi_profile">VPN Hide is installed in %1$d profiles. The main-profile copy is the one that matters — LSPosed hooks system_server, which runs in the main profile only, and the picker there already sees apps from every profile and applies filters to all of them. Extra copies in secondary profiles are redundant and race each other\'s Saves to the shared config. Uninstall from work profile / Second Space / other secondary profiles.</string>
     <string name="dashboard_issue_no_native">No native module installed. Install kmod or zygisk for full protection.</string>
@@ -210,7 +210,7 @@
     <string name="dashboard_issue_kmod_wrong_variant">Wrong kernel module variant: installed %1$s, your kernel needs %2$s. Uninstall the current kmod and install %3$s from the latest release.</string>
     <string name="dashboard_issue_kmod_unknown_variant">Kernel module is installed but not loading, and the zip doesn\'t identify which GKI variant it was built for. Reinstall %1$s from the latest release to make sure it matches your kernel.</string>
     <string name="dashboard_issue_kmod_ambiguous_try_alternative">Kernel module %1$s failed to load this boot. Your kernel\'s GKI branch isn\'t identifiable from uname -r, so install %2$s instead.</string>
-    <string name="dashboard_issue_kmod_load_failed">Kernel module failed to load. insmod error: %1$s. Use Diagnostics → Collect debug log to attach the full boot-time insmod output to a bug report.</string>
+    <string name="dashboard_issue_kmod_load_failed">Kernel module failed to load. insmod error: %1$s. Use Settings → Diagnostics → Collect debug log to attach the full boot-time insmod output to a bug report.</string>
     <string name="dashboard_issue_kmod_signature_enforced">Your kernel enforces module signature verification, so the unsigned kernel module can\'t load (insmod failed with EKEYREJECTED — \"Key was rejected by service\"). Magisk can\'t disable this. Switch to KernelSU Next in GKI mode — it removes the enforcement and the kmod loads. On GKI kernels the kernel module is the right tool; don\'t fall back to Zygisk, whose in-process hooks are easily detected by banking and anti-fraud apps.</string>
     <string name="dashboard_issue_kmod_not_supported_kernel">Your kernel (%1$s) has no matching vpnhide-kmod variant. Uninstall the kmod module and install %2$s instead.</string>
     <string name="dashboard_issue_kprobes_missing">Your kernel was built without CONFIG_KRETPROBES. The VPN Hide kernel module cannot work on this kernel. Uninstall kmod and use vpnhide-zygisk.zip instead.</string>
@@ -283,6 +283,9 @@
     <string name="settings_haptics_sub">Vibrate on taps and toggles</string>
     <string name="settings_animations">Animations</string>
     <string name="settings_animations_sub">Springy transitions and shape morphing</string>
+    <string name="settings_diagnostics_section">Diagnostics</string>
+    <string name="settings_diagnostics_title">Protection checks and debug logs</string>
+    <string name="settings_diagnostics_sub">Run detailed checks, record logcat, and collect a bug-report bundle</string>
     <string name="settings_config_section">Configuration</string>
     <string name="settings_config_backup_title">Config backup</string>
     <string name="settings_config_backup_sub">Save or restore the canonical JSON config</string>

--- a/lsposed/app/src/main/res/values/strings.xml
+++ b/lsposed/app/src/main/res/values/strings.xml
@@ -38,9 +38,13 @@
     <string name="apps_help_title">How it works</string>
     <string name="chip_java" translatable="false">J</string>
     <string name="chip_native" translatable="false">N</string>
-    <string name="chip_native_partial" translatable="false">N*</string>
     <string name="chip_app_hiding" translatable="false">A</string>
     <string name="chip_ports" translatable="false">P</string>
+    <string name="chip_java_full" translatable="false">Java</string>
+    <string name="chip_native_full" translatable="false">Native</string>
+    <string name="chip_app_hiding_full" translatable="false">Apps</string>
+    <string name="chip_ports_full" translatable="false">Ports</string>
+    <string name="java_hooks_title">Java hooks</string>
     <string name="native_hooks_title">Native hooks</string>
     <string name="apps_hint_roles">Tap a chip to toggle that role for an app, or tap the row to toggle all of them. J = LSPosed (Java-level hiding). N = the native backend (kernel-level hiding via kmod/KPM, or Zygisk). A = app hiding (this app sees a sanitized package list). P = block this app from reaching localhost ports. N and P only appear when a native backend / the ports module is installed.</string>
     <string name="apps_hint_restart_target">After Save: J (LSPosed) and a kernel native backend (kmod/KPM) apply to the target immediately — no restart needed. If your native backend is Zygisk, or you changed P (ports), the target app must be force-stopped and reopened for the change to take effect for it.</string>
@@ -178,7 +182,7 @@
     <string name="dashboard_issue_kmod_capable_but_zygisk">Your kernel supports the kernel module — it hooks in kernel space and is invisible to anti-tamper checks. Zygisk works too, but its hooks can be detected by banking and payment apps, so you\'d have to keep Z off for those apps individually. Install %1$s and uninstall the Zygisk module for cleaner coverage.</string>
     <string name="dashboard_issue_native_conflict_kernel">The kernel module (.ko) and the KPM are both installed. They hook the same kernel functions, and having both active can hard-freeze the device. Keep only one — uninstall either the kernel module or the KPM.</string>
     <string name="dashboard_issue_multiple_native">More than one native backend is installed. Only one can be active at a time (priority: kernel module, then KPM, then Zygisk); the others sit idle. Uninstall the ones you don\'t use to keep things clean.</string>
-    <string name="dashboard_issue_debug_logging_on">Debug logging is enabled. VPN Hide is writing verbose lines to logcat that anyone with root can read. Turn it off in Settings → Diagnostics after you\'ve finished collecting a bug report.</string>
+    <string name="dashboard_issue_debug_logging_on">Debug logging is enabled. VPN Hide is writing verbose lines to logcat that anyone with root can read. Turn it off in Settings → Debugging after you\'ve finished collecting a bug report.</string>
     <string name="dashboard_issue_selinux_permissive">SELinux is Permissive. Six detection vectors VPN Hide relies on the kernel to block (RTM_GETROUTE, /proc/net/{tcp,udp,dev,fib_trie}, /sys/class/net) are reachable to target apps. Run `setenforce 1` and investigate what disabled it.</string>
     <string name="dashboard_issue_self_multi_profile">VPN Hide is installed in %1$d profiles. The main-profile copy is the one that matters — LSPosed hooks system_server, which runs in the main profile only, and the picker there already sees apps from every profile and applies filters to all of them. Extra copies in secondary profiles are redundant and race each other\'s Saves to the shared config. Uninstall from work profile / Second Space / other secondary profiles.</string>
     <string name="dashboard_issue_no_native">No native module installed. Install kmod or zygisk for full protection.</string>
@@ -210,7 +214,7 @@
     <string name="dashboard_issue_kmod_wrong_variant">Wrong kernel module variant: installed %1$s, your kernel needs %2$s. Uninstall the current kmod and install %3$s from the latest release.</string>
     <string name="dashboard_issue_kmod_unknown_variant">Kernel module is installed but not loading, and the zip doesn\'t identify which GKI variant it was built for. Reinstall %1$s from the latest release to make sure it matches your kernel.</string>
     <string name="dashboard_issue_kmod_ambiguous_try_alternative">Kernel module %1$s failed to load this boot. Your kernel\'s GKI branch isn\'t identifiable from uname -r, so install %2$s instead.</string>
-    <string name="dashboard_issue_kmod_load_failed">Kernel module failed to load. insmod error: %1$s. Use Settings → Diagnostics → Collect debug log to attach the full boot-time insmod output to a bug report.</string>
+    <string name="dashboard_issue_kmod_load_failed">Kernel module failed to load. insmod error: %1$s. Use Settings → Debugging → Collect debug log to attach the full boot-time insmod output to a bug report.</string>
     <string name="dashboard_issue_kmod_signature_enforced">Your kernel enforces module signature verification, so the unsigned kernel module can\'t load (insmod failed with EKEYREJECTED — \"Key was rejected by service\"). Magisk can\'t disable this. Switch to KernelSU Next in GKI mode — it removes the enforcement and the kmod loads. On GKI kernels the kernel module is the right tool; don\'t fall back to Zygisk, whose in-process hooks are easily detected by banking and anti-fraud apps.</string>
     <string name="dashboard_issue_kmod_not_supported_kernel">Your kernel (%1$s) has no matching vpnhide-kmod variant. Uninstall the kmod module and install %2$s instead.</string>
     <string name="dashboard_issue_kprobes_missing">Your kernel was built without CONFIG_KRETPROBES. The VPN Hide kernel module cannot work on this kernel. Uninstall kmod and use vpnhide-zygisk.zip instead.</string>
@@ -283,9 +287,12 @@
     <string name="settings_haptics_sub">Vibrate on taps and toggles</string>
     <string name="settings_animations">Animations</string>
     <string name="settings_animations_sub">Springy transitions and shape morphing</string>
+    <string name="settings_full_role_labels">Full role labels</string>
+    <string name="settings_full_role_labels_sub">Show Java / Native / Apps / Ports instead of J / N / A / P</string>
     <string name="settings_diagnostics_section">Diagnostics</string>
-    <string name="settings_diagnostics_title">Protection checks and debug logs</string>
-    <string name="settings_diagnostics_sub">Run detailed checks, record logcat, and collect a bug-report bundle</string>
+    <string name="settings_diagnostics_title">Detailed diagnostics</string>
+    <string name="settings_diagnostics_sub">Run the full protection check suite</string>
+    <string name="settings_debug_section">Debugging</string>
     <string name="settings_config_section">Configuration</string>
     <string name="settings_config_backup_title">Config backup</string>
     <string name="settings_config_backup_sub">Save or restore the canonical JSON config</string>

--- a/lsposed/app/src/main/res/values/themes.xml
+++ b/lsposed/app/src/main/res/values/themes.xml
@@ -1,10 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <style name="Theme.VpnHide.Splash" parent="Theme.SplashScreen">
-        <item name="windowSplashScreenBackground">@color/splash_background</item>
-        <item name="windowSplashScreenAnimatedIcon">@mipmap/ic_launcher</item>
-        <item name="postSplashScreenTheme">@style/Theme.VpnHide</item>
-    </style>
-
     <style name="Theme.VpnHide" parent="@android:style/Theme.DeviceDefault.NoActionBar" />
 </resources>

--- a/lsposed/app/src/test/kotlin/dev/okhsunrog/vpnhide/AppPickerDataTest.kt
+++ b/lsposed/app/src/test/kotlin/dev/okhsunrog/vpnhide/AppPickerDataTest.kt
@@ -49,7 +49,14 @@ class AppPickerDataTest {
     fun `save preserves selected apps missing from current picker list`() {
         val snapshot =
             snapshotWithCanonical(
-                "com.frozen" to CanonicalApp(java = true, native = NativeRole.All, appHiding = true, ports = true),
+                "com.frozen" to
+                    CanonicalApp(
+                        java = true,
+                        javaHooks = listOf("lsposed_network_capabilities"),
+                        native = NativeRole.All,
+                        appHiding = true,
+                        ports = true,
+                    ),
             )
 
         val cfg =
@@ -65,6 +72,7 @@ class AppPickerDataTest {
 
         val frozen = cfg.apps.getValue("com.frozen")
         assertEquals(true, frozen.java)
+        assertEquals(listOf("lsposed_network_capabilities"), frozen.javaHooks)
         assertEquals(NativeRole.All, frozen.native)
         assertEquals(true, frozen.appHiding)
         assertEquals(true, frozen.ports)
@@ -116,6 +124,53 @@ class AppPickerDataTest {
 
         assertEquals(customNative, cfg.apps.getValue("com.visible").native)
         assertEquals(customNative, cfg.apps.getValue("com.frozen").native)
+    }
+
+    @Test
+    fun `save preserves custom java hooks for missing and still selected apps`() {
+        val customJava = listOf("lsposed_network_capabilities")
+        val snapshot =
+            snapshotWithCanonical(
+                "com.visible" to CanonicalApp(java = true, javaHooks = customJava),
+                "com.frozen" to CanonicalApp(java = true, javaHooks = customJava),
+            )
+
+        val cfg =
+            buildCanonicalConfigForAppPickerSave(
+                debug = false,
+                selfPkg = self,
+                selections =
+                    listOf(
+                        AppRoleSelection(packageName = "com.visible", java = true, javaHooks = customJava),
+                    ),
+                snapshot = snapshot,
+            )
+
+        assertEquals(customJava, cfg.apps.getValue("com.visible").javaHooks)
+        assertEquals(customJava, cfg.apps.getValue("com.frozen").javaHooks)
+    }
+
+    @Test
+    fun `save converts enabled java role without hook list to all hooks`() {
+        val cfg =
+            buildCanonicalConfigForAppPickerSave(
+                debug = false,
+                selfPkg = self,
+                selections =
+                    listOf(
+                        AppRoleSelection(packageName = "com.visible", java = true),
+                    ),
+                snapshot =
+                    snapshotWithCanonical(
+                        "com.visible" to
+                            CanonicalApp(
+                                java = true,
+                                javaHooks = listOf("lsposed_network_capabilities"),
+                            ),
+                    ),
+            )
+
+        assertEquals(null, cfg.apps.getValue("com.visible").javaHooks)
     }
 
     @Test

--- a/lsposed/app/src/test/kotlin/dev/okhsunrog/vpnhide/RootSnapshotCacheTest.kt
+++ b/lsposed/app/src/test/kotlin/dev/okhsunrog/vpnhide/RootSnapshotCacheTest.kt
@@ -76,6 +76,7 @@ class RootSnapshotCacheTest {
         assertTrue(command.contains("[ -s $SUPERKEY_FILE ] && echo 1 || echo 0"))
         assertTrue(command.contains("cat $PROC_CTL"))
         assertTrue(command.contains("$KPM_ACTIVATOR state"))
+        assertTrue(command.contains(ZYGISK_STATUS_FILE))
         assertTrue(command.contains("probe_ok=1"))
         assertTrue(command.contains("iptables -C OUTPUT -j vpnhide_out"))
         assertTrue(command.contains("ip6tables -C OUTPUT -j vpnhide_out6"))

--- a/lsposed/app/src/test/kotlin/dev/okhsunrog/vpnhide/StatisticsDataTest.kt
+++ b/lsposed/app/src/test/kotlin/dev/okhsunrog/vpnhide/StatisticsDataTest.kt
@@ -2,6 +2,7 @@ package dev.okhsunrog.vpnhide
 
 import dev.okhsunrog.vpnhide.generated.HookIds
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
 import org.junit.Test
 
@@ -59,6 +60,24 @@ class StatisticsDataTest {
         assertEquals(99L, kmod.rows[1].hookId)
         assertNull(kmod.rows[1].hook)
 
+        assertFalse(state.backends.any { it.backend == HookIds.Backend.KPM })
+
+        val lsposed = state.backends.single { it.backend == HookIds.Backend.LSPOSED }
+        assertEquals("1.2.3", lsposed.metadata["version"])
+        assertEquals(HookIds.Hook.LSPOSED_NETWORK_CAPABILITIES, lsposed.rows.single().hook)
+    }
+
+    @Test
+    fun `shows kpm native statistics when kmod is not active`() {
+        val state =
+            buildStatisticsState(
+                RootSnapshot(
+                    statisticsFixtureSnapshot()
+                        .sections + ("kmod_state" to ""),
+                ),
+            )
+
+        assertFalse(state.backends.any { it.backend == HookIds.Backend.KMOD })
         val kpm = state.backends.single { it.backend == HookIds.Backend.KPM }
         assertEquals(
             HookIds.Backend.KPM.id
@@ -72,10 +91,6 @@ class StatisticsDataTest {
                 .packageNames
                 .single(),
         )
-
-        val lsposed = state.backends.single { it.backend == HookIds.Backend.LSPOSED }
-        assertEquals("1.2.3", lsposed.metadata["version"])
-        assertEquals(HookIds.Hook.LSPOSED_NETWORK_CAPABILITIES, lsposed.rows.single().hook)
     }
 
     @Test

--- a/lsposed/app/src/test/kotlin/dev/okhsunrog/vpnhide/StorageConfigTest.kt
+++ b/lsposed/app/src/test/kotlin/dev/okhsunrog/vpnhide/StorageConfigTest.kt
@@ -7,7 +7,7 @@ import java.io.File
 
 class StorageConfigTest {
     @Test
-    fun `canonical config parses roles settings and native hook lists`() {
+    fun `canonical config parses roles settings and hook lists`() {
         val cfg =
             requireNotNull(
                 parseCanonicalConfig(
@@ -16,7 +16,12 @@ class StorageConfigTest {
                       "version": 1,
                       "debug": true,
                       "apps": {
-                        "com.bank": { "java": true, "native": ["sock_ioctl"], "appHiding": false, "ports": true },
+                        "com.bank": {
+                          "java": ["lsposed_network_capabilities"],
+                          "native": ["sock_ioctl"],
+                          "appHiding": false,
+                          "ports": true
+                        },
                         "dev.okhsunrog.vpnhide": { "hidden": true }
                       },
                       "settings": {
@@ -40,6 +45,8 @@ class StorageConfigTest {
             ),
             cfg.settings,
         )
+        assertTrue(cfg.apps.getValue("com.bank").java)
+        assertEquals(listOf("lsposed_network_capabilities"), cfg.apps.getValue("com.bank").javaHooks)
         assertEquals(NativeRole(enabled = true, hooks = listOf("sock_ioctl")), cfg.apps.getValue("com.bank").native)
         assertTrue(cfg.apps.getValue("dev.okhsunrog.vpnhide").hidden)
     }
@@ -110,6 +117,35 @@ class StorageConfigTest {
     }
 
     @Test
+    fun `builder preserves an existing java hook list when role remains enabled`() {
+        val existing =
+            CanonicalConfig(
+                apps =
+                    mapOf(
+                        "com.bank" to
+                            CanonicalApp(
+                                java = true,
+                                javaHooks = listOf("lsposed_network_capabilities"),
+                            ),
+                    ),
+            )
+
+        val cfg =
+            buildCanonicalConfig(
+                debug = false,
+                javaPkgs = setOf("com.bank", "com.new"),
+                nativePkgs = emptySet(),
+                hiddenPkgs = emptySet(),
+                observerPkgs = emptySet(),
+                portsPkgs = emptySet(),
+                existing = existing,
+            )
+
+        assertEquals(listOf("lsposed_network_capabilities"), cfg.apps.getValue("com.bank").javaHooks)
+        assertEquals(null, cfg.apps.getValue("com.new").javaHooks)
+    }
+
+    @Test
     fun `canonical JSON is deterministic and round trips through parser`() {
         val cfg =
             buildCanonicalConfig(
@@ -144,6 +180,29 @@ class StorageConfigTest {
     }
 
     @Test
+    fun `self target merge forces full hook roles`() {
+        val cfg =
+            CanonicalConfig(
+                apps =
+                    mapOf(
+                        "dev.okhsunrog.vpnhide" to
+                            CanonicalApp(
+                                java = true,
+                                javaHooks = listOf("lsposed_network_capabilities"),
+                                native = NativeRole(enabled = true, hooks = listOf("sock_ioctl")),
+                            ),
+                    ),
+            )
+
+        val updated = canonicalConfigWithSelfTarget(cfg, "dev.okhsunrog.vpnhide")
+
+        assertEquals(
+            CanonicalApp(java = true, native = NativeRole.All, hidden = true),
+            updated.apps.getValue("dev.okhsunrog.vpnhide"),
+        )
+    }
+
+    @Test
     fun `import parser accepts canonical json and adds self target`() {
         val cfg =
             requireNotNull(
@@ -168,6 +227,23 @@ class StorageConfigTest {
         assertEquals(
             CanonicalApp(java = true, native = NativeRole.All, hidden = true),
             cfg.apps.getValue("dev.okhsunrog.vpnhide"),
+        )
+    }
+
+    @Test
+    fun `hook role masks honor partial java hook selections`() {
+        val mask =
+            hookSelectionMask(
+                enabled = true,
+                hooks = listOf("lsposed_network_capabilities", "unknown_hook"),
+                entries = LsposedJavaHookEntries,
+            )
+
+        assertEquals(1L shl 11, mask)
+        assertEquals(
+            (1L shl 10) or (1L shl 11) or (1L shl 12) or (1L shl 13) or
+                (1L shl 14) or (1L shl 15) or (1L shl 16),
+            hookSelectionMask(enabled = true, hooks = null, entries = LsposedJavaHookEntries),
         )
     }
 

--- a/lsposed/app/src/test/kotlin/dev/okhsunrog/vpnhide/TargetPickerDataTest.kt
+++ b/lsposed/app/src/test/kotlin/dev/okhsunrog/vpnhide/TargetPickerDataTest.kt
@@ -1,0 +1,135 @@
+package dev.okhsunrog.vpnhide
+
+import android.graphics.drawable.Drawable
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class TargetPickerDataTest {
+    @Test
+    fun `configured first keeps alphabetical order inside both groups`() {
+        val visible =
+            visibleTargetEntries(
+                entries =
+                    listOf(
+                        target("com.zed", "Zed", selected = true),
+                        target("com.alpha", "Alpha"),
+                        target("com.beta", "beta", selected = true),
+                        target("com.gamma", "Gamma"),
+                    ),
+                searchQuery = "",
+                showSystem = false,
+                showRussianOnly = false,
+                showConfiguredOnly = false,
+                sortMode = TargetListSortMode.ConfiguredFirst,
+            )
+
+        assertEquals(listOf("beta", "Zed", "Alpha", "Gamma"), visible.map { it.label })
+
+        val sections = targetListSections(visible, TargetListSortMode.ConfiguredFirst)
+        assertEquals(listOf(TargetListGroup.Configured, TargetListGroup.OtherApps), sections.map { it.group })
+        assertEquals(listOf("beta", "Zed"), sections[0].entries.map { it.label })
+        assertEquals(listOf("Alpha", "Gamma"), sections[1].entries.map { it.label })
+    }
+
+    @Test
+    fun `alphabetical sort ignores configured state`() {
+        val visible =
+            visibleTargetEntries(
+                entries =
+                    listOf(
+                        target("com.zed", "Zed", selected = true),
+                        target("com.alpha", "Alpha"),
+                        target("com.beta", "beta", selected = true),
+                    ),
+                searchQuery = "",
+                showSystem = false,
+                showRussianOnly = false,
+                showConfiguredOnly = false,
+                sortMode = TargetListSortMode.Alphabetical,
+            )
+
+        assertEquals(listOf("Alpha", "beta", "Zed"), visible.map { it.label })
+        assertEquals(null, targetListSections(visible, TargetListSortMode.Alphabetical).single().group)
+    }
+
+    @Test
+    fun `configured only filters unselected apps`() {
+        val visible =
+            visibleTargetEntries(
+                entries =
+                    listOf(
+                        target("com.alpha", "Alpha"),
+                        target("com.beta", "Beta", selected = true),
+                        target("com.gamma", "Gamma"),
+                    ),
+                searchQuery = "",
+                showSystem = false,
+                showRussianOnly = false,
+                showConfiguredOnly = true,
+                sortMode = TargetListSortMode.ConfiguredFirst,
+            )
+
+        assertEquals(listOf("Beta"), visible.map { it.label })
+        assertEquals(TargetListGroup.Configured, targetListSections(visible, TargetListSortMode.ConfiguredFirst).single().group)
+    }
+
+    @Test
+    fun `selected system apps stay visible when system apps are hidden`() {
+        val visible =
+            visibleTargetEntries(
+                entries =
+                    listOf(
+                        target("android.unselected", "Android unselected", isSystem = true),
+                        target("android.selected", "Android selected", isSystem = true, selected = true),
+                        target("com.user", "User app"),
+                    ),
+                searchQuery = "",
+                showSystem = false,
+                showRussianOnly = false,
+                showConfiguredOnly = false,
+                sortMode = TargetListSortMode.ConfiguredFirst,
+            )
+
+        assertEquals(listOf("Android selected", "User app"), visible.map { it.label })
+    }
+
+    @Test
+    fun `scrollbar label skips help and section headers`() {
+        val sections =
+            listOf(
+                TargetListSection(TargetListGroup.Configured, listOf(target("com.alpha", "Alpha", selected = true))),
+                TargetListSection(TargetListGroup.OtherApps, listOf(target("com.beta", "Beta"))),
+            )
+        val labels = targetListIndexLabels(sections, hasHelpItem = true)
+
+        assertEquals(listOf(null, null, "Alpha", null, "Beta"), labels)
+        assertEquals("A", firstVisibleTargetLabel(labels, 0))
+        assertEquals("A", firstVisibleTargetLabel(labels, 1))
+        assertEquals("B", firstVisibleTargetLabel(labels, 3))
+        assertEquals("B", firstVisibleTargetLabel(labels, 99))
+    }
+
+    private fun target(
+        packageName: String,
+        label: String,
+        selected: Boolean = false,
+        isSystem: Boolean = false,
+    ): TestTarget =
+        TestTarget(
+            packageName = packageName,
+            label = label,
+            isSystem = isSystem,
+            selected = selected,
+        )
+
+    private data class TestTarget(
+        override val packageName: String,
+        override val label: String,
+        override val isSystem: Boolean,
+        val selected: Boolean,
+    ) : TargetEntry {
+        override val icon: Drawable? = null
+        override val userIds: List<Int> = emptyList()
+        override val anySelected: Boolean get() = selected
+    }
+}

--- a/lsposed/app/src/test/kotlin/dev/okhsunrog/vpnhide/TargetsCacheTest.kt
+++ b/lsposed/app/src/test/kotlin/dev/okhsunrog/vpnhide/TargetsCacheTest.kt
@@ -91,4 +91,41 @@ class TargetsCacheTest {
         assertEquals(setOf(10123, 1010123), targets.observerUids)
         assertEquals(setOf("com.ports"), targets.portsObservers)
     }
+
+    @Test
+    fun `targets snapshot reports active zygisk only for current boot heartbeat`() {
+        val sections =
+            mapOf(
+                "kmod_module_dir" to "0",
+                "zygisk_module_dir" to "1",
+                "kpm_module_dir" to "0",
+                "ports_prop" to "",
+                "canonical_config" to "",
+                "kmod_targets" to "",
+                "zygisk_targets" to "dev.okhsunrog.vpnhide\ncom.target\n",
+                "kpm_targets" to "",
+                "lsposed_targets" to "",
+                "hidden_pkgs" to "",
+                "observer_uids" to "",
+                "ports_observers" to "",
+                "superkey_saved" to "0",
+                "pm_packages" to "",
+                "kmod_prop" to "",
+                "zygisk_prop" to "version=1.0",
+                "kpm_prop" to "",
+                "proc_exists" to "0",
+                "current_boot_id" to "boot-1",
+                "zygisk_status" to "boot_id=boot-1",
+                "kpm_load_status" to "",
+            )
+
+        assertEquals(
+            NativeBackendId.Zygisk,
+            parseTargetsSnapshot(RootSnapshot(sections)).activeNativeBackendId,
+        )
+        assertEquals(
+            null,
+            parseTargetsSnapshot(RootSnapshot(sections + ("zygisk_status" to "boot_id=old"))).activeNativeBackendId,
+        )
+    }
 }

--- a/lsposed/app/src/test/kotlin/dev/okhsunrog/vpnhide/TargetsCacheTest.kt
+++ b/lsposed/app/src/test/kotlin/dev/okhsunrog/vpnhide/TargetsCacheTest.kt
@@ -58,7 +58,7 @@ class TargetsCacheTest {
                             {
                               "version": 1,
                               "apps": {
-                                "com.java": { "java": true },
+                                "com.java": { "java": ["lsposed_network_capabilities"] },
                                 "com.native": { "native": true },
                                 "com.observer": { "appHiding": true },
                                 "com.ports": { "ports": true },
@@ -79,6 +79,13 @@ class TargetsCacheTest {
         val targets = parseTargetsSnapshot(rootSnapshot)
 
         assertEquals(setOf("com.java"), targets.lsposedTargets)
+        assertEquals(
+            listOf("lsposed_network_capabilities"),
+            targets.canonicalConfig
+                ?.apps
+                ?.get("com.java")
+                ?.javaHooks,
+        )
         assertEquals(setOf("com.native"), targets.nativeTargets)
         assertEquals(setOf("com.hidden"), targets.hiddenPkgs)
         assertEquals(setOf(10123, 1010123), targets.observerUids)

--- a/scripts/build_lib.py
+++ b/scripts/build_lib.py
@@ -41,11 +41,16 @@ def version_sort_key(name: str) -> tuple[int, ...]:
 def get_build_version(repo_root: Path | None = None) -> str:
     """Get the effective build version for vpnhide artifacts.
 
+    - VPNHIDE_BUILD_VERSION set    -> that exact value
     - HEAD on a tag vX.Y.Z        -> "X.Y.Z"          (release build)
     - N commits after tag vX.Y.Z  -> "X.Y.Z-N-gSHA"   (dev build)
     - working tree dirty          -> additional "-dirty" suffix
     - no git / no matching tag    -> falls back to VERSION file
     """
+    override = os.environ.get("VPNHIDE_BUILD_VERSION")
+    if override and override.strip():
+        return override.strip().removeprefix("v")
+
     if repo_root is None:
         repo_root = Path(__file__).resolve().parent.parent
 


### PR DESCRIPTION
## Summary
- move Diagnostics out of bottom navigation into Settings -> Detailed diagnostics, and move Debug logging / logcat / debug zip controls into Settings -> Debugging
- make Dashboard wait for the complete diagnostics check set before showing protection OK, with in-app dashboard loading instead of holding the splash screen
- add per-app Java/LSPosed hook selection, runtime per-hook LSPosed gating, combined Java/Native hook chips, and a setting for full Java / Native / Apps / Ports role labels
- rework Protection help into role cards that follow compact/full label settings, explain Apps hiding, and show the banking-app warning only when Zygisk is the active native backend
- sort the Protection app list with configured apps first by default, keep alphabetical order inside Configured / Other apps groups, and add Alphabetical / Configured only controls
- refine the Statistics tab to show only the active native backend instead of inactive kmod/KPM cards
- preserve host git-derived kmod build versions when the DDK build runs inside Docker/Podman

## Testing
- `ktlint --format "lsposed/app/src/**/*.kt"`
- `cd lsposed && ./gradlew :app:testDebugUnitTest --tests dev.okhsunrog.vpnhide.TargetPickerDataTest`
- `cd lsposed && ./gradlew :app:testDebugUnitTest`
- `cd lsposed && ./gradlew :app:detekt`
- `cd lsposed && ./gradlew :app:ktlintCheck`
- earlier validation on this PR included `:app:compileDebugKotlin`, `:app:lint`, `cpdCheck`, `:app:assembleRelease`, `python3 -m py_compile scripts/build_lib.py kmod/build.py`, `./kmod/build.py --kmi android14-6.1`, and a Pixel 8 Pro install of the previous PR build
