### PR TITLE
fix(lsposed): avoid app-hiding self-lookups

### DIFF
--- a/changelog.d/fixed-keep-apps-hidden-vpn-apps-hidden-5cf2.md
+++ b/changelog.d/fixed-keep-apps-hidden-vpn-apps-hidden-5cf2.md
@@ -1,0 +1,9 @@
+_2026-06-29_
+
+## English
+
+Keep Apps-hidden VPN apps hidden from other observers while letting them see themselves.
+
+## Русский
+
+VPN-приложения, скрытые через Apps, остаются скрытыми от других observer-приложений, но видят сами себя.

--- a/docs/detection-vectors.md
+++ b/docs/detection-vectors.md
@@ -193,7 +193,9 @@ package set in the same canonical JSON:
 - UID mapping: `getPackageUid` (→ −1), `getPackagesForUid` (filtered)
 
 System callers (UID < 10000) are always exempt so the launcher/installer keep
-working.
+working. Self-lookups are exempt too: a hidden package is not hidden from callers
+with the same appId, so a VPN app can protect itself with Apps hiding while still
+being hidden from other observer apps.
 
 ---
 

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/AppPickerData.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/AppPickerData.kt
@@ -8,18 +8,14 @@ package dev.okhsunrog.vpnhide
  * packages and auto-detected VPN apps, and always includes [selfPkg] (managed
  * invisibly, never shown in the picker).
  *
- * Hidden and app-hiding observer roles are **mutually exclusive**: a package
- * that is both crashes the framework on a self-lookup (an observer querying its
- * own PackageInfo gets a NameNotFoundException when it is also hidden). So
- * [observers] win — any package the user just marked "A" is dropped from the
- * hidden set. Self is never an observer (the picker never lists it), so it
- * always stays hidden.
+ * Hidden and app-hiding observer roles can coexist. The package-visibility hook
+ * avoids self-crashes by never hiding a package from callers with the same
+ * appId; other observers still cannot see it.
  */
 internal fun resolveHiddenPackages(
     existing: Set<String>,
-    observers: Set<String>,
     selfPkg: String,
-): List<String> = (existing.filterNot { it in observers } + selfPkg).distinct().sorted()
+): List<String> = (existing + selfPkg).distinct().sorted()
 
 internal data class AppAutoHideSignal(
     val packageName: String,
@@ -92,7 +88,6 @@ internal fun buildCanonicalConfigForAppPickerSave(
     val hiddenPkgs =
         resolveHiddenPackages(
             existing = manualHiddenPkgs,
-            observers = observerPkgs,
             selfPkg = selfPkg,
         )
 
@@ -122,11 +117,10 @@ internal fun applyAutoHiddenPackages(
     val observerPkgs = config.apps.filterValues { it.appHiding }.keys
     val manualHiddenPkgs = config.apps.filterValues { it.hidden }.keys - config.settings.autoHiddenPackages
     val autoHiddenPkgs = resolveAutoHiddenPackages(signals, config.settings, selfPkg)
-    val effectiveAutoHiddenPkgs = autoHiddenPkgs - observerPkgs
+    val effectiveAutoHiddenPkgs = autoHiddenPkgs
     val hiddenPkgs =
         resolveHiddenPackages(
             existing = manualHiddenPkgs + effectiveAutoHiddenPkgs,
-            observers = observerPkgs,
             selfPkg = selfPkg,
         )
     return buildCanonicalConfig(
@@ -160,7 +154,7 @@ internal fun updateManualHiddenPackages(
             debug = config.debug,
             javaPkgs = config.apps.filterValues { it.java }.keys,
             nativePkgs = config.apps.filterValues { it.native.enabled }.keys,
-            hiddenPkgs = resolveHiddenPackages(nextManualHidden, observerPkgs, selfPkg),
+            hiddenPkgs = resolveHiddenPackages(nextManualHidden, selfPkg),
             observerPkgs = observerPkgs,
             portsPkgs = config.apps.filterValues { it.ports }.keys,
             existing = config,

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/PackageVisibilityHooks.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/PackageVisibilityHooks.kt
@@ -39,6 +39,12 @@ internal object PackageVisibilityHooks {
     private const val IPM_LEGACY = "com.android.server.pm.PackageManagerService"
     private const val PARCELED_LIST_SLICE = "android.content.pm.ParceledListSlice"
 
+    private data class ObserverCaller(
+        val uid: Int,
+        val appId: Int,
+        val config: SystemServerConfig,
+    )
+
     @Volatile private var parceledListSliceClass: Class<*>? = null
 
     @Volatile private var fileObserver: FileObserver? = null
@@ -96,17 +102,18 @@ internal object PackageVisibilityHooks {
     //  Caller classification
     // ------------------------------------------------------------------
 
-    private fun observerCallerUid(): Int? {
+    private fun observerCaller(): ObserverCaller? {
         val uid = Binder.getCallingUid()
         // Exempt system callers: installd, shell, system_server itself,
         // LauncherApps, StatusBar, etc. all run under UID < 10000.
         if (uid < Process.FIRST_APPLICATION_UID) return null
         if (uid == Process.myUid()) return null
         val appId = SystemServerConfigCache.appId(uid)
-        return if (SystemServerConfigCache.load().observerAppIds.contains(appId)) uid else null
+        val config = SystemServerConfigCache.load()
+        return if (config.observerAppIds.contains(appId)) ObserverCaller(uid, appId, config) else null
     }
 
-    private fun loadHiddenPackages(): Set<String> = SystemServerConfigCache.load().hiddenPackages
+    private fun ObserverCaller.shouldHidePackage(packageName: String): Boolean = config.shouldHidePackageForCallerAppId(packageName, appId)
 
     private fun watchConfigFiles() {
         fileObserver =
@@ -155,9 +162,8 @@ internal object PackageVisibilityHooks {
         object : XC_MethodHook() {
             override fun afterHookedMethod(param: MethodHookParam) {
                 if (param.hasThrowable()) return
-                val callerUid = observerCallerUid() ?: return
-                val hidden = loadHiddenPackages()
-                if (hidden.isEmpty()) return
+                val caller = observerCaller() ?: return
+                if (caller.config.hiddenPackages.isEmpty()) return
 
                 val result = param.result ?: return
                 val pls = parceledListSliceClass ?: return
@@ -168,15 +174,15 @@ internal object PackageVisibilityHooks {
                 val filtered =
                     original.filter {
                         val p = pkgOf(it)
-                        p == null || p !in hidden
+                        p == null || !caller.shouldHidePackage(p)
                     }
-                val removed = original.mapNotNull { pkgOf(it)?.takeIf(hidden::contains) }
+                val removed = original.mapNotNull { pkgOf(it)?.takeIf { pkg -> caller.shouldHidePackage(pkg) } }
                 if (removed.isEmpty()) return
 
                 param.result = newListResultLike(result, filtered) ?: return
-                LsposedStats.record(callerUid, HookIds.Hook.LSPOSED_PACKAGE_VISIBILITY)
+                LsposedStats.record(caller.uid, HookIds.Hook.LSPOSED_PACKAGE_VISIBILITY)
                 HookLog.i(
-                    "VpnHide/PV: $methodName uid=$callerUid filtered ${removed.size}/${original.size} " +
+                    "VpnHide/PV: $methodName uid=${caller.uid} filtered ${removed.size}/${original.size} " +
                         "hidden=${removed.sorted()} wrapper=${result.javaClass.simpleName}",
                 )
             }
@@ -224,11 +230,11 @@ internal object PackageVisibilityHooks {
                 if (param.hasThrowable()) return
                 if (param.result == null) return
                 val pkg = param.args.firstOrNull() as? String ?: return
-                val callerUid = observerCallerUid() ?: return
-                if (pkg in loadHiddenPackages()) {
+                val caller = observerCaller() ?: return
+                if (caller.shouldHidePackage(pkg)) {
                     param.result = null
-                    LsposedStats.record(callerUid, HookIds.Hook.LSPOSED_PACKAGE_VISIBILITY)
-                    HookLog.i("VpnHide/PV: $methodName uid=$callerUid hid $pkg")
+                    LsposedStats.record(caller.uid, HookIds.Hook.LSPOSED_PACKAGE_VISIBILITY)
+                    HookLog.i("VpnHide/PV: $methodName uid=${caller.uid} hid $pkg")
                 }
             }
         }
@@ -239,11 +245,11 @@ internal object PackageVisibilityHooks {
             override fun afterHookedMethod(param: MethodHookParam) {
                 if (param.hasThrowable()) return
                 val pkg = param.args.firstOrNull() as? String ?: return
-                val callerUid = observerCallerUid() ?: return
-                if (pkg in loadHiddenPackages()) {
+                val caller = observerCaller() ?: return
+                if (caller.shouldHidePackage(pkg)) {
                     param.result = -1
-                    LsposedStats.record(callerUid, HookIds.Hook.LSPOSED_PACKAGE_VISIBILITY)
-                    HookLog.i("VpnHide/PV: getPackageUid uid=$callerUid hid $pkg")
+                    LsposedStats.record(caller.uid, HookIds.Hook.LSPOSED_PACKAGE_VISIBILITY)
+                    HookLog.i("VpnHide/PV: getPackageUid uid=${caller.uid} hid $pkg")
                 }
             }
         }
@@ -254,12 +260,12 @@ internal object PackageVisibilityHooks {
             override fun afterHookedMethod(param: MethodHookParam) {
                 if (param.hasThrowable()) return
                 val ri = param.result as? ResolveInfo ?: return
-                val callerUid = observerCallerUid() ?: return
+                val caller = observerCaller() ?: return
                 val pkg = resolveInfoPackageName(ri) ?: return
-                if (pkg in loadHiddenPackages()) {
+                if (caller.shouldHidePackage(pkg)) {
                     param.result = null
-                    LsposedStats.record(callerUid, HookIds.Hook.LSPOSED_PACKAGE_VISIBILITY)
-                    HookLog.i("VpnHide/PV: $methodName uid=$callerUid hid $pkg")
+                    LsposedStats.record(caller.uid, HookIds.Hook.LSPOSED_PACKAGE_VISIBILITY)
+                    HookLog.i("VpnHide/PV: $methodName uid=${caller.uid} hid $pkg")
                 }
             }
         }
@@ -270,17 +276,16 @@ internal object PackageVisibilityHooks {
             override fun afterHookedMethod(param: MethodHookParam) {
                 if (param.hasThrowable()) return
                 val arr = param.result as? Array<*> ?: return
-                val callerUid = observerCallerUid() ?: return
-                val hidden = loadHiddenPackages()
-                if (hidden.isEmpty()) return
-                val filtered = arr.filterIsInstance<String>().filter { it !in hidden }
+                val caller = observerCaller() ?: return
+                if (caller.config.hiddenPackages.isEmpty()) return
+                val filtered = arr.filterIsInstance<String>().filterNot { caller.shouldHidePackage(it) }
                 if (filtered.size == arr.size) return
                 param.result = if (filtered.isEmpty()) null else filtered.toTypedArray()
-                LsposedStats.record(callerUid, HookIds.Hook.LSPOSED_PACKAGE_VISIBILITY)
+                LsposedStats.record(caller.uid, HookIds.Hook.LSPOSED_PACKAGE_VISIBILITY)
                 val requestedUid = param.args.firstOrNull()
-                val removed = arr.filterIsInstance<String>().filter { it in hidden }
+                val removed = arr.filterIsInstance<String>().filter { caller.shouldHidePackage(it) }
                 HookLog.i(
-                    "VpnHide/PV: getPackagesForUid uid=$callerUid requestedUid=$requestedUid " +
+                    "VpnHide/PV: getPackagesForUid uid=${caller.uid} requestedUid=$requestedUid " +
                         "hidden=${removed.sorted()}",
                 )
             }

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/SystemServerConfigCache.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/SystemServerConfigCache.kt
@@ -8,10 +8,19 @@ internal data class SystemServerConfig(
     val javaTargetHookMasksByAppId: Map<Int, Long> = emptyMap(),
     val observerAppIds: Set<Int> = emptySet(),
     val hiddenPackages: Set<String> = emptySet(),
+    val packageAppIds: Map<String, Int> = emptyMap(),
     val debug: Boolean = false,
 ) {
     val javaTargetAppIds: Set<Int>
         get() = javaTargetHookMasksByAppId.keys
+
+    fun shouldHidePackageForCallerAppId(
+        packageName: String,
+        callerAppId: Int,
+    ): Boolean {
+        if (packageName !in hiddenPackages) return false
+        return packageAppIds[packageName] != callerAppId
+    }
 }
 
 /**
@@ -131,6 +140,7 @@ internal object SystemServerConfigCache {
                 javaTargetHookMasksByAppId = javaTargetHookMasks,
                 observerAppIds = observers,
                 hiddenPackages = hidden,
+                packageAppIds = packageAppIds,
                 debug = canonical.debug,
             )
         } catch (t: Throwable) {

--- a/lsposed/app/src/test/kotlin/dev/okhsunrog/vpnhide/AppPickerDataTest.kt
+++ b/lsposed/app/src/test/kotlin/dev/okhsunrog/vpnhide/AppPickerDataTest.kt
@@ -10,30 +10,28 @@ class AppPickerDataTest {
     fun `preserves existing hidden and always includes self`() {
         assertEquals(
             listOf("com.a", "com.b", self).sorted(),
-            resolveHiddenPackages(existing = setOf("com.b", "com.a"), observers = emptySet(), selfPkg = self),
+            resolveHiddenPackages(existing = setOf("com.b", "com.a"), selfPkg = self),
         )
     }
 
     @Test
     fun `empty existing still hides self`() {
-        assertEquals(listOf(self), resolveHiddenPackages(emptySet(), emptySet(), self))
+        assertEquals(listOf(self), resolveHiddenPackages(emptySet(), self))
     }
 
     @Test
-    fun `observer wins - a package marked observer is dropped from hidden`() {
-        // com.x was previously hidden; now it's also an observer -> must NOT be
-        // written as hidden (the H+O self-lookup crash).
+    fun `observer can stay hidden`() {
         assertEquals(
-            listOf("com.keep", self).sorted(),
-            resolveHiddenPackages(existing = setOf("com.x", "com.keep"), observers = setOf("com.x"), selfPkg = self),
+            listOf("com.keep", "com.x", self).sorted(),
+            resolveHiddenPackages(existing = setOf("com.x", "com.keep"), selfPkg = self),
         )
     }
 
     @Test
-    fun `self stays hidden even if it somehow appears as an observer`() {
+    fun `self stays hidden`() {
         assertEquals(
             listOf(self),
-            resolveHiddenPackages(existing = setOf(self), observers = setOf(self), selfPkg = self),
+            resolveHiddenPackages(existing = setOf(self), selfPkg = self),
         )
     }
 
@@ -41,7 +39,7 @@ class AppPickerDataTest {
     fun `result is deduplicated and sorted`() {
         assertEquals(
             listOf("com.a", "com.z", self).sorted(),
-            resolveHiddenPackages(existing = setOf("com.z", "com.a", self), observers = emptySet(), selfPkg = self),
+            resolveHiddenPackages(existing = setOf("com.z", "com.a", self), selfPkg = self),
         )
     }
 
@@ -249,7 +247,7 @@ class AppPickerDataTest {
     }
 
     @Test
-    fun `observer role still wins over hidden for visible packages`() {
+    fun `observer role can coexist with hidden for visible packages`() {
         val snapshot =
             snapshotWithCanonical(
                 "com.vpn" to CanonicalApp(hidden = true),
@@ -267,7 +265,7 @@ class AppPickerDataTest {
             )
 
         assertEquals(true, cfg.apps.getValue("com.vpn").appHiding)
-        assertEquals(false, cfg.apps.getValue("com.vpn").hidden)
+        assertEquals(true, cfg.apps.getValue("com.vpn").hidden)
         assertEquals(true, cfg.apps.getValue(self).hidden)
     }
 
@@ -318,7 +316,7 @@ class AppPickerDataTest {
     }
 
     @Test
-    fun `app hiding observer wins over auto hidden vpn app`() {
+    fun `app hiding observer can also be auto hidden vpn app`() {
         val cfg =
             buildCanonicalConfigForAppPickerSave(
                 debug = false,
@@ -335,8 +333,8 @@ class AppPickerDataTest {
             )
 
         assertEquals(true, cfg.apps.getValue("com.vpn.client").appHiding)
-        assertEquals(false, cfg.apps.getValue("com.vpn.client").hidden)
-        assertEquals(emptySet<String>(), cfg.settings.autoHiddenPackages)
+        assertEquals(true, cfg.apps.getValue("com.vpn.client").hidden)
+        assertEquals(setOf("com.vpn.client"), cfg.settings.autoHiddenPackages)
     }
 
     @Test

--- a/lsposed/app/src/test/kotlin/dev/okhsunrog/vpnhide/SystemServerConfigCacheTest.kt
+++ b/lsposed/app/src/test/kotlin/dev/okhsunrog/vpnhide/SystemServerConfigCacheTest.kt
@@ -1,0 +1,30 @@
+package dev.okhsunrog.vpnhide
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class SystemServerConfigCacheTest {
+    @Test
+    fun `hidden package is visible to caller with same app id`() {
+        val config =
+            SystemServerConfig(
+                hiddenPackages = setOf("ru.vk.store", "com.example.vpn"),
+                packageAppIds =
+                    mapOf(
+                        "ru.vk.store" to 10_501,
+                        "com.example.vpn" to 10_777,
+                    ),
+            )
+
+        assertEquals(false, config.shouldHidePackageForCallerAppId("ru.vk.store", callerAppId = 10_501))
+        assertEquals(true, config.shouldHidePackageForCallerAppId("ru.vk.store", callerAppId = 10_777))
+        assertEquals(false, config.shouldHidePackageForCallerAppId("com.not.hidden", callerAppId = 10_777))
+    }
+
+    @Test
+    fun `hidden package without resolved app id stays hidden`() {
+        val config = SystemServerConfig(hiddenPackages = setOf("com.missing"))
+
+        assertEquals(true, config.shouldHidePackageForCallerAppId("com.missing", callerAppId = 10_501))
+    }
+}


### PR DESCRIPTION
## Summary
- allow Apps-hidden packages to remain hidden even when they also use Apps protection themselves
- exempt package-visibility self-lookups by comparing the hidden package appId with the caller appId in system_server
- add direct unit coverage and document the package-visibility self-lookup rule

## Why
Previously the picker/config layer removed observer packages from the hidden set to avoid framework crashes when an app queried its own package. That also meant a VPN app such as RuStore could stop being hidden from other observer apps as soon as Apps protection was enabled for it.

This keeps the stronger hidden config and moves the crash avoidance to the hook layer: the package is visible only to callers with the same appId, while other observer apps still get filtered results.

## Testing
- `cd lsposed && ./gradlew :app:testDebugUnitTest --tests 'dev.okhsunrog.vpnhide.AppPickerDataTest' --tests 'dev.okhsunrog.vpnhide.SystemServerConfigCacheTest'`
- `cd lsposed && ./gradlew :app:ktlintCheck`
- `cd lsposed && ./gradlew :app:detekt`
- `cd lsposed && ./gradlew :app:assembleRelease`
