### PR TITLE
Add backend-specific native hook selection

### DIFF
--- a/changelog.d/added-add-backend-specific-native-hook-selection-31fa.md
+++ b/changelog.d/added-add-backend-specific-native-hook-selection-31fa.md
@@ -1,0 +1,9 @@
+_2026-06-29_
+
+## English
+
+Add backend-specific native hook selection for Zygisk.
+
+## Русский
+
+Добавлено отдельное управление нативными хуками для Zygisk.

--- a/crates/activator/src/lib.rs
+++ b/crates/activator/src/lib.rs
@@ -16,7 +16,7 @@ use std::time::Duration;
 
 use serde::Deserialize;
 use vpnhide_protocol::Target;
-use vpnhide_protocol::hook_ids::{HOOK_NAMES, KERNEL_HOOK_MASK};
+use vpnhide_protocol::hook_ids::{HOOK_NAMES, KERNEL_HOOK_MASK, ZYGISK_HOOK_MASK};
 use vpnhide_protocol::{format_config, parse_config};
 
 pub type Result<T> = std::result::Result<T, Box<dyn Error + Send + Sync>>;
@@ -154,6 +154,18 @@ fn default_port_protocol() -> PortProtocol {
 pub enum NativeSelection {
     Enabled(bool),
     Hooks(Vec<String>),
+    Detailed(NativeSelectionDetail),
+}
+
+#[derive(Clone, Debug, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct NativeSelectionDetail {
+    #[serde(default = "default_enabled")]
+    pub enabled: bool,
+    #[serde(default)]
+    pub kernel: Option<Vec<String>>,
+    #[serde(default)]
+    pub zygisk: Option<Vec<String>>,
 }
 
 impl Default for NativeSelection {
@@ -162,14 +174,55 @@ impl Default for NativeSelection {
     }
 }
 
+fn default_enabled() -> bool {
+    true
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum NativeHookFamily {
+    Kernel,
+    Zygisk,
+}
+
+impl NativeHookFamily {
+    fn full_mask(self) -> u32 {
+        match self {
+            NativeHookFamily::Kernel => KERNEL_HOOK_MASK,
+            NativeHookFamily::Zygisk => ZYGISK_HOOK_MASK,
+        }
+    }
+}
+
 impl NativeSelection {
-    fn hookmask(&self) -> Option<u32> {
+    fn hookmask(&self, family: NativeHookFamily) -> Option<u32> {
         match self {
             NativeSelection::Enabled(false) => None,
-            NativeSelection::Enabled(true) => Some(KERNEL_HOOK_MASK),
+            NativeSelection::Enabled(true) => Some(family.full_mask()),
             NativeSelection::Hooks(names) => {
+                if names.is_empty() {
+                    return None;
+                }
+                let mask = match family {
+                    NativeHookFamily::Kernel => {
+                        names.iter().fold(0u32, |acc, name| acc | hook_bit(name)) & KERNEL_HOOK_MASK
+                    }
+                    NativeHookFamily::Zygisk => ZYGISK_HOOK_MASK,
+                };
+                (mask != 0).then_some(mask)
+            }
+            NativeSelection::Detailed(detail) => {
+                if !detail.enabled {
+                    return None;
+                }
+                let selected = match family {
+                    NativeHookFamily::Kernel => &detail.kernel,
+                    NativeHookFamily::Zygisk => &detail.zygisk,
+                };
+                let Some(names) = selected else {
+                    return Some(family.full_mask());
+                };
                 let mask =
-                    names.iter().fold(0u32, |acc, name| acc | hook_bit(name)) & KERNEL_HOOK_MASK;
+                    names.iter().fold(0u32, |acc, name| acc | hook_bit(name)) & family.full_mask();
                 (mask != 0).then_some(mask)
             }
         }
@@ -286,22 +339,36 @@ fn validate_port_policies(cfg: &CanonicalConfig) -> Result<()> {
 }
 
 pub fn project_native(json: &str) -> Result<String> {
-    project_native_with_pm_wait(json, PmReadyWait::Bounded(PM_READY_ATTEMPTS))
+    project_native_with_pm_wait(
+        json,
+        NativeHookFamily::Kernel,
+        PmReadyWait::Bounded(PM_READY_ATTEMPTS),
+    )
 }
 
-fn project_native_with_pm_wait(json: &str, wait: PmReadyWait) -> Result<String> {
+fn project_native_with_pm_wait(
+    json: &str,
+    family: NativeHookFamily,
+    wait: PmReadyWait,
+) -> Result<String> {
     let cfg = parse_canonical(json)?;
-    if !has_native_targets(&cfg) {
+    if !has_native_targets(&cfg, family) {
         return Ok(format_config(cfg.debug, &[]));
     }
     let resolver = PackageUidMap::from_pm_with_wait(wait)?;
-    Ok(project_native_with_resolver(&cfg, &resolver))
+    Ok(project_native_with_resolver_for_family(
+        &cfg, &resolver, family,
+    ))
 }
 
-pub fn project_native_with_resolver(cfg: &CanonicalConfig, resolver: &PackageUidMap) -> String {
+fn project_native_with_resolver_for_family(
+    cfg: &CanonicalConfig,
+    resolver: &PackageUidMap,
+    family: NativeHookFamily,
+) -> String {
     let mut by_uid = BTreeMap::<u32, u32>::new();
     for (pkg, app) in &cfg.apps {
-        let Some(mask) = app.native.hookmask() else {
+        let Some(mask) = app.native.hookmask(family) else {
             continue;
         };
         for uid in resolver.uids_for(pkg) {
@@ -317,6 +384,10 @@ pub fn project_native_with_resolver(cfg: &CanonicalConfig, resolver: &PackageUid
         .map(|(uid, hookmask)| Target { uid, hookmask })
         .collect::<Vec<_>>();
     format_config(cfg.debug, &targets)
+}
+
+pub fn project_native_with_resolver(cfg: &CanonicalConfig, resolver: &PackageUidMap) -> String {
+    project_native_with_resolver_for_family(cfg, resolver, NativeHookFamily::Kernel)
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -400,7 +471,7 @@ pub fn activate_kmod_boot() -> Result<()> {
 }
 
 fn activate_kmod_with_pm_wait(wait: PmReadyWait) -> Result<()> {
-    let wire = project_native_with_pm_wait(&read_canonical()?, wait)?;
+    let wire = project_native_with_pm_wait(&read_canonical()?, NativeHookFamily::Kernel, wait)?;
     // /proc/vpnhide_ctl replaces the entire config per write(), so keep this
     // bounded to MAX_NATIVE_TARGETS and deliver one complete snapshot.
     fs::write(KMOD_CTL, wire)?;
@@ -416,7 +487,7 @@ pub fn activate_zygisk_boot() -> Result<()> {
 }
 
 fn activate_zygisk_with_pm_wait(wait: PmReadyWait) -> Result<()> {
-    let wire = project_native_with_pm_wait(&read_canonical()?, wait)?;
+    let wire = project_native_with_pm_wait(&read_canonical()?, NativeHookFamily::Zygisk, wait)?;
     write_atomic(Path::new(ZYGISK_RUNTIME_CONFIG), wire.as_bytes(), 0o644)
 }
 
@@ -468,7 +539,7 @@ fn activate_kpm_with_pm_wait(wait: PmReadyWait, conflict_is_error: bool) -> Resu
     if skip_kpm_for_kmod_conflict(conflict_is_error)? {
         return Ok(KpmBootOutcome::DeferredConflict);
     }
-    let wire = project_native_with_pm_wait(&read_canonical()?, wait)?;
+    let wire = project_native_with_pm_wait(&read_canonical()?, NativeHookFamily::Kernel, wait)?;
     // Re-check after the (possibly long) PackageManager wait: the .ko may have
     // been loaded meanwhile, in which case we must not configure the KPM.
     if skip_kpm_for_kmod_conflict(conflict_is_error)? {
@@ -508,8 +579,10 @@ pub fn boot_wait_requested_from_env() -> Result<bool> {
     Ok(boot_wait)
 }
 
-fn has_native_targets(cfg: &CanonicalConfig) -> bool {
-    cfg.apps.values().any(|app| app.native.hookmask().is_some())
+fn has_native_targets(cfg: &CanonicalConfig, family: NativeHookFamily) -> bool {
+    cfg.apps
+        .values()
+        .any(|app| app.native.hookmask(family).is_some())
 }
 
 fn has_ports_targets(cfg: &CanonicalConfig) -> bool {
@@ -1136,6 +1209,89 @@ mod tests {
 
         assert_eq!(
             project_native_with_resolver(&cfg, &resolver),
+            "vpnhide 1 config\ndebug 0\n",
+        );
+    }
+
+    #[test]
+    fn projects_backend_specific_native_hook_overrides() {
+        let cfg = parse_canonical(
+            r#"{
+              "version": 1,
+              "apps": {
+                "com.example.app": {
+                  "native": {
+                    "enabled": true,
+                    "kernel": ["sock_ioctl"],
+                    "zygisk": ["zygisk_ioctl", "zygisk_recvfrom_chk"]
+                  }
+                }
+              }
+            }"#,
+        )
+        .unwrap();
+        let resolver = parse_pm_packages("package:com.example.app uid:10234\n");
+
+        assert_eq!(
+            project_native_with_resolver(&cfg, &resolver),
+            "vpnhide 1 config\n\
+             debug 0\n\
+             target 0x27fa 0x40\n",
+        );
+        assert_eq!(
+            project_native_with_resolver_for_family(&cfg, &resolver, NativeHookFamily::Zygisk),
+            "vpnhide 1 config\n\
+             debug 0\n\
+             target 0x27fa 0x1040000\n",
+        );
+    }
+
+    #[test]
+    fn legacy_native_hook_list_is_kernel_only_and_zygisk_defaults_to_all() {
+        let cfg = parse_canonical(
+            r#"{
+              "version": 1,
+              "apps": {
+                "com.example.app": { "native": ["sock_ioctl"] }
+              }
+            }"#,
+        )
+        .unwrap();
+        let resolver = parse_pm_packages("package:com.example.app uid:10234\n");
+
+        assert_eq!(
+            project_native_with_resolver(&cfg, &resolver),
+            "vpnhide 1 config\n\
+             debug 0\n\
+             target 0x27fa 0x40\n",
+        );
+        assert_eq!(
+            project_native_with_resolver_for_family(&cfg, &resolver, NativeHookFamily::Zygisk),
+            "vpnhide 1 config\n\
+             debug 0\n\
+             target 0x27fa 0x1fc0000\n",
+        );
+    }
+
+    #[test]
+    fn empty_legacy_native_hook_list_is_disabled_for_every_backend() {
+        let cfg = parse_canonical(
+            r#"{
+              "version": 1,
+              "apps": {
+                "com.example.app": { "native": [] }
+              }
+            }"#,
+        )
+        .unwrap();
+        let resolver = parse_pm_packages("package:com.example.app uid:10234\n");
+
+        assert_eq!(
+            project_native_with_resolver(&cfg, &resolver),
+            "vpnhide 1 config\ndebug 0\n",
+        );
+        assert_eq!(
+            project_native_with_resolver_for_family(&cfg, &resolver, NativeHookFamily::Zygisk),
             "vpnhide 1 config\ndebug 0\n",
         );
     }

--- a/crates/protocol/src/generated/hook_ids.rs
+++ b/crates/protocol/src/generated/hook_ids.rs
@@ -42,13 +42,27 @@ pub enum Hook {
     LsposedConnectivityNetwork = 16,
     /// PackageManager app-hiding filters
     LsposedPackageVisibility = 17,
+    /// libc ioctl() SIOCGIF* interface probes
+    ZygiskIoctl = 18,
+    /// libc getifaddrs() interface enumeration
+    ZygiskGetifaddrs = 19,
+    /// openat() filtering for /proc/net routes and sockets
+    ZygiskOpenat = 20,
+    /// recvmsg() netlink dump filtering
+    ZygiskRecvmsg = 21,
+    /// recv() netlink dump filtering
+    ZygiskRecv = 22,
+    /// recvfrom() netlink dump filtering
+    ZygiskRecvfrom = 23,
+    /// __recvfrom_chk() fortified netlink dump filtering
+    ZygiskRecvfromChk = 24,
 }
 
-pub const HOOK_COUNT: u32 = 18;
+pub const HOOK_COUNT: u32 = 25;
 
 /// Hooks owned by each backend: apply `mask & own`.
 pub const KERNEL_HOOK_MASK: u32 = 0x3ff;
-pub const ZYGISK_HOOK_MASK: u32 = 0x0;
+pub const ZYGISK_HOOK_MASK: u32 = 0x1fc0000;
 pub const LSPOSED_HOOK_MASK: u32 = 0x3fc00;
 
 /// status error codes (protocol §5.1).
@@ -81,7 +95,7 @@ pub enum Backend {
     Lsposed = 3,
 }
 
-pub const HOOK_NAMES: [&str; 18] = [
+pub const HOOK_NAMES: [&str; 25] = [
     "fib_route_seq_show",
     "ipv6_route_seq_show",
     "rtnl_fill_ifinfo",
@@ -100,4 +114,11 @@ pub const HOOK_NAMES: [&str; 18] = [
     "lsposed_connectivity_callback",
     "lsposed_connectivity_network",
     "lsposed_package_visibility",
+    "zygisk_ioctl",
+    "zygisk_getifaddrs",
+    "zygisk_openat",
+    "zygisk_recvmsg",
+    "zygisk_recv",
+    "zygisk_recvfrom",
+    "zygisk_recvfrom_chk",
 ];

--- a/data/hooks.toml
+++ b/data/hooks.toml
@@ -128,8 +128,49 @@ name = "lsposed_package_visibility"
 backend = "lsposed"
 note = "PackageManager app-hiding filters"
 
-# --- zygisk libc hooks take the next free ids as they are wired into the
-# --- protocol; appended here then (kept here as the record).
+# --- Zygisk libc hooks -----------------------------------------------------
+
+[[hook]]
+id = 18
+name = "zygisk_ioctl"
+backend = "zygisk"
+note = "libc ioctl() SIOCGIF* interface probes"
+
+[[hook]]
+id = 19
+name = "zygisk_getifaddrs"
+backend = "zygisk"
+note = "libc getifaddrs() interface enumeration"
+
+[[hook]]
+id = 20
+name = "zygisk_openat"
+backend = "zygisk"
+note = "openat() filtering for /proc/net routes and sockets"
+
+[[hook]]
+id = 21
+name = "zygisk_recvmsg"
+backend = "zygisk"
+note = "recvmsg() netlink dump filtering"
+
+[[hook]]
+id = 22
+name = "zygisk_recv"
+backend = "zygisk"
+note = "recv() netlink dump filtering"
+
+[[hook]]
+id = 23
+name = "zygisk_recvfrom"
+backend = "zygisk"
+note = "recvfrom() netlink dump filtering"
+
+[[hook]]
+id = 24
+name = "zygisk_recvfrom_chk"
+backend = "zygisk"
+note = "__recvfrom_chk() fortified netlink dump filtering"
 
 # --- backend ids (protocol §4.3 `status backend <id>`) ----------------------
 # Which backend answered a `status` read. Distinct from the hook `backend`

--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -368,8 +368,10 @@ Current kernel hooks (`.ko` / KPM, 10): `fib_route_seq_show`,
 `fib_nl_fill_rule`. Current LSPosed Java hooks (8): `lsposed_link_properties`,
 `lsposed_network_capabilities`, `lsposed_network_info`, `lsposed_network`,
 `lsposed_connectivity_result`, `lsposed_connectivity_callback`,
-`lsposed_connectivity_network`, `lsposed_package_visibility`. Zygisk libc hooks
-take the next free global ids when they are wired into per-hook protocol stats.
+`lsposed_connectivity_network`, `lsposed_package_visibility`. Current Zygisk
+libc hooks (7): `zygisk_ioctl`, `zygisk_getifaddrs`, `zygisk_openat`,
+`zygisk_recvmsg`, `zygisk_recv`, `zygisk_recvfrom`,
+`zygisk_recvfrom_chk`.
 
 ### 5.1 Error codes (`status`)
 
@@ -406,7 +408,7 @@ the only writer of all profiles; each backend reads its own.
 | Channel | config records it acts on | emits stats? | emits status? |
 |---|---|---|---|
 | `.ko` / KPM | `debug`, `target` (kernel-owned mask bits) | yes | yes (§4.3) |
-| Zygisk | `debug`, `target` (zygisk-owned mask bits) | yes (§7, if added) | yes, if a read channel is added |
+| Zygisk | `debug`, `target` (zygisk-owned mask bits) | no, not yet (§7) | yes, via the app heartbeat |
 | LSPosed | `debug`, `target` (lsposed-owned mask bits), package/observer records | yes | yes |
 
 A backend ignores `target` mask bits it does not own (`mask & own_hooks`), so the

--- a/docs/storage.md
+++ b/docs/storage.md
@@ -93,14 +93,28 @@ Shape (illustrative):
 
 Per-hook granularity ("раздельное управление хуками"): the coarse `"java": true`
 or `"native": true` is the common case (enable every hook in that role for the
-app). When the UI exposes per-hook control, the role grows into an explicit hook
-list, e.g. `"java": ["lsposed_network_capabilities"]` or
-`"native": ["fib_route_seq_show", "sock_ioctl"]`. The native activator maps the
-native list to protocol `hookmask` bits. LSPosed reads the Java list directly in
-`system_server`; app-hiding package visibility is still controlled by
-`appHiding`, not by the Java VPN hook list. An absent/`true` value means "all
-hooks for this role". The JSON is the *desired* selection; the native wire
-carries the resolved `hookmask`.
+app). Java per-hook control uses an explicit hook list, e.g.
+`"java": ["lsposed_network_capabilities"]`. Native per-hook control is
+backend-family-specific because `.ko`/KPM kernel hooks and Zygisk libc hooks are
+different hook ids:
+
+```json
+"native": {
+  "enabled": true,
+  "kernel": ["fib_route_seq_show", "sock_ioctl"],
+  "zygisk": ["zygisk_ioctl", "zygisk_recvfrom_chk"]
+}
+```
+
+The old `"native": ["fib_route_seq_show", "sock_ioctl"]` shape is still accepted
+as a legacy **kernel** override. For any active native backend family whose list
+is absent, the role means "all hooks for that family"; switching from Zygisk to
+KPM preserves the Zygisk override but uses all kernel hooks until the user
+configures kernel hooks explicitly, and vice versa. The native activator maps the
+active family list to protocol `hookmask` bits. LSPosed reads the Java list
+directly in `system_server`; app-hiding package visibility is still controlled
+by `appHiding`, not by the Java VPN hook list. The JSON is the *desired*
+selection; the native wire carries the resolved `hookmask`.
 
 The `rememberSuperkey` boolean lives here (it is a preference, not a secret). The
 superkey itself does **not** (§6).
@@ -167,9 +181,11 @@ backend.
 
 ### 4.1 The activator — a Rust workspace, thin bins
 
-The projection is *identical* for all three native backends (take the `native`-role
-packages → resolve to UIDs → emit a `vpnhide 1 config` snapshot); only the
-**delivery sink** differs. Ports use the same canonical parser and package→UID
+The projection is shared for all three native backends (take the `native`-role
+packages → resolve to UIDs → emit a `vpnhide 1 config` snapshot), but the
+resolved hookmask uses the active backend family: `.ko`/KPM consume `kernel`
+overrides, while Zygisk consumes `zygisk` overrides. Only the **delivery sink**
+differs after that. Ports use the same canonical parser and package→UID
 resolver, but project `ports: true` roles into iptables rules instead of the text
 wire. So: one shared core, thin per-target front-ends.
 
@@ -276,8 +292,8 @@ single-writer / atomic-replace, and stats are never written back into it.
   to share *writable* memory across all injected app-domain processes without a
   daemon (the module-dir file isn't writable by `untrusted_app` under SELinux; a
   zygote-inherited memfd must be created in the zygote, where our code does not run).
-  So Zygisk emits **status only**; per-hook stats are a future problem, not a
-  blocker for this design.
+  So Zygisk consumes per-target hookmasks but does not emit per-hook stats yet;
+  stats remain a future problem, not a blocker for this design.
 - **LSPosed: yes** — counters live in `system_server`, so the hook aggregates
   cumulative-since-boot non-zero `(uid, hook_id)` cells and writes them into
   `/data/system/vpnhide_lsposed_state` next to its `status` block.

--- a/kmod/generated/hook_ids.h
+++ b/kmod/generated/hook_ids.h
@@ -21,11 +21,18 @@
 #define VPNHIDE_HOOK_LSPOSED_CONNECTIVITY_CALLBACK 15
 #define VPNHIDE_HOOK_LSPOSED_CONNECTIVITY_NETWORK  16
 #define VPNHIDE_HOOK_LSPOSED_PACKAGE_VISIBILITY    17
-#define VPNHIDE_HOOK_COUNT                         18
+#define VPNHIDE_HOOK_ZYGISK_IOCTL                  18
+#define VPNHIDE_HOOK_ZYGISK_GETIFADDRS             19
+#define VPNHIDE_HOOK_ZYGISK_OPENAT                 20
+#define VPNHIDE_HOOK_ZYGISK_RECVMSG                21
+#define VPNHIDE_HOOK_ZYGISK_RECV                   22
+#define VPNHIDE_HOOK_ZYGISK_RECVFROM               23
+#define VPNHIDE_HOOK_ZYGISK_RECVFROM_CHK           24
+#define VPNHIDE_HOOK_COUNT                         25
 
 /* Hooks owned by each backend: apply `mask & own`, ignore foreign bits. */
 #define VPNHIDE_KERNEL_HOOK_MASK 0x3ffu
-#define VPNHIDE_ZYGISK_HOOK_MASK 0x0u
+#define VPNHIDE_ZYGISK_HOOK_MASK 0x1fc0000u
 #define VPNHIDE_LSPOSED_HOOK_MASK 0x3fc00u
 
 /* status error codes (protocol §5.1). */
@@ -64,6 +71,13 @@ static inline const char *vpnhide_hook_name(int id)
 	case 15: return "lsposed_connectivity_callback";
 	case 16: return "lsposed_connectivity_network";
 	case 17: return "lsposed_package_visibility";
+	case 18: return "zygisk_ioctl";
+	case 19: return "zygisk_getifaddrs";
+	case 20: return "zygisk_openat";
+	case 21: return "zygisk_recvmsg";
+	case 22: return "zygisk_recv";
+	case 23: return "zygisk_recvfrom";
+	case 24: return "zygisk_recvfrom_chk";
 	default: return "?";
 	}
 }

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/AppPickerData.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/AppPickerData.kt
@@ -41,7 +41,7 @@ internal data class AppRoleSelection(
     val java: Boolean = false,
     val javaHooks: List<String>? = null,
     val native: Boolean = false,
-    val nativeHooks: List<String>? = null,
+    val nativeOverrides: NativeHookOverrides = NativeHookOverrides(),
     val appHiding: Boolean = false,
     val ports: Boolean = false,
     val portPolicy: PortPolicy? = null,
@@ -187,8 +187,7 @@ private fun Collection<AppRoleSelection>.selectedPkgs(predicate: (AppRoleSelecti
 private fun Collection<AppRoleSelection>.selectedNativeRoles(): Map<String, NativeRole> =
     filter { it.native }
         .associate { selection ->
-            val hooks = selection.nativeHooks?.takeIf { it.isNotEmpty() }
-            selection.packageName to (hooks?.let { NativeRole(enabled = true, hooks = it) } ?: NativeRole.All)
+            selection.packageName to NativeRole(enabled = true, overrides = selection.nativeOverrides)
         }
 
 private fun Collection<AppRoleSelection>.selectedJavaHooks(): Map<String, List<String>?> =

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/AppPickerScreen.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/AppPickerScreen.kt
@@ -74,7 +74,7 @@ internal data class AppEntry(
     val java: Boolean = false,
     val javaHooks: List<String>? = null,
     val native: Boolean = false,
-    val nativeHooks: List<String>? = null,
+    val nativeOverrides: NativeHookOverrides = NativeHookOverrides(),
     val appHiding: Boolean = false,
     val ports: Boolean = false,
     val portPolicy: PortPolicy? = null,
@@ -131,7 +131,7 @@ internal fun AppPickerScreen(
                             java = canonicalApp?.java ?: (app.packageName in t.lsposedTargets),
                             javaHooks = canonicalApp?.takeIf { it.java }?.javaHooks?.takeIf { it.isNotEmpty() },
                             native = app.packageName in nativeTargets,
-                            nativeHooks = nativeRole?.hooks?.takeIf { it.isNotEmpty() },
+                            nativeOverrides = nativeRole?.overrides ?: NativeHookOverrides(),
                             appHiding = app.packageName in observers,
                             ports = app.packageName in t.portsObservers,
                             portPolicy = canonicalApp?.takeIf { it.ports }?.portPolicy,
@@ -156,16 +156,19 @@ internal fun AppPickerScreen(
             res.getString(R.string.save_success, entries.count { it.anySelected })
         },
     ) { app, userNames, targets, onChange ->
+        val nativeHookFamily = targets.nativeHookFamily
         AppRow(
             app = app,
             userNames = userNames,
             anyNativeInstalled = targets.anyNativeInstalled,
+            nativeBackendId = targets.displayNativeBackendId,
+            nativeHookFamily = nativeHookFamily,
             portsInstalled = targets.portsModuleInstalled,
             onToggle = { layer ->
                 onChange(
                     when (layer) {
                         Layer.JAVA -> app.copy(java = !app.java, javaHooks = null)
-                        Layer.NATIVE -> app.copy(native = !app.native, nativeHooks = null)
+                        Layer.NATIVE -> app.copy(native = !app.native, nativeOverrides = NativeHookOverrides())
                         Layer.APP_HIDING -> app.copy(appHiding = !app.appHiding)
                         Layer.PORTS -> app.copy(ports = !app.ports)
                     },
@@ -183,7 +186,15 @@ internal fun AppPickerScreen(
                 onChange(
                     app.copy(
                         native = hooks == null || hooks.isNotEmpty(),
-                        nativeHooks = hooks?.takeIf { it.isNotEmpty() },
+                        nativeOverrides =
+                            if (hooks == null || hooks.isNotEmpty()) {
+                                app.nativeOverrides.withHooksFor(
+                                    nativeHookFamily,
+                                    hooks?.takeIf { it.isNotEmpty() },
+                                )
+                            } else {
+                                NativeHookOverrides()
+                            },
                     ),
                 )
             },
@@ -202,7 +213,7 @@ internal fun AppPickerScreen(
                         java = newState,
                         javaHooks = null,
                         native = if (targets.anyNativeInstalled) newState else false,
-                        nativeHooks = null,
+                        nativeOverrides = NativeHookOverrides(),
                         appHiding = newState,
                         ports = if (targets.portsModuleInstalled) newState else false,
                     ),
@@ -377,7 +388,7 @@ private fun AppEntry.toRoleSelection(): AppRoleSelection =
         java = java,
         javaHooks = javaHooks,
         native = native,
-        nativeHooks = nativeHooks,
+        nativeOverrides = nativeOverrides,
         appHiding = appHiding,
         ports = ports,
         portPolicy = portPolicy,
@@ -395,6 +406,8 @@ private fun AppRow(
     app: AppEntry,
     userNames: Map<Int, String>,
     anyNativeInstalled: Boolean,
+    nativeBackendId: NativeBackendId?,
+    nativeHookFamily: NativeHookFamily,
     portsInstalled: Boolean,
     onToggle: (Layer) -> Unit,
     onJavaHooksChange: (List<String>?) -> Unit,
@@ -406,6 +419,7 @@ private fun AppRow(
     var nativeHookDialogOpen by remember { mutableStateOf(false) }
     var portsDialogOpen by remember { mutableStateOf(false) }
     val fullRoleLabels = LocalSettingsState.current.fullProtectionRoleLabels
+    val nativeHooks = app.nativeOverrides.hooksFor(nativeHookFamily)
     TargetRowShell(
         label = app.label,
         packageName = app.packageName,
@@ -433,7 +447,7 @@ private fun AppRow(
                     roleLabel(
                         compact = stringResource(R.string.chip_native),
                         full = stringResource(R.string.chip_native_full),
-                        partial = app.nativeHooks != null,
+                        partial = nativeHooks != null,
                         fullLabels = fullRoleLabels,
                     ),
                 enabled = app.native,
@@ -487,9 +501,9 @@ private fun AppRow(
     if (nativeHookDialogOpen) {
         HooksDialog(
             app = app,
-            title = stringResource(R.string.native_hooks_title),
-            hookEntries = NativeHookEntries,
-            selectedHooks = app.nativeHooks,
+            title = nativeHooksTitle(nativeBackendId),
+            hookEntries = nativeHookEntriesFor(nativeHookFamily),
+            selectedHooks = nativeHooks,
             onDismiss = { nativeHookDialogOpen = false },
             onSave = { hooks ->
                 onNativeHooksChange(hooks)
@@ -517,6 +531,18 @@ private fun roleLabel(
     partial: Boolean,
     fullLabels: Boolean,
 ): String = (if (fullLabels) full else compact) + if (partial) "*" else ""
+
+@Composable
+private fun nativeHooksTitle(backend: NativeBackendId?): String {
+    val backendName =
+        when (backend) {
+            NativeBackendId.Kmod -> stringResource(R.string.dashboard_backend_kmod)
+            NativeBackendId.Kpm -> stringResource(R.string.dashboard_backend_kpm)
+            NativeBackendId.Zygisk -> stringResource(R.string.dashboard_backend_zygisk)
+            null -> stringResource(R.string.chip_native_full)
+        }
+    return stringResource(R.string.native_hooks_title_with_backend, backendName)
+}
 
 @Composable
 private fun HookTargetChip(

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/StorageConfig.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/StorageConfig.kt
@@ -36,7 +36,7 @@ internal data class CanonicalApp(
 
 internal data class NativeRole(
     val enabled: Boolean,
-    val hooks: List<String>? = null,
+    val overrides: NativeHookOverrides = NativeHookOverrides(),
 ) {
     companion object {
         val Disabled = NativeRole(enabled = false)
@@ -44,18 +44,63 @@ internal data class NativeRole(
     }
 }
 
+internal enum class NativeHookFamily {
+    Kernel,
+    Zygisk,
+}
+
+internal data class NativeHookOverrides(
+    val kernel: List<String>? = null,
+    val zygisk: List<String>? = null,
+) {
+    fun hooksFor(family: NativeHookFamily): List<String>? =
+        when (family) {
+            NativeHookFamily.Kernel -> kernel
+            NativeHookFamily.Zygisk -> zygisk
+        }
+
+    fun withHooksFor(
+        family: NativeHookFamily,
+        hooks: List<String>?,
+    ): NativeHookOverrides =
+        when (family) {
+            NativeHookFamily.Kernel -> copy(kernel = hooks)
+            NativeHookFamily.Zygisk -> copy(zygisk = hooks)
+        }
+
+    val hasAnyOverride: Boolean
+        get() = kernel != null || zygisk != null
+}
+
 private data class ParsedHookRole(
     val enabled: Boolean,
     val hooks: List<String>? = null,
 )
 
-internal val NativeHookEntries: List<HookIds.Hook> =
+internal val NativeKernelHookEntries: List<HookIds.Hook> =
     HookIds.Hook.entries.filter { hookBit(it) and HookIds.KERNEL_HOOK_MASK.toLong() != 0L }
+
+internal val ZygiskNativeHookEntries: List<HookIds.Hook> =
+    HookIds.Hook.entries.filter { hookBit(it) and HookIds.ZYGISK_HOOK_MASK.toLong() != 0L }
+
+internal val NativeHookEntries: List<HookIds.Hook> = NativeKernelHookEntries
 
 internal val LsposedJavaHookEntries: List<HookIds.Hook> =
     HookIds.Hook.entries.filter {
         hookBit(it) and HookIds.LSPOSED_HOOK_MASK.toLong() != 0L &&
             it != HookIds.Hook.LSPOSED_PACKAGE_VISIBILITY
+    }
+
+internal fun nativeHookEntriesFor(family: NativeHookFamily): List<HookIds.Hook> =
+    when (family) {
+        NativeHookFamily.Kernel -> NativeKernelHookEntries
+        NativeHookFamily.Zygisk -> ZygiskNativeHookEntries
+    }
+
+internal fun nativeHookFamilyFor(backend: NativeBackendId?): NativeHookFamily =
+    when (backend) {
+        NativeBackendId.Zygisk -> NativeHookFamily.Zygisk
+        NativeBackendId.Kmod, NativeBackendId.Kpm, null -> NativeHookFamily.Kernel
     }
 
 internal fun hookSelectionMask(
@@ -159,9 +204,37 @@ private fun parsePortRule(obj: JSONObject): PortRule {
 }
 
 private fun parseNativeRole(value: Any?): NativeRole =
-    parseHookRole(value).let { role ->
-        if (role.enabled) NativeRole(enabled = true, hooks = role.hooks) else NativeRole.Disabled
+    when (value) {
+        is JSONObject -> {
+            parseNativeRoleObject(value)
+        }
+
+        else -> {
+            parseHookRole(value).let { role ->
+                if (role.enabled) {
+                    NativeRole(
+                        enabled = true,
+                        overrides = NativeHookOverrides(kernel = role.hooks),
+                    )
+                } else {
+                    NativeRole.Disabled
+                }
+            }
+        }
     }
+
+private fun parseNativeRoleObject(obj: JSONObject): NativeRole {
+    val enabled = obj.optBoolean("enabled", obj.has("kernel") || obj.has("zygisk"))
+    if (!enabled) return NativeRole.Disabled
+    return NativeRole(
+        enabled = true,
+        overrides =
+            NativeHookOverrides(
+                kernel = parseOptionalStringList(obj, "kernel"),
+                zygisk = parseOptionalStringList(obj, "zygisk"),
+            ),
+    )
+}
 
 private fun parseHookRole(value: Any?): ParsedHookRole =
     when (value) {
@@ -185,6 +258,16 @@ private fun parseStringSet(value: JSONArray?): Set<String> =
     (0 until (value?.length() ?: 0))
         .mapNotNull { idx -> value?.optString(idx)?.takeIf { it.isNotBlank() } }
         .toSortedSet()
+
+private fun parseOptionalStringList(
+    obj: JSONObject,
+    key: String,
+): List<String>? {
+    if (!obj.has(key) || obj.isNull(key)) return null
+    val array = obj.optJSONArray(key) ?: return null
+    return (0 until array.length())
+        .mapNotNull { idx -> array.optString(idx).takeIf { it.isNotBlank() } }
+}
 
 internal fun buildCanonicalConfig(
     debug: Boolean,
@@ -355,7 +438,28 @@ private fun StringBuilder.appendPortRule(rule: PortRule) {
 }
 
 private fun StringBuilder.appendNativeRole(native: NativeRole) {
-    appendHookRole(native.enabled, native.hooks)
+    when {
+        !native.enabled -> {
+            append("false")
+        }
+
+        !native.overrides.hasAnyOverride -> {
+            append("true")
+        }
+
+        else -> {
+            append("{ \"enabled\": true")
+            native.overrides.kernel?.let { hooks ->
+                append(", \"kernel\": ")
+                appendStringArray(hooks)
+            }
+            native.overrides.zygisk?.let { hooks ->
+                append(", \"zygisk\": ")
+                appendStringArray(hooks)
+            }
+            append(" }")
+        }
+    }
 }
 
 private fun StringBuilder.appendHookRole(

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/TargetsCache.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/TargetsCache.kt
@@ -49,6 +49,19 @@ internal data class TargetsSnapshot(
     val nativeTargets: Set<String>
         get() = kmodTargets + kpmTargets + zygiskTargets
 
+    val displayNativeBackendId: NativeBackendId?
+        get() =
+            activeNativeBackendId
+                ?: when {
+                    kmodModuleInstalled -> NativeBackendId.Kmod
+                    kpmModuleInstalled -> NativeBackendId.Kpm
+                    zygiskModuleInstalled -> NativeBackendId.Zygisk
+                    else -> null
+                }
+
+    val nativeHookFamily: NativeHookFamily
+        get() = nativeHookFamilyFor(displayNativeBackendId)
+
     /** Observer UIDs resolved back to current package names via
      * `pm list packages -U`. UIDs that no longer map to an installed
      * package (e.g. after an uninstall) silently drop out.

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/generated/HookIds.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/generated/HookIds.kt
@@ -62,11 +62,32 @@ internal object HookIds {
 
         // PackageManager app-hiding filters
         LSPOSED_PACKAGE_VISIBILITY(17, "lsposed_package_visibility", "PackageManager app-hiding filters"),
+
+        // libc ioctl() SIOCGIF* interface probes
+        ZYGISK_IOCTL(18, "zygisk_ioctl", "libc ioctl() SIOCGIF* interface probes"),
+
+        // libc getifaddrs() interface enumeration
+        ZYGISK_GETIFADDRS(19, "zygisk_getifaddrs", "libc getifaddrs() interface enumeration"),
+
+        // openat() filtering for /proc/net routes and sockets
+        ZYGISK_OPENAT(20, "zygisk_openat", "openat() filtering for /proc/net routes and sockets"),
+
+        // recvmsg() netlink dump filtering
+        ZYGISK_RECVMSG(21, "zygisk_recvmsg", "recvmsg() netlink dump filtering"),
+
+        // recv() netlink dump filtering
+        ZYGISK_RECV(22, "zygisk_recv", "recv() netlink dump filtering"),
+
+        // recvfrom() netlink dump filtering
+        ZYGISK_RECVFROM(23, "zygisk_recvfrom", "recvfrom() netlink dump filtering"),
+
+        // __recvfrom_chk() fortified netlink dump filtering
+        ZYGISK_RECVFROM_CHK(24, "zygisk_recvfrom_chk", "__recvfrom_chk() fortified netlink dump filtering"),
     }
 
     // Hooks owned by each backend: apply `mask and own`.
     const val KERNEL_HOOK_MASK = 0x3ff
-    const val ZYGISK_HOOK_MASK = 0x0
+    const val ZYGISK_HOOK_MASK = 0x1fc0000
     const val LSPOSED_HOOK_MASK = 0x3fc00
 
     /** status error codes (protocol §5.1). */

--- a/lsposed/app/src/main/res/values-ru/strings.xml
+++ b/lsposed/app/src/main/res/values-ru/strings.xml
@@ -42,6 +42,7 @@
     <string name="apps_help_title">Как это работает</string>
     <string name="java_hooks_title">Java-хуки</string>
     <string name="native_hooks_title">Нативные хуки</string>
+    <string name="native_hooks_title_with_backend">Нативные хуки · %1$s</string>
     <string name="ports_policy_title">Правила портов</string>
     <string name="ports_policy_all_title">Все localhost-порты</string>
     <string name="ports_policy_all_body">Блокировать все TCP и UDP подключения к 127.0.0.1 и ::1 для этого приложения. Это стандартное поведение P.</string>

--- a/lsposed/app/src/main/res/values/strings.xml
+++ b/lsposed/app/src/main/res/values/strings.xml
@@ -52,6 +52,7 @@
     <string name="chip_ports_full" translatable="false">Ports</string>
     <string name="java_hooks_title">Java hooks</string>
     <string name="native_hooks_title">Native hooks</string>
+    <string name="native_hooks_title_with_backend">Native hooks · %1$s</string>
     <string name="ports_policy_title">Port rules</string>
     <string name="ports_policy_all_title">All localhost ports</string>
     <string name="ports_policy_all_body">Block every TCP and UDP connection to 127.0.0.1 and ::1 for this app. This is the default P behavior.</string>

--- a/lsposed/app/src/test/kotlin/dev/okhsunrog/vpnhide/AppPickerDataTest.kt
+++ b/lsposed/app/src/test/kotlin/dev/okhsunrog/vpnhide/AppPickerDataTest.kt
@@ -105,7 +105,15 @@ class AppPickerDataTest {
 
     @Test
     fun `save preserves custom native hooks for missing and still selected apps`() {
-        val customNative = NativeRole(enabled = true, hooks = listOf("sock_ioctl"))
+        val customNative =
+            NativeRole(
+                enabled = true,
+                overrides =
+                    NativeHookOverrides(
+                        kernel = listOf("sock_ioctl"),
+                        zygisk = listOf("zygisk_ioctl"),
+                    ),
+            )
         val snapshot =
             snapshotWithCanonical(
                 "com.visible" to CanonicalApp(native = customNative),
@@ -118,7 +126,11 @@ class AppPickerDataTest {
                 selfPkg = self,
                 selections =
                     listOf(
-                        AppRoleSelection(packageName = "com.visible", native = true, nativeHooks = customNative.hooks),
+                        AppRoleSelection(
+                            packageName = "com.visible",
+                            native = true,
+                            nativeOverrides = customNative.overrides,
+                        ),
                     ),
                 snapshot = snapshot,
             )
@@ -233,14 +245,20 @@ class AppPickerDataTest {
                         AppRoleSelection(
                             packageName = "com.visible",
                             native = true,
-                            nativeHooks = listOf("dev_ioctl", "sock_ioctl"),
+                            nativeOverrides =
+                                NativeHookOverrides(
+                                    kernel = listOf("dev_ioctl", "sock_ioctl"),
+                                ),
                         ),
                     ),
                 snapshot = snapshotWithCanonical(),
             )
 
         assertEquals(
-            NativeRole(enabled = true, hooks = listOf("dev_ioctl", "sock_ioctl")),
+            NativeRole(
+                enabled = true,
+                overrides = NativeHookOverrides(kernel = listOf("dev_ioctl", "sock_ioctl")),
+            ),
             cfg.apps.getValue("com.visible").native,
         )
     }
@@ -257,7 +275,14 @@ class AppPickerDataTest {
                     ),
                 snapshot =
                     snapshotWithCanonical(
-                        "com.visible" to CanonicalApp(native = NativeRole(enabled = true, hooks = listOf("sock_ioctl"))),
+                        "com.visible" to
+                            CanonicalApp(
+                                native =
+                                    NativeRole(
+                                        enabled = true,
+                                        overrides = NativeHookOverrides(kernel = listOf("sock_ioctl")),
+                                    ),
+                            ),
                     ),
             )
 

--- a/lsposed/app/src/test/kotlin/dev/okhsunrog/vpnhide/StorageConfigTest.kt
+++ b/lsposed/app/src/test/kotlin/dev/okhsunrog/vpnhide/StorageConfigTest.kt
@@ -7,6 +7,37 @@ import java.io.File
 
 class StorageConfigTest {
     @Test
+    fun `native hook entries are raw backend hooks`() {
+        assertEquals(
+            listOf(
+                "fib_route_seq_show",
+                "ipv6_route_seq_show",
+                "rtnl_fill_ifinfo",
+                "inet_fill_ifaddr",
+                "inet6_fill_ifaddr",
+                "dev_ioctl",
+                "sock_ioctl",
+                "fib_dump_info",
+                "rt6_fill_node",
+                "fib_nl_fill_rule",
+            ),
+            NativeKernelHookEntries.map { it.hookName },
+        )
+        assertEquals(
+            listOf(
+                "zygisk_ioctl",
+                "zygisk_getifaddrs",
+                "zygisk_openat",
+                "zygisk_recvmsg",
+                "zygisk_recv",
+                "zygisk_recvfrom",
+                "zygisk_recvfrom_chk",
+            ),
+            ZygiskNativeHookEntries.map { it.hookName },
+        )
+    }
+
+    @Test
     fun `canonical config parses roles settings and hook lists`() {
         val cfg =
             requireNotNull(
@@ -47,8 +78,50 @@ class StorageConfigTest {
         )
         assertTrue(cfg.apps.getValue("com.bank").java)
         assertEquals(listOf("lsposed_network_capabilities"), cfg.apps.getValue("com.bank").javaHooks)
-        assertEquals(NativeRole(enabled = true, hooks = listOf("sock_ioctl")), cfg.apps.getValue("com.bank").native)
+        assertEquals(
+            NativeRole(
+                enabled = true,
+                overrides = NativeHookOverrides(kernel = listOf("sock_ioctl")),
+            ),
+            cfg.apps.getValue("com.bank").native,
+        )
         assertTrue(cfg.apps.getValue("dev.okhsunrog.vpnhide").hidden)
+    }
+
+    @Test
+    fun `canonical config parses backend specific native hook overrides`() {
+        val cfg =
+            requireNotNull(
+                parseCanonicalConfig(
+                    """
+                    {
+                      "version": 1,
+                      "apps": {
+                        "com.bank": {
+                          "native": {
+                            "enabled": true,
+                            "kernel": ["sock_ioctl"],
+                            "zygisk": ["zygisk_ioctl", "zygisk_recvfrom_chk"]
+                          }
+                        }
+                      }
+                    }
+                    """.trimIndent(),
+                ),
+            )
+
+        assertEquals(
+            NativeRole(
+                enabled = true,
+                overrides =
+                    NativeHookOverrides(
+                        kernel = listOf("sock_ioctl"),
+                        zygisk = listOf("zygisk_ioctl", "zygisk_recvfrom_chk"),
+                    ),
+            ),
+            cfg.apps.getValue("com.bank").native,
+        )
+        assertEquals(cfg, requireNotNull(parseCanonicalConfig(canonicalConfigJson(cfg))))
     }
 
     @Test
@@ -124,7 +197,10 @@ class StorageConfigTest {
         assertEquals(NativeRole.All, cfg.apps.getValue("com.example.bank").native)
         val proxy = cfg.apps.getValue("org.example.proxy")
         assertEquals(
-            NativeRole(enabled = true, hooks = listOf("fib_route_seq_show", "sock_ioctl")),
+            NativeRole(
+                enabled = true,
+                overrides = NativeHookOverrides(kernel = listOf("fib_route_seq_show", "sock_ioctl")),
+            ),
             proxy.native,
         )
         // Per-hook Java selection: the same array shape the native activator
@@ -140,7 +216,14 @@ class StorageConfigTest {
             CanonicalConfig(
                 apps =
                     mapOf(
-                        "com.bank" to CanonicalApp(native = NativeRole(enabled = true, hooks = listOf("sock_ioctl"))),
+                        "com.bank" to
+                            CanonicalApp(
+                                native =
+                                    NativeRole(
+                                        enabled = true,
+                                        overrides = NativeHookOverrides(kernel = listOf("sock_ioctl")),
+                                    ),
+                            ),
                     ),
             )
 
@@ -155,7 +238,13 @@ class StorageConfigTest {
                 existing = existing,
             )
 
-        assertEquals(NativeRole(enabled = true, hooks = listOf("sock_ioctl")), cfg.apps.getValue("com.bank").native)
+        assertEquals(
+            NativeRole(
+                enabled = true,
+                overrides = NativeHookOverrides(kernel = listOf("sock_ioctl")),
+            ),
+            cfg.apps.getValue("com.bank").native,
+        )
         assertEquals(NativeRole.All, cfg.apps.getValue("com.new").native)
     }
 
@@ -269,7 +358,11 @@ class StorageConfigTest {
                             CanonicalApp(
                                 java = true,
                                 javaHooks = listOf("lsposed_network_capabilities"),
-                                native = NativeRole(enabled = true, hooks = listOf("sock_ioctl")),
+                                native =
+                                    NativeRole(
+                                        enabled = true,
+                                        overrides = NativeHookOverrides(kernel = listOf("sock_ioctl")),
+                                    ),
                             ),
                     ),
             )

--- a/zygisk/src/generated/hook_ids.rs
+++ b/zygisk/src/generated/hook_ids.rs
@@ -42,13 +42,27 @@ pub enum Hook {
     LsposedConnectivityNetwork = 16,
     /// PackageManager app-hiding filters
     LsposedPackageVisibility = 17,
+    /// libc ioctl() SIOCGIF* interface probes
+    ZygiskIoctl = 18,
+    /// libc getifaddrs() interface enumeration
+    ZygiskGetifaddrs = 19,
+    /// openat() filtering for /proc/net routes and sockets
+    ZygiskOpenat = 20,
+    /// recvmsg() netlink dump filtering
+    ZygiskRecvmsg = 21,
+    /// recv() netlink dump filtering
+    ZygiskRecv = 22,
+    /// recvfrom() netlink dump filtering
+    ZygiskRecvfrom = 23,
+    /// __recvfrom_chk() fortified netlink dump filtering
+    ZygiskRecvfromChk = 24,
 }
 
-pub const HOOK_COUNT: u32 = 18;
+pub const HOOK_COUNT: u32 = 25;
 
 /// Hooks owned by each backend: apply `mask & own`.
 pub const KERNEL_HOOK_MASK: u32 = 0x3ff;
-pub const ZYGISK_HOOK_MASK: u32 = 0x0;
+pub const ZYGISK_HOOK_MASK: u32 = 0x1fc0000;
 pub const LSPOSED_HOOK_MASK: u32 = 0x3fc00;
 
 /// status error codes (protocol §5.1).
@@ -81,7 +95,7 @@ pub enum Backend {
     Lsposed = 3,
 }
 
-pub const HOOK_NAMES: [&str; 18] = [
+pub const HOOK_NAMES: [&str; 25] = [
     "fib_route_seq_show",
     "ipv6_route_seq_show",
     "rtnl_fill_ifinfo",
@@ -100,4 +114,11 @@ pub const HOOK_NAMES: [&str; 18] = [
     "lsposed_connectivity_callback",
     "lsposed_connectivity_network",
     "lsposed_package_visibility",
+    "zygisk_ioctl",
+    "zygisk_getifaddrs",
+    "zygisk_openat",
+    "zygisk_recvmsg",
+    "zygisk_recv",
+    "zygisk_recvfrom",
+    "zygisk_recvfrom_chk",
 ];

--- a/zygisk/src/lib.rs
+++ b/zygisk/src/lib.rs
@@ -83,6 +83,7 @@ use std::sync::Once;
 
 use log::{debug, error, info};
 use vpnhide_protocol as protocol;
+use vpnhide_protocol::hook_ids::{Hook, ZYGISK_HOOK_MASK};
 use zygisk_api::ZygiskModule;
 use zygisk_api::api::ZygiskApi;
 use zygisk_api::api::v2::{AppSpecializeArgs, V2, ZygiskOption};
@@ -144,9 +145,10 @@ fn set_log_level(enabled: bool) {
 #[derive(Default)]
 pub struct VpnHide {
     /// Set by `preAppSpecialize` if the forked process is a target we want
-    /// to hook. Read by `postAppSpecialize`. Accessed single-threaded
-    /// (Zygisk calls pre/post sequentially on the zygote main thread).
-    is_target: core::cell::Cell<bool>,
+    /// to hook. Carries only Zygisk-owned hook bits and is read by
+    /// `postAppSpecialize`. Accessed single-threaded (Zygisk calls pre/post
+    /// sequentially on the zygote main thread).
+    target_hookmask: core::cell::Cell<u32>,
     /// True only when the currently specializing app is the VPN Hide app
     /// itself, so we can write a heartbeat the dashboard can trust.
     report_status: core::cell::Cell<bool>,
@@ -164,12 +166,11 @@ unsafe impl Sync for VpnHide {}
 /// `targets.txt` are picked up on the next force-stop + restart — no zygote
 /// restart, no reboot needed. See the lifecycle block at the top of this file.
 ///
-/// `target_uids` is the set of UIDs to hide for (protocol §4.3 — UID is the
-/// key on every channel, including Zygisk); `debug` is the folded debug flag.
-/// Zygisk owns no registry hook bits yet, so it acts on target *presence* and
-/// ignores the per-hook mask (protocol §6 note).
+/// `targets` carries one Zygisk-owned hook mask per target UID (protocol §4.3 —
+/// UID is the key on every channel, including Zygisk); `debug` is the folded
+/// debug flag.
 struct ZygiskConfig {
-    target_uids: Vec<u32>,
+    targets: Vec<protocol::Target>,
     debug: bool,
 }
 
@@ -184,7 +185,7 @@ fn load_config_from_dir_fd(dir_fd: std::os::fd::RawFd) -> ZygiskConfig {
     use std::io::Read;
     use std::os::fd::FromRawFd;
     let empty = ZygiskConfig {
-        target_uids: Vec::new(),
+        targets: Vec::new(),
         debug: false,
     };
     let filename = std::ffi::CString::new(TARGETS_FILENAME).unwrap();
@@ -204,7 +205,17 @@ fn load_config_from_dir_fd(dir_fd: std::os::fd::RawFd) -> ZygiskConfig {
     }
     match protocol::parse_config(&content) {
         Some(cfg) => ZygiskConfig {
-            target_uids: cfg.targets.iter().map(|t| t.uid).collect(),
+            targets: cfg
+                .targets
+                .iter()
+                .filter_map(|t| {
+                    let hookmask = t.hookmask & ZYGISK_HOOK_MASK;
+                    (hookmask != 0).then_some(protocol::Target {
+                        uid: t.uid,
+                        hookmask,
+                    })
+                })
+                .collect(),
             debug: cfg.debug.unwrap_or(false),
         },
         None => {
@@ -238,8 +249,8 @@ impl ZygiskModule for VpnHide {
         // anything below logs. Default Off ⇒ silence on a fresh/empty install.
         set_log_level(cfg.debug);
         debug!(
-            "on_load: {} target uids cached, debug={}",
-            cfg.target_uids.len(),
+            "on_load: {} zygisk targets cached, debug={}",
+            cfg.targets.len(),
             cfg.debug
         );
         // dir_fd drops here → closed before any app fork.
@@ -258,13 +269,14 @@ impl ZygiskModule for VpnHide {
         // nice_name is still read, but only to recognise the VPN Hide app
         // itself for the status heartbeat — an identity check, not targeting.
         let package = read_jstring(&env, args.nice_name);
-        if is_target_uid(uid) {
-            info!("pre_app_specialize: targeting uid {uid}");
-            self.is_target.set(true);
+        let hookmask = target_hookmask(uid);
+        if hookmask != 0 {
+            info!("pre_app_specialize: targeting uid {uid} hooks=0x{hookmask:x}");
+            self.target_hookmask.set(hookmask);
             self.report_status
                 .set(package.as_deref() == Some(APP_PACKAGE));
         } else {
-            self.is_target.set(false);
+            self.target_hookmask.set(0);
             self.report_status.set(false);
             mark_cleanup(&mut api);
         }
@@ -276,12 +288,13 @@ impl ZygiskModule for VpnHide {
         _env: JNIEnv<'a>,
         _args: &'a AppSpecializeArgs<'_>,
     ) {
-        if !self.is_target.get() {
+        let hookmask = self.target_hookmask.get();
+        if hookmask == 0 {
             return;
         }
-        match install_hooks() {
+        match install_hooks(hookmask) {
             Ok(()) => {
-                info!("hooks installed (inline libc!ioctl + getifaddrs + openat for proc/net/*)");
+                info!("selected libc hooks installed (mask=0x{hookmask:x})");
                 if self.report_status.get() {
                     write_status_file();
                 }
@@ -338,8 +351,7 @@ fn mark_cleanup(api: &mut ZygiskApi<'_, V2>) {
     api.set_option(ZygiskOption::DlCloseModuleLibrary);
 }
 
-/// Install inline hooks on `libc.so` via ByteDance shadowhook. We patch
-/// three entry points:
+/// Install selected inline hooks on `libc.so` via ByteDance shadowhook.
 ///
 ///   * `ioctl` — catches `SIOCGIFNAME` / `SIOCGIFFLAGS` interface
 ///     probes from native code.
@@ -351,15 +363,16 @@ fn mark_cleanup(api: &mut ZygiskApi<'_, V2>) {
 ///   * `openat` — intercepts opens of `/proc/net/{route,ipv6_route,
 ///     if_inet6,tcp,tcp6}`; returns a `memfd` with VPN
 ///     entries stripped out.
-///   * `recvmsg` — filters netlink `RTM_NEWADDR` / `RTM_NEWLINK`
-///     dump responses, removing VPN interface entries.
+///   * `recvmsg` / `recv` / `recvfrom` / `__recvfrom_chk` — filter netlink
+///     `RTM_NEWADDR` / `RTM_NEWLINK` dump responses, removing VPN interface
+///     entries.
 ///
 /// This replaces the earlier PLT-hook approach. PLT hooks can only patch
 /// callers that are already mapped at `post_app_specialize` time — which
 /// excludes `libflutter.so`/`libapp.so` and any other library loaded later
 /// via `dlopen`. Inline-hooking libc's entry points themselves catches
 /// every caller regardless of load order.
-fn install_hooks() -> Result<(), String> {
+fn install_hooks(hookmask: u32) -> Result<(), String> {
     shadowhook::init_once().map_err(|rc| format!("shadowhook_init: rc={rc}"))?;
 
     // (sym, replacement, stash-original-via). Install order is the
@@ -370,29 +383,42 @@ fn install_hooks() -> Result<(), String> {
     // would break recv. recv itself is 12 bytes (3 instructions),
     // safe for island-mode hooking.
     type StoreFn = fn(*const ());
-    let plan: [(&core::ffi::CStr, *mut core::ffi::c_void, StoreFn); 7] = [
-        (c"ioctl", hooked_ioctl as *mut _, set_real_ioctl_ptr),
-        (
+    let mut plan: Vec<(&core::ffi::CStr, *mut core::ffi::c_void, StoreFn)> = Vec::new();
+    if zygisk_hook_enabled(hookmask, Hook::ZygiskIoctl) {
+        plan.push((c"ioctl", hooked_ioctl as *mut _, set_real_ioctl_ptr));
+    }
+    if zygisk_hook_enabled(hookmask, Hook::ZygiskGetifaddrs) {
+        plan.push((
             c"getifaddrs",
             hooked_getifaddrs as *mut _,
             set_real_getifaddrs_ptr,
-        ),
-        (c"openat", hooked_openat as *mut _, set_real_openat_ptr),
-        (c"recvmsg", hooked_recvmsg as *mut _, set_real_recvmsg_ptr),
-        (c"recv", hooked_recv as *mut _, set_real_recv_ptr),
-        // recvfrom + __recvfrom_chk catch FORTIFY'd / direct callers that
-        // never touch the `recv` symbol (issue #86 native route dump).
-        (
+        ));
+    }
+    if zygisk_hook_enabled(hookmask, Hook::ZygiskOpenat) {
+        plan.push((c"openat", hooked_openat as *mut _, set_real_openat_ptr));
+    }
+    if zygisk_hook_enabled(hookmask, Hook::ZygiskRecvmsg) {
+        plan.push((c"recvmsg", hooked_recvmsg as *mut _, set_real_recvmsg_ptr));
+    }
+    if zygisk_hook_enabled(hookmask, Hook::ZygiskRecv) {
+        plan.push((c"recv", hooked_recv as *mut _, set_real_recv_ptr));
+    }
+    // recvfrom + __recvfrom_chk catch FORTIFY'd / direct callers that
+    // never touch the `recv` symbol (issue #86 native route dump).
+    if zygisk_hook_enabled(hookmask, Hook::ZygiskRecvfrom) {
+        plan.push((
             c"recvfrom",
             hooked_recvfrom as *mut _,
             set_real_recvfrom_ptr,
-        ),
-        (
+        ));
+    }
+    if zygisk_hook_enabled(hookmask, Hook::ZygiskRecvfromChk) {
+        plan.push((
             c"__recvfrom_chk",
             hooked_recvfrom_chk as *mut _,
             set_real_recvfrom_chk_ptr,
-        ),
-    ];
+        ));
+    }
 
     let mut installed: Vec<*mut core::ffi::c_void> = Vec::with_capacity(plan.len());
     for (sym, new_fn, store_orig) in plan {
@@ -552,19 +578,28 @@ fn scrub_shadowhook_maps() {
     }
 }
 
-/// Is this UID one of our targets? (protocol §4.3 — UID is the key on every
-/// channel, including Zygisk.)
+/// Return this UID's Zygisk-owned hook mask, or zero if it is not targeted.
+/// Protocol §4.3 uses UID as the key on every channel, including Zygisk.
 ///
 /// Called from `pre_app_specialize`, which runs on the zygote side BEFORE the
 /// uid drop, so `args.uid` already holds the UID this child will become. One
 /// UID covers every process of a multi-process app, so this needs no
 /// sub-process name handling (the old package-name path did).
 #[inline(never)]
-fn is_target_uid(uid: u32) -> bool {
+fn target_hookmask(uid: u32) -> u32 {
     match CACHED_CONFIG.get() {
-        Some(cfg) => cfg.target_uids.contains(&uid),
-        None => false,
+        Some(cfg) => cfg
+            .targets
+            .iter()
+            .find(|target| target.uid == uid)
+            .map(|target| target.hookmask)
+            .unwrap_or(0),
+        None => 0,
     }
+}
+
+fn zygisk_hook_enabled(hookmask: u32, hook: Hook) -> bool {
+    hookmask & (1u32 << hook as u32) != 0
 }
 
 /// Decode a `JString` (as stored in `AppSpecializeArgs::nice_name`) into


### PR DESCRIPTION
## Summary
- Store native hook overrides separately for kernel/KPM and Zygisk in canonical config.
- Project the active native backend family in activators, so kernel backends use kernel hook IDs and Zygisk uses Zygisk hook IDs.
- Register every current Zygisk libc hook as an individual hook ID: ioctl, getifaddrs, openat, recvmsg, recv, recvfrom, and __recvfrom_chk.
- Update the Protection hook tuning dialog to show the hook list for the displayed native backend family.

## Validation
- cargo test -p vpnhide_activator
- ./gradlew :app:testDebugUnitTest --tests dev.okhsunrog.vpnhide.StorageConfigTest --tests dev.okhsunrog.vpnhide.AppPickerDataTest --tests dev.okhsunrog.vpnhide.SettingsDataTest
- ./gradlew :app:ktlintCheck :app:detekt
- zygisk/build.py
