### PR TITLE
feat(lsposed): full-reset button to remove leftover files after uninstall

### DIFF
--- a/changelog.d/added-add-a-settings-reset-button-that-f5b1.md
+++ b/changelog.d/added-add-a-settings-reset-button-that-f5b1.md
@@ -1,0 +1,9 @@
+_2026-06-29_
+
+## English
+
+Add a Settings reset button that removes the config, state and target files VPN Hide leaves on the device, so nothing is orphaned after you uninstall the app and its modules.
+
+## Русский
+
+Добавлена кнопка сброса в настройках, которая удаляет файлы конфигов, состояния и таргетов, оставляемые VPN Hide на устройстве, чтобы после удаления приложения и модулей не оставалось сирот.

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/FullReset.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/FullReset.kt
@@ -1,0 +1,85 @@
+package dev.okhsunrog.vpnhide
+
+// Full reset: delete the service files VPN Hide and its modules write OUTSIDE
+// their Magisk module directories. These are root-owned and live under
+// /data/system and /data/adb/vpnhide*, so they survive an APK uninstall and are
+// not removed by any module's uninstall.sh — this is the "leftover files after
+// uninstall" users complained about.
+//
+// Deliberately out of scope (each would only add risk):
+//  - /data/adb/modules/vpnhide_* — manager-owned; remove via Magisk/KSU/APatch,
+//    not by rm (would desync the module DB).
+//  - runtime state (iptables chains, /proc/vpnhide_ctl) — cleared by a reboot
+//    once the modules are gone.
+//  - the app's own /data/data (SharedPreferences, zygisk heartbeat) — wiped
+//    when the APK is uninstalled.
+
+// Plain files under /data/system (rm -f).
+internal val FULL_RESET_FILES =
+    listOf(
+        CANONICAL_CONFIG_FILE,
+        "/data/system/vpnhide_uids.txt",
+        "/data/system/vpnhide_debug_logging",
+        SS_HIDDEN_PKGS_FILE,
+        SS_OBSERVER_UIDS_FILE,
+        LSPOSED_STATE_FILE,
+        LEGACY_HOOK_STATUS_FILE,
+    )
+
+// Data directories under /data/adb (rm -rf — covers targets.txt, load_status,
+// superkey, etc. inside). Each is an explicit, vpnhide-prefixed path — never a
+// glob and never a module install dir.
+internal val FULL_RESET_DIRS =
+    listOf(
+        "/data/adb/vpnhide",
+        "/data/adb/vpnhide_kmod",
+        "/data/adb/vpnhide_kpm",
+        "/data/adb/vpnhide_zygisk",
+        "/data/adb/vpnhide_lsposed",
+        "/data/adb/vpnhide_ports",
+    )
+
+/** Single su command that removes every leftover service file/dir. Idempotent:
+ *  paths a module's uninstall.sh already removed are simply no-ops. */
+internal fun buildFullResetCommand(): String =
+    (
+        listOf("rm -f " + FULL_RESET_FILES.joinToString(" ")) +
+            FULL_RESET_DIRS.map { "rm -rf $it" }
+    ).joinToString(" ; ")
+
+// A reason the full reset must wait — something VPN Hide left running is still
+// installed/active, so deleting its state now is unsafe (a live .ko keeps
+// filtering; an active hook re-reads the config). The user must clear these and
+// reboot first.
+internal enum class ResetBlocker {
+    KmodInstalled,
+    KpmInstalled,
+    ZygiskInstalled,
+    PortsInstalled,
+    KernelStillHooked,
+    LsposedActive,
+}
+
+/**
+ * Preconditions for a safe full reset, reusing the dashboard's tested module /
+ * hook detection. Empty list == ready. A backend whose module dir is still
+ * present (even disabled) blocks, as does a still-loaded .ko
+ * ([kernelCtlPresent], from `/proc/vpnhide_ctl`) or an LSPosed hook active this
+ * boot.
+ */
+internal fun resetBlockers(
+    kmod: ModuleState,
+    kpm: ModuleState,
+    zygisk: ModuleState,
+    ports: ModuleState,
+    lsposed: LsposedState,
+    kernelCtlPresent: Boolean,
+): List<ResetBlocker> =
+    buildList {
+        if (kmod is ModuleState.Installed) add(ResetBlocker.KmodInstalled)
+        if (kpm is ModuleState.Installed) add(ResetBlocker.KpmInstalled)
+        if (zygisk is ModuleState.Installed) add(ResetBlocker.ZygiskInstalled)
+        if (ports is ModuleState.Installed) add(ResetBlocker.PortsInstalled)
+        if (kernelCtlPresent) add(ResetBlocker.KernelStillHooked)
+        if (lsposed is LsposedState.Active) add(ResetBlocker.LsposedActive)
+    }

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/FullResetDialog.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/FullResetDialog.kt
@@ -1,0 +1,188 @@
+package dev.okhsunrog.vpnhide
+
+import android.content.Context
+import android.content.Intent
+import android.net.Uri
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import kotlinx.coroutines.launch
+
+private fun resetBlockerLabel(blocker: ResetBlocker): Int =
+    when (blocker) {
+        ResetBlocker.KmodInstalled -> R.string.reset_blocker_kmod
+        ResetBlocker.KpmInstalled -> R.string.reset_blocker_kpm
+        ResetBlocker.ZygiskInstalled -> R.string.reset_blocker_zygisk
+        ResetBlocker.PortsInstalled -> R.string.reset_blocker_ports
+        ResetBlocker.KernelStillHooked -> R.string.reset_blocker_kernel
+        ResetBlocker.LsposedActive -> R.string.reset_blocker_lsposed
+    }
+
+private fun uninstallSelf(context: Context) {
+    runCatching {
+        context.startActivity(
+            Intent(Intent.ACTION_DELETE, Uri.parse("package:${context.packageName}"))
+                .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK),
+        )
+    }
+}
+
+/**
+ * Full-reset confirmation flow. Reuses the dashboard's tested module/hook
+ * detection ([resetBlockers]) to gate the destructive action: it only deletes
+ * leftover service files once every module is removed and the LSPosed hook is
+ * inactive (and the kernel is no longer hooked). On success it offers to
+ * uninstall the app — it never silently closes.
+ */
+@Composable
+internal fun FullResetDialog(
+    selfNeedsRestart: Boolean,
+    onDismiss: () -> Unit,
+) {
+    val context = LocalContext.current
+    val scope = rememberCoroutineScope()
+    val dash by DashboardCache.state.collectAsState()
+    val snap by RootSnapshotCache.snapshot.collectAsState()
+
+    androidx.compose.runtime.LaunchedEffect(Unit) {
+        DashboardCache.ensureLoaded(scope, context, selfNeedsRestart)
+    }
+
+    var running by remember { mutableStateOf(false) }
+    var done by remember { mutableStateOf<Boolean?>(null) } // null = not run; true/false = result
+
+    val blockers =
+        dash?.let {
+            resetBlockers(
+                kmod = it.kmod,
+                kpm = it.kpm,
+                zygisk = it.zygisk,
+                ports = it.ports,
+                lsposed = it.lsposed,
+                kernelCtlPresent = snap?.sections?.get("proc_exists")?.trim() == "1",
+            )
+        }
+    val ready = blockers != null && blockers.isEmpty()
+
+    AlertDialog(
+        onDismissRequest = { if (!running) onDismiss() },
+        title = { Text(stringResource(R.string.reset_title)) },
+        text = {
+            when {
+                done == true -> {
+                    Text(stringResource(R.string.reset_done_body))
+                }
+
+                done == false -> {
+                    Text(stringResource(R.string.reset_failed_body))
+                }
+
+                running -> {
+                    ProgressRow(R.string.reset_running)
+                }
+
+                dash == null -> {
+                    ProgressRow(R.string.reset_checking)
+                }
+
+                ready -> {
+                    Column(verticalArrangement = Arrangement.spacedBy(10.dp)) {
+                        Text(stringResource(R.string.reset_warning))
+                        Text(
+                            text = stringResource(R.string.reset_instructions),
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+                    }
+                }
+
+                else -> {
+                    Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                        Text(stringResource(R.string.reset_blocked_intro))
+                        blockers?.forEach { blocker ->
+                            Text("•  " + stringResource(resetBlockerLabel(blocker)))
+                        }
+                        Text(
+                            text = stringResource(R.string.reset_instructions),
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+                    }
+                }
+            }
+        },
+        confirmButton = {
+            when {
+                done == true -> {
+                    TextButton(onClick = { uninstallSelf(context) }) {
+                        Text(stringResource(R.string.reset_uninstall))
+                    }
+                }
+
+                done == false || running -> {
+                    Unit
+                }
+
+                ready -> {
+                    TextButton(
+                        onClick = {
+                            running = true
+                            scope.launch {
+                                val (exit, _) = suExecAsync(buildFullResetCommand())
+                                running = false
+                                done = exit == 0
+                                if (exit == 0) {
+                                    DashboardCache.refresh(scope, context, selfNeedsRestart)
+                                }
+                            }
+                        },
+                    ) {
+                        Text(
+                            text = stringResource(R.string.reset_confirm),
+                            color = MaterialTheme.colorScheme.error,
+                        )
+                    }
+                }
+
+                else -> {
+                    Unit
+                }
+            }
+        },
+        dismissButton = {
+            if (!running) {
+                TextButton(onClick = onDismiss) {
+                    Text(stringResource(if (done == true) R.string.reset_close else R.string.btn_cancel))
+                }
+            }
+        },
+    )
+}
+
+@Composable
+private fun ProgressRow(textRes: Int) {
+    Row(
+        horizontalArrangement = Arrangement.spacedBy(12.dp),
+        verticalAlignment = androidx.compose.ui.Alignment.CenterVertically,
+    ) {
+        CircularProgressIndicator(modifier = Modifier.size(20.dp), strokeWidth = 2.dp)
+        Text(stringResource(textRes))
+    }
+}

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/SettingsScreen.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/SettingsScreen.kt
@@ -30,6 +30,7 @@ import androidx.compose.material.icons.filled.CheckCircle
 import androidx.compose.material.icons.filled.ContentCopy
 import androidx.compose.material.icons.filled.DarkMode
 import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material.icons.filled.DeleteForever
 import androidx.compose.material.icons.filled.FileDownload
 import androidx.compose.material.icons.filled.FileUpload
 import androidx.compose.material.icons.filled.Forum
@@ -238,7 +239,25 @@ fun SettingsScreen(
             ConfigBackupSection()
             SuperkeySettingsSection()
             CommunitySettingsSection()
+            ResetSettingsSection(selfNeedsRestart = selfNeedsRestart)
         }
+    }
+}
+
+@Composable
+private fun ResetSettingsSection(selfNeedsRestart: Boolean?) {
+    var open by remember { mutableStateOf(false) }
+    if (open) {
+        FullResetDialog(selfNeedsRestart = selfNeedsRestart == true, onDismiss = { open = false })
+    }
+    Column(verticalArrangement = Arrangement.spacedBy(3.dp)) {
+        SettingsSectionHeader(stringResource(R.string.settings_reset_section))
+        PreferenceRow(
+            title = stringResource(R.string.reset_button),
+            subtitle = stringResource(R.string.reset_button_sub),
+            icon = Icons.Default.DeleteForever,
+            onClick = { open = true },
+        )
     }
 }
 

--- a/lsposed/app/src/main/res/values-ru/strings.xml
+++ b/lsposed/app/src/main/res/values-ru/strings.xml
@@ -191,6 +191,27 @@
     <string name="settings_community_section">Сообщество</string>
     <string name="settings_community">Сообщество и обратная связь</string>
     <string name="settings_community_sub">Контакты автора: GitHub, Telegram, 4PDA</string>
+    <!-- Full reset / leftover cleanup -->
+    <string name="settings_reset_section">Сброс</string>
+    <string name="reset_button">Удалить оставшиеся файлы</string>
+    <string name="reset_button_sub">Удалить все файлы конфигов, состояния и таргетов, которые VPN Hide оставил на устройстве</string>
+    <string name="reset_title">Удалить оставшиеся файлы</string>
+    <string name="reset_warning">Будут безвозвратно удалены все файлы конфигов, состояния, статистики и таргетов, которые VPN Hide и его модули писали вне своих модульных каталогов. Действие необратимо.</string>
+    <string name="reset_instructions">Делайте это только после того, как: удалили все модули VPN Hide в root-менеджере, выключили LSPosed-модуль VPN Hide и перезагрузились. Каталоги модулей, само приложение и runtime-состояние здесь не трогаются — они уходят сами после шагов выше.</string>
+    <string name="reset_checking">Проверка состояния модулей…</string>
+    <string name="reset_running">Удаление файлов…</string>
+    <string name="reset_blocked_intro">Пока нельзя — VPN Hide ещё активен. Сначала удалите это и перезагрузитесь:</string>
+    <string name="reset_blocker_kmod">Модуль ядра (.ko) ещё установлен</string>
+    <string name="reset_blocker_kpm">KPM ещё установлен</string>
+    <string name="reset_blocker_zygisk">Модуль Zygisk ещё установлен</string>
+    <string name="reset_blocker_ports">Модуль портов ещё установлен</string>
+    <string name="reset_blocker_kernel">Хук ядра ещё загружен — нужна перезагрузка</string>
+    <string name="reset_blocker_lsposed">LSPosed-хук ещё активен</string>
+    <string name="reset_confirm">Удалить всё</string>
+    <string name="reset_done_body">Готово. Все оставшиеся файлы удалены. Теперь можно удалить VPN Hide.</string>
+    <string name="reset_failed_body">Не удалось удалить файлы. Убедитесь, что предоставлен root-доступ, и попробуйте снова.</string>
+    <string name="reset_uninstall">Удалить VPN Hide</string>
+    <string name="reset_close">Закрыть</string>
     <string name="dashboard_issues">Ошибки (%d)</string>
     <string name="dashboard_warnings">Предупреждения (%d)</string>
     <string name="dashboard_info">Информация (%d)</string>

--- a/lsposed/app/src/main/res/values/strings.xml
+++ b/lsposed/app/src/main/res/values/strings.xml
@@ -230,6 +230,27 @@
     <string name="settings_community_section">Community</string>
     <string name="settings_community">Community &amp; feedback</string>
     <string name="settings_community_sub">Author contacts: GitHub, Telegram, 4PDA</string>
+    <!-- Full reset / leftover cleanup -->
+    <string name="settings_reset_section">Reset</string>
+    <string name="reset_button">Remove leftover files</string>
+    <string name="reset_button_sub">Delete all config, state and target files VPN Hide left on the device</string>
+    <string name="reset_title">Remove leftover files</string>
+    <string name="reset_warning">This permanently deletes every config, state, statistics and target file VPN Hide and its modules wrote outside their module folders. This cannot be undone.</string>
+    <string name="reset_instructions">Do this only after you have: removed all VPN Hide modules in your root manager, disabled the VPN Hide LSPosed module, and rebooted. Module folders, the app itself and runtime state are not touched here — they go away with the steps above.</string>
+    <string name="reset_checking">Checking module state…</string>
+    <string name="reset_running">Deleting files…</string>
+    <string name="reset_blocked_intro">Not ready yet — VPN Hide is still active. Remove these and reboot first:</string>
+    <string name="reset_blocker_kmod">Kernel module (.ko) is still installed</string>
+    <string name="reset_blocker_kpm">KPM is still installed</string>
+    <string name="reset_blocker_zygisk">Zygisk module is still installed</string>
+    <string name="reset_blocker_ports">Ports module is still installed</string>
+    <string name="reset_blocker_kernel">Kernel hook is still loaded — reboot needed</string>
+    <string name="reset_blocker_lsposed">LSPosed hook is still active</string>
+    <string name="reset_confirm">Delete everything</string>
+    <string name="reset_done_body">Done. All leftover files were removed. You can now uninstall VPN Hide.</string>
+    <string name="reset_failed_body">Could not remove the files. Make sure root access is granted and try again.</string>
+    <string name="reset_uninstall">Uninstall VPN Hide</string>
+    <string name="reset_close">Close</string>
     <string name="dashboard_issues">Errors (%d)</string>
     <string name="dashboard_warnings">Warnings (%d)</string>
     <string name="dashboard_info">Info (%d)</string>

--- a/lsposed/app/src/test/kotlin/dev/okhsunrog/vpnhide/FullResetTest.kt
+++ b/lsposed/app/src/test/kotlin/dev/okhsunrog/vpnhide/FullResetTest.kt
@@ -1,0 +1,121 @@
+package dev.okhsunrog.vpnhide
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class FullResetTest {
+    private val installed = ModuleState.Installed(version = "1.0", active = false, targetCount = 0)
+    private val activeLsposed = LsposedState.Active(version = "1.0", targetCount = 0)
+
+    @Test
+    fun `reset command removes every leftover service path`() {
+        val cmd = buildFullResetCommand()
+        // canonical, legacy + SS files, and every /data/adb/vpnhide* data dir.
+        assertTrue(cmd.contains(CANONICAL_CONFIG_FILE))
+        assertTrue(cmd.contains(SS_HIDDEN_PKGS_FILE))
+        assertTrue(cmd.contains(SS_OBSERVER_UIDS_FILE))
+        assertTrue(cmd.contains(LSPOSED_STATE_FILE))
+        assertTrue(cmd.contains(LEGACY_HOOK_STATUS_FILE))
+        assertTrue(cmd.contains("rm -rf /data/adb/vpnhide "))
+        listOf("kmod", "kpm", "zygisk", "lsposed", "ports").forEach {
+            assertTrue("missing /data/adb/vpnhide_$it", cmd.contains("rm -rf /data/adb/vpnhide_$it"))
+        }
+    }
+
+    @Test
+    fun `reset command never touches module dirs, iptables, or proc`() {
+        val cmd = buildFullResetCommand()
+        assertFalse(cmd.contains("/data/adb/modules"))
+        assertFalse(cmd.contains("iptables"))
+        assertFalse(cmd.contains("ip6tables"))
+        assertFalse(cmd.contains("/proc/"))
+    }
+
+    @Test
+    fun `ready when nothing is installed or active`() {
+        assertEquals(
+            emptyList<ResetBlocker>(),
+            resetBlockers(
+                kmod = ModuleState.NotInstalled,
+                kpm = ModuleState.NotInstalled,
+                zygisk = ModuleState.NotInstalled,
+                ports = ModuleState.NotInstalled,
+                lsposed = LsposedState.NotInstalled,
+                kernelCtlPresent = false,
+            ),
+        )
+    }
+
+    @Test
+    fun `each remaining backend or hook is a blocker`() {
+        assertEquals(
+            listOf(
+                ResetBlocker.KmodInstalled,
+                ResetBlocker.KpmInstalled,
+                ResetBlocker.ZygiskInstalled,
+                ResetBlocker.PortsInstalled,
+                ResetBlocker.KernelStillHooked,
+                ResetBlocker.LsposedActive,
+            ),
+            resetBlockers(
+                kmod = installed,
+                kpm = installed,
+                zygisk = installed,
+                ports = installed,
+                lsposed = activeLsposed,
+                kernelCtlPresent = true,
+            ),
+        )
+    }
+
+    @Test
+    fun `a disabled-but-present module still blocks`() {
+        // module dir present (Installed, inactive) -> user must remove it, not
+        // just disable it.
+        assertEquals(
+            listOf(ResetBlocker.KmodInstalled),
+            resetBlockers(
+                kmod = installed,
+                kpm = ModuleState.NotInstalled,
+                zygisk = ModuleState.NotInstalled,
+                ports = ModuleState.NotInstalled,
+                lsposed = LsposedState.NotInstalled,
+                kernelCtlPresent = false,
+            ),
+        )
+    }
+
+    @Test
+    fun `loaded ko with no module dir still blocks via proc`() {
+        // Removed the module but didn't reboot: /proc/vpnhide_ctl still exists.
+        assertEquals(
+            listOf(ResetBlocker.KernelStillHooked),
+            resetBlockers(
+                kmod = ModuleState.NotInstalled,
+                kpm = ModuleState.NotInstalled,
+                zygisk = ModuleState.NotInstalled,
+                ports = ModuleState.NotInstalled,
+                lsposed = LsposedState.NotInstalled,
+                kernelCtlPresent = true,
+            ),
+        )
+    }
+
+    @Test
+    fun `inactive lsposed module does not block`() {
+        // disabled hook (InstalledInactive) is fine — only an active hook blocks.
+        assertEquals(
+            emptyList<ResetBlocker>(),
+            resetBlockers(
+                kmod = ModuleState.NotInstalled,
+                kpm = ModuleState.NotInstalled,
+                zygisk = ModuleState.NotInstalled,
+                ports = ModuleState.NotInstalled,
+                lsposed = LsposedState.InstalledInactive(version = "1.0"),
+                kernelCtlPresent = false,
+            ),
+        )
+    }
+}


### PR DESCRIPTION
Root-owned service files under `/data/system` and `/data/adb/vpnhide*` survive an APK uninstall and aren't removed by any module's `uninstall.sh`, so users were left with orphaned VPN Hide files after removing the app and its modules. This adds a Settings → Reset action that deletes exactly those leftovers, gated on the system being safe to clean.

The cleanup is intentionally narrow — it only removes the config / state / statistics / target / superkey files VPN Hide and its modules write outside their module folders. It never touches `/data/adb/modules/*` (manager-owned — remove those via Magisk/KSU/APatch), runtime state (iptables chains, `/proc/vpnhide_ctl` — cleared by a reboot once modules are gone), or the app's own `/data/data` (wiped on APK uninstall).

- Explicit path list (no globs, no module dirs); `buildFullResetCommand` is idempotent so paths a module's uninstall.sh already removed are no-ops.
- Precondition gate reuses the dashboard's tested module/hook detection: the destructive action is disabled while any backend module is still installed, the kernel module is still loaded (`/proc/vpnhide_ctl`), or the LSPosed hook is active. The dialog lists exactly what's still active and instructs the user to remove modules, disable the LSPosed module, and reboot first.
- On success the dialog offers to uninstall VPN Hide (fires the package uninstall intent) — it never silently closes the app.
- Pure logic (`buildFullResetCommand`, `resetBlockers`) is unit-tested; EN + RU strings.

Testing: the destructive su deletion and the uninstall intent are device-only paths; the path list and the readiness gate are covered by unit tests, but the actual on-device delete + uninstall flow should be sanity-checked on a real device before release.