### PR TITLE
Clean up LSPosed compile warnings

### DIFF
--- a/lsposed/app/build.gradle.kts
+++ b/lsposed/app/build.gradle.kts
@@ -1,6 +1,12 @@
 import java.io.FileInputStream
 import java.util.Properties
+import org.gradle.api.DefaultTask
+import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.tasks.Exec
+import org.gradle.api.tasks.InputFile
+import org.gradle.api.tasks.PathSensitive
+import org.gradle.api.tasks.PathSensitivity
+import org.gradle.api.tasks.TaskAction
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
@@ -63,6 +69,45 @@ uniffi {
     generateFromLibrary {
         packageName = "dev.okhsunrog.vpnhide.checks"
     }
+}
+
+abstract class SuppressGeneratedUniffiWarningsTask : DefaultTask() {
+    @get:InputFile
+    @get:PathSensitive(PathSensitivity.RELATIVE)
+    abstract val bindingFile: RegularFileProperty
+
+    @TaskAction
+    fun suppress() {
+        // UniFFI emits two intentional object references as bare expressions.
+        // Keep the suppression scoped to the generated binding file so real
+        // UNUSED_EXPRESSION warnings in hand-written Kotlin still surface.
+        val binding = bindingFile.get().asFile
+        if (!binding.isFile) return
+
+        val original = binding.readText()
+        val updated =
+            original.replaceFirst(
+                "@file:Suppress(\"RemoveRedundantBackticks\")",
+                "@file:Suppress(\"RemoveRedundantBackticks\", \"UNUSED_EXPRESSION\")",
+            )
+        if (updated != original) {
+            binding.writeText(updated)
+        }
+    }
+}
+
+val generatedUniffiBinding =
+    layout.buildDirectory.file("generated/uniffi/main/dev/okhsunrog/vpnhide/checks/vpnhide_checks.android.kt")
+
+val suppressGeneratedUniffiWarnings =
+    tasks.register<SuppressGeneratedUniffiWarningsTask>("suppressGeneratedUniffiWarnings") {
+        dependsOn("buildUniffiBindings")
+        bindingFile.set(generatedUniffiBinding)
+        outputs.upToDateWhen { false }
+    }
+
+tasks.matching { it.name.startsWith("compile") && it.name.endsWith("Kotlin") }.configureEach {
+    dependsOn(suppressGeneratedUniffiWarnings)
 }
 
 android {

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DashboardData.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DashboardData.kt
@@ -1343,9 +1343,7 @@ internal suspend fun loadDashboardState(
                 }
             }
 
-            else -> {
-                Unit
-            }
+            else -> {}
         }
     }
 

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/HookEntry.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/HookEntry.kt
@@ -42,8 +42,10 @@ import java.lang.reflect.Array as JavaArray
  *
  * Single Xposed entry point for system_server hook wiring; splitting the hook
  * installer is a separate refactor from adding telemetry.
+ *
+ * Deprecated legacy connectivity APIs are still active detection surfaces.
  */
-@Suppress("LargeClass")
+@Suppress("DEPRECATION", "LargeClass")
 class HookEntry : IXposedHookLoadPackage {
     private val hookInstalled = AtomicBoolean(false)
 

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/MainActivity.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/MainActivity.kt
@@ -306,27 +306,33 @@ private fun MainScreen() {
         topBar = {
             if (searchActive && currentTab == Tab.Protection) {
                 SearchBar(
-                    query = searchQuery,
-                    onQueryChange = { searchQuery = it },
-                    onSearch = {},
-                    active = false,
-                    onActiveChange = {},
-                    placeholder = { Text(stringResource(R.string.search_placeholder)) },
-                    leadingIcon = {
-                        IconButton(onClick = {
-                            searchActive = false
-                            searchQuery = ""
-                        }) {
-                            Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = null)
-                        }
+                    inputField = {
+                        SearchBarDefaults.InputField(
+                            query = searchQuery,
+                            onQueryChange = { searchQuery = it },
+                            onSearch = {},
+                            expanded = false,
+                            onExpandedChange = {},
+                            placeholder = { Text(stringResource(R.string.search_placeholder)) },
+                            leadingIcon = {
+                                IconButton(onClick = {
+                                    searchActive = false
+                                    searchQuery = ""
+                                }) {
+                                    Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = null)
+                                }
+                            },
+                            trailingIcon = {
+                                if (searchQuery.isNotEmpty()) {
+                                    IconButton(onClick = { searchQuery = "" }) {
+                                        Icon(Icons.Default.Clear, contentDescription = null)
+                                    }
+                                }
+                            },
+                        )
                     },
-                    trailingIcon = {
-                        if (searchQuery.isNotEmpty()) {
-                            IconButton(onClick = { searchQuery = "" }) {
-                                Icon(Icons.Default.Clear, contentDescription = null)
-                            }
-                        }
-                    },
+                    expanded = false,
+                    onExpandedChange = {},
                     modifier = Modifier.fillMaxWidth(),
                 ) {}
             } else {


### PR DESCRIPTION
## Summary
- Replace deprecated Material3 SearchBar usage with the current inputField overload.
- Remove an unused expression in dashboard issue classification.
- Suppress deprecated NetworkInfo usage at the LSPosed hook entry point because those legacy APIs remain active VPN detection surfaces.
- Add a configuration-cache-safe Gradle task that suppresses UniFFI generated UNUSED_EXPRESSION warnings only in the generated binding file.

## Notes
Fresh Gradle configuration still reports external deprecations from detekt/AGP internals (`ReportingExtension.file` and AGP test component dependency notation). I left those visible instead of globally suppressing Gradle warnings.

## Validation
- ./gradlew :app:compileDebugKotlin :app:compileReleaseKotlin :app:compileDebugUnitTestKotlin --rerun-tasks --warning-mode all
- ./gradlew :app:ktlintCheck :app:detekt
- ./gradlew :app:testDebugUnitTest
- ./gradlew :app:assembleRelease --warning-mode all
- cargo test --workspace
- git diff --check
