### PR TITLE
Enable full role labels by default

### DIFF
--- a/changelog.d/fixed-enable-full-protection-role-labels-by-f924.md
+++ b/changelog.d/fixed-enable-full-protection-role-labels-by-f924.md
@@ -1,0 +1,9 @@
+_2026-06-29_
+
+## English
+
+Enable full Protection role labels by default.
+
+## Русский
+
+Включены полные названия ролей Protection по умолчанию.

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/settings/AppSettings.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/settings/AppSettings.kt
@@ -44,7 +44,7 @@ data class AppSettings(
     /** Subtle haptic feedback on taps/toggles. */
     val hapticsEnabled: Boolean = true,
     /** Use full role labels in the unified Protection picker instead of single-letter chips. */
-    val fullProtectionRoleLabels: Boolean = false,
+    val fullProtectionRoleLabels: Boolean = true,
     /** Whether the user has opened Settings at least once (gates the gear hint). */
     val settingsHintSeen: Boolean = false,
 ) {


### PR DESCRIPTION
## Summary
- Make the Protection role-label setting default to full labels (`Java / Native / Apps / Ports`) instead of compact letters.
- Add a changelog fragment for the default UI behavior change.

## Validation
- ./gradlew :app:ktlintCheck :app:detekt
- ./gradlew :app:compileDebugKotlin
- git diff --check
