### PR TITLE
feat(lsposed): per-app probe statistics + capture sessions

### DIFF
--- a/changelog.d/added-rework-the-statistics-tab-into-a-76a2.md
+++ b/changelog.d/added-rework-the-statistics-tab-into-a-76a2.md
@@ -1,0 +1,9 @@
+_2026-06-29_
+
+## English
+
+Rework the Statistics tab into a per-app view of which apps probe for the VPN and how, with a tap-through per-hook breakdown that explains each detection method, and a capture-session tool to see what a specific app probes in a controlled window.
+
+## Русский
+
+Экран «Статистика» переделан в разбивку по приложениям: кто и какими способами проверяет VPN, с детальной расшифровкой по хукам и объяснением каждого способа детекта, плюс режим «сессии захвата» — что именно проверяет конкретное приложение за выбранное окно.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -88,6 +88,33 @@ Follow-up work (low priority):
 - Keep install-time hook status detailed enough to diagnose Android framework
   drift, especially private-field changes in new Android releases.
 
+### Per-app probe statistics
+
+The Statistics screen surfaces the per-uid × per-hook interception counters
+every active backend already reports (Java + the one installed native backend),
+aggregated per app and labelled by detection method. A capture-session mode
+baselines the counters and shows live deltas while the user exercises a target
+app — "start capture → open the app → see which methods it probed", without any
+per-event timestamps or persistence (counters are u64; a backend restart that
+drops counts below the baseline is detected and re-baselined).
+
+This is intentionally scoped to **target apps only** — the apps the user already
+protects, which are the only ones the hooks currently count. That is where the
+value is: confirming the hiding works and seeing which protected apps probe
+hardest.
+
+Follow-up work (low priority):
+
+- Monitoring / capture of **non-target** apps — counting probes from callers the
+  user has *not* added, to discover new apps attempting VPN detection
+  ([issue 119](https://github.com/okhsunrog/vpnhide/issues/119)). This needs an
+  opt-in "observe" mode in the Java backend (system_server sees every caller;
+  kernel backends only count their target UIDs, and Zygisk is only injected into
+  its own targets), plus write-coalescing on the hot path. Deferred until the
+  target-app statistics prove their value.
+- Fill the Zygisk stats channel (protocol §7) so an active Zygisk backend isn't
+  blank on the Statistics screen.
+
 ## Configuration
 
 - Consider user-defined VPN interface prefixes for uncommon tunnels or renamed

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/LsposedState.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/LsposedState.kt
@@ -1,10 +1,13 @@
 package dev.okhsunrog.vpnhide
 
 import android.os.Build
+import android.os.Handler
+import android.os.HandlerThread
 import android.os.Process
 import dev.okhsunrog.vpnhide.generated.HookIds
 import java.io.File
 import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicLong
 
 internal const val LSPOSED_STATE_FILE = "/data/system/vpnhide_lsposed_state"
@@ -48,7 +51,25 @@ internal fun formatLsposedState(
     }
 
 internal object LsposedStats {
+    // Coalesce disk writes. record() runs on the hot path inside system_server
+    // (potentially every NetworkCapabilities/connectivity call from a probing
+    // app); a full state-file rewrite per call is write-amplification + lock
+    // contention. Counters stay live in memory and the file is flushed at most
+    // once per WRITE_DEBOUNCE_MS on a dedicated thread. setStatus() (rare) still
+    // flushes promptly so install status is published without delay.
+    private const val WRITE_DEBOUNCE_MS = 1_000L
+
     private val counts = ConcurrentHashMap<Int, ConcurrentHashMap<Int, AtomicLong>>()
+
+    private val writeHandler: Handler by lazy {
+        Handler(HandlerThread("vpnhide-stats-writer").apply { start() }.looper)
+    }
+    private val flushPending = AtomicBoolean(false)
+    private val flushRunnable =
+        Runnable {
+            flushPending.set(false)
+            writeState()
+        }
 
     @Volatile private var installedHooks: Int = 0
 
@@ -60,7 +81,10 @@ internal object LsposedStats {
     ) {
         installedHooks = installedHookMask
         brokenFields = broken
-        writeState()
+        // Supersede any coalesced counter write with an immediate flush.
+        writeHandler.removeCallbacks(flushRunnable)
+        flushPending.set(false)
+        writeHandler.post(flushRunnable)
     }
 
     fun record(
@@ -72,7 +96,13 @@ internal object LsposedStats {
             .computeIfAbsent(uid) { ConcurrentHashMap() }
             .computeIfAbsent(hook.id) { AtomicLong() }
             .incrementAndGet()
-        writeState()
+        scheduleWrite()
+    }
+
+    private fun scheduleWrite() {
+        if (flushPending.compareAndSet(false, true)) {
+            writeHandler.postDelayed(flushRunnable, WRITE_DEBOUNCE_MS)
+        }
     }
 
     @Synchronized

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/MainActivity.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/MainActivity.kt
@@ -124,7 +124,7 @@ fun VpnHideApp() {
     }
 }
 
-private enum class Tab { Dashboard, Statistics, Protection }
+private enum class Tab { Dashboard, Protection, Statistics }
 
 private data class RefreshContext(
     val loading: Boolean,
@@ -518,15 +518,6 @@ private fun MainScreen() {
                     label = { Text(stringResource(R.string.tab_dashboard)) },
                 )
                 NavigationBarItem(
-                    selected = currentTab == Tab.Statistics,
-                    onClick = {
-                        tabHaptic()
-                        currentTab = Tab.Statistics
-                    },
-                    icon = { Icon(Icons.Default.BarChart, contentDescription = null) },
-                    label = { Text(stringResource(R.string.tab_statistics)) },
-                )
-                NavigationBarItem(
                     selected = currentTab == Tab.Protection,
                     onClick = {
                         tabHaptic()
@@ -534,6 +525,15 @@ private fun MainScreen() {
                     },
                     icon = { Icon(Icons.AutoMirrored.Filled.List, contentDescription = null) },
                     label = { Text(stringResource(R.string.tab_protection)) },
+                )
+                NavigationBarItem(
+                    selected = currentTab == Tab.Statistics,
+                    onClick = {
+                        tabHaptic()
+                        currentTab = Tab.Statistics
+                    },
+                    icon = { Icon(Icons.Default.BarChart, contentDescription = null) },
+                    label = { Text(stringResource(R.string.tab_statistics)) },
                 )
             }
         },

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/ProbeStats.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/ProbeStats.kt
@@ -141,3 +141,56 @@ internal fun buildAppProbeStats(
                 .thenBy { it.uid },
         )
 }
+
+// ── Capture session: baseline-diff over a user-controlled window ──────────
+//
+// No backend reset command and no per-event timestamps — the app snapshots the
+// cumulative counters at "Start capture" and shows current − baseline. Lets a
+// user start a session, exercise a target app, and see exactly what it probed
+// in that window, on any active backend.
+
+/** Snapshot of cumulative counters keyed by (uid, hookId), taken at capture start. */
+internal fun snapshotCounters(state: StatisticsState): Map<Pair<Long, Long>, Long> =
+    state.backends
+        .flatMap { it.rows }
+        .associate { (it.uid to it.hookId) to it.count }
+
+internal data class CaptureDiff(
+    val apps: List<AppProbeStats>,
+    // A counter dropped below its baseline — the backend restarted (reboot /
+    // system_server restart / Zygisk re-inject). The caller should re-baseline.
+    val backendReset: Boolean,
+)
+
+/** Probes that happened since [baseline] was taken, as a per-app rollup. */
+internal fun diffCapture(
+    baseline: Map<Pair<Long, Long>, Long>,
+    current: StatisticsState,
+    selfPackage: String? = null,
+): CaptureDiff {
+    var reset = false
+    val deltaRows =
+        current.backends
+            .flatMap { it.rows }
+            .mapNotNull { row ->
+                val base = baseline[row.uid to row.hookId] ?: 0L
+                val delta = row.count - base
+                when {
+                    delta < 0L -> {
+                        reset = true
+                        null
+                    }
+
+                    delta == 0L -> {
+                        null
+                    }
+
+                    else -> {
+                        row.copy(count = delta)
+                    }
+                }
+            }
+    val synthetic =
+        StatisticsState(backends = listOf(BackendStatistics(backend = HookIds.Backend.LSPOSED, status = null, rows = deltaRows)))
+    return CaptureDiff(apps = buildAppProbeStats(synthetic, selfPackage), backendReset = reset)
+}

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/ProbeStats.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/ProbeStats.kt
@@ -80,12 +80,20 @@ internal enum class DetectionMethod(
 
 // Per-app rollup of probe counts, aggregated across every active backend (the
 // one native backend + Java). Counts are cumulative since each backend started.
+// [byHook] is the exact per-hook breakdown the backends report (for the detail
+// modal); [byMethod] folds those hooks into the user-facing taxonomy (for the
+// card chips).
 internal data class AppProbeStats(
     val uid: Long,
     val packageNames: List<String>,
     val total: ULong,
-    val byMethod: Map<DetectionMethod, Long>,
+    val byHook: Map<HookIds.Hook, Long>,
 ) {
+    val byMethod: Map<DetectionMethod, Long> =
+        byHook.entries
+            .groupBy({ DetectionMethod.of(it.key) }, { it.value })
+            .mapValues { (_, counts) -> counts.sum() }
+
     val surfaces: Set<MethodSurface> = byMethod.keys.map { it.surface }.toSet()
 }
 
@@ -103,7 +111,7 @@ internal fun buildAppProbeStats(
     class Acc {
         var total: ULong = 0uL
         var packages: List<String> = emptyList()
-        val byMethod = linkedMapOf<DetectionMethod, Long>()
+        val byHook = linkedMapOf<HookIds.Hook, Long>()
     }
 
     val byUid = linkedMapOf<Long, Acc>()
@@ -114,8 +122,8 @@ internal fun buildAppProbeStats(
             val acc = byUid.getOrPut(row.uid) { Acc() }
             acc.total += row.count.toULong()
             if (row.packageNames.isNotEmpty()) acc.packages = row.packageNames
-            val method = row.hook?.let(DetectionMethod::of) ?: return@forEach
-            acc.byMethod[method] = (acc.byMethod[method] ?: 0L) + row.count
+            val hook = row.hook ?: return@forEach
+            acc.byHook[hook] = (acc.byHook[hook] ?: 0L) + row.count
         }
 
     return byUid
@@ -124,7 +132,7 @@ internal fun buildAppProbeStats(
                 uid = uid,
                 packageNames = acc.packages,
                 total = acc.total,
-                byMethod = acc.byMethod.toMap(),
+                byHook = acc.byHook.toMap(),
             )
         }.filterNot { selfPackage != null && selfPackage in it.packageNames }
         .sortedWith(

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/ProbeStats.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/ProbeStats.kt
@@ -92,7 +92,14 @@ internal data class AppProbeStats(
 // Collapse the per-backend / per-(uid×hook) rows into one entry per app, with a
 // per-method breakdown. Hooks map to methods; an unknown hook id still counts
 // toward the app total but has no method bucket. Sorted by total, descending.
-internal fun buildAppProbeStats(state: StatisticsState): List<AppProbeStats> {
+//
+// [selfPackage] (VPN Hide's own package) is excluded: the app's cold-start
+// diagnostic check suite probes every vector against itself, which would
+// otherwise dominate the list as self-noise rather than a real prober.
+internal fun buildAppProbeStats(
+    state: StatisticsState,
+    selfPackage: String? = null,
+): List<AppProbeStats> {
     class Acc {
         var total: ULong = 0uL
         var packages: List<String> = emptyList()
@@ -119,7 +126,8 @@ internal fun buildAppProbeStats(state: StatisticsState): List<AppProbeStats> {
                 total = acc.total,
                 byMethod = acc.byMethod.toMap(),
             )
-        }.sortedWith(
+        }.filterNot { selfPackage != null && selfPackage in it.packageNames }
+        .sortedWith(
             compareByDescending<AppProbeStats> { it.total }
                 .thenBy { it.packageNames.joinToString() }
                 .thenBy { it.uid },

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/ProbeStats.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/ProbeStats.kt
@@ -13,17 +13,19 @@ internal enum class MethodSurface { Java, Native, Package }
 internal enum class DetectionMethod(
     val surface: MethodSurface,
     val labelRes: Int,
+    // Explains what the probe is and how an app uses it to infer a VPN is up.
+    val descriptionRes: Int,
 ) {
-    Routes(MethodSurface.Native, R.string.method_routes),
-    Interfaces(MethodSurface.Native, R.string.method_interfaces),
-    InterfaceIoctl(MethodSurface.Native, R.string.method_interface_ioctl),
-    PolicyRules(MethodSurface.Native, R.string.method_policy_rules),
-    NetworkCapabilities(MethodSurface.Java, R.string.method_network_capabilities),
-    LinkProperties(MethodSurface.Java, R.string.method_link_properties),
-    NetworkInfo(MethodSurface.Java, R.string.method_network_info),
-    NetworkHandle(MethodSurface.Java, R.string.method_network_handle),
-    ConnectivityService(MethodSurface.Java, R.string.method_connectivity_service),
-    PackageEnumeration(MethodSurface.Package, R.string.method_package_enumeration),
+    Routes(MethodSurface.Native, R.string.method_routes, R.string.method_desc_routes),
+    Interfaces(MethodSurface.Native, R.string.method_interfaces, R.string.method_desc_interfaces),
+    InterfaceIoctl(MethodSurface.Native, R.string.method_interface_ioctl, R.string.method_desc_interface_ioctl),
+    PolicyRules(MethodSurface.Native, R.string.method_policy_rules, R.string.method_desc_policy_rules),
+    NetworkCapabilities(MethodSurface.Java, R.string.method_network_capabilities, R.string.method_desc_network_capabilities),
+    LinkProperties(MethodSurface.Java, R.string.method_link_properties, R.string.method_desc_link_properties),
+    NetworkInfo(MethodSurface.Java, R.string.method_network_info, R.string.method_desc_network_info),
+    NetworkHandle(MethodSurface.Java, R.string.method_network_handle, R.string.method_desc_network_handle),
+    ConnectivityService(MethodSurface.Java, R.string.method_connectivity_service, R.string.method_desc_connectivity_service),
+    PackageEnumeration(MethodSurface.Package, R.string.method_package_enumeration, R.string.method_desc_package_enumeration),
     ;
 
     companion object {

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/ProbeStats.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/ProbeStats.kt
@@ -1,0 +1,127 @@
+package dev.okhsunrog.vpnhide
+
+import dev.okhsunrog.vpnhide.generated.HookIds
+
+// Where a detection method lives — used to group methods on the per-app card and
+// to explain (native syscall/libc vs Java API vs package enumeration) at a
+// glance. "Native" covers both the kernel backends and Zygisk's libc hooks.
+internal enum class MethodSurface { Java, Native, Package }
+
+// User-facing detection method: a small taxonomy over the 18 raw hooks so the
+// Statistics screen reads as "what the app tried" instead of kernel symbol
+// names. Several hooks fold into one method (e.g. the four route hooks).
+internal enum class DetectionMethod(
+    val surface: MethodSurface,
+    val labelRes: Int,
+) {
+    Routes(MethodSurface.Native, R.string.method_routes),
+    Interfaces(MethodSurface.Native, R.string.method_interfaces),
+    InterfaceIoctl(MethodSurface.Native, R.string.method_interface_ioctl),
+    PolicyRules(MethodSurface.Native, R.string.method_policy_rules),
+    NetworkCapabilities(MethodSurface.Java, R.string.method_network_capabilities),
+    LinkProperties(MethodSurface.Java, R.string.method_link_properties),
+    NetworkInfo(MethodSurface.Java, R.string.method_network_info),
+    NetworkHandle(MethodSurface.Java, R.string.method_network_handle),
+    ConnectivityService(MethodSurface.Java, R.string.method_connectivity_service),
+    PackageEnumeration(MethodSurface.Package, R.string.method_package_enumeration),
+    ;
+
+    companion object {
+        fun of(hook: HookIds.Hook): DetectionMethod =
+            when (hook) {
+                HookIds.Hook.FIB_ROUTE_SEQ_SHOW,
+                HookIds.Hook.IPV6_ROUTE_SEQ_SHOW,
+                HookIds.Hook.FIB_DUMP_INFO,
+                HookIds.Hook.RT6_FILL_NODE,
+                -> Routes
+
+                HookIds.Hook.RTNL_FILL_IFINFO,
+                HookIds.Hook.INET_FILL_IFADDR,
+                HookIds.Hook.INET6_FILL_IFADDR,
+                -> Interfaces
+
+                HookIds.Hook.DEV_IOCTL,
+                HookIds.Hook.SOCK_IOCTL,
+                -> InterfaceIoctl
+
+                HookIds.Hook.FIB_NL_FILL_RULE -> PolicyRules
+
+                HookIds.Hook.LSPOSED_NETWORK_CAPABILITIES -> NetworkCapabilities
+
+                HookIds.Hook.LSPOSED_LINK_PROPERTIES -> LinkProperties
+
+                HookIds.Hook.LSPOSED_NETWORK_INFO -> NetworkInfo
+
+                HookIds.Hook.LSPOSED_NETWORK,
+                HookIds.Hook.LSPOSED_CONNECTIVITY_NETWORK,
+                -> NetworkHandle
+
+                HookIds.Hook.LSPOSED_CONNECTIVITY_RESULT,
+                HookIds.Hook.LSPOSED_CONNECTIVITY_CALLBACK,
+                -> ConnectivityService
+
+                HookIds.Hook.LSPOSED_PACKAGE_VISIBILITY -> PackageEnumeration
+
+                // Zygisk libc hooks — native-level probes from inside the app.
+                HookIds.Hook.ZYGISK_IOCTL -> InterfaceIoctl
+
+                HookIds.Hook.ZYGISK_GETIFADDRS -> Interfaces
+
+                HookIds.Hook.ZYGISK_OPENAT -> Routes
+
+                HookIds.Hook.ZYGISK_RECVMSG,
+                HookIds.Hook.ZYGISK_RECV,
+                HookIds.Hook.ZYGISK_RECVFROM,
+                HookIds.Hook.ZYGISK_RECVFROM_CHK,
+                -> Interfaces
+            }
+    }
+}
+
+// Per-app rollup of probe counts, aggregated across every active backend (the
+// one native backend + Java). Counts are cumulative since each backend started.
+internal data class AppProbeStats(
+    val uid: Long,
+    val packageNames: List<String>,
+    val total: ULong,
+    val byMethod: Map<DetectionMethod, Long>,
+) {
+    val surfaces: Set<MethodSurface> = byMethod.keys.map { it.surface }.toSet()
+}
+
+// Collapse the per-backend / per-(uid×hook) rows into one entry per app, with a
+// per-method breakdown. Hooks map to methods; an unknown hook id still counts
+// toward the app total but has no method bucket. Sorted by total, descending.
+internal fun buildAppProbeStats(state: StatisticsState): List<AppProbeStats> {
+    class Acc {
+        var total: ULong = 0uL
+        var packages: List<String> = emptyList()
+        val byMethod = linkedMapOf<DetectionMethod, Long>()
+    }
+
+    val byUid = linkedMapOf<Long, Acc>()
+    state.backends
+        .asSequence()
+        .flatMap { it.rows.asSequence() }
+        .forEach { row ->
+            val acc = byUid.getOrPut(row.uid) { Acc() }
+            acc.total += row.count.toULong()
+            if (row.packageNames.isNotEmpty()) acc.packages = row.packageNames
+            val method = row.hook?.let(DetectionMethod::of) ?: return@forEach
+            acc.byMethod[method] = (acc.byMethod[method] ?: 0L) + row.count
+        }
+
+    return byUid
+        .map { (uid, acc) ->
+            AppProbeStats(
+                uid = uid,
+                packageNames = acc.packages,
+                total = acc.total,
+                byMethod = acc.byMethod.toMap(),
+            )
+        }.sortedWith(
+            compareByDescending<AppProbeStats> { it.total }
+                .thenBy { it.packageNames.joinToString() }
+                .thenBy { it.uid },
+        )
+}

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/StatisticsScreen.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/StatisticsScreen.kt
@@ -553,53 +553,32 @@ private fun AppProbeDetailDialog(
             Column(
                 modifier =
                     Modifier
-                        .heightIn(max = 420.dp)
+                        .heightIn(max = 480.dp)
                         .verticalScroll(rememberScrollState()),
-                verticalArrangement = Arrangement.spacedBy(10.dp),
+                verticalArrangement = Arrangement.spacedBy(14.dp),
             ) {
-                Text(
-                    text = stringResource(R.string.statistics_apps_caption),
-                    style = MaterialTheme.typography.bodySmall,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                )
-                // Grouped by surface (Java API / Native / Packages) with a
-                // coloured header, so it's clear which hooks are framework-level
-                // vs native syscall/libc.
+                // Grouped: surface (Java API / Native / Packages, coloured) →
+                // detection method (with an explanation of how it reveals a VPN)
+                // → the exact hooks behind it when a method folds several.
                 app.byHook.entries
                     .groupBy { DetectionMethod.of(it.key).surface }
                     .entries
                     .sortedByDescending { (_, hooks) -> hooks.sumOf { it.value } }
-                    .forEach { (surface, hooks) ->
-                        Column(verticalArrangement = Arrangement.spacedBy(6.dp)) {
+                    .forEach { (surface, surfaceHooks) ->
+                        Column(verticalArrangement = Arrangement.spacedBy(10.dp)) {
                             Text(
                                 text = surfaceLabel(surface),
                                 style = MaterialTheme.typography.labelMedium,
                                 fontWeight = FontWeight.Bold,
                                 color = surfaceAccentColor(surface),
                             )
-                            hooks.sortedByDescending { it.value }.forEach { (hook, hookCount) ->
-                                Row(verticalAlignment = Alignment.CenterVertically) {
-                                    Column(Modifier.weight(1f)) {
-                                        Text(
-                                            text = stringResource(DetectionMethod.of(hook).labelRes),
-                                            style = MaterialTheme.typography.bodyMedium,
-                                            fontWeight = FontWeight.Medium,
-                                        )
-                                        Text(
-                                            text = hook.note,
-                                            style = MaterialTheme.typography.labelSmall,
-                                            color = MaterialTheme.colorScheme.onSurfaceVariant,
-                                        )
-                                    }
-                                    Spacer(Modifier.width(10.dp))
-                                    Text(
-                                        text = formatStatCount(hookCount),
-                                        style = MaterialTheme.typography.titleSmall,
-                                        fontWeight = FontWeight.Bold,
-                                        color = StatusColors.infoAccent,
-                                    )
+                            surfaceHooks
+                                .groupBy { DetectionMethod.of(it.key) }
+                                .entries
+                                .sortedByDescending { (_, hooks) -> hooks.sumOf { it.value } }
+                                .forEach { (method, methodHooks) ->
+                                    MethodDetailBlock(method = method, hooks = methodHooks)
                                 }
-                            }
                         }
                     }
             }
@@ -608,6 +587,55 @@ private fun AppProbeDetailDialog(
             TextButton(onClick = onDismiss) { Text(stringResource(R.string.contact_close)) }
         },
     )
+}
+
+@Composable
+private fun MethodDetailBlock(
+    method: DetectionMethod,
+    hooks: List<Map.Entry<HookIds.Hook, Long>>,
+) {
+    val total = hooks.sumOf { it.value }
+    Column(verticalArrangement = Arrangement.spacedBy(3.dp)) {
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            Text(
+                text = stringResource(method.labelRes),
+                modifier = Modifier.weight(1f),
+                style = MaterialTheme.typography.titleSmall,
+                fontWeight = FontWeight.Bold,
+            )
+            Spacer(Modifier.width(10.dp))
+            Text(
+                text = formatStatCount(total),
+                style = MaterialTheme.typography.titleSmall,
+                fontWeight = FontWeight.Bold,
+                color = StatusColors.infoAccent,
+            )
+        }
+        Text(
+            text = stringResource(method.descriptionRes),
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+        // When a method folds several hooks, list the exact ones behind it.
+        if (hooks.size > 1) {
+            hooks.sortedByDescending { it.value }.forEach { (hook, count) ->
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    Text(
+                        text = "·  ${hook.note}",
+                        modifier = Modifier.weight(1f),
+                        style = MaterialTheme.typography.labelSmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                    Spacer(Modifier.width(8.dp))
+                    Text(
+                        text = formatStatCount(count),
+                        style = MaterialTheme.typography.labelSmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+            }
+        }
+    }
 }
 
 @Composable

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/StatisticsScreen.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/StatisticsScreen.kt
@@ -21,6 +21,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
@@ -69,7 +70,8 @@ fun StatisticsScreen(modifier: Modifier = Modifier) {
             return@Column
         }
 
-        val appStats = remember(s) { buildAppProbeStats(s) }
+        val selfPackage = LocalContext.current.packageName
+        val appStats = remember(s, selfPackage) { buildAppProbeStats(s, selfPackage) }
         val methodCount = remember(appStats) { appStats.flatMap { it.byMethod.keys }.toSet().size }
 
         StatisticsHeroCard(state = s, appCount = appStats.size, methodCount = methodCount)
@@ -102,6 +104,12 @@ fun StatisticsScreen(modifier: Modifier = Modifier) {
         if (appStats.isNotEmpty()) {
             Spacer(Modifier.height(20.dp))
             SectionHeader(stringResource(R.string.statistics_apps_header))
+            Spacer(Modifier.height(2.dp))
+            Text(
+                text = stringResource(R.string.statistics_apps_caption),
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
             Spacer(Modifier.height(8.dp))
             Column(verticalArrangement = Arrangement.spacedBy(3.dp)) {
                 appStats.forEachIndexed { index, app ->

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/StatisticsScreen.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/StatisticsScreen.kt
@@ -17,6 +17,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableLongStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
@@ -34,8 +35,10 @@ import androidx.compose.ui.unit.dp
 import dev.okhsunrog.vpnhide.generated.HookIds
 import dev.okhsunrog.vpnhide.ui.components.EnhancedButton
 import dev.okhsunrog.vpnhide.ui.components.EnhancedCard
+import dev.okhsunrog.vpnhide.ui.components.EnhancedOutlinedButton
 import dev.okhsunrog.vpnhide.ui.components.GroupedCard
 import dev.okhsunrog.vpnhide.ui.theme.AppColors
+import kotlinx.coroutines.delay
 
 @Composable
 fun StatisticsScreen(modifier: Modifier = Modifier) {
@@ -43,9 +46,19 @@ fun StatisticsScreen(modifier: Modifier = Modifier) {
     val state by StatisticsCache.state.collectAsState()
     val loadError by StatisticsCache.error.collectAsState()
     var detailApp by remember { mutableStateOf<AppProbeStats?>(null) }
+    var captureBaseline by remember { mutableStateOf<Map<Pair<Long, Long>, Long>?>(null) }
+    var captureStartMs by remember { mutableLongStateOf(0L) }
+    var nowMs by remember { mutableLongStateOf(0L) }
 
     LaunchedEffect(Unit) {
         StatisticsCache.ensureLoaded(scope)
+    }
+    // Tick the elapsed clock while a capture session is active.
+    LaunchedEffect(captureBaseline != null) {
+        while (captureBaseline != null) {
+            nowMs = System.currentTimeMillis()
+            delay(1000)
+        }
     }
 
     Column(
@@ -79,11 +92,38 @@ fun StatisticsScreen(modifier: Modifier = Modifier) {
         val appStats = remember(s, selfPackage) { buildAppProbeStats(s, selfPackage) }
         val methodCount = remember(appStats) { appStats.flatMap { it.byMethod.keys }.toSet().size }
 
+        val capturing = captureBaseline != null
+        val capture = captureBaseline?.let { diffCapture(it, s, selfPackage) }
+        val backendReset = capture?.backendReset == true
+        // Backend restarted mid-session (a counter dropped): re-baseline so the
+        // deltas restart from the fresh counter values instead of going negative.
+        LaunchedEffect(backendReset) {
+            if (backendReset) {
+                captureBaseline = snapshotCounters(s)
+                captureStartMs = System.currentTimeMillis()
+            }
+        }
+        val shownApps = capture?.apps ?: appStats
+
         detailApp?.let { app ->
             AppProbeDetailDialog(app = app, onDismiss = { detailApp = null })
         }
 
         StatisticsHeroCard(state = s, appCount = appStats.size, methodCount = methodCount)
+        Spacer(Modifier.height(20.dp))
+
+        CaptureControlCard(
+            capturing = capturing,
+            elapsedMs = if (capturing) (nowMs - captureStartMs).coerceAtLeast(0L) else 0L,
+            capturedAppCount = capture?.apps?.size ?: 0,
+            onStart = {
+                captureBaseline = snapshotCounters(s)
+                captureStartMs = System.currentTimeMillis()
+                nowMs = captureStartMs
+            },
+            onStop = { captureBaseline = null },
+            onRefresh = { StatisticsCache.refresh(scope) },
+        )
         Spacer(Modifier.height(20.dp))
 
         SectionHeader(stringResource(R.string.statistics_backends))
@@ -110,19 +150,34 @@ fun StatisticsScreen(modifier: Modifier = Modifier) {
             )
         }
 
-        if (appStats.isNotEmpty()) {
+        if (capturing || shownApps.isNotEmpty()) {
             Spacer(Modifier.height(20.dp))
-            SectionHeader(stringResource(R.string.statistics_apps_header))
+            SectionHeader(
+                stringResource(
+                    if (capturing) R.string.statistics_capture_apps_header else R.string.statistics_apps_header,
+                ),
+            )
             Spacer(Modifier.height(2.dp))
             Text(
-                text = stringResource(R.string.statistics_apps_caption),
+                text =
+                    stringResource(
+                        if (capturing) R.string.statistics_capture_hint else R.string.statistics_apps_caption,
+                    ),
                 style = MaterialTheme.typography.bodySmall,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
             )
             Spacer(Modifier.height(8.dp))
-            Column(verticalArrangement = Arrangement.spacedBy(3.dp)) {
-                appStats.forEachIndexed { index, app ->
-                    AppProbeCard(app, index = index, count = appStats.size, onClick = { detailApp = app })
+            if (capturing && shownApps.isEmpty()) {
+                StatusBanner(
+                    text = stringResource(R.string.statistics_capture_empty),
+                    containerColor = StatusColors.infoContainer(),
+                    contentColor = MaterialTheme.colorScheme.onSurface,
+                )
+            } else {
+                Column(verticalArrangement = Arrangement.spacedBy(3.dp)) {
+                    shownApps.forEachIndexed { index, app ->
+                        AppProbeCard(app, index = index, count = shownApps.size, onClick = { detailApp = app })
+                    }
                 }
             }
         }
@@ -250,6 +305,63 @@ private fun StatisticsHeroCard(
             }
         }
     }
+}
+
+@Composable
+private fun CaptureControlCard(
+    capturing: Boolean,
+    elapsedMs: Long,
+    capturedAppCount: Int,
+    onStart: () -> Unit,
+    onStop: () -> Unit,
+    onRefresh: () -> Unit,
+) {
+    EnhancedCard(modifier = Modifier.fillMaxWidth(), color = AppColors.cardContainer) {
+        Column(
+            modifier = Modifier.padding(16.dp).fillMaxWidth(),
+            verticalArrangement = Arrangement.spacedBy(10.dp),
+        ) {
+            Text(
+                text = stringResource(R.string.statistics_capture_title),
+                style = MaterialTheme.typography.titleSmall,
+                fontWeight = FontWeight.Bold,
+            )
+            if (!capturing) {
+                Text(
+                    text = stringResource(R.string.statistics_capture_intro),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+                EnhancedButton(onClick = onStart, modifier = Modifier.fillMaxWidth()) {
+                    Text(stringResource(R.string.statistics_capture_start))
+                }
+            } else {
+                Text(
+                    text =
+                        stringResource(
+                            R.string.statistics_capture_active,
+                            formatElapsed(elapsedMs),
+                            capturedAppCount,
+                        ),
+                    style = MaterialTheme.typography.bodyMedium,
+                    fontWeight = FontWeight.Medium,
+                )
+                Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                    EnhancedButton(onClick = onRefresh, modifier = Modifier.weight(1f)) {
+                        Text(stringResource(R.string.action_refresh))
+                    }
+                    EnhancedOutlinedButton(onClick = onStop, modifier = Modifier.weight(1f)) {
+                        Text(stringResource(R.string.statistics_capture_stop))
+                    }
+                }
+            }
+        }
+    }
+}
+
+private fun formatElapsed(ms: Long): String {
+    val totalSeconds = ms / 1000
+    return "%d:%02d".format(totalSeconds / 60, totalSeconds % 60)
 }
 
 @Composable

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/StatisticsScreen.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/StatisticsScreen.kt
@@ -562,29 +562,44 @@ private fun AppProbeDetailDialog(
                     style = MaterialTheme.typography.bodySmall,
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                 )
+                // Grouped by surface (Java API / Native / Packages) with a
+                // coloured header, so it's clear which hooks are framework-level
+                // vs native syscall/libc.
                 app.byHook.entries
-                    .sortedByDescending { it.value }
-                    .forEach { (hook, hookCount) ->
-                        Row(verticalAlignment = Alignment.CenterVertically) {
-                            Column(Modifier.weight(1f)) {
-                                Text(
-                                    text = stringResource(DetectionMethod.of(hook).labelRes),
-                                    style = MaterialTheme.typography.bodyMedium,
-                                    fontWeight = FontWeight.Medium,
-                                )
-                                Text(
-                                    text = hook.note,
-                                    style = MaterialTheme.typography.labelSmall,
-                                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                                )
-                            }
-                            Spacer(Modifier.width(10.dp))
+                    .groupBy { DetectionMethod.of(it.key).surface }
+                    .entries
+                    .sortedByDescending { (_, hooks) -> hooks.sumOf { it.value } }
+                    .forEach { (surface, hooks) ->
+                        Column(verticalArrangement = Arrangement.spacedBy(6.dp)) {
                             Text(
-                                text = formatStatCount(hookCount),
-                                style = MaterialTheme.typography.titleSmall,
+                                text = surfaceLabel(surface),
+                                style = MaterialTheme.typography.labelMedium,
                                 fontWeight = FontWeight.Bold,
-                                color = StatusColors.infoAccent,
+                                color = surfaceAccentColor(surface),
                             )
+                            hooks.sortedByDescending { it.value }.forEach { (hook, hookCount) ->
+                                Row(verticalAlignment = Alignment.CenterVertically) {
+                                    Column(Modifier.weight(1f)) {
+                                        Text(
+                                            text = stringResource(DetectionMethod.of(hook).labelRes),
+                                            style = MaterialTheme.typography.bodyMedium,
+                                            fontWeight = FontWeight.Medium,
+                                        )
+                                        Text(
+                                            text = hook.note,
+                                            style = MaterialTheme.typography.labelSmall,
+                                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                        )
+                                    }
+                                    Spacer(Modifier.width(10.dp))
+                                    Text(
+                                        text = formatStatCount(hookCount),
+                                        style = MaterialTheme.typography.titleSmall,
+                                        fontWeight = FontWeight.Bold,
+                                        color = StatusColors.infoAccent,
+                                    )
+                                }
+                            }
                         }
                     }
             }
@@ -630,6 +645,24 @@ private fun surfaceContainerColor(surface: MethodSurface): Color =
         MethodSurface.Native -> StatusColors.successContainer()
         MethodSurface.Package -> StatusColors.neutralContainer()
     }
+
+@Composable
+private fun surfaceAccentColor(surface: MethodSurface): Color =
+    when (surface) {
+        MethodSurface.Java -> StatusColors.infoAccent
+        MethodSurface.Native -> StatusColors.successDot
+        MethodSurface.Package -> StatusColors.neutralAccent
+    }
+
+@Composable
+private fun surfaceLabel(surface: MethodSurface): String =
+    stringResource(
+        when (surface) {
+            MethodSurface.Java -> R.string.surface_java
+            MethodSurface.Native -> R.string.surface_native
+            MethodSurface.Package -> R.string.surface_package
+        },
+    )
 
 @Composable
 private fun appLabel(app: AppProbeStats): String =

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/StatisticsScreen.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/StatisticsScreen.kt
@@ -7,16 +7,20 @@ import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.BarChart
+import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -38,6 +42,7 @@ fun StatisticsScreen(modifier: Modifier = Modifier) {
     val scope = rememberCoroutineScope()
     val state by StatisticsCache.state.collectAsState()
     val loadError by StatisticsCache.error.collectAsState()
+    var detailApp by remember { mutableStateOf<AppProbeStats?>(null) }
 
     LaunchedEffect(Unit) {
         StatisticsCache.ensureLoaded(scope)
@@ -73,6 +78,10 @@ fun StatisticsScreen(modifier: Modifier = Modifier) {
         val selfPackage = LocalContext.current.packageName
         val appStats = remember(s, selfPackage) { buildAppProbeStats(s, selfPackage) }
         val methodCount = remember(appStats) { appStats.flatMap { it.byMethod.keys }.toSet().size }
+
+        detailApp?.let { app ->
+            AppProbeDetailDialog(app = app, onDismiss = { detailApp = null })
+        }
 
         StatisticsHeroCard(state = s, appCount = appStats.size, methodCount = methodCount)
         Spacer(Modifier.height(20.dp))
@@ -113,7 +122,7 @@ fun StatisticsScreen(modifier: Modifier = Modifier) {
             Spacer(Modifier.height(8.dp))
             Column(verticalArrangement = Arrangement.spacedBy(3.dp)) {
                 appStats.forEachIndexed { index, app ->
-                    AppProbeCard(app, index = index, count = appStats.size)
+                    AppProbeCard(app, index = index, count = appStats.size, onClick = { detailApp = app })
                 }
             }
         }
@@ -362,12 +371,14 @@ private fun AppProbeCard(
     app: AppProbeStats,
     index: Int,
     count: Int,
+    onClick: () -> Unit,
 ) {
     GroupedCard(
         index = index,
         count = count,
         modifier = Modifier.fillMaxWidth(),
         color = AppColors.cardContainer,
+        onClick = onClick,
     ) {
         Column(modifier = Modifier.padding(14.dp).fillMaxWidth()) {
             Row(verticalAlignment = Alignment.CenterVertically) {
@@ -412,6 +423,64 @@ private fun AppProbeCard(
             }
         }
     }
+}
+
+// Tap-through detail: the exact per-hook breakdown the backends report, so a
+// user can see precisely which VPN-detection techniques an app uses (the card
+// only shows the folded methods). The friendly method label is the primary
+// line; the hook's technical note is the precise secondary line.
+@Composable
+private fun AppProbeDetailDialog(
+    app: AppProbeStats,
+    onDismiss: () -> Unit,
+) {
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text(appLabel(app)) },
+        text = {
+            Column(
+                modifier =
+                    Modifier
+                        .heightIn(max = 420.dp)
+                        .verticalScroll(rememberScrollState()),
+                verticalArrangement = Arrangement.spacedBy(10.dp),
+            ) {
+                Text(
+                    text = stringResource(R.string.statistics_apps_caption),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+                app.byHook.entries
+                    .sortedByDescending { it.value }
+                    .forEach { (hook, hookCount) ->
+                        Row(verticalAlignment = Alignment.CenterVertically) {
+                            Column(Modifier.weight(1f)) {
+                                Text(
+                                    text = stringResource(DetectionMethod.of(hook).labelRes),
+                                    style = MaterialTheme.typography.bodyMedium,
+                                    fontWeight = FontWeight.Medium,
+                                )
+                                Text(
+                                    text = hook.note,
+                                    style = MaterialTheme.typography.labelSmall,
+                                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                )
+                            }
+                            Spacer(Modifier.width(10.dp))
+                            Text(
+                                text = formatStatCount(hookCount),
+                                style = MaterialTheme.typography.titleSmall,
+                                fontWeight = FontWeight.Bold,
+                                color = StatusColors.infoAccent,
+                            )
+                        }
+                    }
+            }
+        },
+        confirmButton = {
+            TextButton(onClick = onDismiss) { Text(stringResource(R.string.contact_close)) }
+        },
+    )
 }
 
 @Composable

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/StatisticsScreen.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/StatisticsScreen.kt
@@ -15,6 +15,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -68,7 +69,10 @@ fun StatisticsScreen(modifier: Modifier = Modifier) {
             return@Column
         }
 
-        StatisticsHeroCard(s)
+        val appStats = remember(s) { buildAppProbeStats(s) }
+        val methodCount = remember(appStats) { appStats.flatMap { it.byMethod.keys }.toSet().size }
+
+        StatisticsHeroCard(state = s, appCount = appStats.size, methodCount = methodCount)
         Spacer(Modifier.height(20.dp))
 
         SectionHeader(stringResource(R.string.statistics_backends))
@@ -95,31 +99,29 @@ fun StatisticsScreen(modifier: Modifier = Modifier) {
             )
         }
 
-        s.backends
-            .filter { it.isActive }
-            .forEach { backend ->
-                Spacer(Modifier.height(20.dp))
-                SectionHeader(backendName(backend.backend))
-                Spacer(Modifier.height(8.dp))
-                if (backend.unavailableReason != null) {
-                    StatusBanner(
-                        text = statisticsUnavailableText(backend.unavailableReason),
-                        containerColor = StatusColors.infoContainer(),
-                        contentColor = MaterialTheme.colorScheme.onSurface,
-                    )
-                } else if (backend.rows.isEmpty()) {
-                    StatusBanner(
-                        text = stringResource(R.string.statistics_no_counters),
-                        containerColor = StatusColors.infoContainer(),
-                        contentColor = MaterialTheme.colorScheme.onSurface,
-                    )
-                } else {
-                    Column(verticalArrangement = Arrangement.spacedBy(3.dp)) {
-                        backend.rows.forEachIndexed { index, row ->
-                            StatisticsRowCard(row, index = index, count = backend.rows.size)
-                        }
-                    }
+        if (appStats.isNotEmpty()) {
+            Spacer(Modifier.height(20.dp))
+            SectionHeader(stringResource(R.string.statistics_apps_header))
+            Spacer(Modifier.height(8.dp))
+            Column(verticalArrangement = Arrangement.spacedBy(3.dp)) {
+                appStats.forEachIndexed { index, app ->
+                    AppProbeCard(app, index = index, count = appStats.size)
                 }
+            }
+        }
+
+        // The active native backend can't report counters (Zygisk): keep the
+        // explanatory note so the per-app list reading "Java only" makes sense.
+        s.backends
+            .firstOrNull { it.unavailableReason != null }
+            ?.unavailableReason
+            ?.let { reason ->
+                Spacer(Modifier.height(12.dp))
+                StatusBanner(
+                    text = statisticsUnavailableText(reason),
+                    containerColor = StatusColors.infoContainer(),
+                    contentColor = MaterialTheme.colorScheme.onSurface,
+                )
             }
 
         Spacer(Modifier.height(16.dp))
@@ -164,7 +166,11 @@ private fun StatisticsLoadErrorCard(
 }
 
 @Composable
-private fun StatisticsHeroCard(state: StatisticsState) {
+private fun StatisticsHeroCard(
+    state: StatisticsState,
+    appCount: Int,
+    methodCount: Int,
+) {
     EnhancedCard(
         modifier = Modifier.fillMaxWidth(),
         shape = MaterialTheme.shapes.extraLarge,
@@ -212,14 +218,14 @@ private fun StatisticsHeroCard(state: StatisticsState) {
                 }
                 Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
                     StatisticsMetric(
-                        label = stringResource(R.string.statistics_counter_rows),
-                        value = state.totalRows.toString(),
+                        label = stringResource(R.string.statistics_apps_metric),
+                        value = appCount.toString(),
                         accent = StatusColors.successDot,
                         modifier = Modifier.weight(1f),
                     )
                     StatisticsMetric(
-                        label = stringResource(R.string.statistics_hooks),
-                        value = state.backends.sumOf { it.hookedCount }.toString(),
+                        label = stringResource(R.string.statistics_methods_metric),
+                        value = methodCount.toString(),
                         accent = StatusColors.successDot,
                         modifier = Modifier.weight(1f),
                     )
@@ -342,9 +348,10 @@ private fun BackendSummaryCard(
     }
 }
 
+@OptIn(ExperimentalLayoutApi::class)
 @Composable
-private fun StatisticsRowCard(
-    row: StatisticsRow,
+private fun AppProbeCard(
+    app: AppProbeStats,
     index: Int,
     count: Int,
 ) {
@@ -354,46 +361,106 @@ private fun StatisticsRowCard(
         modifier = Modifier.fillMaxWidth(),
         color = AppColors.cardContainer,
     ) {
-        Row(
-            modifier = Modifier.padding(14.dp).fillMaxWidth(),
-            verticalAlignment = Alignment.CenterVertically,
-        ) {
-            Column(Modifier.weight(1f)) {
-                Text(
-                    text = rowTargetText(row),
-                    style = MaterialTheme.typography.titleSmall,
-                    fontWeight = FontWeight.Bold,
-                    maxLines = 2,
-                    overflow = TextOverflow.Ellipsis,
-                )
-                Spacer(Modifier.height(3.dp))
-                Text(
-                    text = rowHookText(row),
-                    style = MaterialTheme.typography.bodySmall,
-                    fontFamily = FontFamily.Monospace,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    maxLines = 1,
-                    overflow = TextOverflow.Ellipsis,
-                )
-                row.hook?.note?.takeIf { it.isNotBlank() }?.let { note ->
+        Column(modifier = Modifier.padding(14.dp).fillMaxWidth()) {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Column(Modifier.weight(1f)) {
                     Text(
-                        text = note,
-                        style = MaterialTheme.typography.labelSmall,
+                        text = appLabel(app),
+                        style = MaterialTheme.typography.titleSmall,
+                        fontWeight = FontWeight.Bold,
+                        maxLines = 2,
+                        overflow = TextOverflow.Ellipsis,
+                    )
+                    Text(
+                        text = appSurfacesText(app),
+                        style = MaterialTheme.typography.bodySmall,
                         color = MaterialTheme.colorScheme.onSurfaceVariant,
                         maxLines = 1,
                         overflow = TextOverflow.Ellipsis,
                     )
                 }
+                Spacer(Modifier.width(12.dp))
+                Text(
+                    text = formatStatCount(app.total),
+                    style = MaterialTheme.typography.titleMedium,
+                    fontWeight = FontWeight.Bold,
+                    color = StatusColors.infoAccent,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                )
             }
-            Spacer(Modifier.width(12.dp))
-            Text(
-                text = formatStatCount(row.count),
-                style = MaterialTheme.typography.titleMedium,
-                fontWeight = FontWeight.Bold,
-                color = StatusColors.infoAccent,
-                maxLines = 1,
-                overflow = TextOverflow.Ellipsis,
-            )
+            if (app.byMethod.isNotEmpty()) {
+                Spacer(Modifier.height(10.dp))
+                FlowRow(
+                    horizontalArrangement = Arrangement.spacedBy(6.dp),
+                    verticalArrangement = Arrangement.spacedBy(6.dp),
+                ) {
+                    app.byMethod.entries
+                        .sortedByDescending { it.value }
+                        .forEach { (method, methodCount) ->
+                            MethodChip(method = method, count = methodCount)
+                        }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun MethodChip(
+    method: DetectionMethod,
+    count: Long,
+) {
+    Row(
+        modifier =
+            Modifier
+                .clip(MaterialTheme.shapes.small)
+                .background(surfaceContainerColor(method.surface))
+                .padding(horizontal = 10.dp, vertical = 5.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Text(
+            text = stringResource(method.labelRes),
+            style = MaterialTheme.typography.labelMedium,
+            color = MaterialTheme.colorScheme.onSurface,
+        )
+        Spacer(Modifier.width(6.dp))
+        Text(
+            text = formatStatCount(count),
+            style = MaterialTheme.typography.labelMedium,
+            fontWeight = FontWeight.Bold,
+            color = MaterialTheme.colorScheme.onSurface,
+        )
+    }
+}
+
+@Composable
+private fun surfaceContainerColor(surface: MethodSurface): Color =
+    when (surface) {
+        MethodSurface.Java -> StatusColors.infoContainer()
+        MethodSurface.Native -> StatusColors.successContainer()
+        MethodSurface.Package -> StatusColors.neutralContainer()
+    }
+
+@Composable
+private fun appLabel(app: AppProbeStats): String =
+    app.packageNames
+        .takeIf { it.isNotEmpty() }
+        ?.joinToString(", ")
+        ?: stringResource(R.string.statistics_unknown_uid, app.uid)
+
+@Composable
+private fun appSurfacesText(app: AppProbeStats): String {
+    // Resolve labels up front: stringResource can't be called inside the
+    // joinToString transform (not a @Composable context).
+    val java = stringResource(R.string.surface_java)
+    val native = stringResource(R.string.surface_native)
+    val pkg = stringResource(R.string.surface_package)
+    return app.surfaces.sorted().joinToString(" · ") { surface ->
+        when (surface) {
+            MethodSurface.Java -> java
+            MethodSurface.Native -> native
+            MethodSurface.Package -> pkg
         }
     }
 }
@@ -450,16 +517,6 @@ private fun backendBadge(backend: HookIds.Backend): String =
         HookIds.Backend.ZYGISK -> "Z"
         HookIds.Backend.LSPOSED -> "J"
     }
-
-@Composable
-private fun rowTargetText(row: StatisticsRow): String =
-    row.packageNames
-        .takeIf { it.isNotEmpty() }
-        ?.joinToString(", ")
-        ?: stringResource(R.string.statistics_unknown_uid, row.uid)
-
-@Composable
-private fun rowHookText(row: StatisticsRow): String = row.hook?.hookName ?: stringResource(R.string.statistics_unknown_hook, row.hookId)
 
 private enum class BackendHealth { Ok, Partial, Error, NoData, Unavailable }
 

--- a/lsposed/app/src/main/res/values-ru/strings.xml
+++ b/lsposed/app/src/main/res/values-ru/strings.xml
@@ -134,6 +134,7 @@
     <string name="statistics_load_failed_message">VPN Hide не смог собрать root-состояние для этой вкладки. Проверьте менеджер root, если разрешение было прервано, затем нажмите «Повторить».</string>
     <string name="statistics_refresh_failed_message">Обновление не удалось. Показываются предыдущие данные статистики.</string>
     <string name="statistics_apps_header">Приложения, проверявшие VPN</string>
+    <string name="statistics_apps_caption">Накопительно с момента загрузки, по способам детекта</string>
     <string name="statistics_apps_metric">Приложений</string>
     <string name="statistics_methods_metric">Способов</string>
     <!-- Способы детекта (разбивка по приложениям) -->

--- a/lsposed/app/src/main/res/values-ru/strings.xml
+++ b/lsposed/app/src/main/res/values-ru/strings.xml
@@ -136,7 +136,7 @@
     <string name="statistics_apps_header">Приложения, проверявшие VPN</string>
     <string name="statistics_apps_caption">Накопительно с момента загрузки. Нажмите приложение для полной разбивки по хукам.</string>
     <string name="statistics_capture_title">Сессия захвата</string>
-    <string name="statistics_capture_intro">Снимок счётчиков, затем откройте и потыкайте целевое приложение и нажмите «Обновить», чтобы увидеть, что именно оно проверяло за это окно.</string>
+    <string name="statistics_capture_intro">Начните захват, затем откройте целевое приложение и попользуйтесь им. Нажмите «Обновить» — увидите, какие проверки VPN оно сделало за это время.</string>
     <string name="statistics_capture_start">Начать захват</string>
     <string name="statistics_capture_active">Идёт захват · %1$s · приложений: %2$d</string>
     <string name="statistics_capture_stop">Стоп</string>

--- a/lsposed/app/src/main/res/values-ru/strings.xml
+++ b/lsposed/app/src/main/res/values-ru/strings.xml
@@ -156,6 +156,17 @@
     <string name="method_network_handle">Сетевой хэндл</string>
     <string name="method_connectivity_service">ConnectivityService</string>
     <string name="method_package_enumeration">Перечисление пакетов</string>
+    <!-- Описания способов детекта: что это за проверка + как она выдаёт VPN -->
+    <string name="method_desc_routes">Приложение читает таблицу маршрутов (/proc/net/route или netlink). VPN добавляет маршрут по умолчанию через свой туннель-интерфейс — его наличие выдаёт VPN.</string>
+    <string name="method_desc_interfaces">Приложение перечисляет сетевые интерфейсы и их адреса (getifaddrs / netlink). VPN виден как лишний интерфейс tunNN с адресом, не совпадающим с Wi-Fi или моб. сетью.</string>
+    <string name="method_desc_interface_ioctl">Приложение запрашивает интерфейсы напрямую через ioctl (SIOCGIFCONF / SIOCGIFFLAGS). Туннель-интерфейс VPN появляется в списке или числится поднятым.</string>
+    <string name="method_desc_policy_rules">Приложение читает правила маршрутизации (RTM_GETRULE). VPN добавляет правила, заворачивающие трафик в туннель, — они его выдают.</string>
+    <string name="method_desc_network_capabilities">Приложение запрашивает NetworkCapabilities. Активный VPN выставляет флаг VPN-транспорта — прямой признак включённого VPN.</string>
+    <string name="method_desc_link_properties">Приложение читает LinkProperties. VPN раскрывает имя своего интерфейса tunNN, VPN-маршруты и DNS-серверы.</string>
+    <string name="method_desc_network_info">Приложение проверяет NetworkInfo (устаревший API). Активный VPN сообщает тип VPN вместо моб. сети или Wi-Fi.</string>
+    <string name="method_desc_network_handle">Приложение получает хэндл активной сети. VPN возвращает свою виртуальную сеть вместо физической.</string>
+    <string name="method_desc_connectivity_service">Приложение перечисляет все сети или подписывается на колбэки через ConnectivityService. VPN-сеть всплывает в списке или в колбэках.</string>
+    <string name="method_desc_package_enumeration">Приложение перечисляет установленные пакеты или ищет компоненты VpnService. Наличие известных VPN-приложений выдаёт использование VPN.</string>
     <string name="surface_java">Java API</string>
     <string name="surface_native">Нативные</string>
     <string name="surface_package">Пакеты</string>

--- a/lsposed/app/src/main/res/values-ru/strings.xml
+++ b/lsposed/app/src/main/res/values-ru/strings.xml
@@ -134,7 +134,15 @@
     <string name="statistics_load_failed_message">VPN Hide не смог собрать root-состояние для этой вкладки. Проверьте менеджер root, если разрешение было прервано, затем нажмите «Повторить».</string>
     <string name="statistics_refresh_failed_message">Обновление не удалось. Показываются предыдущие данные статистики.</string>
     <string name="statistics_apps_header">Приложения, проверявшие VPN</string>
-    <string name="statistics_apps_caption">Накопительно с момента загрузки, по способам детекта</string>
+    <string name="statistics_apps_caption">Накопительно с момента загрузки. Нажмите приложение для полной разбивки по хукам.</string>
+    <string name="statistics_capture_title">Сессия захвата</string>
+    <string name="statistics_capture_intro">Снимок счётчиков, затем откройте и потыкайте целевое приложение и нажмите «Обновить», чтобы увидеть, что именно оно проверяло за это окно.</string>
+    <string name="statistics_capture_start">Начать захват</string>
+    <string name="statistics_capture_active">Идёт захват · %1$s · приложений: %2$d</string>
+    <string name="statistics_capture_stop">Стоп</string>
+    <string name="statistics_capture_apps_header">Пробы за сессию</string>
+    <string name="statistics_capture_hint">Что целевые приложения проверяли с начала захвата. Нажмите для разбивки по хукам.</string>
+    <string name="statistics_capture_empty">Пока ничего не поймано. Откройте целевое приложение и нажмите «Обновить».</string>
     <string name="statistics_apps_metric">Приложений</string>
     <string name="statistics_methods_metric">Способов</string>
     <!-- Способы детекта (разбивка по приложениям) -->

--- a/lsposed/app/src/main/res/values-ru/strings.xml
+++ b/lsposed/app/src/main/res/values-ru/strings.xml
@@ -118,17 +118,13 @@
     <string name="statistics_backends">Бэкенды</string>
     <string name="statistics_total_events">События</string>
     <string name="statistics_active_backends">Активные бэкенды</string>
-    <string name="statistics_counter_rows">Строки счётчиков</string>
-    <string name="statistics_hooks">Хуки</string>
     <string name="statistics_backend_detail">%1$s · хуков: %2$d</string>
     <string name="statistics_backend_unavailable_detail">Нативные счётчики недоступны</string>
     <string name="statistics_events">события</string>
     <string name="statistics_no_data">Runtime-статистики пока нет. Счётчики появятся после того, как защищённое приложение попадёт в установленный хук.</string>
     <string name="statistics_no_data_supported_backends">Счётчиков от бэкендов, которые поддерживают статистику, пока нет.</string>
-    <string name="statistics_no_counters">Счётчиков пока нет.</string>
     <string name="statistics_zygisk_native_unavailable">Нативные счётчики недоступны для Zygisk. Java и Apps счётчики по-прежнему отдаёт LSPosed.</string>
     <string name="statistics_unknown_uid">uid %1$d</string>
-    <string name="statistics_unknown_hook">неизвестный хук %1$d</string>
     <string name="statistics_status_ok">ОК</string>
     <string name="statistics_status_partial">Частично</string>
     <string name="statistics_status_error">Ошибка</string>
@@ -137,6 +133,23 @@
     <string name="statistics_load_failed_title">Статистика недоступна</string>
     <string name="statistics_load_failed_message">VPN Hide не смог собрать root-состояние для этой вкладки. Проверьте менеджер root, если разрешение было прервано, затем нажмите «Повторить».</string>
     <string name="statistics_refresh_failed_message">Обновление не удалось. Показываются предыдущие данные статистики.</string>
+    <string name="statistics_apps_header">Приложения, проверявшие VPN</string>
+    <string name="statistics_apps_metric">Приложений</string>
+    <string name="statistics_methods_metric">Способов</string>
+    <!-- Способы детекта (разбивка по приложениям) -->
+    <string name="method_routes">Таблица маршрутов</string>
+    <string name="method_interfaces">Сетевые интерфейсы</string>
+    <string name="method_interface_ioctl">Запрос интерфейсов (ioctl)</string>
+    <string name="method_policy_rules">Правила маршрутизации</string>
+    <string name="method_network_capabilities">NetworkCapabilities</string>
+    <string name="method_link_properties">LinkProperties</string>
+    <string name="method_network_info">NetworkInfo</string>
+    <string name="method_network_handle">Сетевой хэндл</string>
+    <string name="method_connectivity_service">ConnectivityService</string>
+    <string name="method_package_enumeration">Перечисление пакетов</string>
+    <string name="surface_java">Java API</string>
+    <string name="surface_native">Нативные</string>
+    <string name="surface_package">Пакеты</string>
 
     <string name="dashboard_install_recommendation_title">Рекомендация по установке</string>
     <string name="dashboard_install_recommendation_device">Ваше устройство: %1$s, ядро %2$s</string>

--- a/lsposed/app/src/main/res/values/strings.xml
+++ b/lsposed/app/src/main/res/values/strings.xml
@@ -187,6 +187,17 @@
     <string name="method_network_handle">Network handle</string>
     <string name="method_connectivity_service">ConnectivityService</string>
     <string name="method_package_enumeration">Package enumeration</string>
+    <!-- Detection method descriptions: what the probe is + how it reveals a VPN -->
+    <string name="method_desc_routes">An app reads the routing table (/proc/net/route or netlink). A VPN installs a catch-all default route through its tunnel interface — its presence gives the VPN away.</string>
+    <string name="method_desc_interfaces">An app enumerates network interfaces and their addresses (getifaddrs / netlink). A VPN appears as an extra tunNN interface with an address that doesn\'t match Wi-Fi or cellular.</string>
+    <string name="method_desc_interface_ioctl">An app queries interfaces directly via ioctl (SIOCGIFCONF / SIOCGIFFLAGS). The VPN tunnel interface shows up in the list or reports as up.</string>
+    <string name="method_desc_policy_rules">An app reads policy routing rules (RTM_GETRULE). A VPN adds rules that steer traffic into the tunnel, which betray its presence.</string>
+    <string name="method_desc_network_capabilities">An app queries NetworkCapabilities. An active VPN sets the VPN transport flag — a direct signal that a VPN is up.</string>
+    <string name="method_desc_link_properties">An app reads LinkProperties. A VPN exposes its tunNN interface name, VPN routes and DNS servers.</string>
+    <string name="method_desc_network_info">An app checks NetworkInfo (legacy API). An active VPN reports type VPN instead of mobile or Wi-Fi.</string>
+    <string name="method_desc_network_handle">An app resolves the active Network handle. A VPN returns its own virtual network instead of the physical one.</string>
+    <string name="method_desc_connectivity_service">An app lists all networks or subscribes to network callbacks via ConnectivityService. The VPN network shows up in the list or through callbacks.</string>
+    <string name="method_desc_package_enumeration">An app lists installed packages or queries VpnService components. The presence of known VPN apps reveals VPN use.</string>
     <string name="surface_java">Java API</string>
     <string name="surface_native">Native</string>
     <string name="surface_package">Packages</string>

--- a/lsposed/app/src/main/res/values/strings.xml
+++ b/lsposed/app/src/main/res/values/strings.xml
@@ -167,7 +167,7 @@
     <string name="statistics_apps_header">Apps probing VPN</string>
     <string name="statistics_apps_caption">Cumulative since boot. Tap an app for the full per-hook breakdown.</string>
     <string name="statistics_capture_title">Capture session</string>
-    <string name="statistics_capture_intro">Snapshot the counters, open and use a target app, then Refresh to see exactly what it probed in this window.</string>
+    <string name="statistics_capture_intro">Start a capture, then open and use a target app. Tap Refresh to see which VPN checks it ran during that time.</string>
     <string name="statistics_capture_start">Start capture</string>
     <string name="statistics_capture_active">Capturing · %1$s · %2$d apps</string>
     <string name="statistics_capture_stop">Stop</string>

--- a/lsposed/app/src/main/res/values/strings.xml
+++ b/lsposed/app/src/main/res/values/strings.xml
@@ -165,6 +165,7 @@
     <string name="statistics_load_failed_message">VPN Hide could not collect the root state needed for this tab. Check your root manager if permission was interrupted, then tap Retry.</string>
     <string name="statistics_refresh_failed_message">Refresh failed. Showing the previous statistics data.</string>
     <string name="statistics_apps_header">Apps probing VPN</string>
+    <string name="statistics_apps_caption">Cumulative since boot, by detection method</string>
     <string name="statistics_apps_metric">Apps</string>
     <string name="statistics_methods_metric">Methods</string>
     <!-- Detection methods (per-app breakdown) -->

--- a/lsposed/app/src/main/res/values/strings.xml
+++ b/lsposed/app/src/main/res/values/strings.xml
@@ -165,7 +165,15 @@
     <string name="statistics_load_failed_message">VPN Hide could not collect the root state needed for this tab. Check your root manager if permission was interrupted, then tap Retry.</string>
     <string name="statistics_refresh_failed_message">Refresh failed. Showing the previous statistics data.</string>
     <string name="statistics_apps_header">Apps probing VPN</string>
-    <string name="statistics_apps_caption">Cumulative since boot, by detection method</string>
+    <string name="statistics_apps_caption">Cumulative since boot. Tap an app for the full per-hook breakdown.</string>
+    <string name="statistics_capture_title">Capture session</string>
+    <string name="statistics_capture_intro">Snapshot the counters, open and use a target app, then Refresh to see exactly what it probed in this window.</string>
+    <string name="statistics_capture_start">Start capture</string>
+    <string name="statistics_capture_active">Capturing · %1$s · %2$d apps</string>
+    <string name="statistics_capture_stop">Stop</string>
+    <string name="statistics_capture_apps_header">Probes during capture</string>
+    <string name="statistics_capture_hint">What target apps probed since the capture started. Tap for the per-hook breakdown.</string>
+    <string name="statistics_capture_empty">No probes captured yet. Open a target app, then tap Refresh.</string>
     <string name="statistics_apps_metric">Apps</string>
     <string name="statistics_methods_metric">Methods</string>
     <!-- Detection methods (per-app breakdown) -->

--- a/lsposed/app/src/main/res/values/strings.xml
+++ b/lsposed/app/src/main/res/values/strings.xml
@@ -149,17 +149,13 @@
     <string name="statistics_backends">Backends</string>
     <string name="statistics_total_events">Events</string>
     <string name="statistics_active_backends">Active backends</string>
-    <string name="statistics_counter_rows">Counter rows</string>
-    <string name="statistics_hooks">Hooks</string>
     <string name="statistics_backend_detail">%1$s · hooks: %2$d</string>
     <string name="statistics_backend_unavailable_detail">Native counters unavailable</string>
     <string name="statistics_events">events</string>
     <string name="statistics_no_data">No runtime statistics yet. Counters appear after a protected app hits an installed hook.</string>
     <string name="statistics_no_data_supported_backends">No counters yet from backends that support statistics.</string>
-    <string name="statistics_no_counters">No counters yet.</string>
     <string name="statistics_zygisk_native_unavailable">Native counters are not available for Zygisk. Java and Apps counters are still reported by LSPosed.</string>
     <string name="statistics_unknown_uid">uid %1$d</string>
-    <string name="statistics_unknown_hook">unknown hook %1$d</string>
     <string name="statistics_status_ok">OK</string>
     <string name="statistics_status_partial">Partial</string>
     <string name="statistics_status_error">Error</string>
@@ -168,6 +164,23 @@
     <string name="statistics_load_failed_title">Statistics unavailable</string>
     <string name="statistics_load_failed_message">VPN Hide could not collect the root state needed for this tab. Check your root manager if permission was interrupted, then tap Retry.</string>
     <string name="statistics_refresh_failed_message">Refresh failed. Showing the previous statistics data.</string>
+    <string name="statistics_apps_header">Apps probing VPN</string>
+    <string name="statistics_apps_metric">Apps</string>
+    <string name="statistics_methods_metric">Methods</string>
+    <!-- Detection methods (per-app breakdown) -->
+    <string name="method_routes">Routing table</string>
+    <string name="method_interfaces">Network interfaces</string>
+    <string name="method_interface_ioctl">Interface query (ioctl)</string>
+    <string name="method_policy_rules">Routing policy rules</string>
+    <string name="method_network_capabilities">NetworkCapabilities</string>
+    <string name="method_link_properties">LinkProperties</string>
+    <string name="method_network_info">NetworkInfo</string>
+    <string name="method_network_handle">Network handle</string>
+    <string name="method_connectivity_service">ConnectivityService</string>
+    <string name="method_package_enumeration">Package enumeration</string>
+    <string name="surface_java">Java API</string>
+    <string name="surface_native">Native</string>
+    <string name="surface_package">Packages</string>
 
     <string name="dashboard_install_recommendation_title">Installation recommendation</string>
     <string name="dashboard_install_recommendation_device">Your device: %1$s, kernel %2$s</string>

--- a/lsposed/app/src/test/kotlin/dev/okhsunrog/vpnhide/ProbeStatsTest.kt
+++ b/lsposed/app/src/test/kotlin/dev/okhsunrog/vpnhide/ProbeStatsTest.kt
@@ -1,0 +1,83 @@
+package dev.okhsunrog.vpnhide
+
+import dev.okhsunrog.vpnhide.generated.HookIds
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class ProbeStatsTest {
+    private fun row(
+        uid: Long,
+        hook: HookIds.Hook,
+        count: Long,
+        pkg: String = "pkg$uid",
+    ) = StatisticsRow(uid = uid, packageNames = listOf(pkg), hookId = hook.id.toLong(), hook = hook, count = count)
+
+    private fun backend(
+        id: HookIds.Backend,
+        rows: List<StatisticsRow>,
+    ) = BackendStatistics(backend = id, status = null, rows = rows)
+
+    @Test
+    fun `every hook maps to a method`() {
+        // Exhaustive-when is enforced at compile time; this also pins surfaces.
+        HookIds.Hook.entries.forEach { DetectionMethod.of(it) }
+        assertEquals(MethodSurface.Java, DetectionMethod.of(HookIds.Hook.LSPOSED_NETWORK_CAPABILITIES).surface)
+        assertEquals(MethodSurface.Native, DetectionMethod.of(HookIds.Hook.DEV_IOCTL).surface)
+        assertEquals(MethodSurface.Native, DetectionMethod.of(HookIds.Hook.ZYGISK_GETIFADDRS).surface)
+        assertEquals(MethodSurface.Package, DetectionMethod.of(HookIds.Hook.LSPOSED_PACKAGE_VISIBILITY).surface)
+        // Hooks fold into a shared method.
+        assertEquals(DetectionMethod.Routes, DetectionMethod.of(HookIds.Hook.FIB_ROUTE_SEQ_SHOW))
+        assertEquals(DetectionMethod.Routes, DetectionMethod.of(HookIds.Hook.FIB_DUMP_INFO))
+    }
+
+    @Test
+    fun `aggregates per app across backends, folds hooks into methods, sorts by total`() {
+        val state =
+            StatisticsState(
+                backends =
+                    listOf(
+                        backend(
+                            HookIds.Backend.LSPOSED,
+                            listOf(
+                                row(10100, HookIds.Hook.LSPOSED_NETWORK_CAPABILITIES, 5),
+                                row(10100, HookIds.Hook.LSPOSED_LINK_PROPERTIES, 3),
+                            ),
+                        ),
+                        backend(
+                            HookIds.Backend.KMOD,
+                            listOf(
+                                row(10100, HookIds.Hook.DEV_IOCTL, 2),
+                                row(10200, HookIds.Hook.FIB_ROUTE_SEQ_SHOW, 7),
+                                row(10200, HookIds.Hook.FIB_DUMP_INFO, 1),
+                            ),
+                        ),
+                    ),
+            )
+
+        val apps = buildAppProbeStats(state)
+
+        assertEquals(listOf(10100L, 10200L), apps.map { it.uid }) // total 10 before total 8
+        val first = apps[0]
+        assertEquals(10uL, first.total)
+        assertEquals(
+            mapOf(
+                DetectionMethod.NetworkCapabilities to 5L,
+                DetectionMethod.LinkProperties to 3L,
+                DetectionMethod.InterfaceIoctl to 2L,
+            ),
+            first.byMethod,
+        )
+        assertEquals(setOf(MethodSurface.Java, MethodSurface.Native), first.surfaces)
+
+        val second = apps[1]
+        assertEquals(8uL, second.total)
+        // The two route hooks folded into one Routes method.
+        assertEquals(mapOf(DetectionMethod.Routes to 8L), second.byMethod)
+        assertEquals(setOf(MethodSurface.Native), second.surfaces)
+    }
+
+    @Test
+    fun `empty state yields no apps`() {
+        assertEquals(emptyList<AppProbeStats>(), buildAppProbeStats(StatisticsState(backends = emptyList())))
+    }
+}

--- a/lsposed/app/src/test/kotlin/dev/okhsunrog/vpnhide/ProbeStatsTest.kt
+++ b/lsposed/app/src/test/kotlin/dev/okhsunrog/vpnhide/ProbeStatsTest.kt
@@ -77,6 +77,27 @@ class ProbeStatsTest {
     }
 
     @Test
+    fun `self package is excluded from the list`() {
+        val state =
+            StatisticsState(
+                backends =
+                    listOf(
+                        backend(
+                            HookIds.Backend.LSPOSED,
+                            listOf(
+                                row(10100, HookIds.Hook.LSPOSED_NETWORK_CAPABILITIES, 5, pkg = "com.other"),
+                                row(10999, HookIds.Hook.LSPOSED_NETWORK_CAPABILITIES, 99, pkg = "dev.okhsunrog.vpnhide"),
+                            ),
+                        ),
+                    ),
+            )
+
+        val apps = buildAppProbeStats(state, selfPackage = "dev.okhsunrog.vpnhide")
+
+        assertEquals(listOf(listOf("com.other")), apps.map { it.packageNames })
+    }
+
+    @Test
     fun `empty state yields no apps`() {
         assertEquals(emptyList<AppProbeStats>(), buildAppProbeStats(StatisticsState(backends = emptyList())))
     }

--- a/lsposed/app/src/test/kotlin/dev/okhsunrog/vpnhide/ProbeStatsTest.kt
+++ b/lsposed/app/src/test/kotlin/dev/okhsunrog/vpnhide/ProbeStatsTest.kt
@@ -101,4 +101,48 @@ class ProbeStatsTest {
     fun `empty state yields no apps`() {
         assertEquals(emptyList<AppProbeStats>(), buildAppProbeStats(StatisticsState(backends = emptyList())))
     }
+
+    @Test
+    fun `capture diff shows only probes since the baseline`() {
+        val baseline =
+            snapshotCounters(
+                StatisticsState(listOf(backend(HookIds.Backend.LSPOSED, listOf(row(10100, HookIds.Hook.LSPOSED_NETWORK_CAPABILITIES, 5))))),
+            )
+        val current =
+            StatisticsState(
+                listOf(
+                    backend(
+                        HookIds.Backend.LSPOSED,
+                        listOf(
+                            row(10100, HookIds.Hook.LSPOSED_NETWORK_CAPABILITIES, 8), // +3
+                            row(10200, HookIds.Hook.FIB_ROUTE_SEQ_SHOW, 4), // new, +4
+                        ),
+                    ),
+                ),
+            )
+
+        val diff = diffCapture(baseline, current)
+
+        assertEquals(false, diff.backendReset)
+        assertEquals(listOf(10200L, 10100L), diff.apps.map { it.uid }) // delta 4 before delta 3
+        assertEquals(4uL, diff.apps[0].total)
+        assertEquals(mapOf(DetectionMethod.Routes to 4L), diff.apps[0].byMethod)
+        assertEquals(3uL, diff.apps[1].total)
+        assertEquals(mapOf(DetectionMethod.NetworkCapabilities to 3L), diff.apps[1].byMethod)
+    }
+
+    @Test
+    fun `capture diff flags a backend restart when a counter drops`() {
+        val baseline =
+            snapshotCounters(
+                StatisticsState(listOf(backend(HookIds.Backend.LSPOSED, listOf(row(10100, HookIds.Hook.LSPOSED_NETWORK_CAPABILITIES, 5))))),
+            )
+        val afterReboot =
+            StatisticsState(listOf(backend(HookIds.Backend.LSPOSED, listOf(row(10100, HookIds.Hook.LSPOSED_NETWORK_CAPABILITIES, 2)))))
+
+        val diff = diffCapture(baseline, afterReboot)
+
+        assertEquals(true, diff.backendReset)
+        assertEquals(emptyList<AppProbeStats>(), diff.apps)
+    }
 }


### PR DESCRIPTION
Reworks the Statistics tab from raw per-backend counter rows into a monitoring view of which apps probe for the VPN and how, addressing the request in #119. The data was always per-(uid, hook) on the wire — this aggregates it per app, labels it by detection method, and adds a capture-session tool to see what a specific app does in a controlled window. Scoped to target apps (the apps the hooks already count); monitoring non-target apps to discover new probers is deferred in docs/ROADMAP.md.

- Per-app cards: each app that triggered a hook is one card with its total probe count and a breakdown by detection method. The 25 raw hooks fold into a friendly taxonomy (routes, interfaces, ioctl, policy rules, NetworkCapabilities, LinkProperties, NetworkInfo, network handle, ConnectivityService, package enumeration) tagged by surface (Java API / Native / Packages), aggregated across the Java backend and the one active native backend.
- Tap an app for a dialog with the exact per-hook breakdown (friendly method name + the hook's technical note + count) — so you can see precisely which detection techniques an app uses.
- Capture session: snapshot the counters, exercise a target app, Refresh to see deltas (current − baseline) for that window; Stop returns to the cumulative view. Pure baseline-diff, no backend reset command, no per-event timestamps; a counter dropping below baseline (backend restart) is detected and re-baselines automatically.
- Exclude VPN Hide's own package (its cold-start diagnostics self-probe every vector) and label the counts as cumulative since boot, both from on-device review.
- Coalesce LSPosed stats disk writes: record() no longer rewrites the whole state file on every intercepted call inside system_server (debounced ~1s on a writer thread).
- Swap the bottom-nav order to Dashboard / Protection / Statistics.

Pure logic (taxonomy, per-app aggregation, capture diff incl. reset detection) is unit-tested; detekt, ktlint, Android lint and unit tests pass.

Testing: built and installed on a Pixel 4a (APatch) and a Pixel 8 Pro (KSU-Next); the per-app list, per-hook detail dialog, and the manual-Refresh capture flow are device-only paths worth a sanity pass. Live auto-polling for the capture session is intentionally not included in v1 (the full root snapshot is too heavy to poll); it can follow if the manual flow feels clunky.

Closes #119
