### PR TITLE
feat(lsposed): group the hook pickers by detection method with explanations

### DIFF
--- a/changelog.d/added-the-per-app-java-and-native-d5b9.md
+++ b/changelog.d/added-the-per-app-java-and-native-d5b9.md
@@ -1,0 +1,9 @@
+_2026-06-29_
+
+## English
+
+The per-app Java and Native hook pickers now group hooks by detection method, with an explanation of what each method is and how an app uses it to detect a VPN.
+
+## Русский
+
+Пикеры Java- и Native-хуков для приложения теперь сгруппированы по способам детекта, с пояснением, что это за способ и как приложение через него определяет VPN.

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/AppPickerScreen.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/AppPickerScreen.kt
@@ -834,21 +834,32 @@ private fun HooksDialog(
                     style = MaterialTheme.typography.bodySmall,
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                 )
-                LazyColumn(modifier = Modifier.heightIn(max = 420.dp)) {
-                    items(hookEntries, key = { it.hookName }) { hook ->
-                        val checked = hook.hookName in selected
-                        HookRow(
-                            hook = hook,
-                            checked = checked,
-                            onCheckedChange = { enabled ->
-                                selected =
-                                    if (enabled) {
-                                        selected + hook.hookName
-                                    } else {
-                                        selected - hook.hookName
-                                    }
-                            },
-                        )
+                // Group hooks by detection method, with a header explaining what
+                // the method is and how an app uses it to detect a VPN — same
+                // taxonomy/wording as the Statistics per-hook detail.
+                val grouped =
+                    remember(hookEntries) {
+                        hookEntries.groupBy { DetectionMethod.of(it) }.toSortedMap(compareBy { it.ordinal })
+                    }
+                LazyColumn(modifier = Modifier.heightIn(max = 460.dp)) {
+                    grouped.forEach { (method, hooks) ->
+                        item(key = "header_${method.name}") {
+                            MethodHeader(method)
+                        }
+                        items(hooks, key = { it.hookName }) { hook ->
+                            HookRow(
+                                hook = hook,
+                                checked = hook.hookName in selected,
+                                onCheckedChange = { enabled ->
+                                    selected =
+                                        if (enabled) {
+                                            selected + hook.hookName
+                                        } else {
+                                            selected - hook.hookName
+                                        }
+                                },
+                            )
+                        }
                     }
                 }
             }
@@ -871,6 +882,22 @@ private fun HooksDialog(
 }
 
 @Composable
+private fun MethodHeader(method: DetectionMethod) {
+    Column(modifier = Modifier.padding(top = 10.dp, bottom = 2.dp)) {
+        Text(
+            text = stringResource(method.labelRes),
+            style = MaterialTheme.typography.titleSmall,
+            fontWeight = FontWeight.Bold,
+        )
+        Text(
+            text = stringResource(method.descriptionRes),
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+    }
+}
+
+@Composable
 private fun HookRow(
     hook: HookIds.Hook,
     checked: Boolean,
@@ -881,19 +908,16 @@ private fun HookRow(
             Modifier
                 .clickable { onCheckedChange(!checked) }
                 .fillMaxWidth()
-                .padding(vertical = 6.dp),
+                .padding(vertical = 4.dp),
+        verticalAlignment = Alignment.CenterVertically,
     ) {
         Checkbox(checked = checked, onCheckedChange = onCheckedChange)
-        Column(modifier = Modifier.padding(start = 8.dp)) {
-            Text(
-                text = hook.hookName,
-                style = MaterialTheme.typography.bodyMedium,
-            )
-            Text(
-                text = hook.note,
-                style = MaterialTheme.typography.bodySmall,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
-            )
-        }
+        // The friendly method name + explanation live in the group header; the
+        // row just needs the precise hook (its technical note) to disambiguate.
+        Text(
+            text = hook.note,
+            style = MaterialTheme.typography.bodyMedium,
+            modifier = Modifier.padding(start = 8.dp),
+        )
     }
 }


### PR DESCRIPTION
The per-app Java and Native hook selection sheets on the Protection tab listed raw hooks by their internal id (e.g. `lsposed_network_capabilities`) with a terse technical note. They now group hooks under a detection-method header — a friendly name plus an explanation of what the probe is and how an app uses it to detect a VPN — reusing the `DetectionMethod` taxonomy and descriptions introduced for the Statistics screen (#193), so the two surfaces read consistently.

- Each picker groups its hooks by method; the header carries the friendly label and the 'how it detects VPN' description (one per method, not per hook — the hooks within a method detect the same way, differing only in API).
- Individual hook checkboxes keep their technical note to disambiguate the exact API; the raw hook id is no longer shown.
- Selection semantics are unchanged.

Testing: built the release APK and installed on a Pixel 4a (APatch) and a Pixel 8 Pro (KSU-Next); reviewed the Java and Native pickers. Pure UI grouping over existing data; detekt, ktlint, Android lint and unit tests pass.