### PR TITLE
Developer settings section with version-warning toggle

### DIFF
--- a/changelog.d/added-developer-settings-section-with-a-toggle-e056.md
+++ b/changelog.d/added-developer-settings-section-with-a-toggle-e056.md
@@ -1,0 +1,9 @@
+_2026-06-29_
+
+## English
+
+Developer settings section with a toggle to ignore the dev-build suffix when comparing the running LSPosed hook to the installed app
+
+## Русский
+
+Раздел настроек «Для разработчиков» с переключателем, скрывающим суффикс dev-сборки при сравнении запущенного хука LSPosed с установленным приложением

--- a/changelog.d/added-developer-settings-section-with-a-toggle-e056.md
+++ b/changelog.d/added-developer-settings-section-with-a-toggle-e056.md
@@ -2,8 +2,8 @@ _2026-06-29_
 
 ## English
 
-Developer settings section with a toggle to ignore the dev-build suffix when comparing the running LSPosed hook to the installed app
+Developer settings section with a toggle to mute version and changelog notices on dev builds (ignores the dev-build suffix when comparing the running LSPosed hook to the installed app, and skips the changelog after each rebuild)
 
 ## Русский
 
-Раздел настроек «Для разработчиков» с переключателем, скрывающим суффикс dev-сборки при сравнении запущенного хука LSPosed с установленным приложением
+Раздел настроек «Для разработчиков» с переключателем, скрывающим уведомления о версиях и changelog на dev-сборках (игнорирует суффикс dev-сборки при сравнении запущенного хука LSPosed с установленным приложением и не показывает changelog после каждой пересборки)

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DashboardData.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DashboardData.kt
@@ -5,6 +5,8 @@ import android.database.sqlite.SQLiteDatabase
 import android.os.Build
 import android.os.SystemClock
 import dev.okhsunrog.vpnhide.generated.HookIds
+import dev.okhsunrog.vpnhide.settings.SettingsRepository
+import kotlinx.coroutines.flow.first
 import java.io.File
 
 // ── Domain types — invalid states are unrepresentable ────────────────────
@@ -1301,10 +1303,24 @@ internal suspend fun loadDashboardState(
     if (ports is ModuleState.Installed && ports.targetCount == 0) {
         info(res.getString(R.string.dashboard_issue_ports_no_observers))
     }
+    // The running-LSPosed-vs-installed-APK check compares the FULL version by
+    // default: the hook code lives in system_server and only swaps on reboot, so
+    // a dev who reinstalls the APK on the same base keeps running the old hook
+    // until reboot. Developers who reinstall constantly can flip
+    // suppressVersionWarnings to fall back to base-compare (release users see no
+    // difference — release versions carry no dev suffix).
+    val suppressVersionWarnings =
+        SettingsRepository(context.applicationContext).settings.first().suppressVersionWarnings
     var lsposedVersionMismatch: String? = null
     if (lsposed is LsposedState.Active) {
         val runningVersion = lsposed.version
-        if (versionsMismatch(runningVersion, appVersion)) {
+        val mismatch =
+            if (suppressVersionWarnings) {
+                versionsMismatch(runningVersion, appVersion)
+            } else {
+                versionsMismatchFull(runningVersion, appVersion)
+            }
+        if (mismatch) {
             VpnHideLog.w(TAG, "version mismatch: running=$runningVersion app=$appVersion")
             lsposedVersionMismatch = res.getString(R.string.dashboard_issue_version_mismatch, runningVersion, appVersion)
         }

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DashboardScreen.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DashboardScreen.kt
@@ -37,12 +37,14 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import dev.okhsunrog.vpnhide.settings.LocalSettingsState
+import dev.okhsunrog.vpnhide.settings.SettingsRepository
 import dev.okhsunrog.vpnhide.ui.components.EnhancedButton
 import dev.okhsunrog.vpnhide.ui.components.EnhancedCard
 import dev.okhsunrog.vpnhide.ui.components.GroupedCard
 import dev.okhsunrog.vpnhide.ui.components.pulse
 import dev.okhsunrog.vpnhide.ui.theme.AppColors
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.withContext
 
 @Composable
@@ -72,7 +74,14 @@ fun DashboardScreen(
         UpdateCheckCache.ensureFresh(scope, BuildConfig.VERSION_NAME)
     }
     LaunchedEffect(Unit) {
-        if (shouldShowChangelog(context)) {
+        // Read the persisted flag directly rather than LocalSettingsState: the
+        // ambient snapshot is the default (false) until DataStore loads, which
+        // would race this cold-start effect and pop the changelog anyway. When
+        // suppressed we also skip markChangelogSeen, so turning the toggle back
+        // off still shows the changelog for the current version.
+        val suppress =
+            SettingsRepository(context.applicationContext).settings.first().suppressVersionWarnings
+        if (!suppress && shouldShowChangelog(context)) {
             val data = withContext(Dispatchers.IO) { loadChangelog(context) }
             // Only raise the dialog when there's something to show — the
             // emptiness guard lives here (a side-effect scope) rather than

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/SettingsScreen.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/SettingsScreen.kt
@@ -40,6 +40,7 @@ import androidx.compose.material.icons.filled.Palette
 import androidx.compose.material.icons.filled.RoundedCorner
 import androidx.compose.material.icons.filled.Save
 import androidx.compose.material.icons.filled.TextFields
+import androidx.compose.material.icons.filled.Update
 import androidx.compose.material.icons.filled.Vibration
 import androidx.compose.material.icons.filled.VisibilityOff
 import androidx.compose.material.icons.filled.VpnKey
@@ -236,6 +237,7 @@ fun SettingsScreen(
             AutoHideSettingsSection()
             DiagnosticsSettingsSection(onOpen = { diagnosticsOpen = true })
             DebugToolsSettingsSection(selfNeedsRestart = selfNeedsRestart)
+            DeveloperSettingsSection()
             ConfigBackupSection()
             SuperkeySettingsSection()
             CommunitySettingsSection()
@@ -328,6 +330,24 @@ private fun DebugToolsSettingsSection(selfNeedsRestart: Boolean?) {
     Column(verticalArrangement = Arrangement.spacedBy(3.dp)) {
         SettingsSectionHeader(stringResource(R.string.settings_debug_section))
         DebugToolsSection(selfNeedsRestart = selfNeedsRestart)
+    }
+}
+
+@Composable
+private fun DeveloperSettingsSection() {
+    val settings = LocalSettingsState.current
+    val interactor = LocalSettingsInteractor.current
+    Column(verticalArrangement = Arrangement.spacedBy(3.dp)) {
+        SettingsSectionHeader(stringResource(R.string.settings_developer_section))
+        PreferenceRowSwitch(
+            title = stringResource(R.string.settings_suppress_version_warnings),
+            subtitle = stringResource(R.string.settings_suppress_version_warnings_sub),
+            icon = Icons.Default.Update,
+            index = 0,
+            count = 1,
+            checked = settings.suppressVersionWarnings,
+            onCheckedChange = interactor::setSuppressVersionWarnings,
+        )
     }
 }
 

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/SettingsScreen.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/SettingsScreen.kt
@@ -237,11 +237,11 @@ fun SettingsScreen(
             AutoHideSettingsSection()
             DiagnosticsSettingsSection(onOpen = { diagnosticsOpen = true })
             DebugToolsSettingsSection(selfNeedsRestart = selfNeedsRestart)
-            DeveloperSettingsSection()
             ConfigBackupSection()
             SuperkeySettingsSection()
             CommunitySettingsSection()
             ResetSettingsSection(selfNeedsRestart = selfNeedsRestart)
+            DeveloperSettingsSection()
         }
     }
 }

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/UpdateChecker.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/UpdateChecker.kt
@@ -57,6 +57,21 @@ internal fun versionsMismatch(
     return baseVersion(moduleVersion) != baseVersion(appVersion)
 }
 
+// Like [versionsMismatch] but compares the FULL version string (git-describe
+// dev suffix included). Used for the running-LSPosed-vs-installed-APK check:
+// the hook code lives in system_server and is only swapped on reboot, so a dev
+// who rebuilds + reinstalls the APK on the same base keeps running the old hook
+// until they reboot — base-compare hides that, full-compare surfaces it.
+// Release versions are clean (no suffix) so this is identical to
+// [versionsMismatch] for end users.
+internal fun versionsMismatchFull(
+    moduleVersion: String?,
+    appVersion: String,
+): Boolean {
+    if (moduleVersion == null) return false
+    return normalizeVersion(moduleVersion) != normalizeVersion(appVersion)
+}
+
 // True when `remote` is a strictly newer release than `current` — used
 // to decide whether to offer an in-app update prompt. Both sides go
 // through baseVersion() so a dev APK built on top of 0.6.2 still gets

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/settings/AppSettings.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/settings/AppSettings.kt
@@ -47,6 +47,14 @@ data class AppSettings(
     val fullProtectionRoleLabels: Boolean = true,
     /** Whether the user has opened Settings at least once (gates the gear hint). */
     val settingsHintSeen: Boolean = false,
+    /**
+     * Suppress the LSPosed running-vs-installed version warning by comparing only
+     * the release base version (ignoring the git-describe dev suffix). Off by
+     * default, so a stale dev build surfaces; a developer who reinstalls the APK
+     * repeatedly without rebooting can flip this to silence the reminder. No
+     * effect on release builds (their versions carry no dev suffix).
+     */
+    val suppressVersionWarnings: Boolean = false,
 ) {
     companion object {
         /** Brand seed — a crisp blue-teal, used as the non-dynamic fallback palette. */

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/settings/SettingsInteractor.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/settings/SettingsInteractor.kt
@@ -41,6 +41,8 @@ interface SettingsInteractor {
     fun setFullProtectionRoleLabels(value: Boolean)
 
     fun setSettingsHintSeen(value: Boolean)
+
+    fun setSuppressVersionWarnings(value: Boolean)
 }
 
 /**
@@ -72,6 +74,8 @@ class RepositorySettingsInteractor(
     override fun setFullProtectionRoleLabels(value: Boolean) = launch { repository.setFullProtectionRoleLabels(value) }
 
     override fun setSettingsHintSeen(value: Boolean) = launch { repository.setSettingsHintSeen(value) }
+
+    override fun setSuppressVersionWarnings(value: Boolean) = launch { repository.setSuppressVersionWarnings(value) }
 
     private inline fun launch(crossinline block: suspend () -> Unit) {
         scope.launch { block() }

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/settings/SettingsRepository.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/settings/SettingsRepository.kt
@@ -36,6 +36,7 @@ class SettingsRepository(
         val HAPTICS = booleanPreferencesKey("haptics_enabled")
         val FULL_PROTECTION_ROLE_LABELS = booleanPreferencesKey("full_protection_role_labels")
         val SETTINGS_HINT_SEEN = booleanPreferencesKey("settings_hint_seen")
+        val SUPPRESS_VERSION_WARNINGS = booleanPreferencesKey("suppress_version_warnings")
     }
 
     val settings: Flow<AppSettings> =
@@ -54,6 +55,8 @@ class SettingsRepository(
                 fullProtectionRoleLabels =
                     p[Keys.FULL_PROTECTION_ROLE_LABELS] ?: defaults.fullProtectionRoleLabels,
                 settingsHintSeen = p[Keys.SETTINGS_HINT_SEEN] ?: defaults.settingsHintSeen,
+                suppressVersionWarnings =
+                    p[Keys.SUPPRESS_VERSION_WARNINGS] ?: defaults.suppressVersionWarnings,
             )
         }
 
@@ -78,6 +81,8 @@ class SettingsRepository(
     suspend fun setFullProtectionRoleLabels(value: Boolean) = edit { it[Keys.FULL_PROTECTION_ROLE_LABELS] = value }
 
     suspend fun setSettingsHintSeen(value: Boolean) = edit { it[Keys.SETTINGS_HINT_SEEN] = value }
+
+    suspend fun setSuppressVersionWarnings(value: Boolean) = edit { it[Keys.SUPPRESS_VERSION_WARNINGS] = value }
 
     private suspend fun edit(block: (androidx.datastore.preferences.core.MutablePreferences) -> Unit) {
         context.uiSettingsStore.edit(block)

--- a/lsposed/app/src/main/res/values-ru/strings.xml
+++ b/lsposed/app/src/main/res/values-ru/strings.xml
@@ -328,8 +328,8 @@
     <string name="settings_diagnostics_sub">Полный набор проверок защиты</string>
     <string name="settings_debug_section">Отладка</string>
     <string name="settings_developer_section">Для разработчиков</string>
-    <string name="settings_suppress_version_warnings">Скрыть предупреждения о версии</string>
-    <string name="settings_suppress_version_warnings_sub">Игнорировать суффикс dev-сборки при сравнении запущенного хука LSPosed с установленным приложением. Актуально только при сборке из исходников; на релизных версиях не влияет.</string>
+    <string name="settings_suppress_version_warnings">Скрыть предупреждения о версиях и changelog</string>
+    <string name="settings_suppress_version_warnings_sub">Игнорировать суффикс dev-сборки при сравнении запущенного хука LSPosed с установленным приложением и не показывать changelog после каждой пересборки. Актуально только при сборке из исходников; на релизных версиях не влияет.</string>
     <string name="settings_config_section">Конфигурация</string>
     <string name="settings_config_backup_title">Резервная копия конфига</string>
     <string name="settings_config_backup_sub">Сохранить или восстановить канонический JSON-конфиг</string>

--- a/lsposed/app/src/main/res/values-ru/strings.xml
+++ b/lsposed/app/src/main/res/values-ru/strings.xml
@@ -327,6 +327,9 @@
     <string name="settings_diagnostics_title">Подробная диагностика</string>
     <string name="settings_diagnostics_sub">Полный набор проверок защиты</string>
     <string name="settings_debug_section">Отладка</string>
+    <string name="settings_developer_section">Для разработчиков</string>
+    <string name="settings_suppress_version_warnings">Скрыть предупреждения о версии</string>
+    <string name="settings_suppress_version_warnings_sub">Игнорировать суффикс dev-сборки при сравнении запущенного хука LSPosed с установленным приложением. Актуально только при сборке из исходников; на релизных версиях не влияет.</string>
     <string name="settings_config_section">Конфигурация</string>
     <string name="settings_config_backup_title">Резервная копия конфига</string>
     <string name="settings_config_backup_sub">Сохранить или восстановить канонический JSON-конфиг</string>

--- a/lsposed/app/src/main/res/values/strings.xml
+++ b/lsposed/app/src/main/res/values/strings.xml
@@ -370,8 +370,8 @@
     <string name="settings_diagnostics_sub">Run the full protection check suite</string>
     <string name="settings_debug_section">Debugging</string>
     <string name="settings_developer_section">Developer</string>
-    <string name="settings_suppress_version_warnings">Suppress version warnings</string>
-    <string name="settings_suppress_version_warnings_sub">Ignore the dev-build suffix when comparing the running LSPosed hook against the installed app. Only relevant when running your own builds; no effect on release versions.</string>
+    <string name="settings_suppress_version_warnings">Hide version and changelog notices</string>
+    <string name="settings_suppress_version_warnings_sub">Ignore the dev-build suffix when comparing the running LSPosed hook against the installed app, and don\'t pop the changelog after each rebuild. Only relevant when running your own builds; no effect on release versions.</string>
     <string name="settings_config_section">Configuration</string>
     <string name="settings_config_backup_title">Config backup</string>
     <string name="settings_config_backup_sub">Save or restore the canonical JSON config</string>

--- a/lsposed/app/src/main/res/values/strings.xml
+++ b/lsposed/app/src/main/res/values/strings.xml
@@ -369,6 +369,9 @@
     <string name="settings_diagnostics_title">Detailed diagnostics</string>
     <string name="settings_diagnostics_sub">Run the full protection check suite</string>
     <string name="settings_debug_section">Debugging</string>
+    <string name="settings_developer_section">Developer</string>
+    <string name="settings_suppress_version_warnings">Suppress version warnings</string>
+    <string name="settings_suppress_version_warnings_sub">Ignore the dev-build suffix when comparing the running LSPosed hook against the installed app. Only relevant when running your own builds; no effect on release versions.</string>
     <string name="settings_config_section">Configuration</string>
     <string name="settings_config_backup_title">Config backup</string>
     <string name="settings_config_backup_sub">Save or restore the canonical JSON config</string>

--- a/lsposed/app/src/test/kotlin/dev/okhsunrog/vpnhide/UpdateCheckerTest.kt
+++ b/lsposed/app/src/test/kotlin/dev/okhsunrog/vpnhide/UpdateCheckerTest.kt
@@ -171,6 +171,42 @@ class VersionsMismatchTest {
     }
 }
 
+class VersionsMismatchFullTest {
+    @Test
+    fun `identical full versions do not mismatch`() {
+        assertFalse(versionsMismatchFull("0.6.2", "0.6.2"))
+        assertFalse(versionsMismatchFull("0.6.2-14-g1f2205e", "0.6.2-14-g1f2205e"))
+    }
+
+    @Test
+    fun `v-prefix difference does not mismatch`() {
+        assertFalse(versionsMismatchFull("v0.6.2", "0.6.2"))
+    }
+
+    @Test
+    fun `dev build on top of release does mismatch under full compare`() {
+        // The whole point of full-compare: a dev APK rebuilt past the tag runs
+        // a different hook than the released module/system_server still holds.
+        assertTrue(versionsMismatchFull("0.6.2", "0.6.2-14-g1f2205e"))
+        assertTrue(versionsMismatchFull("0.6.2-14-g1f2205e", "0.6.2"))
+    }
+
+    @Test
+    fun `two dev builds on same base but different commit do mismatch`() {
+        assertTrue(versionsMismatchFull("0.6.2-3-gabc1234", "0.6.2-14-g1f2205e"))
+    }
+
+    @Test
+    fun `different release versions do mismatch`() {
+        assertTrue(versionsMismatchFull("0.6.1", "0.6.2"))
+    }
+
+    @Test
+    fun `null module version never mismatches`() {
+        assertFalse(versionsMismatchFull(null, "0.6.2-14-g1f2205e"))
+    }
+}
+
 class IsNewerVersionTest {
     @Test
     fun `newer release beats older release`() {


### PR DESCRIPTION
The dashboard's running-LSPosed-vs-installed-app version check now compares the full version (git-describe dev suffix included) instead of just the release base. The hook code lives in system_server and only swaps on reboot, so a developer who rebuilds and reinstalls the APK on the same base keeps running the old hook until reboot — base-compare hid that, full-compare surfaces it. Release versions carry no dev suffix, so end users see no change. A new Developer settings section (at the bottom of Settings) hosts one toggle that mutes both this version notice and the post-rebuild changelog popup, cutting dev-build noise.

- Add `versionsMismatchFull()` and switch the dashboard LSPosed version check to it by default
- Add a Developer settings section with a "Hide version and changelog notices" toggle, backed by a new `suppressVersionWarnings` DataStore preference (app-local, not part of the canonical config)
- When the toggle is on, fall back to base-version compare and skip the changelog dialog (without marking it seen, so turning the toggle off still shows it)
- Cover the new comparator with unit tests