### PR TITLE
Drop card-shadows setting and make Debug logging a consistent row

### DIFF
--- a/changelog.d/changed-moved-the-debug-logging-toggle-into-7016.md
+++ b/changelog.d/changed-moved-the-debug-logging-toggle-into-7016.md
@@ -2,8 +2,8 @@ _2026-06-30_
 
 ## English
 
-Moved the Debug logging toggle into the Developer settings section
+Moved the Debug logging toggle into the Developer settings section as a standard preference row
 
 ## Русский
 
-Переключатель отладочных логов перемещён в раздел настроек «Для разработчиков»
+Переключатель отладочных логов перемещён в раздел настроек «Для разработчиков» в виде обычной строки настроек

--- a/changelog.d/removed-removed-the-card-shadows-appearance-setting-b6a9.md
+++ b/changelog.d/removed-removed-the-card-shadows-appearance-setting-b6a9.md
@@ -1,0 +1,9 @@
+_2026-06-30_
+
+## English
+
+Removed the card-shadows appearance setting (the 1dp shadow was barely visible; cards keep their hairline border)
+
+## Русский
+
+Удалена настройка теней карточек (тень в 1dp была почти незаметна; карточки сохраняют тонкую рамку)

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DiagnosticsScreen.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DiagnosticsScreen.kt
@@ -254,48 +254,6 @@ fun DebugToolsSection(
 }
 
 @Composable
-internal fun DebugLoggingCard() {
-    val context = LocalContext.current
-    val scope = rememberCoroutineScope()
-    var enabled by remember { mutableStateOf(VpnHideLog.enabled) }
-
-    EnhancedCard(
-        modifier = Modifier.fillMaxWidth(),
-        color = MaterialTheme.colorScheme.surfaceVariant,
-        shape = MaterialTheme.shapes.medium,
-    ) {
-        Row(
-            modifier = Modifier.padding(16.dp).fillMaxWidth(),
-            verticalAlignment = Alignment.CenterVertically,
-        ) {
-            Column(Modifier.weight(1f)) {
-                Text(
-                    text = stringResource(R.string.diag_debug_logging_title),
-                    style = MaterialTheme.typography.titleSmall,
-                    fontWeight = FontWeight.Bold,
-                )
-                Spacer(Modifier.height(4.dp))
-                Text(
-                    text = stringResource(R.string.diag_debug_logging_description),
-                    style = MaterialTheme.typography.bodySmall,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                )
-            }
-            Spacer(Modifier.width(12.dp))
-            Switch(
-                checked = enabled,
-                onCheckedChange = { newValue ->
-                    enabled = newValue
-                    scope.launch(Dispatchers.IO) {
-                        setDebugLoggingEnabled(context, newValue)
-                    }
-                },
-            )
-        }
-    }
-}
-
-@Composable
 private fun LogcatRecordCard() {
     val context = LocalContext.current
     val scope = rememberCoroutineScope()

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/SettingsScreen.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/SettingsScreen.kt
@@ -27,6 +27,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Animation
 import androidx.compose.material.icons.filled.BrightnessMedium
+import androidx.compose.material.icons.filled.BugReport
 import androidx.compose.material.icons.filled.CheckCircle
 import androidx.compose.material.icons.filled.ContentCopy
 import androidx.compose.material.icons.filled.DarkMode
@@ -35,7 +36,6 @@ import androidx.compose.material.icons.filled.DeleteForever
 import androidx.compose.material.icons.filled.FileDownload
 import androidx.compose.material.icons.filled.FileUpload
 import androidx.compose.material.icons.filled.Forum
-import androidx.compose.material.icons.filled.Layers
 import androidx.compose.material.icons.filled.Lock
 import androidx.compose.material.icons.filled.Palette
 import androidx.compose.material.icons.filled.RoundedCorner
@@ -138,7 +138,7 @@ fun SettingsScreen(
                     .padding(16.dp),
             verticalArrangement = Arrangement.spacedBy(20.dp),
         ) {
-            // ── Appearance ── one grouped block of five rows.
+            // ── Appearance ── one grouped block of four rows.
             Column(verticalArrangement = Arrangement.spacedBy(3.dp)) {
                 SettingsSectionHeader(stringResource(R.string.settings_appearance))
 
@@ -153,7 +153,7 @@ fun SettingsScreen(
                     subtitle = themeModeLabel,
                     icon = Icons.Default.BrightnessMedium,
                     index = 0,
-                    count = 5,
+                    count = 4,
                     onClick = {
                         val next =
                             when (settings.themeMode) {
@@ -169,7 +169,7 @@ fun SettingsScreen(
                     subtitle = stringResource(R.string.settings_dynamic_color_sub),
                     icon = Icons.Default.Palette,
                     index = 1,
-                    count = 5,
+                    count = 4,
                     checked = settings.dynamicColor,
                     onCheckedChange = interactor::setDynamicColor,
                 )
@@ -178,7 +178,7 @@ fun SettingsScreen(
                     subtitle = stringResource(R.string.settings_amoled_sub),
                     icon = Icons.Default.DarkMode,
                     index = 2,
-                    count = 5,
+                    count = 4,
                     checked = settings.amoled,
                     onCheckedChange = interactor::setAmoled,
                 )
@@ -187,20 +187,11 @@ fun SettingsScreen(
                     subtitle = stringResource(R.string.settings_squircle_sub),
                     icon = Icons.Default.RoundedCorner,
                     index = 3,
-                    count = 5,
+                    count = 4,
                     checked = settings.cornerStyle == CornerStyle.Smooth,
                     onCheckedChange = { value ->
                         interactor.setCornerStyle(if (value) CornerStyle.Smooth else CornerStyle.Rounded)
                     },
-                )
-                PreferenceRowSwitch(
-                    title = stringResource(R.string.settings_shadows),
-                    subtitle = stringResource(R.string.settings_shadows_sub),
-                    icon = Icons.Default.Layers,
-                    index = 4,
-                    count = 5,
-                    checked = settings.drawContainerShadows,
-                    onCheckedChange = interactor::setDrawContainerShadows,
                 )
             }
 
@@ -339,6 +330,12 @@ private fun DebugToolsSettingsSection(selfNeedsRestart: Boolean?) {
 private fun DeveloperSettingsSection() {
     val settings = LocalSettingsState.current
     val interactor = LocalSettingsInteractor.current
+    val context = LocalContext.current
+    val scope = rememberCoroutineScope()
+    // Debug logging isn't a UI-DataStore setting — it's a stealth-sensitive runtime
+    // flag in its own prefs store (DebugLoggingPrefs), so it's driven by local state
+    // and a direct write rather than through the settings interactor.
+    var debugLogging by remember { mutableStateOf(VpnHideLog.enabled) }
     Column(verticalArrangement = Arrangement.spacedBy(3.dp)) {
         SettingsSectionHeader(stringResource(R.string.settings_developer_section))
         PreferenceRowSwitch(
@@ -346,7 +343,7 @@ private fun DeveloperSettingsSection() {
             subtitle = stringResource(R.string.settings_suppress_version_warnings_sub),
             icon = Icons.Default.Update,
             index = 0,
-            count = 2,
+            count = 3,
             checked = settings.suppressVersionWarnings,
             onCheckedChange = interactor::setSuppressVersionWarnings,
         )
@@ -358,15 +355,22 @@ private fun DeveloperSettingsSection() {
             subtitle = stringResource(R.string.settings_agent_control_sub),
             icon = Icons.Default.Settings,
             index = 1,
-            count = 2,
+            count = 3,
             checked = settings.agentControlEnabled,
             onCheckedChange = interactor::setAgentControlEnabled,
         )
-        // Debug logging is a stealth-sensitive runtime flag (its own prefs store,
-        // not the UI DataStore), so it stays a self-contained card rather than a
-        // preference row — but it belongs with the other developer toggles.
-        Spacer(Modifier.height(10.dp))
-        DebugLoggingCard()
+        PreferenceRowSwitch(
+            title = stringResource(R.string.diag_debug_logging_title),
+            subtitle = stringResource(R.string.settings_debug_logging_sub),
+            icon = Icons.Default.BugReport,
+            index = 2,
+            count = 3,
+            checked = debugLogging,
+            onCheckedChange = { value ->
+                debugLogging = value
+                scope.launch(Dispatchers.IO) { setDebugLoggingEnabled(context, value) }
+            },
+        )
     }
 }
 

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/settings/AppSettings.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/settings/AppSettings.kt
@@ -37,8 +37,6 @@ data class AppSettings(
     val seedColor: Long = DEFAULT_SEED,
     val cornerStyle: CornerStyle = CornerStyle.Smooth,
     val themeMode: ThemeMode = ThemeMode.System,
-    /** Draw soft elevation shadows under cards/surfaces (off = flat, bordered). */
-    val drawContainerShadows: Boolean = true,
     /** Master switch for the new expressive motion (springs, transitions). */
     val animationsEnabled: Boolean = true,
     /** Subtle haptic feedback on taps/toggles. */

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/settings/SettingsInteractor.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/settings/SettingsInteractor.kt
@@ -32,8 +32,6 @@ interface SettingsInteractor {
 
     fun setThemeMode(value: ThemeMode)
 
-    fun setDrawContainerShadows(value: Boolean)
-
     fun setAnimationsEnabled(value: Boolean)
 
     fun setHapticsEnabled(value: Boolean)
@@ -66,8 +64,6 @@ class RepositorySettingsInteractor(
     override fun setCornerStyle(value: CornerStyle) = launch { repository.setCornerStyle(value) }
 
     override fun setThemeMode(value: ThemeMode) = launch { repository.setThemeMode(value) }
-
-    override fun setDrawContainerShadows(value: Boolean) = launch { repository.setDrawContainerShadows(value) }
 
     override fun setAnimationsEnabled(value: Boolean) = launch { repository.setAnimationsEnabled(value) }
 

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/settings/SettingsRepository.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/settings/SettingsRepository.kt
@@ -31,7 +31,6 @@ class SettingsRepository(
         val SEED = longPreferencesKey("seed_color")
         val CORNER_STYLE = intPreferencesKey("corner_style")
         val THEME_MODE = intPreferencesKey("theme_mode")
-        val CONTAINER_SHADOWS = booleanPreferencesKey("container_shadows")
         val ANIMATIONS = booleanPreferencesKey("animations_enabled")
         val HAPTICS = booleanPreferencesKey("haptics_enabled")
         val FULL_PROTECTION_ROLE_LABELS = booleanPreferencesKey("full_protection_role_labels")
@@ -50,7 +49,6 @@ class SettingsRepository(
                 seedColor = p[Keys.SEED] ?: defaults.seedColor,
                 cornerStyle = p[Keys.CORNER_STYLE]?.let { CornerStyle.entries.getOrNull(it) } ?: defaults.cornerStyle,
                 themeMode = p[Keys.THEME_MODE]?.let { ThemeMode.entries.getOrNull(it) } ?: defaults.themeMode,
-                drawContainerShadows = p[Keys.CONTAINER_SHADOWS] ?: defaults.drawContainerShadows,
                 animationsEnabled = p[Keys.ANIMATIONS] ?: defaults.animationsEnabled,
                 hapticsEnabled = p[Keys.HAPTICS] ?: defaults.hapticsEnabled,
                 fullProtectionRoleLabels =
@@ -73,8 +71,6 @@ class SettingsRepository(
     suspend fun setCornerStyle(value: CornerStyle) = edit { it[Keys.CORNER_STYLE] = value.ordinal }
 
     suspend fun setThemeMode(value: ThemeMode) = edit { it[Keys.THEME_MODE] = value.ordinal }
-
-    suspend fun setDrawContainerShadows(value: Boolean) = edit { it[Keys.CONTAINER_SHADOWS] = value }
 
     suspend fun setAnimationsEnabled(value: Boolean) = edit { it[Keys.ANIMATIONS] = value }
 

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/ui/components/Modifiers.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/ui/components/Modifiers.kt
@@ -49,17 +49,13 @@ fun Modifier.container(
     borderColor: Color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.35f),
     drawBorder: Boolean = true,
     shadowElevation: Dp = 1.dp,
-): Modifier {
-    // The soft shadow is a user-tunable knob (ImageToolbox-style): when off,
-    // surfaces read flat and rely on the hairline border for separation.
-    val elevation = if (LocalSettingsState.current.drawContainerShadows) shadowElevation else 0.dp
-    return this
-        .shadow(elevation = elevation, shape = shape, clip = false)
+): Modifier =
+    this
+        .shadow(elevation = shadowElevation, shape = shape, clip = false)
         // clip before background so a following clickable's ripple is shape-clipped
         .clip(shape)
         .background(color = color)
         .then(if (drawBorder) Modifier.border(width = 1.dp, color = borderColor, shape = shape) else Modifier)
-}
 
 /**
  * Clickable that fires a light haptic tick before [onClick] when haptics are

--- a/lsposed/app/src/main/res/values-ru/strings.xml
+++ b/lsposed/app/src/main/res/values-ru/strings.xml
@@ -285,7 +285,7 @@
     <string name="btn_save_debug">Сохранить</string>
     <string name="btn_share_debug">Поделиться</string>
     <string name="diag_debug_logging_title">Отладочные логи</string>
-    <string name="diag_debug_logging_description">По умолчанию выключено — VPN Hide почти ничего не пишет в logcat и dmesg. Переключатель не нужен для сбора разового багрепорта: инструменты захвата в Настройки → Отладка автоматически включают логирование на время захвата. Этот переключатель — только если вы хотите, чтобы логи писались постоянно во всех компонентах: приложение, хуки в system_server, Zygisk-хуки в приложениях и модуль ядра (kmod пишет в dmesg). Приложениям с хуками Zygisk нужен перезапуск, чтобы для них применилось изменение.</string>
+    <string name="settings_debug_logging_sub">По умолчанию выключено ради скрытности. Инструменты захвата в «Отладке» включают его автоматически — этот тумблер нужен только для постоянных логов во всех компонентах.</string>
     <string name="logcat_card_title">Полный системный logcat</string>
     <string name="logcat_card_description">Записывает неотфильтрованные логи из всех буферов (main/system/crash/events/radio) для диагностики проблем, которые не видны в стандартных проверках. Начните запись, воспроизведите баг, затем остановите.</string>
     <string name="logcat_btn_start">Начать запись</string>
@@ -318,8 +318,6 @@
     <string name="settings_amoled_sub">Чистый чёрный фон в тёмной теме</string>
     <string name="settings_squircle">Squircle-углы</string>
     <string name="settings_squircle_sub">Плавные углы в стиле iOS</string>
-    <string name="settings_shadows">Тени карточек</string>
-    <string name="settings_shadows_sub">Мягкая тень под карточками</string>
     <string name="settings_haptics">Тактильный отклик</string>
     <string name="settings_haptics_sub">Вибрация при нажатиях и переключениях</string>
     <string name="settings_animations">Анимации</string>

--- a/lsposed/app/src/main/res/values/strings.xml
+++ b/lsposed/app/src/main/res/values/strings.xml
@@ -76,7 +76,7 @@
     <string name="btn_save_debug">Save</string>
     <string name="btn_share_debug">Share</string>
     <string name="diag_debug_logging_title">Debug logging</string>
-    <string name="diag_debug_logging_description">Off by default — VPN Hide keeps logcat and dmesg near-silent. You don\'t need to flip this to collect a bug report: the capture tools in Settings → Debugging turn logging on automatically for the duration of the capture. Use this toggle only if you want logs to be emitted continuously across the app, system_server hooks, Zygisk-hooked apps, and the kernel module (kmod logs to dmesg). Zygisk-hooked apps must be restarted for the change to take effect for them.</string>
+    <string name="settings_debug_logging_sub">Off by default for stealth. The capture tools in Debugging enable it automatically — turn this on only for continuous logs across every component.</string>
     <string name="logcat_card_title">Full system logcat</string>
     <string name="logcat_card_description">Records unfiltered logs from all buffers (main/system/crash/events/radio) for debugging issues that aren\'t visible in the standard checks. Start recording, reproduce the bug, then stop.</string>
     <string name="logcat_btn_start">Start recording</string>
@@ -360,8 +360,6 @@
     <string name="settings_amoled_sub">Pure black surfaces in dark theme</string>
     <string name="settings_squircle">Squircle corners</string>
     <string name="settings_squircle_sub">iOS-style continuous corners</string>
-    <string name="settings_shadows">Card shadows</string>
-    <string name="settings_shadows_sub">Soft elevation under cards</string>
     <string name="settings_haptics">Haptic feedback</string>
     <string name="settings_haptics_sub">Vibrate on taps and toggles</string>
     <string name="settings_animations">Animations</string>


### PR DESCRIPTION
Two small Settings cleanups.

The card-shadows appearance toggle is removed along with its plumbing (`AppSettings`/`SettingsRepository`/`SettingsInteractor`, the DataStore key, strings). The shadow it controlled was a fixed 1dp that is barely perceptible, and cards already separate via their hairline border, so the toggle was noise. `Modifier.container` now always applies the default elevation, so the look is unchanged.

The Debug logging control is reshaped: it was a standalone card that looked foreign next to the Developer section's grouped preference rows. It's now a `PreferenceRowSwitch` like the version-warning and agent-control toggles (icon + concise subtitle), and the orphaned `DebugLoggingCard` is deleted.

- Remove `drawContainerShadows` setting and the Card shadows row
- Make Debug logging a grouped Developer row; delete `DebugLoggingCard`
- Trim/rebalance the Appearance group (4 rows) and shorten the debug-logging subtitle