### PR TITLE
Close audit zygisk stealth/memory findings

### DIFF
--- a/changelog.d/fixed-zygisk-fix-an-out-of-bounds-718b.md
+++ b/changelog.d/fixed-zygisk-fix-an-out-of-bounds-718b.md
@@ -1,0 +1,9 @@
+_2026-06-30_
+
+## English
+
+Zygisk: fix an out-of-bounds buffer access when a netlink read uses MSG_TRUNC
+
+## Русский
+
+Zygisk: исправлен выход за границы буфера при netlink-чтении с флагом MSG_TRUNC

--- a/changelog.d/security-zygisk-block-vpn-interface-index-probes-b717.md
+++ b/changelog.d/security-zygisk-block-vpn-interface-index-probes-b717.md
@@ -1,0 +1,9 @@
+_2026-06-30_
+
+## English
+
+Zygisk: block VPN interface-index probes (if_nametoindex / ioctl(SIOCGIFINDEX)) and intercept /proc/net/{dev,udp,udp6} and /proc/thread-self and task path forms that could reveal a hidden VPN
+
+## Русский
+
+Zygisk: блокирует запросы индекса VPN-интерфейса (if_nametoindex / ioctl(SIOCGIFINDEX)) и перехватывает /proc/net/{dev,udp,udp6} и формы путей /proc/thread-self и task, которые могли выдать скрытый VPN

--- a/zygisk/src/filter.rs
+++ b/zygisk/src/filter.rs
@@ -85,6 +85,67 @@ pub fn filter_ipv6_route_buf(data: &mut [u8]) -> usize {
     filter_by_last_field(data)
 }
 
+/// Filter `/proc/net/dev` in-place. Each data line is `  <iface>: <stats>`;
+/// drop lines whose interface name (trimmed, before the first ':') is a VPN
+/// interface. The two header lines have no `name:` token and are kept.
+pub fn filter_dev_buf(data: &mut [u8]) -> usize {
+    if data.is_empty() {
+        return 0;
+    }
+
+    let len = data.len();
+    let mut read_pos = 0usize;
+    let mut write_pos = 0usize;
+
+    while read_pos < len {
+        let line_end = data[read_pos..]
+            .iter()
+            .position(|&b| b == b'\n')
+            .map(|p| read_pos + p + 1)
+            .unwrap_or(len);
+
+        let line = &data[read_pos..line_end];
+        let hide = match line.iter().position(|&b| b == b':') {
+            Some(colon) => {
+                let name = trim_ascii_ws(&line[..colon]);
+                !name.is_empty() && is_vpn_iface_bytes(name)
+            }
+            None => false,
+        };
+
+        if !hide {
+            let line_len = line_end - read_pos;
+            if write_pos != read_pos {
+                data.copy_within(read_pos..line_end, write_pos);
+            }
+            write_pos += line_len;
+        }
+
+        read_pos = line_end;
+    }
+
+    write_pos
+}
+
+/// Trim leading and trailing ASCII whitespace from a byte slice.
+fn trim_ascii_ws(mut s: &[u8]) -> &[u8] {
+    while let [first, rest @ ..] = s {
+        if matches!(first, b' ' | b'\t' | b'\n' | b'\r') {
+            s = rest;
+        } else {
+            break;
+        }
+    }
+    while let [rest @ .., last] = s {
+        if matches!(last, b' ' | b'\t' | b'\n' | b'\r') {
+            s = rest;
+        } else {
+            break;
+        }
+    }
+    s
+}
+
 /// Filter `/proc/net/if_inet6` in-place. Interface name is the LAST
 /// whitespace-delimited field on each line.
 pub fn filter_if_inet6_buf(data: &mut [u8]) -> usize {
@@ -430,6 +491,27 @@ mod tests {
         assert!(is_vpn_iface_bytes(b"tun0"));
         assert!(is_vpn_iface_bytes(b"tun1"));
         assert!(is_vpn_iface_bytes(b"TUN0"));
+    }
+
+    #[test]
+    fn filter_dev_removes_vpn_iface_keeps_headers() {
+        let mut buf = b"Inter-|   Receive                                                |  Transmit\n \
+face |bytes    packets errs drop\n    lo:  100    1    0    0\n  wlan0:  200    2    0    0\n  \
+tun0:  300    3    0    0\n"
+            .to_vec();
+        let n = filter_dev_buf(&mut buf);
+        let out = core::str::from_utf8(&buf[..n]).unwrap();
+        assert!(out.contains("Inter-|"), "header kept");
+        assert!(out.contains("face |"), "second header kept");
+        assert!(out.contains("lo:"), "lo kept");
+        assert!(out.contains("wlan0:"), "wlan0 kept");
+        assert!(!out.contains("tun0"), "tun0 removed");
+    }
+
+    #[test]
+    fn filter_dev_empty() {
+        let mut buf = Vec::new();
+        assert_eq!(filter_dev_buf(&mut buf), 0);
     }
 
     #[test]

--- a/zygisk/src/filter.rs
+++ b/zygisk/src/filter.rs
@@ -495,10 +495,11 @@ mod tests {
 
     #[test]
     fn filter_dev_removes_vpn_iface_keeps_headers() {
-        let mut buf = b"Inter-|   Receive                                                |  Transmit\n \
+        let mut buf =
+            b"Inter-|   Receive                                                |  Transmit\n \
 face |bytes    packets errs drop\n    lo:  100    1    0    0\n  wlan0:  200    2    0    0\n  \
 tun0:  300    3    0    0\n"
-            .to_vec();
+                .to_vec();
         let n = filter_dev_buf(&mut buf);
         let out = core::str::from_utf8(&buf[..n]).unwrap();
         assert!(out.contains("Inter-|"), "header kept");

--- a/zygisk/src/hooks.rs
+++ b/zygisk/src/hooks.rs
@@ -201,12 +201,17 @@ pub unsafe extern "C" fn hooked_ioctl(
     unsafe { real(fd, request, arg) }
 }
 
-/// Check if the ioctl request is a SIOCGIF* command (0x8910..0x8930 range).
-/// These all use struct ifreq with ifr_name as input.
+/// Check if the ioctl request is a SIOCGIF* command that takes a struct
+/// ifreq with `ifr_name` as input. Covers the whole get-by-name family,
+/// 0x8910 (SIOCGIFNAME) through 0x8970 (SIOCGIFMAP).
+///
+/// The old ceiling of 0x8930 silently excluded SIOCGIFINDEX (0x8933) — the
+/// ioctl `if_nametoindex()` issues — so `if_nametoindex("tun0")` returned the
+/// real index and leaked VPN presence. SIOCGIFTXQLEN (0x8942) and SIOCGIFMAP
+/// (0x8970) sat above the ceiling too. SIOCGIFNAME (0x8910) and SIOCGIFCONF
+/// (0x8912) are handled in their own branches before this check.
 fn is_siocgif(request: libc::c_ulong) -> bool {
-    // SIOCGIF* range: 0x8910 (SIOCGIFNAME) to ~0x8927 (SIOCGIFVLAN)
-    // SIOCGIFCONF (0x8912) is handled separately above.
-    (0x8910..=0x8930).contains(&(request as u32))
+    (0x8910..=0x8970).contains(&(request as u32))
 }
 
 /// Walk the `ifreq[]` array inside an `ifconf` and remove VPN entries
@@ -365,13 +370,16 @@ pub fn set_real_openat_ptr(p: *const ()) {
 }
 
 /// Which /proc/net file was matched.
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
 enum ProcNetFile {
     Route,
     Ipv6Route,
     IfInet6,
     Tcp,
     Tcp6,
+    Udp,
+    Udp6,
+    Dev,
 }
 
 /// The basenames we intercept under /proc/.../net/.
@@ -381,28 +389,54 @@ const PROC_NET_FILES: &[(&[u8], ProcNetFile)] = &[
     (b"if_inet6", ProcNetFile::IfInet6),
     (b"tcp", ProcNetFile::Tcp),
     (b"tcp6", ProcNetFile::Tcp6),
+    // udp/udp6 share the tcp/tcp6 line format (local address is filtered the
+    // same way); dev lists interface names verbatim. On enforcing SELinux these
+    // are blocked for untrusted_app, but we filter them too as defence in depth.
+    (b"udp", ProcNetFile::Udp),
+    (b"udp6", ProcNetFile::Udp6),
+    (b"dev", ProcNetFile::Dev),
 ];
 
-/// Check an absolute path like `/proc/net/<file>`, `/proc/self/net/<file>`,
-/// or `/proc/<pid>/net/<file>`.
-fn match_abs_proc_net(path: &[u8]) -> Option<ProcNetFile> {
-    // Strip the /proc/{net,self/net,<pid>/net}/ prefix, leaving the basename.
-    let basename = if let Some(rest) = path.strip_prefix(b"/proc/net/") {
-        rest
-    } else if let Some(rest) = path.strip_prefix(b"/proc/self/net/") {
-        rest
-    } else if let Some(rest) = path.strip_prefix(b"/proc/") {
-        // /proc/<digits>/net/<file>
-        let slash = rest.iter().position(|&b| b == b'/')?;
-        let pid = &rest[..slash];
-        if pid.is_empty() || !pid.iter().all(|b| b.is_ascii_digit()) {
-            return None;
-        }
-        rest.get(slash + 1..)?.strip_prefix(b"net/")?
-    } else {
+/// Given the text after `/proc/`, return the basename following the
+/// `.../net/` segment for any owner form we recognise:
+/// `net/`, `self/net/`, `thread-self/net/`, `<pid>/net/`,
+/// `<pid>/task/<tid>/net/`. Returns `None` if the shape doesn't match.
+///
+/// Covering `thread-self` and the `task/<tid>` forms closes the bypass where
+/// a detector opens `/proc/thread-self/net/tcp` (or its own task dir) to dodge
+/// a matcher that only knew `self` and the top-level pid dir.
+fn strip_owner_net(rest: &[u8]) -> Option<&[u8]> {
+    if let Some(r) = rest.strip_prefix(b"net/") {
+        return Some(r);
+    }
+    if let Some(r) = rest.strip_prefix(b"self/net/") {
+        return Some(r);
+    }
+    if let Some(r) = rest.strip_prefix(b"thread-self/net/") {
+        return Some(r);
+    }
+    // <pid>/... — either <pid>/net/ or <pid>/task/<tid>/net/.
+    let slash = rest.iter().position(|&b| b == b'/')?;
+    if rest[..slash].is_empty() || !rest[..slash].iter().all(|b| b.is_ascii_digit()) {
         return None;
-    };
+    }
+    let after = &rest[slash + 1..];
+    if let Some(r) = after.strip_prefix(b"net/") {
+        return Some(r);
+    }
+    let after = after.strip_prefix(b"task/")?;
+    let slash2 = after.iter().position(|&b| b == b'/')?;
+    if after[..slash2].is_empty() || !after[..slash2].iter().all(|b| b.is_ascii_digit()) {
+        return None;
+    }
+    after.get(slash2 + 1..)?.strip_prefix(b"net/")
+}
 
+/// Check an absolute path like `/proc/net/<file>`, `/proc/self/net/<file>`,
+/// `/proc/thread-self/net/<file>`, `/proc/<pid>/net/<file>`, or
+/// `/proc/<pid>/task/<tid>/net/<file>`.
+fn match_abs_proc_net(path: &[u8]) -> Option<ProcNetFile> {
+    let basename = strip_owner_net(path.strip_prefix(b"/proc/")?)?;
     PROC_NET_FILES
         .iter()
         .find(|(name, _)| *name == basename)
@@ -460,14 +494,18 @@ fn is_dirfd_proc_net(dirfd: c_int) -> bool {
     }
     let target = &link_buf[..n as usize];
 
-    if target == b"/proc/net" || target == b"/proc/self/net" {
-        return true;
-    }
+    // A dirfd pointing at any `.../net` directory we recognise. Reuse
+    // strip_owner_net by appending a trailing '/': it expects `.../net/<rest>`,
+    // so an empty <rest> means the dir itself.
     if let Some(rest) = target.strip_prefix(b"/proc/") {
-        if let Some(slash) = rest.iter().position(|&b| b == b'/') {
-            let pid = &rest[..slash];
-            let tail = &rest[slash..];
-            return !pid.is_empty() && pid.iter().all(|b| b.is_ascii_digit()) && tail == b"/net";
+        let mut probe = [0u8; 160];
+        let body = rest.len();
+        if body < probe.len() {
+            probe[..body].copy_from_slice(rest);
+            probe[body] = b'/';
+            if let Some(tail) = strip_owner_net(&probe[..body + 1]) {
+                return tail.is_empty();
+            }
         }
     }
     false
@@ -643,6 +681,15 @@ fn apply_filter(data: &mut [u8], kind: ProcNetFile) -> usize {
             let (_, _, addrs6, n6) = collect_vpn_addrs();
             filter_tcp6_buf(data, &addrs6, n6)
         }
+        ProcNetFile::Udp => {
+            let (addrs4, n4, _, _) = collect_vpn_addrs();
+            filter_tcp4_buf(data, &addrs4, n4)
+        }
+        ProcNetFile::Udp6 => {
+            let (_, _, addrs6, n6) = collect_vpn_addrs();
+            filter_tcp6_buf(data, &addrs6, n6)
+        }
+        ProcNetFile::Dev => filter_dev_buf(data),
     }
 }
 
@@ -900,7 +947,12 @@ pub unsafe extern "C" fn hooked_recv(
 
     let ret = unsafe { real(fd, buf, len, flags) };
 
-    unsafe { maybe_filter_netlink_buf(fd, buf as *mut u8, ret) }
+    // Clamp to the buffer size: with MSG_TRUNC the kernel returns the full
+    // datagram length, which can exceed `len`, and the filter must never read
+    // or write past the caller's buffer. Propagate any shrink like recvmsg.
+    let in_buf = ret.min(len as isize);
+    let filtered = unsafe { maybe_filter_netlink_buf(fd, buf as *mut u8, in_buf) };
+    ret - (in_buf - filtered)
 }
 
 // ============================================================================
@@ -954,7 +1006,10 @@ pub unsafe extern "C" fn hooked_recvfrom(
 
     let ret = unsafe { real(fd, buf, len, flags, src_addr, addrlen) };
 
-    unsafe { maybe_filter_netlink_buf(fd, buf as *mut u8, ret) }
+    // Clamp to the buffer size (MSG_TRUNC can return more than `len`).
+    let in_buf = ret.min(len as isize);
+    let filtered = unsafe { maybe_filter_netlink_buf(fd, buf as *mut u8, in_buf) };
+    ret - (in_buf - filtered)
 }
 
 static REAL_RECVFROM_CHK: AtomicPtr<c_void> = AtomicPtr::new(core::ptr::null_mut());
@@ -1002,7 +1057,11 @@ pub unsafe extern "C" fn hooked_recvfrom_chk(
 
     let ret = unsafe { real(fd, buf, len, buf_size, flags, src_addr, addrlen) };
 
-    unsafe { maybe_filter_netlink_buf(fd, buf as *mut u8, ret) }
+    // Clamp to the requested length, itself bounded by the FORTIFY buffer size
+    // (MSG_TRUNC can return more than was written).
+    let in_buf = ret.min(len.min(buf_size) as isize);
+    let filtered = unsafe { maybe_filter_netlink_buf(fd, buf as *mut u8, in_buf) };
+    ret - (in_buf - filtered)
 }
 
 /// Collect interface indices of VPN interfaces. Uses real_getifaddrs
@@ -1019,7 +1078,17 @@ fn collect_vpn_iface_indices() -> ([u32; crate::filter::MAX_VPN_ADDRS], usize) {
             if n >= MAX_VPN_ADDRS {
                 return;
             }
-            let idx = libc::if_nametoindex(entry.ifa_name);
+            // if_nametoindex issues ioctl(SIOCGIFINDEX), which our ioctl hook
+            // now blocks for VPN names. Run it under the IN_GETIFADDRS guard so
+            // it passes through to the real index — otherwise this filter loses
+            // the VPN indices and the netlink route dump (#86) stops filtering.
+            let idx = IN_GETIFADDRS.with(|f| {
+                let prev = f.get();
+                f.set(true);
+                let i = libc::if_nametoindex(entry.ifa_name);
+                f.set(prev);
+                i
+            });
             if idx == 0 || indices[..n].contains(&idx) {
                 return;
             }
@@ -1029,4 +1098,39 @@ fn collect_vpn_iface_indices() -> ([u32; crate::filter::MAX_VPN_ADDRS], usize) {
     }
 
     (indices, n)
+}
+
+#[cfg(test)]
+mod proc_net_path_tests {
+    use super::{match_abs_proc_net, strip_owner_net, ProcNetFile};
+
+    #[test]
+    fn matches_classic_forms() {
+        assert_eq!(match_abs_proc_net(b"/proc/net/tcp"), Some(ProcNetFile::Tcp));
+        assert_eq!(match_abs_proc_net(b"/proc/self/net/tcp6"), Some(ProcNetFile::Tcp6));
+        assert_eq!(match_abs_proc_net(b"/proc/1234/net/route"), Some(ProcNetFile::Route));
+    }
+
+    #[test]
+    fn matches_new_dev_udp_files() {
+        assert_eq!(match_abs_proc_net(b"/proc/net/dev"), Some(ProcNetFile::Dev));
+        assert_eq!(match_abs_proc_net(b"/proc/net/udp"), Some(ProcNetFile::Udp));
+        assert_eq!(match_abs_proc_net(b"/proc/net/udp6"), Some(ProcNetFile::Udp6));
+    }
+
+    #[test]
+    fn matches_thread_self_and_task_forms() {
+        // These previously bypassed the matcher (#14/#52).
+        assert_eq!(match_abs_proc_net(b"/proc/thread-self/net/tcp"), Some(ProcNetFile::Tcp));
+        assert_eq!(match_abs_proc_net(b"/proc/1234/task/5678/net/tcp"), Some(ProcNetFile::Tcp));
+        assert_eq!(match_abs_proc_net(b"/proc/self/net/dev"), Some(ProcNetFile::Dev));
+    }
+
+    #[test]
+    fn rejects_non_proc_net() {
+        assert_eq!(match_abs_proc_net(b"/proc/net/unknownfile"), None);
+        assert_eq!(match_abs_proc_net(b"/etc/passwd"), None);
+        assert_eq!(match_abs_proc_net(b"/proc/abc/net/tcp"), None);
+        assert_eq!(strip_owner_net(b"bogus/path"), None);
+    }
 }

--- a/zygisk/src/hooks.rs
+++ b/zygisk/src/hooks.rs
@@ -1102,28 +1102,46 @@ fn collect_vpn_iface_indices() -> ([u32; crate::filter::MAX_VPN_ADDRS], usize) {
 
 #[cfg(test)]
 mod proc_net_path_tests {
-    use super::{match_abs_proc_net, strip_owner_net, ProcNetFile};
+    use super::{ProcNetFile, match_abs_proc_net, strip_owner_net};
 
     #[test]
     fn matches_classic_forms() {
         assert_eq!(match_abs_proc_net(b"/proc/net/tcp"), Some(ProcNetFile::Tcp));
-        assert_eq!(match_abs_proc_net(b"/proc/self/net/tcp6"), Some(ProcNetFile::Tcp6));
-        assert_eq!(match_abs_proc_net(b"/proc/1234/net/route"), Some(ProcNetFile::Route));
+        assert_eq!(
+            match_abs_proc_net(b"/proc/self/net/tcp6"),
+            Some(ProcNetFile::Tcp6)
+        );
+        assert_eq!(
+            match_abs_proc_net(b"/proc/1234/net/route"),
+            Some(ProcNetFile::Route)
+        );
     }
 
     #[test]
     fn matches_new_dev_udp_files() {
         assert_eq!(match_abs_proc_net(b"/proc/net/dev"), Some(ProcNetFile::Dev));
         assert_eq!(match_abs_proc_net(b"/proc/net/udp"), Some(ProcNetFile::Udp));
-        assert_eq!(match_abs_proc_net(b"/proc/net/udp6"), Some(ProcNetFile::Udp6));
+        assert_eq!(
+            match_abs_proc_net(b"/proc/net/udp6"),
+            Some(ProcNetFile::Udp6)
+        );
     }
 
     #[test]
     fn matches_thread_self_and_task_forms() {
         // These previously bypassed the matcher (#14/#52).
-        assert_eq!(match_abs_proc_net(b"/proc/thread-self/net/tcp"), Some(ProcNetFile::Tcp));
-        assert_eq!(match_abs_proc_net(b"/proc/1234/task/5678/net/tcp"), Some(ProcNetFile::Tcp));
-        assert_eq!(match_abs_proc_net(b"/proc/self/net/dev"), Some(ProcNetFile::Dev));
+        assert_eq!(
+            match_abs_proc_net(b"/proc/thread-self/net/tcp"),
+            Some(ProcNetFile::Tcp)
+        );
+        assert_eq!(
+            match_abs_proc_net(b"/proc/1234/task/5678/net/tcp"),
+            Some(ProcNetFile::Tcp)
+        );
+        assert_eq!(
+            match_abs_proc_net(b"/proc/self/net/dev"),
+            Some(ProcNetFile::Dev)
+        );
     }
 
     #[test]


### PR DESCRIPTION
Fixes from the codebase audit, zygisk batch.

- **VPN interface-index leak:** `is_siocgif` only covered `0x8910..=0x8930`, excluding `SIOCGIFINDEX` (0x8933) — the ioctl `if_nametoindex()` issues. So `if_nametoindex("tun0")` returned the real index and revealed the VPN when Zygisk is the active backend. Widen the range to the full get-by-name family (`0x8910..=0x8970`, also covering `SIOCGIFTXQLEN`/`SIOCGIFMAP`). The internal `collect_vpn_iface_indices` resolves indices under the `IN_GETIFADDRS` guard so the netlink route filter keeps working.
- **Netlink recv OOB:** the flat `recv`/`recvfrom`/`__recvfrom_chk` paths passed the raw return value into the in-place filter; with `MSG_TRUNC` that exceeds the buffer, causing an out-of-bounds read/write. Clamp to the buffer size and propagate the shrink, matching the existing `recvmsg` path.
- **procfs coverage:** intercept `/proc/net/{dev,udp,udp6}` (udp/udp6 reuse the tcp address filters; new `filter_dev_buf` drops VPN-interface lines) and recognise `/proc/thread-self/net` and `/proc/<pid>/task/<tid>/net` path forms that previously bypassed the matcher.

Host unit tests added for `filter_dev_buf` and the path matcher (28 pass).

Deferred (accepted exposure): the memfd substitution is the serving mechanism itself; the relative multi-component path via dirfd is already covered by the documented dirfd TOCTOU exposure. Zygisk hook-table refactors will come in a separate cleanup PR.