### PR TITLE
Bound KPM ctl0 reply and reject overflowing version (kmod audit, safe batch)

### DIFF
--- a/changelog.d/fixed-kpm-bound-the-ctl0-stats-status-341f.md
+++ b/changelog.d/fixed-kpm-bound-the-ctl0-stats-status-341f.md
@@ -1,0 +1,9 @@
+_2026-06-30_
+
+## English
+
+KPM: bound the ctl0 stats/status reply to its buffer so a large request can no longer read past the kernel stack buffer; reject an overflowing version in the protocol header parser
+
+## Русский
+
+KPM: ответ ctl0 со статистикой/статусом ограничен размером буфера, чтобы большой запрос не читал за пределами стекового буфера ядра; отвергается переполняющая версия в парсере заголовка протокола

--- a/kmod/kpm/vpnhide_kpm.c
+++ b/kmod/kpm/vpnhide_kpm.c
@@ -1032,6 +1032,15 @@ static long vpnhide_kpm_ctl0(const char *args, char *__user out_msg, int outlen)
 			full = vpnhide_format_status(buf, sizeof(buf), &st);
 		}
 
+		/*
+		 * vpnhide_format_* report the FULL intended length, which can
+		 * exceed sizeof(buf); the bytes past the buffer were never
+		 * written. Clamp before clamp_to_line/copy_to_user so a
+		 * generous outlen can't drive a read past the 4096-byte stack
+		 * buffer (kernel infoleak / OOB). The .ko bounds the same way.
+		 */
+		if (full > sizeof(buf))
+			full = sizeof(buf);
 		n = vpnhide_clamp_to_line(
 			buf, full, outlen > 0 ? (unsigned long)outlen : 0);
 		if (_copy_to_user && out_msg && n)

--- a/kmod/shared/vpnhide_logic.h
+++ b/kmod/shared/vpnhide_logic.h
@@ -344,14 +344,20 @@ static inline int vpnhide_tok_eq(const char *b, unsigned long ts,
 static inline int vpnhide_tok_decimal(const char *b, unsigned long ts,
 				      unsigned long te, unsigned long *out)
 {
-	unsigned long v = 0, p;
+	unsigned long v = 0, p, digit;
 
 	if (ts >= te)
 		return 0;
 	for (p = ts; p < te; p++) {
 		if (b[p] < '0' || b[p] > '9')
 			return 0;
-		v = v * 10u + (unsigned long)(b[p] - '0');
+		digit = (unsigned long)(b[p] - '0');
+		/* Reject values that would overflow unsigned long instead of
+		 * wrapping mod 2^64 and slipping past the version fuse — same
+		 * contract as the hex parser below. */
+		if (v > (~0UL - digit) / 10u)
+			return 0;
+		v = v * 10u + digit;
 	}
 	*out = v;
 	return 1;


### PR DESCRIPTION
Host-verifiable kmod fixes from the audit.

- **KPM ctl0 out-of-bounds read:** `vpnhide_format_stats`/`format_status` return the full intended length, which can exceed the 4096-byte stack buffer when there are enough targets; the old code clamped only to the caller's `outlen`, so a generous `outlen` made `copy_to_user` read past the buffer (kernel stack info leak / panic). Clamp to `sizeof(buf)` first, like the `.ko` already does.
- **Version-parser overflow:** `vpnhide_tok_decimal` accumulated `v = v*10 + digit` with no overflow check, so a huge decimal wrapped mod 2^64 and could slip past the header version fuse. Reject overflow, matching the hex token parser's documented contract.

Host shared-logic + 32 protocol-vector tests pass.

**Deferred to a device-tested follow-up** (these change kernel runtime behaviour and risk freezing a device if wrong, so they should be built and validated on-device rather than shipped blind): the SIOCGIFCONF size-probe leaking the unfiltered count, the 32-bit/compat `sock_ioctl` path not being hooked, the KPM public-host-route filter parity with the .ko (low real-world value — Android doesn't create such routes), and the KPM stats/config concurrency findings + the seq-file compaction refactor.