### PR TITLE
Config resilience, update-check, diagnostics race, off-thread saves (lsposed audit)

### DIFF
--- a/changelog.d/fixed-a-malformed-port-rule-in-the-38d6.md
+++ b/changelog.d/fixed-a-malformed-port-rule-in-the-38d6.md
@@ -1,0 +1,9 @@
+_2026-06-30_
+
+## English
+
+A malformed port rule in the stored config no longer discards the entire configuration (which silently disabled all hooks); a failed update check no longer overwrites a found update or suppresses retries; diagnostics no longer wedges after its screen is left mid-run; debug-log and logcat saves run off the main thread
+
+## Русский
+
+Некорректное правило портов в сохранённом конфиге больше не отбрасывает всю конфигурацию (что молча отключало все хуки); неудачная проверка обновлений больше не затирает найденное обновление и не блокирует повторы; диагностика больше не зависает, если уйти с экрана во время прогона; сохранение отладочных логов и logcat выполняется вне главного потока

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DiagnosticsCache.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DiagnosticsCache.kt
@@ -11,8 +11,10 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.job
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import kotlin.coroutines.coroutineContext
 
 /**
  * Cache for `runAllChecks` results.
@@ -146,7 +148,7 @@ internal object DiagnosticsCache {
             // structured concurrency unwinds — never get reinterpreted as a
             // VpnOff result. If we were cancelled before publishing a result,
             // reset Running back to NotRun so a later run() can relaunch.
-            if (_state.value is State.Running) _state.value = State.NotRun
+            resetRunningIfStillOurs(coroutineContext.job)
             throw e
         } catch (e: Exception) {
             // A real failure (root dropped, shell exec failure) — distinct from
@@ -155,6 +157,27 @@ internal object DiagnosticsCache {
             _state.value = State.Failed
             StartupTrace.mark("diagnostics_cache_failed")
             VpnHideLog.w("VpnHide-Diag", "runAllChecks failed: ${e.message}")
+        }
+    }
+
+    /**
+     * Reset a stranded [State.Running] back to [State.NotRun] on cancellation —
+     * but only if [self] is still the current [inflight] job.
+     *
+     * [doRun]'s catch runs asynchronously on a dispatcher after [run] has
+     * already returned and released the monitor. Between a run's cancellation
+     * (its job goes `!isActive`) and its catch actually landing, a later [run]
+     * can fall through the dead-job guard and relaunch — setting `inflight` to
+     * the new job and `_state = Running` for *its* run. An unconditional reset
+     * from the cancelled run would then clobber the live run's state with a
+     * spurious NotRun. Guarding on job identity (and doing the read-modify-write
+     * under the same monitor [run] uses) keeps only our own cancellation able to
+     * reset, atomically against a concurrent relaunch.
+     */
+    @Synchronized
+    private fun resetRunningIfStillOurs(self: Job?) {
+        if (inflight === self && _state.value is State.Running) {
+            _state.value = State.NotRun
         }
     }
 }

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DiagnosticsCache.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DiagnosticsCache.kt
@@ -72,6 +72,7 @@ internal object DiagnosticsCache {
      * completed result yet. Idempotent — safe to call from both
      * Dashboard and Diagnostics screens on every composition.
      */
+    @Synchronized
     fun run(
         scope: CoroutineScope,
         context: Context,
@@ -83,7 +84,11 @@ internal object DiagnosticsCache {
             }
 
             State.Running -> {
-                return
+                // Only bail if a run is genuinely still in flight. If the
+                // launching scope was cancelled mid-run, the state stays
+                // Running but the job is dead — fall through and relaunch so
+                // Diagnostics/Dashboard don't wedge on a stale Running forever.
+                if (inflight?.isActive == true) return
             }
 
             State.NotRun, State.VpnOff, State.Failed -> { /* proceed */ }
@@ -139,7 +144,9 @@ internal object DiagnosticsCache {
         } catch (e: CancellationException) {
             // A cancelled job (e.g. the screen left) must propagate so
             // structured concurrency unwinds — never get reinterpreted as a
-            // VpnOff result.
+            // VpnOff result. If we were cancelled before publishing a result,
+            // reset Running back to NotRun so a later run() can relaunch.
+            if (_state.value is State.Running) _state.value = State.NotRun
             throw e
         } catch (e: Exception) {
             // A real failure (root dropped, shell exec failure) — distinct from

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DiagnosticsScreen.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DiagnosticsScreen.kt
@@ -197,8 +197,14 @@ fun DebugToolsSection(
         ) { uri: Uri? ->
             val zip = debugZipFile ?: return@rememberLauncherForActivityResult
             if (uri != null) {
-                context.contentResolver.openOutputStream(uri)?.use { out ->
-                    zip.inputStream().use { it.copyTo(out) }
+                // Copy off the main thread and swallow IO errors — a large zip
+                // would otherwise block the UI and a write failure would crash.
+                scope.launch(Dispatchers.IO) {
+                    runCatching {
+                        context.contentResolver.openOutputStream(uri)?.use { out ->
+                            zip.inputStream().use { it.copyTo(out) }
+                        }
+                    }.onFailure { HookLog.e("VpnHide: debug-zip save failed: ${it.message}") }
                 }
             }
         }
@@ -277,8 +283,12 @@ private fun LogcatRecordCard() {
         ) { uri: Uri? ->
             val src = (state as? LogcatRecorder.State.Stopped)?.lastFile ?: return@rememberLauncherForActivityResult
             if (uri != null) {
-                context.contentResolver.openOutputStream(uri)?.use { out ->
-                    src.inputStream().use { it.copyTo(out) }
+                scope.launch(Dispatchers.IO) {
+                    runCatching {
+                        context.contentResolver.openOutputStream(uri)?.use { out ->
+                            src.inputStream().use { it.copyTo(out) }
+                        }
+                    }.onFailure { HookLog.e("VpnHide: logcat save failed: ${it.message}") }
                 }
             }
         }

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/StorageConfig.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/StorageConfig.kt
@@ -168,29 +168,30 @@ private fun parseCanonicalApp(obj: JSONObject?): CanonicalApp {
 
 private fun parsePortPolicy(obj: JSONObject?): PortPolicy? {
     if (obj == null) return null
-    val rulesJson =
-        obj.optJSONArray("rules")
-            ?: throw IllegalArgumentException("portPolicy.rules is required")
-    val rules =
-        (0 until rulesJson.length())
-            .map { idx ->
-                parsePortRule(
-                    rulesJson.optJSONObject(idx)
-                        ?: throw IllegalArgumentException("portPolicy.rules[$idx] must be an object"),
-                )
+    // Best-effort: a single malformed rule (e.g. an out-of-range port that trips
+    // PortRule's require()) must not throw and unwind the WHOLE canonical config,
+    // which would silently disable every hook. Drop the offending rule/policy and
+    // treat the app as ports-disabled instead.
+    return runCatching {
+        val rulesJson = obj.optJSONArray("rules") ?: return@runCatching null
+        val rules =
+            (0 until rulesJson.length()).mapNotNull { idx ->
+                val ruleObj = rulesJson.optJSONObject(idx) ?: return@mapNotNull null
+                runCatching { parsePortRule(ruleObj) }.getOrNull()
             }
-    return normalizePortPolicy(
-        PortPolicy(
-            mode = PortPolicyMode.fromJson(obj.optString("mode", PortPolicyMode.Custom.jsonName)),
-            preset =
-                if (obj.has("preset") && !obj.isNull("preset")) {
-                    obj.optString("preset").takeIf { it.isNotBlank() }
-                } else {
-                    null
-                },
-            rules = rules,
-        ),
-    )
+        normalizePortPolicy(
+            PortPolicy(
+                mode = PortPolicyMode.fromJson(obj.optString("mode", PortPolicyMode.Custom.jsonName)),
+                preset =
+                    if (obj.has("preset") && !obj.isNull("preset")) {
+                        obj.optString("preset").takeIf { it.isNotBlank() }
+                    } else {
+                        null
+                    },
+                rules = rules,
+            ),
+        )
+    }.getOrNull()
 }
 
 private fun parsePortRule(obj: JSONObject): PortRule {

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/UpdateCheckCache.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/UpdateCheckCache.kt
@@ -59,8 +59,23 @@ internal object UpdateCheckCache {
     }
 
     private suspend fun run(currentVersion: String) {
-        val result = withContext(Dispatchers.IO) { checkForUpdate(currentVersion) }
-        _info.value = result
-        lastCheckMs = System.currentTimeMillis()
+        when (val result = withContext(Dispatchers.IO) { checkForUpdate(currentVersion) }) {
+            is UpdateCheckResult.Available -> {
+                _info.value = result.info
+                lastCheckMs = System.currentTimeMillis()
+            }
+
+            UpdateCheckResult.UpToDate -> {
+                _info.value = null
+                lastCheckMs = System.currentTimeMillis()
+            }
+
+            // Transient failure: leave a previously-found update in place and
+            // DON'T advance lastCheckMs, so the next ensureFresh retries instead
+            // of caching the failure as a fresh "no update" for 6 hours.
+            UpdateCheckResult.Failed -> {
+                VpnHideLog.d("VpnHide-Update", "update check failed; keeping prior state, will retry")
+            }
+        }
     }
 }

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/UpdateChecker.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/UpdateChecker.kt
@@ -109,11 +109,27 @@ internal fun compareSemver(
 }
 
 /**
- * Check GitHub Releases for a newer APK version.
- * Returns [UpdateInfo] if a newer version exists, null otherwise.
- * Silently returns null on any error (network, parse, rate limit).
+ * Outcome of a GitHub update check. [Failed] (network/rate-limit/parse error) is
+ * kept distinct from [UpToDate] so a transient failure doesn't get cached as a
+ * fresh "no update" — see [UpdateCheckCache].
  */
-fun checkForUpdate(currentVersion: String): UpdateInfo? {
+sealed interface UpdateCheckResult {
+    data class Available(
+        val info: UpdateInfo,
+    ) : UpdateCheckResult
+
+    data object UpToDate : UpdateCheckResult
+
+    data object Failed : UpdateCheckResult
+}
+
+/**
+ * Check GitHub Releases for a newer APK version. Returns [UpdateCheckResult]:
+ * [Available] with the newer release, [UpToDate] when current, or [Failed] on
+ * any error (network, parse, rate limit) so the caller can retry instead of
+ * caching the failure.
+ */
+fun checkForUpdate(currentVersion: String): UpdateCheckResult {
     try {
         val conn = URL(GITHUB_RELEASES_URL).openConnection() as HttpURLConnection
         conn.setRequestProperty("User-Agent", "vpnhide-android")
@@ -123,14 +139,14 @@ fun checkForUpdate(currentVersion: String): UpdateInfo? {
         try {
             if (conn.responseCode != 200) {
                 VpnHideLog.d(TAG, "GitHub API returned ${conn.responseCode}")
-                return null
+                return UpdateCheckResult.Failed
             }
             val body = conn.inputStream.bufferedReader().readText()
             val release = JSONObject(body)
             val remoteVersion = normalizeVersion(release.getString("tag_name"))
             if (!isNewerVersion(remoteVersion, currentVersion)) {
                 VpnHideLog.d(TAG, "No update: remote=$remoteVersion current=$currentVersion")
-                return null
+                return UpdateCheckResult.UpToDate
             }
             val assets = release.getJSONArray("assets")
             var apkUrl: String? = null
@@ -143,13 +159,13 @@ fun checkForUpdate(currentVersion: String): UpdateInfo? {
             }
             val downloadUrl = apkUrl ?: release.getString("html_url")
             VpnHideLog.i(TAG, "Update available: $remoteVersion (url=$downloadUrl)")
-            return UpdateInfo(latestVersion = remoteVersion, downloadUrl = downloadUrl)
+            return UpdateCheckResult.Available(UpdateInfo(latestVersion = remoteVersion, downloadUrl = downloadUrl))
         } finally {
             conn.disconnect()
         }
     } catch (e: Exception) {
         VpnHideLog.d(TAG, "Update check failed: ${e.message}")
-        return null
+        return UpdateCheckResult.Failed
     }
 }
 


### PR DESCRIPTION
Medium/low correctness fixes from the audit.

- **Config resilience:** `parsePortPolicy` now parses best-effort. A single out-of-range port rule tripped `PortRule`'s `require()`, threw, and unwound the *entire* canonical-config parse — silently disabling every hook for every app. Now the offending rule/policy is dropped (that app is treated as ports-disabled) instead.
- **Update check:** `checkForUpdate` returned `null` for both "no update" and a transient error, so a network blip overwrote a previously-found update with null and advanced the 6-hour staleness timestamp (suppressing retries). It now returns a sealed `UpdateCheckResult` (Available / UpToDate / Failed); on failure the cache keeps the prior state and doesn't advance the timestamp, so the next check retries.
- **Diagnostics wedge + race:** `DiagnosticsCache.run()` did a non-atomic check-then-launch from several threads, and if the launching scope was cancelled mid-run the state stayed `Running` forever while the guard refused to relaunch (Diagnostics/Dashboard spinner forever). `run()` is now `@Synchronized` and relaunches when `Running` has a dead job; cancellation resets `Running -> NotRun`.
- **Off-thread saves:** the debug-zip and logcat save callbacks did stream IO on the main thread with no error handling — a large file blocked the UI and a write failure crashed the app. Moved to `Dispatchers.IO` + `runCatching`.

ktlint / detekt / compile / unit tests pass.