### PR TITLE
Drop dead proc diagnostics, fix misaligned reads, align parser parity

### DIFF
--- a/crates/protocol/src/lib.rs
+++ b/crates/protocol/src/lib.rs
@@ -107,6 +107,20 @@ fn significant(line: &[u8]) -> Option<&[u8]> {
     Some(rest)
 }
 
+/// True for a line that may legally precede the header (§4.2): blank /
+/// whitespace-only, or a `#` comment. A line carrying any non-comment token —
+/// **even a non-ASCII one** — is NOT ignorable: the first such line must be the
+/// header. This is deliberately narrower than [significant], which also folds in
+/// the ASCII check; the header scan needs to tell "skip this" apart from
+/// "significant but invalid", to match the C and Kotlin parsers which reject the
+/// whole payload when the first significant line is non-ASCII.
+fn is_ignorable(line: &[u8]) -> bool {
+    match line.iter().position(|&b| !is_sep(b)) {
+        None => true,                  // blank / whitespace-only
+        Some(start) => line[start] == b'#', // comment
+    }
+}
+
 /// Whitespace-delimited tokens of a line (runs of separators collapse, §4.1).
 fn tokens(line: &[u8]) -> impl Iterator<Item = &[u8]> {
     line.split(|&b| is_sep(b)).filter(|t| !t.is_empty())
@@ -160,9 +174,15 @@ fn parse_header(buf: &[u8]) -> Option<(Kind, &[u8])> {
             end -= 1; // CRLF → LF (§4.1)
         }
 
-        let Some(content) = significant(&buf[s..end]) else {
+        let line = &buf[s..end];
+        if is_ignorable(line) {
             continue; // blank / comment before the header is allowed
-        };
+        }
+        // The first significant line MUST be the header. If it is significant
+        // but non-ASCII, `significant` returns None and `?` rejects the whole
+        // payload rather than skipping it — parity with the C (kmod/KPM) and
+        // Kotlin (LSPosed) parsers (§4.2).
+        let content = significant(line)?;
         // first significant line == the mandatory header
         let mut it = tokens(content);
         if it.next() != Some(b"vpnhide".as_slice()) {

--- a/crates/protocol/src/lib.rs
+++ b/crates/protocol/src/lib.rs
@@ -116,7 +116,7 @@ fn significant(line: &[u8]) -> Option<&[u8]> {
 /// whole payload when the first significant line is non-ASCII.
 fn is_ignorable(line: &[u8]) -> bool {
     match line.iter().position(|&b| !is_sep(b)) {
-        None => true,                  // blank / whitespace-only
+        None => true,                       // blank / whitespace-only
         Some(start) => line[start] == b'#', // comment
     }
 }

--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -220,6 +220,13 @@ vpnhide <version> <kind>
 A payload without this header, or with `version` > the reader's known version,
 is rejected whole (§3).
 
+"Significant" is decided by **non-blank, non-comment alone** — a non-ASCII line
+is significant. So if the first significant line is non-ASCII, it *is* the line
+that MUST be the header; being an invalid header, it rejects the payload whole.
+The §4.1 "reject that line" (skip-and-continue) rule applies to **records**,
+once a valid header is established — it does **not** let the header search step
+over a non-ASCII first significant line to find a header on a later line.
+
 ### 4.3 Records
 
 **config** (`kind = config`):

--- a/kmod/shared/protocol_vectors.tsv
+++ b/kmod/shared/protocol_vectors.tsv
@@ -48,6 +48,10 @@ cfg|vpnhide 1 config\r\ntarget 0x9 0x1\r\n|debug=-1;0x9:0x1
 cfg|vpnhide 1 config\ntarget 0xa 0x2|debug=-1;0xa:0x2
 # non-ASCII byte -> reject just that line
 cfg|vpnhide 1 config\ntarget 0x1 0x1\n\x80bad 0x2\ntarget 0x2 0x2\n|debug=-1;0x1:0x1;0x2:0x2
+# non-ASCII byte as the FIRST significant line -> reject whole. It is significant
+# (not blank/comment), so per §4.2 it must be the header; a non-ASCII line is not
+# a valid header, so the payload is rejected rather than skipped to the next line.
+cfg|\x80bad\nvpnhide 1 config\ntarget 0x1 0x1\n|REJECT
 
 # --- peek_kind dispatch (§7.1) ---------------------------------------------
 kind|vpnhide 1 config\n|CONFIG
@@ -55,6 +59,9 @@ kind|vpnhide 1 stats|STATS
 kind|\n\nvpnhide 1 status\n|STATUS
 kind|vpnhide 2 config\n|INVALID
 kind|garbage\n|INVALID
+# non-ASCII first significant line rejects the whole payload — the parser must
+# NOT skip it and find the header on the following line (§4.2 parity).
+kind|\x80bad\nvpnhide 1 config\n|INVALID
 
 # --- stats serialise (§4.3) ------------------------------------------------
 stats|0x27fa,0x0,0x5;0x27fa,0x3,0xc;0x2947,0x2,0x1|vpnhide 1 stats\n0x27fa 0x0:0x5 0x3:0xc\n0x2947 0x2:0x1\n

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/NativeChecks.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/NativeChecks.kt
@@ -9,14 +9,9 @@ import dev.okhsunrog.vpnhide.checks.checkIoctlSiocgifmtu
 import dev.okhsunrog.vpnhide.checks.checkNetlinkGetlink
 import dev.okhsunrog.vpnhide.checks.checkNetlinkGetroute
 import dev.okhsunrog.vpnhide.checks.checkProcNetDev
-import dev.okhsunrog.vpnhide.checks.checkProcNetFibTrie
 import dev.okhsunrog.vpnhide.checks.checkProcNetIfInet6
 import dev.okhsunrog.vpnhide.checks.checkProcNetIpv6Route
 import dev.okhsunrog.vpnhide.checks.checkProcNetRoute
-import dev.okhsunrog.vpnhide.checks.checkProcNetTcp
-import dev.okhsunrog.vpnhide.checks.checkProcNetTcp6
-import dev.okhsunrog.vpnhide.checks.checkProcNetUdp
-import dev.okhsunrog.vpnhide.checks.checkProcNetUdp6
 import dev.okhsunrog.vpnhide.checks.checkSysClassNet
 
 /**
@@ -61,11 +56,6 @@ internal val NATIVE_CHECKS: List<NativeCheckSpec> =
         NativeCheckSpec("proc_route", R.string.check_proc_route) { checkProcNetRoute() },
         NativeCheckSpec("proc_ipv6_route", R.string.check_proc_ipv6_route) { checkProcNetIpv6Route() },
         NativeCheckSpec("proc_if_inet6", R.string.check_proc_if_inet6) { checkProcNetIfInet6() },
-        NativeCheckSpec("proc_tcp", R.string.check_proc_tcp) { checkProcNetTcp() },
-        NativeCheckSpec("proc_tcp6", R.string.check_proc_tcp6) { checkProcNetTcp6() },
-        NativeCheckSpec("proc_udp", R.string.check_proc_udp) { checkProcNetUdp() },
-        NativeCheckSpec("proc_udp6", R.string.check_proc_udp6) { checkProcNetUdp6() },
         NativeCheckSpec("proc_dev", R.string.check_proc_dev) { checkProcNetDev() },
-        NativeCheckSpec("proc_fib_trie", R.string.check_proc_fib_trie) { checkProcNetFibTrie() },
         NativeCheckSpec("sys_class_net", R.string.check_sys_class_net) { checkSysClassNet() },
     )

--- a/lsposed/app/src/main/res/values/strings.xml
+++ b/lsposed/app/src/main/res/values/strings.xml
@@ -320,12 +320,7 @@
     <string name="check_proc_route" translatable="false">/proc/net/route</string>
     <string name="check_proc_ipv6_route" translatable="false">/proc/net/ipv6_route</string>
     <string name="check_proc_if_inet6" translatable="false">/proc/net/if_inet6</string>
-    <string name="check_proc_tcp" translatable="false">/proc/net/tcp</string>
-    <string name="check_proc_tcp6" translatable="false">/proc/net/tcp6</string>
-    <string name="check_proc_udp" translatable="false">/proc/net/udp</string>
-    <string name="check_proc_udp6" translatable="false">/proc/net/udp6</string>
     <string name="check_proc_dev" translatable="false">/proc/net/dev</string>
-    <string name="check_proc_fib_trie" translatable="false">/proc/net/fib_trie</string>
     <string name="check_sys_class_net" translatable="false">/sys/class/net</string>
     <string name="check_net_iface_enum" translatable="false">NetworkInterface enum</string>
     <string name="check_proc_route_java" translatable="false">/proc/net/route (Java)</string>

--- a/lsposed/native/src/lib.rs
+++ b/lsposed/native/src/lib.rs
@@ -56,6 +56,22 @@ fn is_vpn_iface(name: &str) -> bool {
     matches_vpn(name.as_bytes())
 }
 
+/// 8-byte-aligned byte buffer. Several probes reinterpret the raw bytes the
+/// kernel writes back (`ifreq` from SIOCGIFCONF, `nlmsghdr`/`rtattr` from a
+/// netlink dump) as typed structs. A plain `[u8; N]` is only 1-aligned, so
+/// forming a reference/slice of those types over it is undefined behaviour even
+/// when it happens to work. Over-aligning the backing storage to 8 — at least
+/// the alignment of every struct read out of these buffers — makes every such
+/// reference well-formed.
+#[repr(align(8))]
+struct AlignedBytes<const N: usize>([u8; N]);
+
+impl<const N: usize> AlignedBytes<N> {
+    fn zeroed() -> Self {
+        Self([0u8; N])
+    }
+}
+
 fn is_selinux_denial(e: &std::io::Error) -> bool {
     e.kind() == ErrorKind::PermissionDenied
 }
@@ -217,10 +233,10 @@ fn check_ioctl_siocgifmtu() -> CheckOutput {
 fn check_ioctl_siocgifconf() -> CheckOutput {
     unsafe {
         with_inet_dgram_socket(|fd| {
-            let mut buf = [0u8; 4096];
+            let mut buf = AlignedBytes::<4096>::zeroed();
             let mut ifc: libc::ifconf = std::mem::zeroed();
-            ifc.ifc_len = buf.len() as libc::c_int;
-            ifc.ifc_ifcu.ifcu_buf = buf.as_mut_ptr().cast();
+            ifc.ifc_len = buf.0.len() as libc::c_int;
+            ifc.ifc_ifcu.ifcu_buf = buf.0.as_mut_ptr().cast();
 
             if libc::ioctl(fd, libc::SIOCGIFCONF as _, &mut ifc) < 0 {
                 let e = last_os_error();
@@ -228,7 +244,7 @@ fn check_ioctl_siocgifconf() -> CheckOutput {
             }
 
             let count = ifc.ifc_len as usize / std::mem::size_of::<libc::ifreq>();
-            let reqs = std::slice::from_raw_parts(buf.as_ptr() as *const libc::ifreq, count);
+            let reqs = std::slice::from_raw_parts(buf.0.as_ptr() as *const libc::ifreq, count);
 
             let mut all = Vec::new();
             let mut vpn = Vec::new();
@@ -472,19 +488,19 @@ fn check_netlink_getlink() -> CheckOutput {
             return CheckOutput::fail(format!("send error: {e}"));
         }
 
-        let mut buf = [0u8; 32768];
+        let mut buf = AlignedBytes::<32768>::zeroed();
         let mut all = Vec::new();
         let mut vpn = Vec::new();
         let hdr_plus_ifinfo =
             std::mem::size_of::<libc::nlmsghdr>() + std::mem::size_of::<Ifinfomsg>();
 
         for _ in 0..MAX_NETLINK_RECV_ITERS {
-            let len = netlink_recv(fd, &mut buf);
+            let len = netlink_recv(fd, &mut buf.0);
             if len <= 0 {
                 break;
             }
             let cont = parse_netlink_msgs(
-                &buf,
+                &buf.0,
                 len as usize,
                 libc::RTM_NEWLINK,
                 |b, offset, msg_len| {
@@ -548,18 +564,18 @@ fn check_netlink_getroute() -> CheckOutput {
             return CheckOutput::fail(format!("send error: {e}"));
         }
 
-        let mut buf = [0u8; 32768];
+        let mut buf = AlignedBytes::<32768>::zeroed();
         let mut vpn = Vec::new();
         let mut total = 0u32;
         let hdr_plus_rtmsg = std::mem::size_of::<libc::nlmsghdr>() + std::mem::size_of::<Rtmsg>();
 
         for _ in 0..MAX_NETLINK_RECV_ITERS {
-            let len = netlink_recv(fd, &mut buf);
+            let len = netlink_recv(fd, &mut buf.0);
             if len <= 0 {
                 break;
             }
             let cont = parse_netlink_msgs(
-                &buf,
+                &buf.0,
                 len as usize,
                 libc::RTM_NEWROUTE,
                 |b, offset, msg_len| {
@@ -642,32 +658,15 @@ fn check_proc_net_ipv6_route() -> CheckOutput {
     check_proc_file("/proc/net/ipv6_route")
 }
 
-#[uniffi::export]
-fn check_proc_net_tcp() -> CheckOutput {
-    check_proc_file("/proc/net/tcp")
-}
-
-#[uniffi::export]
-fn check_proc_net_tcp6() -> CheckOutput {
-    check_proc_file("/proc/net/tcp6")
-}
-
-#[uniffi::export]
-fn check_proc_net_udp() -> CheckOutput {
-    check_proc_file("/proc/net/udp")
-}
-
-#[uniffi::export]
-fn check_proc_net_udp6() -> CheckOutput {
-    check_proc_file("/proc/net/udp6")
-}
+// NOTE: /proc/net/{tcp,tcp6,udp,udp6,fib_trie} are intentionally NOT probed
+// here. Those files expose the VPN only as a hex *local address*, never as an
+// interface name, so a name-matching probe could only ever report a green pass
+// regardless of an actual leak. From inside the targeted (and thus self-hidden)
+// process we have no reference tunnel address to decode and compare, so there is
+// no honest check to run; the address-leak vector on these files is covered by
+// zygisk's tcp/tcp6/udp socket-table filters, not by a self-diagnostic.
 
 #[uniffi::export]
 fn check_proc_net_dev() -> CheckOutput {
     check_proc_file("/proc/net/dev")
-}
-
-#[uniffi::export]
-fn check_proc_net_fib_trie() -> CheckOutput {
-    check_proc_file("/proc/net/fib_trie")
 }


### PR DESCRIPTION
Three native-correctness fixes from the codebase audit.

**Diagnostics that always pass.** `/proc/net/{tcp,tcp6,udp,udp6,fib_trie}` expose the VPN only as a hex *local address*, never as an interface name, so the name-matching probe could only ever report a green "no VPN entries" regardless of an actual leak. From inside the targeted (and thus self-hidden) process there is no reference tunnel address to decode and compare, so there is no honest check to run. Remove those five probes rather than keep a meaningless always-pass; the address-leak vector on these files is covered by zygisk's tcp/tcp6/udp socket-table filters. `/proc/net/{route,ipv6_route,if_inet6,dev}`, which do carry interface names, are unchanged.

**Misaligned-reference UB.** `check_ioctl_siocgifconf` and the netlink dumps reinterpret the kernel's bytes as `ifreq` / `nlmsghdr` / `rtattr` over plain `[u8; N]` buffers (align 1), so forming those references is undefined behaviour even when it happens to work. Back the three buffers with an 8-byte-aligned wrapper (≥ the alignment of every struct read out) so every such reference is well-formed.

**Cross-language parser parity.** The Rust `parse_header` skipped a non-ASCII first significant line and kept searching, while the C (kmod/KPM) and Kotlin (LSPosed) parsers reject the whole payload — same wire bytes, different accept decision across the mutually exclusive backends. Distinguish "blank/comment" (skip) from "significant but non-ASCII" (reject) so all three agree. The §4.2 corner is now spelled out in `docs/protocol.md`, and header-position golden vectors (`cfg` + `kind`) were added to the shared vector file that the C, Rust and Kotlin parsers all run.

The five removed diagnostics belong to the still-unreleased detailed-diagnostics feature, so no separate changelog entry.