### PR TITLE
Stop the hook dialog enabling a disabled role; dedup UI primitives

### DIFF
--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/AppPickerScreen.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/AppPickerScreen.kt
@@ -490,6 +490,7 @@ private fun AppRow(
             title = stringResource(R.string.java_hooks_title),
             hookEntries = LsposedJavaHookEntries,
             selectedHooks = app.javaHooks,
+            roleEnabled = app.java,
             onDismiss = { javaHookDialogOpen = false },
             onSave = { hooks ->
                 onJavaHooksChange(hooks)
@@ -504,6 +505,7 @@ private fun AppRow(
             title = nativeHooksTitle(nativeBackendId),
             hookEntries = nativeHookEntriesFor(nativeHookFamily),
             selectedHooks = nativeHooks,
+            roleEnabled = app.native,
             onDismiss = { nativeHookDialogOpen = false },
             onSave = { hooks ->
                 onNativeHooksChange(hooks)
@@ -812,12 +814,24 @@ private fun HooksDialog(
     title: String,
     hookEntries: List<HookIds.Hook>,
     selectedHooks: List<String>?,
+    roleEnabled: Boolean,
     onDismiss: () -> Unit,
     onSave: (List<String>?) -> Unit,
 ) {
     val hookNames = remember(hookEntries) { hookEntries.map { it.hookName } }
-    var selected by remember(app.packageName, selectedHooks, hookNames) {
-        mutableStateOf(selectedHooks?.toSet() ?: hookNames.toSet())
+    // `selectedHooks == null` is ambiguous: it means BOTH "role on with all
+    // hooks" and "role off". Disambiguate with roleEnabled so opening the dialog
+    // on a disabled role starts with nothing checked — otherwise it would show
+    // every hook pre-checked and Save would silently turn the role into a full
+    // target (resolveHookSelection(all) -> null -> enabled).
+    var selected by remember(app.packageName, selectedHooks, roleEnabled, hookNames) {
+        mutableStateOf(
+            when {
+                selectedHooks != null -> selectedHooks.toSet()
+                roleEnabled -> hookNames.toSet()
+                else -> emptySet()
+            },
+        )
     }
 
     AlertDialog(

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DashboardScreen.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DashboardScreen.kt
@@ -41,11 +41,14 @@ import dev.okhsunrog.vpnhide.settings.SettingsRepository
 import dev.okhsunrog.vpnhide.ui.components.EnhancedButton
 import dev.okhsunrog.vpnhide.ui.components.EnhancedCard
 import dev.okhsunrog.vpnhide.ui.components.GroupedCard
+import dev.okhsunrog.vpnhide.ui.components.IconBubble
+import dev.okhsunrog.vpnhide.ui.components.MetricTile
 import dev.okhsunrog.vpnhide.ui.components.pulse
 import dev.okhsunrog.vpnhide.ui.theme.AppColors
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.withContext
+import dev.okhsunrog.vpnhide.ui.components.SectionHeader as SharedSectionHeader
 
 @Composable
 fun DashboardScreen(
@@ -442,18 +445,17 @@ private fun LoadingBlock(
     )
 }
 
-/** A bold section title. Pass [color] for the colored issue/warning headers. */
+/**
+ * Dashboard section title: the emphasized (titleMedium) variant, defaulting to
+ * onSurface. Pass [color] for the colored issue/warning headers. Delegates to
+ * the shared [SharedSectionHeader] so the rendering isn't duplicated per screen.
+ */
 @Composable
 private fun SectionHeader(
     text: String,
     color: Color = MaterialTheme.colorScheme.onSurface,
 ) {
-    Text(
-        text = text,
-        style = MaterialTheme.typography.titleMedium,
-        fontWeight = FontWeight.Bold,
-        color = color,
-    )
+    SharedSectionHeader(text = text, color = color, emphasized = true)
 }
 
 private data class HeroVisual(
@@ -529,9 +531,9 @@ private fun DashboardHeroCard(
                 modifier = Modifier.fillMaxWidth(),
                 verticalAlignment = Alignment.CenterVertically,
             ) {
-                StatusIconBubble(
+                IconBubble(
                     icon = visual.icon,
-                    accent = visual.accent,
+                    tint = visual.accent,
                     container = visual.container,
                     modifier =
                         Modifier.pulse(
@@ -564,13 +566,13 @@ private fun DashboardHeroCard(
             Spacer(Modifier.height(16.dp))
             Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
                 Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-                    HeroMetric(
+                    MetricTile(
                         label = stringResource(R.string.dashboard_summary_modules),
                         value = moduleSummaryText(state),
                         accent = moduleSummaryAccent(state),
                         modifier = Modifier.weight(1f),
                     )
-                    HeroMetric(
+                    MetricTile(
                         label = stringResource(R.string.dashboard_native_protection),
                         value = nativeSummaryText(state.protection),
                         accent = nativeSummaryAccent(state.protection),
@@ -578,13 +580,13 @@ private fun DashboardHeroCard(
                     )
                 }
                 Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-                    HeroMetric(
+                    MetricTile(
                         label = stringResource(R.string.dashboard_java_protection),
                         value = javaSummaryText(state.protection),
                         accent = javaSummaryAccent(state.protection),
                         modifier = Modifier.weight(1f),
                     )
-                    HeroMetric(
+                    MetricTile(
                         label = stringResource(R.string.dashboard_summary_issues),
                         value = (errorCount + warningCount).toString(),
                         accent =
@@ -598,30 +600,6 @@ private fun DashboardHeroCard(
                 }
             }
         }
-    }
-}
-
-@Composable
-private fun StatusIconBubble(
-    icon: ImageVector,
-    accent: Color,
-    container: Color,
-    modifier: Modifier = Modifier,
-) {
-    Box(
-        modifier =
-            modifier
-                .size(58.dp)
-                .clip(CircleShape)
-                .background(container),
-        contentAlignment = Alignment.Center,
-    ) {
-        Icon(
-            imageVector = icon,
-            contentDescription = null,
-            tint = accent,
-            modifier = Modifier.size(31.dp),
-        )
     }
 }
 
@@ -646,39 +624,6 @@ private fun StatusPill(
             style = MaterialTheme.typography.labelMedium,
             fontWeight = FontWeight.Bold,
             color = contentColor,
-            maxLines = 1,
-            overflow = TextOverflow.Ellipsis,
-        )
-    }
-}
-
-@Composable
-private fun HeroMetric(
-    label: String,
-    value: String,
-    accent: Color,
-    modifier: Modifier = Modifier,
-) {
-    Column(
-        modifier =
-            modifier
-                .clip(MaterialTheme.shapes.medium)
-                .background(AppColors.cardContainerStrong)
-                .padding(horizontal = 12.dp, vertical = 10.dp),
-    ) {
-        Text(
-            text = label,
-            style = MaterialTheme.typography.labelMedium,
-            color = MaterialTheme.colorScheme.onSurfaceVariant,
-            maxLines = 1,
-            overflow = TextOverflow.Ellipsis,
-        )
-        Spacer(Modifier.height(3.dp))
-        Text(
-            text = value,
-            style = MaterialTheme.typography.titleMedium,
-            fontWeight = FontWeight.Bold,
-            color = accent,
             maxLines = 1,
             overflow = TextOverflow.Ellipsis,
         )

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DiagnosticsScreen.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DiagnosticsScreen.kt
@@ -32,6 +32,7 @@ import dev.okhsunrog.vpnhide.generated.IfaceLists
 import dev.okhsunrog.vpnhide.ui.components.EnhancedButton
 import dev.okhsunrog.vpnhide.ui.components.EnhancedCard
 import dev.okhsunrog.vpnhide.ui.components.GroupedCard
+import dev.okhsunrog.vpnhide.ui.components.SectionHeader
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
@@ -388,16 +389,6 @@ private fun formatSize(bytes: Long): String {
     if (kb < 1024.0) return "%.1f KB".format(kb)
     val mb = kb / 1024.0
     return "%.1f MB".format(mb)
-}
-
-@Composable
-private fun SectionHeader(title: String) {
-    Text(
-        text = title,
-        style = MaterialTheme.typography.titleSmall,
-        fontWeight = FontWeight.Bold,
-        color = MaterialTheme.colorScheme.primary,
-    )
 }
 
 @Composable

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/SettingsScreen.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/SettingsScreen.kt
@@ -83,6 +83,7 @@ import dev.okhsunrog.vpnhide.ui.components.EnhancedButton
 import dev.okhsunrog.vpnhide.ui.components.EnhancedOutlinedButton
 import dev.okhsunrog.vpnhide.ui.components.PreferenceRow
 import dev.okhsunrog.vpnhide.ui.components.PreferenceRowSwitch
+import dev.okhsunrog.vpnhide.ui.components.SectionHeader
 import dev.okhsunrog.vpnhide.ui.theme.AppColors
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
@@ -1337,12 +1338,13 @@ private fun writeManualHiddenApps(
     return exit
 }
 
+// Settings headers are the non-bold, indented variant; delegate to the shared
+// component so the Text rendering isn't duplicated per screen.
 @Composable
 private fun SettingsSectionHeader(text: String) {
-    Text(
+    SectionHeader(
         text = text,
-        style = MaterialTheme.typography.titleSmall,
-        color = MaterialTheme.colorScheme.primary,
+        bold = false,
         modifier = Modifier.padding(start = 4.dp, top = 4.dp, bottom = 4.dp),
     )
 }

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/StatisticsScreen.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/StatisticsScreen.kt
@@ -37,6 +37,9 @@ import dev.okhsunrog.vpnhide.ui.components.EnhancedButton
 import dev.okhsunrog.vpnhide.ui.components.EnhancedCard
 import dev.okhsunrog.vpnhide.ui.components.EnhancedOutlinedButton
 import dev.okhsunrog.vpnhide.ui.components.GroupedCard
+import dev.okhsunrog.vpnhide.ui.components.IconBubble
+import dev.okhsunrog.vpnhide.ui.components.MetricTile
+import dev.okhsunrog.vpnhide.ui.components.SectionHeader
 import dev.okhsunrog.vpnhide.ui.theme.AppColors
 import kotlinx.coroutines.delay
 
@@ -93,7 +96,13 @@ fun StatisticsScreen(modifier: Modifier = Modifier) {
         val methodCount = remember(appStats) { appStats.flatMap { it.byMethod.keys }.toSet().size }
 
         val capturing = captureBaseline != null
-        val capture = captureBaseline?.let { diffCapture(it, s, selfPackage) }
+        // Memoize the diff so the once-per-second elapsed-clock tick (which flips
+        // nowMs and recomposes the whole screen) does not rebuild the per-app
+        // rollup every second; it only changes when the baseline or stats do.
+        val capture =
+            remember(captureBaseline, s, selfPackage) {
+                captureBaseline?.let { diffCapture(it, s, selfPackage) }
+            }
         val backendReset = capture?.backendReset == true
         // Backend restarted mid-session (a counter dropped): re-baseline so the
         // deltas restart from the fresh counter values instead of going negative.
@@ -254,7 +263,8 @@ private fun StatisticsHeroCard(
                 verticalAlignment = Alignment.CenterVertically,
             ) {
                 IconBubble(
-                    iconTint = StatusColors.infoAccent,
+                    icon = Icons.Default.BarChart,
+                    tint = StatusColors.infoAccent,
                     container = StatusColors.infoContainer(),
                 )
                 Spacer(Modifier.width(16.dp))
@@ -275,13 +285,13 @@ private fun StatisticsHeroCard(
             Spacer(Modifier.height(16.dp))
             Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
                 Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-                    StatisticsMetric(
+                    MetricTile(
                         label = stringResource(R.string.statistics_total_events),
                         value = formatStatCount(state.totalCount),
                         accent = StatusColors.infoAccent,
                         modifier = Modifier.weight(1f),
                     )
-                    StatisticsMetric(
+                    MetricTile(
                         label = stringResource(R.string.statistics_active_backends),
                         value = "${state.activeBackendCount}/${state.backends.size}",
                         accent = if (state.hasAnyData) StatusColors.successDot else StatusColors.warningAccent,
@@ -289,13 +299,13 @@ private fun StatisticsHeroCard(
                     )
                 }
                 Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-                    StatisticsMetric(
+                    MetricTile(
                         label = stringResource(R.string.statistics_apps_metric),
                         value = appCount.toString(),
                         accent = StatusColors.successDot,
                         modifier = Modifier.weight(1f),
                     )
-                    StatisticsMetric(
+                    MetricTile(
                         label = stringResource(R.string.statistics_methods_metric),
                         value = methodCount.toString(),
                         accent = StatusColors.successDot,
@@ -362,61 +372,6 @@ private fun CaptureControlCard(
 private fun formatElapsed(ms: Long): String {
     val totalSeconds = ms / 1000
     return "%d:%02d".format(totalSeconds / 60, totalSeconds % 60)
-}
-
-@Composable
-private fun IconBubble(
-    iconTint: Color,
-    container: Color,
-) {
-    Box(
-        modifier =
-            Modifier
-                .size(58.dp)
-                .clip(CircleShape)
-                .background(container),
-        contentAlignment = Alignment.Center,
-    ) {
-        Icon(
-            imageVector = Icons.Default.BarChart,
-            contentDescription = null,
-            tint = iconTint,
-            modifier = Modifier.size(31.dp),
-        )
-    }
-}
-
-@Composable
-private fun StatisticsMetric(
-    label: String,
-    value: String,
-    accent: Color,
-    modifier: Modifier = Modifier,
-) {
-    Column(
-        modifier =
-            modifier
-                .clip(MaterialTheme.shapes.medium)
-                .background(AppColors.cardContainerStrong)
-                .padding(horizontal = 12.dp, vertical = 10.dp),
-    ) {
-        Text(
-            text = label,
-            style = MaterialTheme.typography.labelMedium,
-            color = MaterialTheme.colorScheme.onSurfaceVariant,
-            maxLines = 1,
-            overflow = TextOverflow.Ellipsis,
-        )
-        Spacer(Modifier.height(4.dp))
-        Text(
-            text = value,
-            style = MaterialTheme.typography.titleMedium,
-            fontWeight = FontWeight.Bold,
-            color = accent,
-            maxLines = 1,
-            overflow = TextOverflow.Ellipsis,
-        )
-    }
 }
 
 @Composable
@@ -737,16 +692,6 @@ private fun BackendBadge(
             maxLines = 1,
         )
     }
-}
-
-@Composable
-private fun SectionHeader(text: String) {
-    Text(
-        text = text,
-        style = MaterialTheme.typography.titleSmall,
-        fontWeight = FontWeight.Bold,
-        color = MaterialTheme.colorScheme.primary,
-    )
 }
 
 @Composable

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/ui/components/HeroComponents.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/ui/components/HeroComponents.kt
@@ -1,0 +1,90 @@
+package dev.okhsunrog.vpnhide.ui.components
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import dev.okhsunrog.vpnhide.ui.theme.AppColors
+
+/**
+ * 58dp circular icon bubble used in the Dashboard and Statistics hero cards,
+ * which each used to carry their own copy (one with the icon as a parameter,
+ * the other hard-coding it).
+ */
+@Composable
+fun IconBubble(
+    icon: ImageVector,
+    tint: Color,
+    container: Color,
+    modifier: Modifier = Modifier,
+) {
+    Box(
+        modifier =
+            modifier
+                .size(58.dp)
+                .clip(CircleShape)
+                .background(container),
+        contentAlignment = Alignment.Center,
+    ) {
+        Icon(
+            imageVector = icon,
+            contentDescription = null,
+            tint = tint,
+            modifier = Modifier.size(31.dp),
+        )
+    }
+}
+
+/**
+ * label-over-value metric tile used in the Dashboard and Statistics hero cards.
+ * The two screens previously kept near-identical copies that had already drifted
+ * (3dp vs 4dp label/value gap); this is the single source.
+ */
+@Composable
+fun MetricTile(
+    label: String,
+    value: String,
+    accent: Color,
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        modifier =
+            modifier
+                .clip(MaterialTheme.shapes.medium)
+                .background(AppColors.cardContainerStrong)
+                .padding(horizontal = 12.dp, vertical = 10.dp),
+    ) {
+        Text(
+            text = label,
+            style = MaterialTheme.typography.labelMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis,
+        )
+        Spacer(Modifier.height(4.dp))
+        Text(
+            text = value,
+            style = MaterialTheme.typography.titleMedium,
+            fontWeight = FontWeight.Bold,
+            color = accent,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis,
+        )
+    }
+}

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/ui/components/SectionHeader.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/ui/components/SectionHeader.kt
@@ -1,0 +1,34 @@
+package dev.okhsunrog.vpnhide.ui.components
+
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+
+/**
+ * Section title shared across the Dashboard / Statistics / Diagnostics / Settings
+ * screens, which each used to carry their own near-identical copy.
+ *
+ * Defaults match the most common form (Statistics & Diagnostics): bold
+ * `titleSmall` in the primary color. [emphasized] switches to `titleMedium`
+ * (Dashboard), [bold] off drops the weight (Settings), and [color] / [modifier]
+ * cover the remaining per-screen tweaks.
+ */
+@Composable
+fun SectionHeader(
+    text: String,
+    modifier: Modifier = Modifier,
+    color: Color = MaterialTheme.colorScheme.primary,
+    emphasized: Boolean = false,
+    bold: Boolean = true,
+) {
+    Text(
+        text = text,
+        style = if (emphasized) MaterialTheme.typography.titleMedium else MaterialTheme.typography.titleSmall,
+        fontWeight = if (bold) FontWeight.Bold else null,
+        color = color,
+        modifier = modifier,
+    )
+}


### PR DESCRIPTION
From the codebase audit — one bug fix plus three no-behavior-change UI cleanups.

**Hook dialog could silently enable a disabled role.** `app.javaHooks` / `nativeHooks` is `null` for *both* "role on with all hooks" and "role off", so opening the per-app hook-config dialog on a disabled role showed every hook pre-checked, and pressing Save resolved all-checked → `null` → the role flipped on as a full target. A user inspecting the hook list of an app they had **not** selected could turn it into an unintended target. Fix: thread the role's enabled state into `HooksDialog` and initialize the checkboxes empty when the role is off, so inspecting (or Save) no longer creates a target. Selecting hooks still enables the role with that subset, as before.

**Capture diff recomputed every second.** The Statistics capture diff ran on every recomposition, and the once-per-second elapsed-clock tick forces a full recomposition, so the per-app rollup was rebuilt every second. Memoized with `remember(baseline, stats, self)`.

**Four `SectionHeader` copies → one.** Promoted a single shared `SectionHeader` to `ui/components` (params cover the titleSmall/titleMedium, color, bold and padding variants) and deleted the per-screen copies — two were byte-identical.

**Duplicated hero primitives → shared.** Promoted `MetricTile` + `IconBubble` for the Dashboard/Statistics hero cards, replacing the copy-pasted pair and unifying a 3dp/4dp label-gap drift to 4dp.

The hook dialog and per-app hooks are still unreleased, so no changelog entry.