### PR TITLE
Block the whole loopback range; warn on native-target overflow

### DIFF
--- a/changelog.d/fixed-activator-now-warns-on-stderr-when-8cb6.md
+++ b/changelog.d/fixed-activator-now-warns-on-stderr-when-8cb6.md
@@ -1,0 +1,9 @@
+_2026-06-30_
+
+## English
+
+Activator now warns on stderr when more than 64 native targets are configured (the backend cap) instead of silently dropping the highest-UID apps from native protection
+
+## Русский
+
+Активатор теперь предупреждает в stderr, когда настроено больше 64 нативных целей (лимит бэкенда), вместо молчаливого исключения приложений с наибольшим UID из нативной защиты

--- a/changelog.d/security-localhost-port-blocking-now-covers-the-f58a.md
+++ b/changelog.d/security-localhost-port-blocking-now-covers-the-f58a.md
@@ -1,0 +1,9 @@
+_2026-06-30_
+
+## English
+
+Localhost port blocking now covers the whole 127.0.0.0/8 loopback range, so a proxy or VPN daemon bound to 0.0.0.0 can no longer be reached on a 127.x.x.x alias
+
+## Русский
+
+Блокировка localhost-портов теперь покрывает весь диапазон loopback 127.0.0.0/8, чтобы прокси или VPN-демон на 0.0.0.0 нельзя было достать через алиас 127.x.x.x

--- a/crates/activator/src/lib.rs
+++ b/crates/activator/src/lib.rs
@@ -469,7 +469,12 @@ pub fn project_ports_with_resolver(
         // alias, so an observer could `connect(127.0.0.2:port)` and still get a
         // handshake — a positive fingerprint — if only 127.0.0.1 were rejected.
         // (::1 already is the entire IPv6 loopback.)
-        ipv4: build_ports_ruleset(PORTS_CHAIN4, "127.0.0.0/8", "icmp-port-unreachable", &targets),
+        ipv4: build_ports_ruleset(
+            PORTS_CHAIN4,
+            "127.0.0.0/8",
+            "icmp-port-unreachable",
+            &targets,
+        ),
         ipv6: build_ports_ruleset(PORTS_CHAIN6, "::1", "icmp6-port-unreachable", &targets),
         target_count: targets.len(),
     }

--- a/crates/activator/src/lib.rs
+++ b/crates/activator/src/lib.rs
@@ -17,7 +17,7 @@ use std::time::Duration;
 use serde::Deserialize;
 use vpnhide_protocol::Target;
 use vpnhide_protocol::hook_ids::{HOOK_NAMES, KERNEL_HOOK_MASK, ZYGISK_HOOK_MASK};
-use vpnhide_protocol::{format_config, parse_config};
+use vpnhide_protocol::{MAX_TARGET_UIDS, format_config, parse_config};
 
 pub type Result<T> = std::result::Result<T, Box<dyn Error + Send + Sync>>;
 
@@ -32,7 +32,10 @@ const APP_PACKAGE: &str = "dev.okhsunrog.vpnhide";
 const KPM_NAME: &str = "vpnhide";
 const PORTS_CHAIN4: &str = "vpnhide_out";
 const PORTS_CHAIN6: &str = "vpnhide_out6";
-const MAX_NATIVE_TARGETS: usize = 64;
+// The native-target cap is owned by the shared protocol crate (and mirrored by
+// the C backends' `#define MAX_TARGET_UIDS`); alias it here so all three stay in
+// lock-step instead of restating the literal 64.
+const MAX_NATIVE_TARGETS: usize = MAX_TARGET_UIDS;
 const PM_READY_ATTEMPTS: u32 = 60;
 const APATCH_SUPERCALL_NR: c_long = 45;
 const APATCH_SUPERCALL_DEFAULT_VERSION_CODE: c_long = 0x000d00;
@@ -378,6 +381,19 @@ fn project_native_with_resolver_for_family(
                 .or_insert(mask);
         }
     }
+    // `by_uid` is a BTreeMap, so iteration is ascending by UID; truncating would
+    // silently drop the highest-UID (typically most-recently-installed) apps with
+    // no diagnostic. Warn so a user with more native targets than the backend can
+    // hold learns their protection is partial, instead of failing closed silently.
+    if by_uid.len() > MAX_NATIVE_TARGETS {
+        eprintln!(
+            "vpnhide: WARNING: {} native targets exceed the backend cap of {}; \
+             dropping the {} highest-UID app(s) from native protection",
+            by_uid.len(),
+            MAX_NATIVE_TARGETS,
+            by_uid.len() - MAX_NATIVE_TARGETS,
+        );
+    }
     let targets = by_uid
         .into_iter()
         .take(MAX_NATIVE_TARGETS)
@@ -447,7 +463,13 @@ pub fn project_ports_with_resolver(
         }
     }
     PortsRuleset {
-        ipv4: build_ports_ruleset(PORTS_CHAIN4, "127.0.0.1", "icmp-port-unreachable", &targets),
+        // Match the whole IPv4 loopback block, not just 127.0.0.1: a localhost
+        // proxy/VPN daemon bound to the wildcard 0.0.0.0 (the common allow-lan /
+        // TUN config for Clash, sing-box, V2Ray) is reachable on every 127.x.x.x
+        // alias, so an observer could `connect(127.0.0.2:port)` and still get a
+        // handshake — a positive fingerprint — if only 127.0.0.1 were rejected.
+        // (::1 already is the entire IPv6 loopback.)
+        ipv4: build_ports_ruleset(PORTS_CHAIN4, "127.0.0.0/8", "icmp-port-unreachable", &targets),
         ipv6: build_ports_ruleset(PORTS_CHAIN6, "::1", "icmp6-port-unreachable", &targets),
         target_count: targets.len(),
     }
@@ -1382,10 +1404,10 @@ mod tests {
             rules.ipv4,
             "*filter\n\
              :vpnhide_out - [0:0]\n\
-             -A vpnhide_out -m owner --uid-owner 10123 -d 127.0.0.1 -p tcp -j REJECT --reject-with tcp-reset\n\
-             -A vpnhide_out -m owner --uid-owner 10123 -d 127.0.0.1 -p udp -j REJECT --reject-with icmp-port-unreachable\n\
-             -A vpnhide_out -m owner --uid-owner 1010123 -d 127.0.0.1 -p tcp -j REJECT --reject-with tcp-reset\n\
-             -A vpnhide_out -m owner --uid-owner 1010123 -d 127.0.0.1 -p udp -j REJECT --reject-with icmp-port-unreachable\n\
+             -A vpnhide_out -m owner --uid-owner 10123 -d 127.0.0.0/8 -p tcp -j REJECT --reject-with tcp-reset\n\
+             -A vpnhide_out -m owner --uid-owner 10123 -d 127.0.0.0/8 -p udp -j REJECT --reject-with icmp-port-unreachable\n\
+             -A vpnhide_out -m owner --uid-owner 1010123 -d 127.0.0.0/8 -p tcp -j REJECT --reject-with tcp-reset\n\
+             -A vpnhide_out -m owner --uid-owner 1010123 -d 127.0.0.0/8 -p udp -j REJECT --reject-with icmp-port-unreachable\n\
              -A vpnhide_out -j RETURN\n\
              COMMIT\n",
         );
@@ -1432,10 +1454,10 @@ mod tests {
             rules.ipv4,
             "*filter\n\
              :vpnhide_out - [0:0]\n\
-             -A vpnhide_out -m owner --uid-owner 10123 -d 127.0.0.1 -p tcp --dport 1080 -j REJECT --reject-with tcp-reset\n\
-             -A vpnhide_out -m owner --uid-owner 10123 -d 127.0.0.1 -p udp --dport 1080 -j REJECT --reject-with icmp-port-unreachable\n\
-             -A vpnhide_out -m owner --uid-owner 10123 -d 127.0.0.1 -p udp --dport 5353 -j REJECT --reject-with icmp-port-unreachable\n\
-             -A vpnhide_out -m owner --uid-owner 10123 -d 127.0.0.1 -p tcp --dport 7890:7892 -j REJECT --reject-with tcp-reset\n\
+             -A vpnhide_out -m owner --uid-owner 10123 -d 127.0.0.0/8 -p tcp --dport 1080 -j REJECT --reject-with tcp-reset\n\
+             -A vpnhide_out -m owner --uid-owner 10123 -d 127.0.0.0/8 -p udp --dport 1080 -j REJECT --reject-with icmp-port-unreachable\n\
+             -A vpnhide_out -m owner --uid-owner 10123 -d 127.0.0.0/8 -p udp --dport 5353 -j REJECT --reject-with icmp-port-unreachable\n\
+             -A vpnhide_out -m owner --uid-owner 10123 -d 127.0.0.0/8 -p tcp --dport 7890:7892 -j REJECT --reject-with tcp-reset\n\
              -A vpnhide_out -j RETURN\n\
              COMMIT\n",
         );

--- a/crates/protocol/src/lib.rs
+++ b/crates/protocol/src/lib.rs
@@ -18,6 +18,14 @@ pub use generated::hook_ids;
 /// Wire version this implementation speaks (header line, §4.2).
 pub const PROTO_VERSION: u32 = 1;
 
+/// Maximum number of `target` records a native backend will store. The backends
+/// keep a fixed `targets[MAX_TARGET_UIDS]` array, so a config carrying more than
+/// this many native targets is truncated on projection. This is the single
+/// source of truth for the cap on the wire boundary; the C backends mirror it as
+/// `#define MAX_TARGET_UIDS` in kmod/vpnhide_kmod.c and kmod/kpm/vpnhide_kpm.c —
+/// keep all three in sync.
+pub const MAX_TARGET_UIDS: usize = 64;
+
 #[derive(Copy, Clone, PartialEq, Eq, Debug)]
 pub enum Kind {
     Config,

--- a/kmod/kpm/vpnhide_kpm.c
+++ b/kmod/kpm/vpnhide_kpm.c
@@ -52,6 +52,9 @@ KPM_AUTHOR("okhsunrog");
 KPM_DESCRIPTION("Hide VPN interfaces from selected UIDs (KPM backend, WIP)");
 
 #define MODNAME "vpnhide"
+/* Mirror of vpnhide_protocol::MAX_TARGET_UIDS (crates/protocol/src/lib.rs); the
+ * activator truncates the projected config to this many targets, so keep both in
+ * sync. */
 #define MAX_TARGET_UIDS 64
 
 /* ------------------------------------------------------------------ */

--- a/kmod/vpnhide_kmod.c
+++ b/kmod/vpnhide_kmod.c
@@ -65,6 +65,9 @@
 #endif
 
 #define MODNAME "vpnhide"
+/* Mirror of vpnhide_protocol::MAX_TARGET_UIDS (crates/protocol/src/lib.rs); the
+ * activator truncates the projected config to this many targets, so keep both in
+ * sync. */
 #define MAX_TARGET_UIDS 64
 #define MAX_STATS_ENTRIES (MAX_TARGET_UIDS * VPNHIDE_HOOK_COUNT)
 #define CTL_READ_BUF_SIZE 32768

--- a/portshide/README.md
+++ b/portshide/README.md
@@ -12,12 +12,15 @@ packages through PackageManager, and installs `iptables` / `ip6tables` rules
 inside a dedicated chain `vpnhide_out` / `vpnhide_out6`:
 
 ```
-iptables -A vpnhide_out -m owner --uid-owner <UID> -d 127.0.0.1 -p tcp -j REJECT --reject-with tcp-reset
-iptables -A vpnhide_out -m owner --uid-owner <UID> -d 127.0.0.1 -p udp -j REJECT --reject-with icmp-port-unreachable
+iptables -A vpnhide_out -m owner --uid-owner <UID> -d 127.0.0.0/8 -p tcp -j REJECT --reject-with tcp-reset
+iptables -A vpnhide_out -m owner --uid-owner <UID> -d 127.0.0.0/8 -p udp -j REJECT --reject-with icmp-port-unreachable
 ```
 
 ...for every UID whose package has `"ports": true` in
 `/data/system/vpnhide_config.json`, plus the same for `::1` via `ip6tables`.
+The IPv4 rules match the whole `127.0.0.0/8` loopback block, not just
+`127.0.0.1`, so a daemon bound to the wildcard `0.0.0.0` stays unreachable on
+every `127.x.x.x` alias (`::1` is already the entire IPv6 loopback).
 If the app also has a `portPolicy.rules` list, the activator adds `--dport`
 matches for those TCP/UDP ports instead of blocking the whole loopback range.
 A jump from `OUTPUT` into the dedicated chain is inserted exactly once


### PR DESCRIPTION
Two activator findings from the codebase audit.

**Loopback port blocking only covered 127.0.0.1.** The ports activator generated REJECT rules whose IPv4 destination was the single address `127.0.0.1`, but a proxy/VPN daemon bound to the wildcard `0.0.0.0` (the common allow-lan / TUN setup for Clash, sing-box, V2Ray) listens on every `127.x.x.x` address. An observer app with `ports:true` could `connect(127.0.0.2:port)` and get a handshake a clean device would refuse — a positive VPN/proxy fingerprint, defeating the hiding for exactly the wildcard-bound setups portshide targets. Now the IPv4 rules match the whole `127.0.0.0/8` block (`::1` already is the entire IPv6 loopback). Tests and the portshide README are updated.

**The 64-target cap was a triplicated magic constant with silent truncation.** `MAX_NATIVE_TARGETS = 64` restated the C backends' `#define MAX_TARGET_UIDS 64` independently, and projection dropped the overflow with a bare `.take(64)` — because the map iterates ascending by UID, the highest-UID (typically most-recently-installed) apps silently lost native protection with no diagnostic. Export the cap once from the shared `vpnhide_protocol` crate, alias it in the activator, cross-reference it from both C `#define`s, and warn on stderr when the resolved target set exceeds it.