### PR TITLE
Close audit findings in clean-device, release, changelog, update-json, codegen

### DIFF
--- a/scripts/changelog.py
+++ b/scripts/changelog.py
@@ -40,6 +40,7 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 from changelog_lib import (  # type: ignore[import-not-found]
     FRAGMENTS_DIR,
+    REPO_ROOT,
     VALID_TYPES,
 )
 from rich.console import Console
@@ -94,7 +95,11 @@ def main() -> int:
     path = fragment_path(args.type, slug)
     write_fragment(path, args.en.strip(), args.ru.strip())
 
-    console.print(f"[green]wrote[/green] {path.relative_to(Path.cwd())}")
+    # Relative to REPO_ROOT, not cwd: the fragment always lives under the repo,
+    # but cwd need not be an ancestor of it (e.g. run from scripts/), and
+    # Path.relative_to raises ValueError in that case — a spurious traceback
+    # after the fragment was already written fine.
+    console.print(f"[green]wrote[/green] {path.relative_to(REPO_ROOT)}")
     console.print(f"  [cyan]type:[/cyan] {args.type}")
     console.print(f"  [cyan]en:[/cyan]   {args.en}")
     console.print(f"  [cyan]ru:[/cyan]   {args.ru}")

--- a/scripts/clean-device.sh
+++ b/scripts/clean-device.sh
@@ -1,16 +1,44 @@
 #!/usr/bin/env bash
 # Wipe all VPN Hide data from a connected device for clean install testing.
 # Usage: ./scripts/clean-device.sh
+#
+# The path lists below mirror FULL_RESET_FILES / FULL_RESET_DIRS in
+# lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/FullReset.kt — keep them in
+# sync. They cover the canonical config, the derived runtime wires, the root-
+# owned APatch superkey under /data/adb/vpnhide, and the KPM/ports state, none of
+# which an APK uninstall touches.
 set -euo pipefail
+
+# Files under /data/system (rm -f).
+RESET_FILES=(
+  /data/system/vpnhide_config.json
+  /data/system/vpnhide_uids.txt
+  /data/system/vpnhide_debug_logging
+  /data/system/vpnhide_hidden_pkgs.txt
+  /data/system/vpnhide_observer_uids.txt
+  /data/system/vpnhide_lsposed_state
+  /data/system/vpnhide_hook_active
+)
+
+# Directories under /data/adb (rm -rf — covers targets.txt, load_status,
+# superkey, etc. inside). /data/adb/vpnhide holds the superkey, so it goes first.
+RESET_DIRS=(
+  /data/adb/vpnhide
+  /data/adb/vpnhide_kmod
+  /data/adb/vpnhide_kpm
+  /data/adb/vpnhide_zygisk
+  /data/adb/vpnhide_lsposed
+  /data/adb/vpnhide_ports
+)
 
 echo "Uninstalling app..."
 adb shell pm uninstall dev.okhsunrog.vpnhide 2>/dev/null || true
 
-echo "Removing persistent data..."
-adb shell su -c "rm -rf /data/adb/vpnhide_kmod /data/adb/vpnhide_zygisk /data/adb/vpnhide_lsposed" 2>/dev/null || true
+echo "Removing persistent data (config, superkey, KPM/ports/runtime state)..."
+adb shell su -c "rm -f ${RESET_FILES[*]}" 2>/dev/null || true
+adb shell su -c "rm -rf ${RESET_DIRS[*]}" 2>/dev/null || true
 
-echo "Removing runtime files..."
-adb shell su -c "rm -f /data/system/vpnhide_uids.txt" 2>/dev/null || true
+echo "Removing app data dir..."
 adb shell su -c "rm -rf /data/user/0/dev.okhsunrog.vpnhide" 2>/dev/null || true
 
 echo "Done. Reboot recommended if modules were installed."

--- a/scripts/codegen-hooks.py
+++ b/scripts/codegen-hooks.py
@@ -32,7 +32,14 @@ import tomllib
 from pathlib import Path
 from typing import Any
 
-REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from codegen_lib import (  # type: ignore[import-not-found]
+    REPO_ROOT,
+    emit_outputs,
+    generated_header,
+    lsposed_generated_kt,
+)
+
 TOML_PATH = REPO_ROOT / "data" / "hooks.toml"
 
 # Targets are only the protocol participants (§1.4): the kernel backends (C),
@@ -42,23 +49,10 @@ TOML_PATH = REPO_ROOT / "data" / "hooks.toml"
 OUT_KMOD = REPO_ROOT / "kmod" / "generated" / "hook_ids.h"
 OUT_PROTOCOL_RS = REPO_ROOT / "crates" / "protocol" / "src" / "generated" / "hook_ids.rs"
 OUT_ZYGISK = REPO_ROOT / "zygisk" / "src" / "generated" / "hook_ids.rs"
-OUT_LSP_KT = (
-    REPO_ROOT
-    / "lsposed"
-    / "app"
-    / "src"
-    / "main"
-    / "kotlin"
-    / "dev"
-    / "okhsunrog"
-    / "vpnhide"
-    / "generated"
-    / "HookIds.kt"
-)
+OUT_LSP_KT = lsposed_generated_kt("HookIds.kt")
 
-GENERATED_HEADER_LINE = (
-    "AUTO-GENERATED from data/hooks.toml — do not edit by hand. "
-    "Regenerate with: uv run scripts/codegen-hooks.py"
+GENERATED_HEADER_LINE = generated_header(
+    "data/hooks.toml", "uv run scripts/codegen-hooks.py"
 )
 
 KNOWN_BACKENDS = ("kernel", "zygisk", "lsposed")
@@ -290,37 +284,16 @@ def emit_kotlin(hooks: list[Hook], errs: list[Err], backends: list[Backend]) -> 
 # ---------------------------------------------------------------------------
 
 
-def write_if_changed(path: Path, content: str) -> bool:
-    path.parent.mkdir(parents=True, exist_ok=True)
-    if path.exists() and path.read_text(encoding="utf-8") == content:
-        return False
-    path.write_text(content, encoding="utf-8")
-    return True
-
-
 def main() -> int:
     hooks, errs, backends = load()
-    outputs = {
-        OUT_KMOD: emit_kmod(hooks, errs, backends),
-        OUT_PROTOCOL_RS: emit_rust(hooks, errs, backends),
-        OUT_ZYGISK: emit_rust(hooks, errs, backends),
-        OUT_LSP_KT: emit_kotlin(hooks, errs, backends),
-    }
-    # Skip rewriting unchanged files (and report only what changed), matching
-    # codegen-interfaces.py — avoids bumping mtimes and forcing needless
-    # downstream Gradle/cargo incremental rebuilds when the data didn't change.
-    changed = []
-    for path, text in outputs.items():
-        if write_if_changed(path, text):
-            changed.append(path.relative_to(REPO_ROOT))
-
-    if changed:
-        print("Regenerated:")
-        for p in changed:
-            print(f"  {p}")
-    else:
-        print("All generated files already up to date.")
-    return 0
+    return emit_outputs(
+        {
+            OUT_KMOD: emit_kmod(hooks, errs, backends),
+            OUT_PROTOCOL_RS: emit_rust(hooks, errs, backends),
+            OUT_ZYGISK: emit_rust(hooks, errs, backends),
+            OUT_LSP_KT: emit_kotlin(hooks, errs, backends),
+        }
+    )
 
 
 if __name__ == "__main__":

--- a/scripts/codegen-hooks.py
+++ b/scripts/codegen-hooks.py
@@ -290,7 +290,15 @@ def emit_kotlin(hooks: list[Hook], errs: list[Err], backends: list[Backend]) -> 
 # ---------------------------------------------------------------------------
 
 
-def main() -> None:
+def write_if_changed(path: Path, content: str) -> bool:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    if path.exists() and path.read_text(encoding="utf-8") == content:
+        return False
+    path.write_text(content, encoding="utf-8")
+    return True
+
+
+def main() -> int:
     hooks, errs, backends = load()
     outputs = {
         OUT_KMOD: emit_kmod(hooks, errs, backends),
@@ -298,11 +306,22 @@ def main() -> None:
         OUT_ZYGISK: emit_rust(hooks, errs, backends),
         OUT_LSP_KT: emit_kotlin(hooks, errs, backends),
     }
+    # Skip rewriting unchanged files (and report only what changed), matching
+    # codegen-interfaces.py — avoids bumping mtimes and forcing needless
+    # downstream Gradle/cargo incremental rebuilds when the data didn't change.
+    changed = []
     for path, text in outputs.items():
-        path.parent.mkdir(parents=True, exist_ok=True)
-        path.write_text(text, encoding="utf-8")
-        print(f"wrote {path.relative_to(REPO_ROOT)}")
+        if write_if_changed(path, text):
+            changed.append(path.relative_to(REPO_ROOT))
+
+    if changed:
+        print("Regenerated:")
+        for p in changed:
+            print(f"  {p}")
+    else:
+        print("All generated files already up to date.")
+    return 0
 
 
 if __name__ == "__main__":
-    main()
+    sys.exit(main())

--- a/scripts/codegen-hooks.py
+++ b/scripts/codegen-hooks.py
@@ -51,9 +51,7 @@ OUT_PROTOCOL_RS = REPO_ROOT / "crates" / "protocol" / "src" / "generated" / "hoo
 OUT_ZYGISK = REPO_ROOT / "zygisk" / "src" / "generated" / "hook_ids.rs"
 OUT_LSP_KT = lsposed_generated_kt("HookIds.kt")
 
-GENERATED_HEADER_LINE = generated_header(
-    "data/hooks.toml", "uv run scripts/codegen-hooks.py"
-)
+GENERATED_HEADER_LINE = generated_header("data/hooks.toml", "uv run scripts/codegen-hooks.py")
 
 KNOWN_BACKENDS = ("kernel", "zygisk", "lsposed")
 

--- a/scripts/codegen-interfaces.py
+++ b/scripts/codegen-interfaces.py
@@ -21,7 +21,14 @@ import tomllib
 from pathlib import Path
 from typing import Any
 
-REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from codegen_lib import (  # type: ignore[import-not-found]
+    REPO_ROOT,
+    emit_outputs,
+    generated_header,
+    lsposed_generated_kt,
+)
+
 TOML_PATH = REPO_ROOT / "data" / "interfaces.toml"
 
 # Output paths — kept next to the code that consumes them so include /
@@ -30,36 +37,11 @@ OUT_KMOD = REPO_ROOT / "kmod" / "generated" / "iface_lists.h"
 OUT_KMOD_TEST = REPO_ROOT / "kmod" / "test_iface_lists.c"
 OUT_ZYGISK = REPO_ROOT / "zygisk" / "src" / "generated" / "iface_lists.rs"
 OUT_LSP_NATIVE = REPO_ROOT / "lsposed" / "native" / "src" / "generated" / "iface_lists.rs"
-OUT_LSP_KT = (
-    REPO_ROOT
-    / "lsposed"
-    / "app"
-    / "src"
-    / "main"
-    / "kotlin"
-    / "dev"
-    / "okhsunrog"
-    / "vpnhide"
-    / "generated"
-    / "IfaceLists.kt"
-)
-OUT_LSP_KT_TEST = (
-    REPO_ROOT
-    / "lsposed"
-    / "app"
-    / "src"
-    / "test"
-    / "kotlin"
-    / "dev"
-    / "okhsunrog"
-    / "vpnhide"
-    / "generated"
-    / "IfaceListsGeneratedTest.kt"
-)
+OUT_LSP_KT = lsposed_generated_kt("IfaceLists.kt")
+OUT_LSP_KT_TEST = lsposed_generated_kt("IfaceListsGeneratedTest.kt", test=True)
 
-GENERATED_HEADER_LINE = (
-    "AUTO-GENERATED from data/interfaces.toml — do not edit by hand. "
-    "Regenerate with: python3 scripts/codegen-interfaces.py"
+GENERATED_HEADER_LINE = generated_header(
+    "data/interfaces.toml", "python3 scripts/codegen-interfaces.py"
 )
 
 
@@ -545,37 +527,19 @@ def emit_kotlin_test(tests: list[TestVector]) -> str:
 # ---------------------------------------------------------------------------
 
 
-def write_if_changed(path: Path, content: str) -> bool:
-    path.parent.mkdir(parents=True, exist_ok=True)
-    if path.exists() and path.read_text(encoding="utf-8") == content:
-        return False
-    path.write_text(content, encoding="utf-8")
-    return True
-
-
 def main() -> int:
     rules, tests = load()
     rust_body = emit_rust(rules, tests)
-    outputs = {
-        OUT_KMOD: emit_kmod(rules),
-        OUT_KMOD_TEST: emit_kmod_test(tests),
-        OUT_ZYGISK: rust_body,
-        OUT_LSP_NATIVE: rust_body,
-        OUT_LSP_KT: emit_kotlin(rules),
-        OUT_LSP_KT_TEST: emit_kotlin_test(tests),
-    }
-    changed = []
-    for path, content in outputs.items():
-        if write_if_changed(path, content):
-            changed.append(path.relative_to(REPO_ROOT))
-
-    if changed:
-        print("Regenerated:")
-        for p in changed:
-            print(f"  {p}")
-    else:
-        print("All generated files already up to date.")
-    return 0
+    return emit_outputs(
+        {
+            OUT_KMOD: emit_kmod(rules),
+            OUT_KMOD_TEST: emit_kmod_test(tests),
+            OUT_ZYGISK: rust_body,
+            OUT_LSP_NATIVE: rust_body,
+            OUT_LSP_KT: emit_kotlin(rules),
+            OUT_LSP_KT_TEST: emit_kotlin_test(tests),
+        }
+    )
 
 
 if __name__ == "__main__":

--- a/scripts/codegen_lib.py
+++ b/scripts/codegen_lib.py
@@ -1,0 +1,72 @@
+"""Shared scaffolding for the codegen scripts (codegen-interfaces.py and
+codegen-hooks.py).
+
+Both generators rendered the same boilerplate independently: the repo root, the
+"AUTO-GENERATED … Regenerate with …" banner, the 11-segment path to the LSPosed
+app's generated Kotlin package, and the write-if-changed + change-reporting tail
+of main(). That duplication had already drifted (one script rewrote every file
+unconditionally). Keep it here, imported by both, the way scripts/ already does
+for changelog_lib.py / build_lib.py.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
+def generated_header(source: str, regen_cmd: str) -> str:
+    """The banner text for a generated file (without the per-language comment
+    marker): ``AUTO-GENERATED from <source> … Regenerate with: <regen_cmd>``."""
+    return (
+        f"AUTO-GENERATED from {source} — do not edit by hand. "
+        f"Regenerate with: {regen_cmd}"
+    )
+
+
+def lsposed_generated_kt(filename: str, *, test: bool = False) -> Path:
+    """Path to a generated Kotlin file under the LSPosed app's generated package
+    (``…/src/{main,test}/kotlin/dev/okhsunrog/vpnhide/generated/<filename>``)."""
+    source = "test" if test else "main"
+    return (
+        REPO_ROOT
+        / "lsposed"
+        / "app"
+        / "src"
+        / source
+        / "kotlin"
+        / "dev"
+        / "okhsunrog"
+        / "vpnhide"
+        / "generated"
+        / filename
+    )
+
+
+def write_if_changed(path: Path, content: str) -> bool:
+    """Write ``content`` to ``path`` only if it differs (preserving mtime when it
+    doesn't, so downstream Gradle/cargo don't needlessly rebuild). Returns True
+    if the file was written."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    if path.exists() and path.read_text(encoding="utf-8") == content:
+        return False
+    path.write_text(content, encoding="utf-8")
+    return True
+
+
+def emit_outputs(outputs: dict[Path, str]) -> int:
+    """Write each {path: content} via [write_if_changed], report only what
+    changed, and return 0 — the shared tail of both generators' main()."""
+    changed = []
+    for path, content in outputs.items():
+        if write_if_changed(path, content):
+            changed.append(path.relative_to(REPO_ROOT))
+
+    if changed:
+        print("Regenerated:")
+        for p in changed:
+            print(f"  {p}")
+    else:
+        print("All generated files already up to date.")
+    return 0

--- a/scripts/codegen_lib.py
+++ b/scripts/codegen_lib.py
@@ -19,10 +19,7 @@ REPO_ROOT = Path(__file__).resolve().parent.parent
 def generated_header(source: str, regen_cmd: str) -> str:
     """The banner text for a generated file (without the per-language comment
     marker): ``AUTO-GENERATED from <source> … Regenerate with: <regen_cmd>``."""
-    return (
-        f"AUTO-GENERATED from {source} — do not edit by hand. "
-        f"Regenerate with: {regen_cmd}"
-    )
+    return f"AUTO-GENERATED from {source} — do not edit by hand. Regenerate with: {regen_cmd}"
 
 
 def lsposed_generated_kt(filename: str, *, test: bool = False) -> Path:

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -60,12 +60,21 @@ def parse_version(raw: str) -> tuple[str, int]:
     return raw, major * 10000 + minor * 100 + patch
 
 
-def patch_file(path: Path, replacements: list[tuple[re.Pattern[str], str]]) -> None:
+def patch_file(
+    path: Path,
+    replacements: list[tuple[re.Pattern[str], str]],
+    *,
+    dry_run: bool = False,
+) -> None:
     """Apply each pattern → replacement once.
 
     Hard-fails if any pattern doesn't match. Silently leaving a stale
     version in some file because the format drifted from what the regex
     expects is exactly the failure mode we want to catch loudly.
+
+    With ``dry_run=True`` the patterns are still validated (and a miss still
+    raises) but nothing is written — used to pre-flight every source patch
+    before the irreversible changelog rotation.
     """
     text = path.read_text(encoding="utf-8")
     new_text = text
@@ -76,36 +85,54 @@ def patch_file(path: Path, replacements: list[tuple[re.Pattern[str], str]]) -> N
                 f"error: pattern {pattern.pattern!r} did not match in {path}. "
                 f"File format probably changed — update release.py."
             )
-    if new_text != text:
+    if not dry_run and new_text != text:
         path.write_text(new_text, encoding="utf-8")
 
 
-def update_module_prop(path: Path, version: str, version_code: int) -> None:
+def update_module_prop(
+    path: Path, version: str, version_code: int, *, dry_run: bool = False
+) -> None:
     patch_file(
         path,
         [
             (re.compile(r"^version=.*$", re.M), f"version=v{version}"),
             (re.compile(r"^versionCode=.*$", re.M), f"versionCode={version_code}"),
         ],
+        dry_run=dry_run,
     )
 
 
-def update_cargo_toml(path: Path, version: str) -> None:
+def update_cargo_toml(path: Path, version: str, *, dry_run: bool = False) -> None:
     """Replace the first `version = "..."` line — package version sits at top."""
     patch_file(
         path,
         [(re.compile(r'^version = "[^"]*"$', re.M), f'version = "{version}"')],
+        dry_run=dry_run,
     )
 
 
-def update_gradle_kts(path: Path, version: str, version_code: int) -> None:
+def update_gradle_kts(
+    path: Path, version: str, version_code: int, *, dry_run: bool = False
+) -> None:
     patch_file(
         path,
         [
             (re.compile(r"versionCode = \d+"), f"versionCode = {version_code}"),
             (re.compile(r'versionName = "[^"]*"'), f'versionName = "{version}"'),
         ],
+        dry_run=dry_run,
     )
+
+
+def patch_all_sources(version: str, version_code: int, *, dry_run: bool) -> None:
+    """Patch (or, with dry_run, just validate) every version-bearing source file."""
+    vc = version_code  # local alias to keep the patch calls within the line limit
+    update_module_prop(REPO_ROOT / "kmod/module/module.prop", version, vc, dry_run=dry_run)
+    update_module_prop(REPO_ROOT / "zygisk/module/module.prop", version, vc, dry_run=dry_run)
+    update_module_prop(REPO_ROOT / "portshide/module/module.prop", version, vc, dry_run=dry_run)
+    update_cargo_toml(REPO_ROOT / "zygisk/Cargo.toml", version, dry_run=dry_run)
+    update_cargo_toml(REPO_ROOT / "lsposed/native/Cargo.toml", version, dry_run=dry_run)
+    update_gradle_kts(REPO_ROOT / "lsposed/app/build.gradle.kts", version, vc, dry_run=dry_run)
 
 
 def write_version_file(version: str) -> None:
@@ -151,9 +178,16 @@ def main() -> int:
             console.print(f"[red]missing:[/red] {f.relative_to(REPO_ROOT)}")
             return 1
 
+    # Pre-flight: validate every version-patch regex BEFORE the irreversible
+    # changelog rotation. patch_file hard-fails on a drifted module.prop /
+    # Cargo.toml / gradle format; if that failure happened after save_json +
+    # delete_fragment_files, changelog.json would already hold the release and
+    # the fragments would be gone, while the duplicate-version guard above then
+    # refuses any retry. Catching it here leaves the changelog fully retryable.
+    patch_all_sources(version, version_code, dry_run=True)
+
     # Changelog: rotate fragments into history, persist, then delete the
-    # fragment files. Order matters — if save_json/write_md fails, the
-    # fragments are still on disk and the run can be retried safely.
+    # fragment files. Now safe — the source patches are known to match.
     rotate_fragments_into_history(data, fragments, version)
     save_json(data)
     write_md(data)
@@ -166,13 +200,8 @@ def main() -> int:
     write_version_file(version)
     console.print("  [green]✓[/green] VERSION")
 
-    # Version-bearing source files.
-    update_module_prop(REPO_ROOT / "kmod/module/module.prop", version, version_code)
-    update_module_prop(REPO_ROOT / "zygisk/module/module.prop", version, version_code)
-    update_module_prop(REPO_ROOT / "portshide/module/module.prop", version, version_code)
-    update_cargo_toml(REPO_ROOT / "zygisk/Cargo.toml", version)
-    update_cargo_toml(REPO_ROOT / "lsposed/native/Cargo.toml", version)
-    update_gradle_kts(REPO_ROOT / "lsposed/app/build.gradle.kts", version, version_code)
+    # Version-bearing source files (validated above, so these will not fail).
+    patch_all_sources(version, version_code, dry_run=False)
 
     console.print("  [green]✓[/green] kmod/module/module.prop")
     console.print("  [green]✓[/green] zygisk/module/module.prop")

--- a/scripts/update-json.sh
+++ b/scripts/update-json.sh
@@ -12,7 +12,9 @@ if ! [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
 fi
 
 IFS='.' read -r MAJOR MINOR PATCH <<< "$VERSION"
-VERSION_CODE=$(( MAJOR * 10000 + MINOR * 100 + PATCH ))
+# Force base-10: the regex above accepts a zero-padded component (e.g. 1.08.0),
+# which bash would otherwise read as octal in $(( )) and abort on a digit 8/9.
+VERSION_CODE=$(( 10#$MAJOR * 10000 + 10#$MINOR * 100 + 10#$PATCH ))
 
 REPO="https://github.com/okhsunrog/vpnhide"
 RAW="https://raw.githubusercontent.com/okhsunrog/vpnhide/main"


### PR DESCRIPTION
Five tooling fixes from the codebase audit.

- **`clean-device.sh` left state behind.** It removed only three `/data/adb` dirs and the legacy `vpnhide_uids.txt`, so a "clean" install test inherited the canonical config, the root-owned APatch superkey under `/data/adb/vpnhide`, and the KPM/ports state. Now mirrors the full `FULL_RESET_FILES` / `FULL_RESET_DIRS` list from `FullReset.kt` (superkey dir removed first).
- **`release.py` could half-release.** The irreversible changelog rotation (`save_json` + delete fragment files) ran *before* patching the version-bearing source files, so a drifted `module.prop` / `Cargo.toml` / gradle format raised `SystemExit` mid-release — with `changelog.json` already holding the new version and the fragments deleted, while the duplicate-version guard then refused a retry. Now every version-patch regex is dry-run-validated before the changelog step.
- **`changelog.py` crashed from the wrong cwd.** It printed the new fragment path relative to `Path.cwd()`, raising `ValueError` when cwd isn't an ancestor of `changelog.d` (e.g. run from `scripts/`) — a spurious traceback after the fragment was already written. Now relative to `REPO_ROOT`.
- **`update-json.sh` mis-parsed zero-padded versions.** `versionCode` used bare `$(( ))`, so a component like `08` was read as octal and aborted on digit 8/9. Forced base-10 (`10#`).
- **`codegen-hooks.py` churned mtimes.** It rewrote every generated file unconditionally; now uses `write_if_changed` and reports only what changed, matching `codegen-interfaces.py`. Verified the generated output is byte-identical.

All tooling-only — no changelog entry.