### PR TITLE
kmod kernel-behavior: host-route parity, config race, shared compactor, stats-slot race

### DIFF
--- a/changelog.d/fixed-kpm-bound-the-ctl0-stats-status-341f.md
+++ b/changelog.d/fixed-kpm-bound-the-ctl0-stats-status-341f.md
@@ -1,0 +1,9 @@
+_2026-06-30_
+
+## English
+
+KPM: bound the ctl0 stats/status reply to its buffer so a large request can no longer read past the kernel stack buffer; reject an overflowing version in the protocol header parser
+
+## Русский
+
+KPM: ответ ctl0 со статистикой/статусом ограничен размером буфера, чтобы большой запрос не читал за пределами стекового буфера ядра; отвергается переполняющая версия в парсере заголовка протокола

--- a/changelog.d/security-kpm-backend-now-hides-the-vpn-fbfb.md
+++ b/changelog.d/security-kpm-backend-now-hides-the-vpn-fbfb.md
@@ -2,8 +2,8 @@ _2026-06-30_
 
 ## English
 
-KPM backend now hides the VPN server's public IPv4 host-route (a /32 route pinned to a physical interface) from a target app's routing-table dump, matching the kernel-module backend
+KPM backend now hides the VPN server's public host-route (a /32 or /128 route pinned to a physical interface) from a target app's routing-table dump, matching the kernel-module backend
 
 ## Русский
 
-KPM-бэкенд теперь скрывает публичный IPv4 host-route VPN-сервера (маршрут /32 на физическом интерфейсе) из дампа таблицы маршрутов целевого приложения, как и kernel-module бэкенд
+KPM-бэкенд теперь скрывает публичный host-route VPN-сервера (маршрут /32 или /128 на физическом интерфейсе) из дампа таблицы маршрутов целевого приложения, как и kernel-module бэкенд

--- a/changelog.d/security-kpm-backend-now-hides-the-vpn-fbfb.md
+++ b/changelog.d/security-kpm-backend-now-hides-the-vpn-fbfb.md
@@ -1,0 +1,9 @@
+_2026-06-30_
+
+## English
+
+KPM backend now hides the VPN server's public IPv4 host-route (a /32 route pinned to a physical interface) from a target app's routing-table dump, matching the kernel-module backend
+
+## Русский
+
+KPM-бэкенд теперь скрывает публичный IPv4 host-route VPN-сервера (маршрут /32 на физическом интерфейсе) из дампа таблицы маршрутов целевого приложения, как и kernel-module бэкенд

--- a/docs/detection-vectors.md
+++ b/docs/detection-vectors.md
@@ -122,6 +122,24 @@ Notes: bionic's `getifaddrs` itself runs over netlink, so the kmod
 at once. zygisk additionally unlinks entries from the `getifaddrs` result list
 directly, so it works even if a future bionic stops using netlink.
 
+**Two known narrow `SIOCGIFCONF` gaps (kmod `.ko`), tracked not yet closed:**
+
+- **Size-query subcase.** The classic two-step `SIOCGIFCONF` (first call with
+  `ifc_req == NULL` to learn the buffer size, then a sized call to fill it) — the
+  `.ko` filters the fill but returns the *unfiltered* length from the size query,
+  so a target comparing the two back-to-back sees a one-interface discrepancy.
+  Closing it means, on the `ifc_req == NULL` path, enumerating netdevs (rcu) and
+  subtracting `sizeof(struct ifreq)` per *IPv4-addressed* VPN iface — feasible
+  but unvalidated without a dedicated probe. zygisk (its own `getifaddrs`/procfs
+  filtering) and modern apps (netlink `getifaddrs`, not `SIOCGIFCONF`) are
+  unaffected; the leak needs an app deliberately doing the legacy NULL-probe.
+- **32-bit (compat) callers.** `sock_ioctl_krp` hooks `sock_ioctl` only; a 32-bit
+  app's `SIOCGIFCONF` enters through `compat_sock_ioctl` → `compat_dev_ifconf`
+  and never reaches it, so the size/fill filtering is skipped for 32-bit
+  enumeration. Most current Android apps are 64-bit and modern enumeration uses
+  netlink (which the rtnl/inet fill hooks do cover), so this is narrow; closing
+  it means also hooking `compat_sock_ioctl` with the compat `ifconf` layout.
+
 ### 3B. Route table — "is the default route a tunnel?"
 
 | Vector | How it manifests | kmod | zygisk | lsposed | SELinux |

--- a/kmod/kpm/kver_offsets.h
+++ b/kmod/kpm/kver_offsets.h
@@ -76,6 +76,13 @@ struct vpnhide_offsets {
 	unsigned int fib6_info_nh;
 	unsigned int fib6_info_fib6_nh;
 
+	/* fib6_info.fib6_dst (struct rt6key { in6_addr addr@0; int plen@16; }) —
+	 * the destination of an IPv6 route, used to spot a public /128 host-route
+	 * pinned to a physical uplink. 0 disables that check for this version
+	 * (e.g. the pre-fib6_info 4.14 rt6_info path, and the non-GKI kernels that
+	 * the QEMU matrix can't validate — a wrong offset here would fault). */
+	unsigned int fib6_info_fib6_dst;
+
 	/* Pre-fib6_info kernels (<= 4.14): rt6_fill_node takes a struct rt6_info*
 	 * (which begins with a struct dst_entry), not a fib6_info. When
 	 * rt6_via_dst is set, dev = *(rt + rt6_dst_dev) (dst_entry.dev). */
@@ -122,9 +129,11 @@ static const struct vpnhide_offsets vpnhide_off_6_1 = {
 	.fib_dump_fi_arg = 4, /* fib_rt_info* form (5.6+) */
 	.fib_dump_fi_via_fri = 1,
 	/* fib6_info: bitfield@136, rcu@144, nh@160, ANDROID_KABI_RESERVE(1)@168,
-	 * fib6_nh[]@176; nhc_dev first in fib6_nh -> dev@176. */
+	 * fib6_nh[]@176; nhc_dev first in fib6_nh -> dev@176. fib6_dst is the first
+	 * rt6key after fib6_metrics@56 -> @64 (no gc_link, same head as 5.10). */
 	.fib6_info_nh = 160,
 	.fib6_info_fib6_nh = 176,
+	.fib6_info_fib6_dst = 64,
 	/* struct fib_rule layout identical to 5.10. */
 	.fib_rule_table = 36,
 	.fib_rule_iifname = 88,
@@ -157,9 +166,11 @@ static const struct vpnhide_offsets vpnhide_off_6_12 = {
 	.fib_info_fib_nh = 128,
 	.fib_dump_fi_arg = 4,
 	.fib_dump_fi_via_fri = 1,
-	/* fib6_info + gc_link(16) before fib6_metrics -> nh@176, fib6_nh[]@192. */
+	/* fib6_info + gc_link(16) before fib6_metrics -> nh@176, fib6_nh[]@192.
+	 * The same gc_link shifts fib6_metrics@72 and fib6_dst@80 (vs @64 elsewhere). */
 	.fib6_info_nh = 176,
 	.fib6_info_fib6_nh = 192,
+	.fib6_info_fib6_dst = 80,
 	.fib_rule_table = 36,
 	.fib_rule_iifname = 88,
 	.fib_rule_oifname = 104,
@@ -195,9 +206,11 @@ static const struct vpnhide_offsets vpnhide_off_5_x = {
 	.fib_dump_fi_arg = 4,
 	.fib_dump_fi_via_fri = 1,
 	/* android12-5.10 fib6_info (LP64; rt6key=20, ANDROID_KABI_RESERVE=8):
-	 * nh@152, fib6_nh[]@168; nhc_dev first in fib6_nh -> +168. */
+	 * nh@152, fib6_nh[]@168; nhc_dev first in fib6_nh -> +168. fib6_dst is the
+	 * first rt6key after fib6_metrics@56 -> @64. */
 	.fib6_info_nh = 152,
 	.fib6_info_fib6_nh = 168,
+	.fib6_info_fib6_dst = 64,
 	/* android12-5.10 struct fib_rule (LP64). */
 	.fib_rule_table = 36,
 	.fib_rule_iifname = 88,
@@ -229,9 +242,11 @@ static const struct vpnhide_offsets vpnhide_off_5_15 = {
 	.fib_info_fib_nh = 128,
 	.fib_dump_fi_arg = 4,
 	.fib_dump_fi_via_fri = 1,
-	/* fib6_info with offload/offload_failed (cf. 6.1): nh@160, fib6_nh[]@176. */
+	/* fib6_info with offload/offload_failed (cf. 6.1): nh@160, fib6_nh[]@176.
+	 * The offload fields are after the rt6keys, so fib6_dst stays @64. */
 	.fib6_info_nh = 160,
 	.fib6_info_fib6_nh = 176,
+	.fib6_info_fib6_dst = 64,
 	.fib_rule_table = 36,
 	.fib_rule_iifname = 88,
 	.fib_rule_oifname = 104,
@@ -269,9 +284,13 @@ static const struct vpnhide_offsets vpnhide_off_5_4 = {
 	 * passed directly (not via fib_rt_info). */
 	.fib_dump_fi_arg = 9,
 	.fib_dump_fi_via_fri = 0,
-	/* fib6_info: rt6key=20, NO KABI reserve -> nh@152, fib6_nh[]@160. */
+	/* fib6_info: rt6key=20, NO KABI reserve -> nh@152, fib6_nh[]@160. fib6_dst
+	 * is almost certainly @64 (same head as 5.10), but 5.4 is not in the QEMU
+	 * matrix, so leave the public-/128-host-route check disabled here (0) rather
+	 * than ship an unvalidated offset — the .ko covers 5.4-class devices anyway. */
 	.fib6_info_nh = 152,
 	.fib6_info_fib6_nh = 160,
+	.fib6_info_fib6_dst = 0,
 	/* struct fib_rule layout identical to 5.10. */
 	.fib_rule_table = 36,
 	.fib_rule_iifname = 88,
@@ -314,6 +333,9 @@ static const struct vpnhide_offsets vpnhide_off_4_19 = {
 	 * (Without ROUTER_PREF it would be @168 — config-sensitive.) */
 	.fib6_info_nh = 0,
 	.fib6_info_fib6_nh = 176,
+	/* 4.19's fib6_info head differs (config-sensitive) and is not in the QEMU
+	 * matrix, so leave the public-/128-host-route check disabled (0). */
+	.fib6_info_fib6_dst = 0,
 	/* struct fib_rule layout identical to 5.4/5.10. */
 	.fib_rule_table = 36,
 	.fib_rule_iifname = 88,

--- a/kmod/kpm/vpnhide_kpm.c
+++ b/kmod/kpm/vpnhide_kpm.c
@@ -1032,6 +1032,15 @@ static long vpnhide_kpm_ctl0(const char *args, char *__user out_msg, int outlen)
 			full = vpnhide_format_status(buf, sizeof(buf), &st);
 		}
 
+		/*
+		 * vpnhide_format_* report the FULL intended length, which can
+		 * exceed sizeof(buf); the bytes past the buffer were never
+		 * written. Clamp before clamp_to_line/copy_to_user so a
+		 * generous outlen can't drive a read past the 4096-byte stack
+		 * buffer (kernel infoleak / OOB). The .ko bounds the same way.
+		 */
+		if (full > sizeof(buf))
+			full = sizeof(buf);
 		n = vpnhide_clamp_to_line(
 			buf, full, outlen > 0 ? (unsigned long)outlen : 0);
 		if (_copy_to_user && out_msg && n)

--- a/kmod/kpm/vpnhide_kpm.c
+++ b/kmod/kpm/vpnhide_kpm.c
@@ -62,10 +62,23 @@ static const struct vpnhide_offsets *off; /* selected per running kver */
 
 /* Live config (protocol §4.3). Each target carries a per-hook mask so the app
  * can enable hooks individually; a hook fires only if its bit is set for the
- * calling uid. */
-static struct vpnhide_target targets[MAX_TARGET_UIDS];
-static int nr_targets;
-static uint32_t active_hook_mask;
+ * calling uid.
+ *
+ * Double-buffered so a hook reader (every hooked syscall, on any CPU) never sees
+ * a half-applied target set. A writer (rare, root-initiated: ctl0 config or the
+ * init load-args path) fills the INACTIVE buffer, then publishes it with a
+ * single release-store of `active_cfg`; readers acquire-load `active_cfg` once
+ * and use only that snapshot. KP has no kernel spinlock/RCU, so this is the
+ * lock-free equivalent of the .ko's parse-into-staging-then-publish-under-lock.
+ * Config writes are assumed serialized (single control path), so two writers
+ * never pick the same inactive buffer. */
+struct vpnhide_config {
+	struct vpnhide_target targets[MAX_TARGET_UIDS];
+	int nr_targets;
+	uint32_t active_hook_mask;
+};
+static struct vpnhide_config cfg_buf[2];
+static int active_cfg; /* index into cfg_buf; release-published / acquire-read */
 static bool debug_enabled;
 
 /* status (protocol §4.3/§5.1): which hooks actually installed, and the dominant
@@ -104,37 +117,46 @@ static void (*_skb_trim)(void *, unsigned int);
 /*  Core helpers                                                      */
 /* ------------------------------------------------------------------ */
 
-static uint32_t compute_active_hook_mask(int count)
+/* Fill the inactive buffer from a parsed target set, derive its active-hook
+ * mask, then publish it with one release-store. Single-writer (see the cfg_buf
+ * comment): a concurrent reader sees either the whole old or whole new config. */
+static void publish_config(const struct vpnhide_target *t, int count)
 {
+	int inactive = 1 - __atomic_load_n(&active_cfg, __ATOMIC_RELAXED);
+	struct vpnhide_config *c = &cfg_buf[inactive];
 	uint32_t mask = 0;
 	int i;
 
-	for (i = 0; i < count; i++)
-		mask |= targets[i].hookmask & VPNHIDE_KERNEL_HOOK_MASK;
-	return mask;
+	if (count < 0)
+		count = 0;
+	if (count > MAX_TARGET_UIDS)
+		count = MAX_TARGET_UIDS;
+	for (i = 0; i < count; i++) {
+		c->targets[i] = t[i];
+		mask |= t[i].hookmask & VPNHIDE_KERNEL_HOOK_MASK;
+	}
+	c->nr_targets = count;
+	c->active_hook_mask = mask;
+	__atomic_store_n(&active_cfg, inactive, __ATOMIC_RELEASE);
 }
 
-/* The enabled-hook mask for the calling uid (0 if it is not a target). */
-static uint32_t target_mask(void)
+/* True if `hook_id` is enabled for the calling uid (per-hook gate, §4.3). Reads
+ * the published snapshot once (acquire) so the mask gate and the per-uid scan
+ * always come from the same consistent config. */
+static int hook_active(uint32_t hook_id)
 {
+	int b = __atomic_load_n(&active_cfg, __ATOMIC_ACQUIRE);
+	const struct vpnhide_config *c = &cfg_buf[b];
 	uid_t uid;
 	int i;
 
-	if (nr_targets <= 0)
+	if (!(c->active_hook_mask & (1u << hook_id)))
 		return 0;
 	uid = current_uid();
-	for (i = 0; i < nr_targets; i++)
-		if (targets[i].uid == uid)
-			return targets[i].hookmask;
+	for (i = 0; i < c->nr_targets; i++)
+		if (c->targets[i].uid == uid)
+			return (c->targets[i].hookmask & (1u << hook_id)) != 0;
 	return 0;
-}
-
-/* True if `hook_id` is enabled for the calling uid (per-hook gate, §4.3). */
-static int hook_active(uint32_t hook_id)
-{
-	if (!(active_hook_mask & (1u << hook_id)))
-		return 0;
-	return (target_mask() & (1u << hook_id)) != 0;
 }
 
 static int stats_slot_for_uid(uint32_t uid)
@@ -936,6 +958,7 @@ static int resolve_symbols(void)
 static void apply_targets(const char *s)
 {
 	unsigned int uids[MAX_TARGET_UIDS];
+	struct vpnhide_target newt[MAX_TARGET_UIDS];
 	unsigned long n = 0;
 	int cnt, i;
 
@@ -945,13 +968,11 @@ static void apply_targets(const char *s)
 		n++;
 	cnt = vpnhide_parse_target_uids(s, n, uids, MAX_TARGET_UIDS);
 	for (i = 0; i < cnt; i++) {
-		targets[i].uid = uids[i];
-		targets[i].hookmask = VPNHIDE_KERNEL_HOOK_MASK;
+		newt[i].uid = uids[i];
+		newt[i].hookmask = VPNHIDE_KERNEL_HOOK_MASK;
 	}
-	nr_targets = cnt;
-	active_hook_mask = compute_active_hook_mask(cnt);
-	vpnhide_dbg("loaded %d target UIDs (active hooks=0x%x)\n", cnt,
-		    active_hook_mask);
+	publish_config(newt, cnt);
+	vpnhide_dbg("loaded %d target UIDs\n", cnt);
 }
 
 /* Resolve `name`, wrap it, and record the install in `installed_hooks` so the
@@ -975,7 +996,7 @@ static long vpnhide_kpm_init(const char *args, const char *event,
 
 	installed_hooks = 0;
 	last_error = VPNHIDE_ERR_OK;
-	active_hook_mask = 0;
+	publish_config(0, 0); /* start with an empty (no-op) active config */
 
 	/* `kver` is KernelPatch's running-kernel version (common.h), encoded
 	 * the same way as VPNHIDE_KVER. NULL table = unsupported → bail. */
@@ -1078,17 +1099,19 @@ static long vpnhide_kpm_ctl0(const char *args, char *__user out_msg, int outlen)
 	kind = vpnhide_peek_kind(args, n_args);
 
 	if (kind == VPNHIDE_KIND_CONFIG) {
+		/* Parse into a stack-local staging set, then publish atomically —
+		 * never mutate the live config in place (a hook reader on another
+		 * CPU must not see a half-written targets[]). */
+		struct vpnhide_target newt[MAX_TARGET_UIDS];
 		int dbg = debug_enabled ? 1 : 0;
-		int n = vpnhide_parse_config(args, n_args, targets,
-					     MAX_TARGET_UIDS, &dbg);
+		int n = vpnhide_parse_config(args, n_args, newt, MAX_TARGET_UIDS,
+					     &dbg);
 
 		if (n < 0)
 			return -1; /* rejected whole (bad header / version) */
-		nr_targets = n;
-		active_hook_mask = compute_active_hook_mask(n);
+		publish_config(newt, n);
 		debug_enabled = dbg ? true : false;
-		vpnhide_dbg("ctl0 config: %d targets, debug=%d active=0x%x\n",
-			    n, dbg, active_hook_mask);
+		vpnhide_dbg("ctl0 config: %d targets, debug=%d\n", n, dbg);
 		return 0;
 	}
 

--- a/kmod/kpm/vpnhide_kpm.c
+++ b/kmod/kpm/vpnhide_kpm.c
@@ -64,21 +64,19 @@ static const struct vpnhide_offsets *off; /* selected per running kver */
  * can enable hooks individually; a hook fires only if its bit is set for the
  * calling uid.
  *
- * Double-buffered so a hook reader (every hooked syscall, on any CPU) never sees
- * a half-applied target set. A writer (rare, root-initiated: ctl0 config or the
- * init load-args path) fills the INACTIVE buffer, then publishes it with a
- * single release-store of `active_cfg`; readers acquire-load `active_cfg` once
- * and use only that snapshot. KP has no kernel spinlock/RCU, so this is the
- * lock-free equivalent of the .ko's parse-into-staging-then-publish-under-lock.
- * Config writes are assumed serialized (single control path), so two writers
- * never pick the same inactive buffer. */
-struct vpnhide_config {
-	struct vpnhide_target targets[MAX_TARGET_UIDS];
-	int nr_targets;
-	uint32_t active_hook_mask;
-};
-static struct vpnhide_config cfg_buf[2];
-static int active_cfg; /* index into cfg_buf; release-published / acquire-read */
+ * Guarded by a seqlock so a hook reader (every hooked syscall, on any CPU) never
+ * sees a half-applied target set. A writer (rare, root-initiated: ctl0 config or
+ * the init load-args path) bumps cfg_seq odd, mutates targets[] in place, then
+ * bumps it even; readers snapshot under matching even-seq reads and retry on a
+ * concurrent write. KP has no kernel spinlock/RCU, and a double-buffer (two
+ * copies of targets[]) grew the .kpm enough to break KP boot on the 6.12 image —
+ * the seqlock costs one extra word instead. Writes are the serialized control
+ * path, so writers never race each other. */
+static struct vpnhide_target targets[MAX_TARGET_UIDS];
+static int nr_targets;
+static uint32_t active_hook_mask;
+static volatile uint32_t
+	cfg_seq; /* even = stable, odd = a writer is mid-update */
 static bool debug_enabled;
 
 /* status (protocol §4.3/§5.1): which hooks actually installed, and the dominant
@@ -117,46 +115,65 @@ static void (*_skb_trim)(void *, unsigned int);
 /*  Core helpers                                                      */
 /* ------------------------------------------------------------------ */
 
-/* Fill the inactive buffer from a parsed target set, derive its active-hook
- * mask, then publish it with one release-store. Single-writer (see the cfg_buf
- * comment): a concurrent reader sees either the whole old or whole new config. */
-static void publish_config(const struct vpnhide_target *t, int count)
+/* Recompute the OR of all targets' hookmasks (the fast-path gate). Called by a
+ * writer while holding the seqlock (cfg_seq odd), reading the live targets[]. */
+static uint32_t compute_active_hook_mask(int count)
 {
-	int inactive = 1 - __atomic_load_n(&active_cfg, __ATOMIC_RELAXED);
-	struct vpnhide_config *c = &cfg_buf[inactive];
 	uint32_t mask = 0;
 	int i;
 
-	if (count < 0)
-		count = 0;
-	if (count > MAX_TARGET_UIDS)
-		count = MAX_TARGET_UIDS;
-	for (i = 0; i < count; i++) {
-		c->targets[i] = t[i];
-		mask |= t[i].hookmask & VPNHIDE_KERNEL_HOOK_MASK;
-	}
-	c->nr_targets = count;
-	c->active_hook_mask = mask;
-	__atomic_store_n(&active_cfg, inactive, __ATOMIC_RELEASE);
+	for (i = 0; i < count; i++)
+		mask |= targets[i].hookmask & VPNHIDE_KERNEL_HOOK_MASK;
+	return mask;
 }
 
-/* True if `hook_id` is enabled for the calling uid (per-hook gate, §4.3). Reads
- * the published snapshot once (acquire) so the mask gate and the per-uid scan
- * always come from the same consistent config. */
+/* Seqlock write side. Bump odd before mutating targets[]/nr_targets/
+ * active_hook_mask in place, bump even after. Writes are serialized (single
+ * control path), so no CAS is needed on the counter itself. */
+static void cfg_write_begin(void)
+{
+	__atomic_store_n(&cfg_seq,
+			 __atomic_load_n(&cfg_seq, __ATOMIC_RELAXED) + 1,
+			 __ATOMIC_RELEASE);
+}
+
+static void cfg_write_end(void)
+{
+	__atomic_store_n(&cfg_seq,
+			 __atomic_load_n(&cfg_seq, __ATOMIC_RELAXED) + 1,
+			 __ATOMIC_RELEASE);
+}
+
+/* True if `hook_id` is enabled for the calling uid (per-hook gate, §4.3).
+ * Seqlock read side: retry while a writer holds the lock (odd) or if the config
+ * changed across the read, so the mask gate and the per-uid scan always come
+ * from one consistent snapshot. Config writes are rare, so this normally makes
+ * a single pass. */
 static int hook_active(uint32_t hook_id)
 {
-	int b = __atomic_load_n(&active_cfg, __ATOMIC_ACQUIRE);
-	const struct vpnhide_config *c = &cfg_buf[b];
-	uid_t uid;
-	int i;
+	uid_t uid = current_uid();
+	uint32_t s1, s2;
+	int result;
 
-	if (!(c->active_hook_mask & (1u << hook_id)))
-		return 0;
-	uid = current_uid();
-	for (i = 0; i < c->nr_targets; i++)
-		if (c->targets[i].uid == uid)
-			return (c->targets[i].hookmask & (1u << hook_id)) != 0;
-	return 0;
+	do {
+		s1 = __atomic_load_n(&cfg_seq, __ATOMIC_ACQUIRE);
+		if (s1 & 1u)
+			continue; /* a writer is mid-update */
+		result = 0;
+		if (active_hook_mask & (1u << hook_id)) {
+			int i;
+
+			for (i = 0; i < nr_targets; i++) {
+				if (targets[i].uid == uid) {
+					result = (targets[i].hookmask &
+						  (1u << hook_id)) != 0;
+					break;
+				}
+			}
+		}
+		s2 = __atomic_load_n(&cfg_seq, __ATOMIC_ACQUIRE);
+	} while (s1 != s2); /* s1 was even; retry if a write started/finished */
+	return result;
 }
 
 static int stats_slot_for_uid(uint32_t uid)
@@ -178,8 +195,8 @@ static int stats_slot_for_uid(uint32_t uid)
 		 * SECOND slot for the SAME uid. The init window is a few
 		 * instructions (CAS -> store uid -> store state 1), so this
 		 * settles immediately. */
-		while ((st = __atomic_load_n(&stats_used[i], __ATOMIC_ACQUIRE)) ==
-		       2)
+		while ((st = __atomic_load_n(&stats_used[i],
+					     __ATOMIC_ACQUIRE)) == 2)
 			;
 		if (st == 1) {
 			if (stats_uids[i] == uid)
@@ -977,7 +994,6 @@ static int resolve_symbols(void)
 static void apply_targets(const char *s)
 {
 	unsigned int uids[MAX_TARGET_UIDS];
-	struct vpnhide_target newt[MAX_TARGET_UIDS];
 	unsigned long n = 0;
 	int cnt, i;
 
@@ -986,11 +1002,14 @@ static void apply_targets(const char *s)
 	while (s[n])
 		n++;
 	cnt = vpnhide_parse_target_uids(s, n, uids, MAX_TARGET_UIDS);
+	cfg_write_begin();
 	for (i = 0; i < cnt; i++) {
-		newt[i].uid = uids[i];
-		newt[i].hookmask = VPNHIDE_KERNEL_HOOK_MASK;
+		targets[i].uid = uids[i];
+		targets[i].hookmask = VPNHIDE_KERNEL_HOOK_MASK;
 	}
-	publish_config(newt, cnt);
+	nr_targets = cnt;
+	active_hook_mask = compute_active_hook_mask(cnt);
+	cfg_write_end();
 	vpnhide_dbg("loaded %d target UIDs\n", cnt);
 }
 
@@ -1015,7 +1034,9 @@ static long vpnhide_kpm_init(const char *args, const char *event,
 
 	installed_hooks = 0;
 	last_error = VPNHIDE_ERR_OK;
-	publish_config(0, 0); /* start with an empty (no-op) active config */
+	nr_targets =
+		0; /* empty config until load-args / ctl0 (pre-hook, no readers) */
+	active_hook_mask = 0;
 
 	/* `kver` is KernelPatch's running-kernel version (common.h), encoded
 	 * the same way as VPNHIDE_KVER. NULL table = unsupported → bail. */
@@ -1118,17 +1139,25 @@ static long vpnhide_kpm_ctl0(const char *args, char *__user out_msg, int outlen)
 	kind = vpnhide_peek_kind(args, n_args);
 
 	if (kind == VPNHIDE_KIND_CONFIG) {
-		/* Parse into a stack-local staging set, then publish atomically —
-		 * never mutate the live config in place (a hook reader on another
-		 * CPU must not see a half-written targets[]). */
-		struct vpnhide_target newt[MAX_TARGET_UIDS];
+		/* Parse in place under the seqlock. vpnhide_parse_config only
+		 * writes targets[] AFTER validating the header, so a reject-whole
+		 * (n < 0, bad header / too-new version) never touches the live
+		 * array — the old config is preserved. A concurrent hook reader
+		 * retries while cfg_seq is odd, so it never sees the half-written
+		 * array. */
 		int dbg = debug_enabled ? 1 : 0;
-		int n = vpnhide_parse_config(args, n_args, newt, MAX_TARGET_UIDS,
-					     &dbg);
+		int n;
 
+		cfg_write_begin();
+		n = vpnhide_parse_config(args, n_args, targets, MAX_TARGET_UIDS,
+					 &dbg);
+		if (n >= 0) {
+			nr_targets = n;
+			active_hook_mask = compute_active_hook_mask(n);
+		}
+		cfg_write_end();
 		if (n < 0)
 			return -1; /* rejected whole (bad header / version) */
-		publish_config(newt, n);
 		debug_enabled = dbg ? true : false;
 		vpnhide_dbg("ctl0 config: %d targets, debug=%d\n", n, dbg);
 		return 0;

--- a/kmod/kpm/vpnhide_kpm.c
+++ b/kmod/kpm/vpnhide_kpm.c
@@ -243,6 +243,31 @@ static int kpm_is_public_host_route4(const void *fri, void *dev)
 	return vpnhide_iface_is_physical(netdev_name(dev));
 }
 
+/* IPv6 analogue of kpm_is_public_host_route4: a public /128 host-route pinned to
+ * a physical uplink (the route a VPN client installs to reach the server, which
+ * leaks its IPv6 even when the tun is hidden — the .ko's
+ * is_public_host_route6_via_physical). Reads fib6_info.fib6_dst (rt6key { addr@0;
+ * int plen@16 }) at the per-kver offset; off->fib6_info_fib6_dst == 0 disables
+ * it (the pre-fib6_info 4.14 rt6_info path, and non-GKI kernels the QEMU matrix
+ * can't validate). `rt` is the fib6_info* arg to rt6_fill_node and fib6_dst sits
+ * before fib6_nh — which dev_from_fib6_info already reads — so it is in-bounds.
+ * The address/iface logic is shared with the .ko (shared/vpnhide_logic.h). */
+static int kpm_is_public_host_route6(void *rt, void *dev)
+{
+	const unsigned char *dst;
+	int plen;
+
+	if (!rt || !dev || !off->fib6_info_fib6_dst)
+		return 0;
+	dst = (const unsigned char *)rt + off->fib6_info_fib6_dst;
+	plen = *(const int *)(dst + 16); /* rt6key.plen */
+	if (plen != 128)
+		return 0;
+	if (!vpnhide_is_public_ipv6(dst)) /* rt6key.addr @ +0 */
+		return 0;
+	return vpnhide_iface_is_physical(netdev_name(dev));
+}
+
 /* ================================================================== */
 /*  Hook 1 (PoC): fib_route_seq_show — /proc/net/route                */
 /*  arg0 = struct seq_file *.  Compact VPN lines out of this call's    */
@@ -661,7 +686,12 @@ static void rt6_fill_before(hook_fargs12_t *fargs, void *udata)
 	if (!hook_active(VPNHIDE_HOOK_RT6_FILL_NODE) || !skb || !rt)
 		return;
 	dev = dev_from_fib6_info(rt);
-	if (!dev || !iface_is_vpn(netdev_name(dev)))
+	if (!dev)
+		return;
+	/* Hide the route if its output dev is a VPN iface, OR it is a public /128
+	 * host-route pinned to a physical uplink (parity with the .ko). */
+	if (!iface_is_vpn(netdev_name(dev)) &&
+	    !kpm_is_public_host_route6(rt, dev))
 		return;
 
 	fargs->local.data0 = 1;
@@ -761,16 +791,21 @@ static void fib_rule_after(hook_fargs8_t *fargs, void *udata)
  *                                                   physical — constant
  *                                                   fib_rt_info offsets, A/B on
  *                                                   5.10 + 6.12)
- *   rt6_fill_node          RTM_GETROUTE v6 dump   ✓ (fib6_info nexthop)
+ *   rt6_fill_node          RTM_GETROUTE v6 dump   ✓ (fib6_info nexthop +
+ *                                                   public /128 host-route via a
+ *                                                   physical uplink, the .ko's
+ *                                                   is_public_host_route6_via_
+ *                                                   physical — per-kver
+ *                                                   fib6_info.fib6_dst offset,
+ *                                                   A/B on 5.10/5.15/6.1/6.12)
  *   fib_nl_fill_rule       RTM_GETRULE            ✓ (fib_rule iif/oif/uid)
  *   ( rt_fill_info — intentionally NOT hooked; unstable arg->reg ABI )
  *
- * PARITY GAP (TODO): the .ko also hides a public /128 IPv6 host-route pinned to
- * a physical uplink (is_public_host_route6_via_physical). The KPM does not yet,
- * because that needs the per-kver offset of fib6_info.fib6_dst (it varies, e.g.
- * 64 on 5.10..6.6 vs 80 on 6.12 due to the new gc_link) added to kver_offsets.h
- * and A/B-validated per version. The IPv4 host-route above needs no such offset
- * (fib_rt_info.dst/dst_len are at a constant +12/+16 on 5.6+).
+ * Both host-route predicates (v4 + v6) and their address/iface logic are now
+ * shared with the .ko via shared/vpnhide_logic.h. The IPv4 path needs no offset
+ * (fib_rt_info.dst/dst_len are at a constant +12/+16 on 5.6+); the IPv6 path
+ * reads fib6_info.fib6_dst at the per-kver offset (64 on 5.10..6.6, 80 on 6.12),
+ * disabled (0) on the non-GKI kernels the QEMU matrix can't validate.
  */
 
 /* ------------------------------------------------------------------ */

--- a/kmod/kpm/vpnhide_kpm.c
+++ b/kmod/kpm/vpnhide_kpm.c
@@ -217,6 +217,32 @@ static const char *netdev_name(void *dev)
 	return dev ? (const char *)((char *)dev + off->netdev_name) : 0;
 }
 
+/* True when `dev` (a route's output device) is physical AND the route is a
+ * public /32 host-route — the route a VPN client pins to the uplink so tunnel
+ * packets can reach the server, which leaks the server's public IPv4 even when
+ * the tun interface itself is hidden. The address/iface logic is shared with
+ * the .ko (vpnhide_is_public_ipv4 / vpnhide_iface_is_physical in
+ * shared/vpnhide_logic.h); only the kernel-struct read is KPM-specific.
+ *
+ * Only valid on the 5.6+ fib_rt_info path: `fri` is
+ * `fargs->args[fib_dump_fi_arg]`, with dst (__be32) at a constant +12 and
+ * dst_len (int) at +16 (struct fib_rt_info is stable across GKI 5.10..6.12,
+ * verified against the kernel sources). The fri is stack-resident in the
+ * caller, so reading those two fields is in-bounds. */
+static int kpm_is_public_host_route4(const void *fri, void *dev)
+{
+	int dst_len;
+
+	if (!fri || !dev)
+		return 0;
+	dst_len = *(const int *)((const char *)fri + 16);
+	if (dst_len != 32)
+		return 0;
+	if (!vpnhide_is_public_ipv4((const unsigned char *)fri + 12))
+		return 0;
+	return vpnhide_iface_is_physical(netdev_name(dev));
+}
+
 /* ================================================================== */
 /*  Hook 1 (PoC): fib_route_seq_show — /proc/net/route                */
 /*  arg0 = struct seq_file *.  Compact VPN lines out of this call's    */
@@ -569,7 +595,14 @@ static void fib_dump_before(hook_fargs12_t *fargs, void *udata)
 		return;
 	fi = off->fib_dump_fi_via_fri ? *(void **)p : p; /* fib_rt_info.fi @0 */
 	dev = dev_from_fib_info(fi);
-	if (!dev || !iface_is_vpn(netdev_name(dev)))
+	if (!dev)
+		return;
+	/* Hide the route if its output dev is a VPN iface, OR (5.6+ only, where
+	 * dst/dst_len live at fixed offsets in the fib_rt_info) it is a public
+	 * /32 host-route pinned to a physical uplink — the .ko hides both, so the
+	 * KPM must too for backend parity. */
+	if (!iface_is_vpn(netdev_name(dev)) &&
+	    !(off->fib_dump_fi_via_fri && kpm_is_public_host_route4(p, dev)))
 		return;
 
 	fargs->local.data0 = 1;
@@ -721,10 +754,23 @@ static void fib_rule_after(hook_fargs8_t *fargs, void *udata)
  *   inet6_fill_ifaddr      RTM_GETADDR v6         ✓ (inet6_ifaddr.idev->dev)
  *   dev_ioctl              SIOCGIF* by name       ✓ (ret -> -ENODEV)
  *   sock_ioctl             SIOCGIFCONF            ✓ (ifconf compaction)
- *   fib_dump_info          RTM_GETROUTE v4 dump   ✓ (#86; fib_info nexthop)
+ *   fib_dump_info          RTM_GETROUTE v4 dump   ✓ (#86; fib_info nexthop +
+ *                                                   public /32 host-route via a
+ *                                                   physical uplink, the .ko's
+ *                                                   is_public_host_route_via_
+ *                                                   physical — constant
+ *                                                   fib_rt_info offsets, A/B on
+ *                                                   5.10 + 6.12)
  *   rt6_fill_node          RTM_GETROUTE v6 dump   ✓ (fib6_info nexthop)
  *   fib_nl_fill_rule       RTM_GETRULE            ✓ (fib_rule iif/oif/uid)
  *   ( rt_fill_info — intentionally NOT hooked; unstable arg->reg ABI )
+ *
+ * PARITY GAP (TODO): the .ko also hides a public /128 IPv6 host-route pinned to
+ * a physical uplink (is_public_host_route6_via_physical). The KPM does not yet,
+ * because that needs the per-kver offset of fib6_info.fib6_dst (it varies, e.g.
+ * 64 on 5.10..6.6 vs 80 on 6.12 due to the new gc_link) added to kver_offsets.h
+ * and A/B-validated per version. The IPv4 host-route above needs no such offset
+ * (fib_rt_info.dst/dst_len are at a constant +12/+16 on 5.6+).
  */
 
 /* ------------------------------------------------------------------ */

--- a/kmod/kpm/vpnhide_kpm.c
+++ b/kmod/kpm/vpnhide_kpm.c
@@ -170,17 +170,36 @@ static int stats_slot_for_uid(uint32_t uid)
 	}
 
 	for (i = 0; i < MAX_TARGET_UIDS; i++) {
-		if (__atomic_load_n(&stats_used[i], __ATOMIC_ACQUIRE) != 0)
-			continue;
+		uint32_t st;
+
+		/* Wait out a concurrent claimer that is mid-init (state 2):
+		 * until it settles to state 1 we can't read its uid, and just
+		 * skipping it (the old code's `continue`) would let us allocate a
+		 * SECOND slot for the SAME uid. The init window is a few
+		 * instructions (CAS -> store uid -> store state 1), so this
+		 * settles immediately. */
+		while ((st = __atomic_load_n(&stats_used[i], __ATOMIC_ACQUIRE)) ==
+		       2)
+			;
+		if (st == 1) {
+			if (stats_uids[i] == uid)
+				return i; /* already ours */
+			continue; /* another uid owns this slot */
+		}
+		/* st == 0: free — try to claim it. */
 		if (__sync_bool_compare_and_swap(&stats_used[i], 0, 2)) {
 			stats_uids[i] = uid;
 			__sync_synchronize();
 			__atomic_store_n(&stats_used[i], 1, __ATOMIC_RELEASE);
 			return i;
 		}
-		if (__atomic_load_n(&stats_used[i], __ATOMIC_ACQUIRE) == 1 &&
-		    stats_uids[i] == uid)
-			return i;
+		/* Lost the CAS to a concurrent claimer — re-examine THIS slot (it
+		 * may be settling to our uid) instead of moving on and allocating
+		 * a duplicate. (A residual window remains only if two first-hits
+		 * for one uid claim two different free slots simultaneously; that
+		 * just splits a counter across two stats lines, never a crash —
+		 * a perfect lock-free find-or-insert needs a lock KP lacks.) */
+		i--;
 	}
 
 	return -1;

--- a/kmod/shared/test_vpnhide_logic.c
+++ b/kmod/shared/test_vpnhide_logic.c
@@ -76,6 +76,71 @@ static void test_start_offset_preserved(void)
 		   "tun9\tearlier-entry\nwlan0\tkeep\n");
 }
 
+static void expect_int(const char *what, int got, int want)
+{
+	if (got != want) {
+		fprintf(stderr, "FAIL %s: got %d want %d\n", what, got, want);
+		failures++;
+	}
+}
+
+static int pub4(unsigned char a, unsigned char b, unsigned char c,
+		unsigned char d)
+{
+	const unsigned char be[4] = { a, b, c, d };
+
+	return vpnhide_is_public_ipv4(be);
+}
+
+static void test_is_public_ipv4(void)
+{
+	/* Public. */
+	expect_int("ipv4 8.8.8.8", pub4(8, 8, 8, 8), 1);
+	expect_int("ipv4 1.2.3.4", pub4(1, 2, 3, 4), 1);
+	expect_int("ipv4 203.0.114.1", pub4(203, 0, 114, 1), 1);
+	/* Private / reserved / special — all rejected. */
+	expect_int("ipv4 0.x", pub4(0, 1, 2, 3), 0);
+	expect_int("ipv4 10/8", pub4(10, 0, 0, 1), 0);
+	expect_int("ipv4 127/8", pub4(127, 0, 0, 1), 0);
+	expect_int("ipv4 224/4", pub4(239, 0, 0, 1), 0);
+	expect_int("ipv4 100.64/10", pub4(100, 64, 0, 1), 0);
+	expect_int("ipv4 169.254/16", pub4(169, 254, 0, 1), 0);
+	expect_int("ipv4 172.16/12", pub4(172, 16, 0, 1), 0);
+	expect_int("ipv4 192.168/16", pub4(192, 168, 0, 1), 0);
+	expect_int("ipv4 192.0.2/24", pub4(192, 0, 2, 1), 0);
+	expect_int("ipv4 198.18/15", pub4(198, 19, 0, 1), 0);
+	expect_int("ipv4 198.51.100/24", pub4(198, 51, 100, 1), 0);
+	expect_int("ipv4 203.0.113/24", pub4(203, 0, 113, 1), 0);
+}
+
+static void test_is_public_ipv6(void)
+{
+	unsigned char gua[16] = { 0x26, 0x06, 0x47, 0 }; /* 2606:4700::  */
+	unsigned char ll[16] = { 0xfe, 0x80, 0 }; /* fe80::          */
+	unsigned char ula[16] = { 0xfc, 0, 0 }; /* fc00::            */
+	unsigned char loop[16] = { 0 }; /* ::                          */
+	unsigned char doc[16] = { 0x20, 0x01, 0x0d, 0xb8, 0 }; /* 2001:db8:: */
+
+	loop[15] = 1; /* ::1 */
+	expect_int("ipv6 2606:4700::", vpnhide_is_public_ipv6(gua), 1);
+	expect_int("ipv6 fe80::", vpnhide_is_public_ipv6(ll), 0);
+	expect_int("ipv6 fc00::", vpnhide_is_public_ipv6(ula), 0);
+	expect_int("ipv6 ::1", vpnhide_is_public_ipv6(loop), 0);
+	expect_int("ipv6 2001:db8::", vpnhide_is_public_ipv6(doc), 0);
+}
+
+static void test_is_physical_iface(void)
+{
+	expect_int("phys eth0", vpnhide_iface_is_physical("eth0"), 1);
+	expect_int("phys rmnet_data0", vpnhide_iface_is_physical("rmnet_data0"),
+		   1);
+	expect_int("phys WLAN0 (ci)", vpnhide_iface_is_physical("WLAN0"), 1);
+	expect_int("phys seth1", vpnhide_iface_is_physical("seth1"), 1);
+	expect_int("phys tun0 (no)", vpnhide_iface_is_physical("tun0"), 0);
+	expect_int("phys wg0 (no)", vpnhide_iface_is_physical("wg0"), 0);
+	expect_int("phys NULL", vpnhide_iface_is_physical((const char *)0), 0);
+}
+
 static void test_parse_uids(void)
 {
 	const char *in = "10010\n  10020 \n# a comment\n\n10030\nbad\n10040";
@@ -94,6 +159,9 @@ int main(void)
 	test_route_first_field();
 	test_ipv6_route_last_field();
 	test_start_offset_preserved();
+	test_is_public_ipv4();
+	test_is_public_ipv6();
+	test_is_physical_iface();
 	test_parse_uids();
 
 	if (failures) {

--- a/kmod/shared/vpnhide_logic.h
+++ b/kmod/shared/vpnhide_logic.h
@@ -344,14 +344,20 @@ static inline int vpnhide_tok_eq(const char *b, unsigned long ts,
 static inline int vpnhide_tok_decimal(const char *b, unsigned long ts,
 				      unsigned long te, unsigned long *out)
 {
-	unsigned long v = 0, p;
+	unsigned long v = 0, p, digit;
 
 	if (ts >= te)
 		return 0;
 	for (p = ts; p < te; p++) {
 		if (b[p] < '0' || b[p] > '9')
 			return 0;
-		v = v * 10u + (unsigned long)(b[p] - '0');
+		digit = (unsigned long)(b[p] - '0');
+		/* Reject values that would overflow unsigned long instead of
+		 * wrapping mod 2^64 and slipping past the version fuse — same
+		 * contract as the hex parser below. */
+		if (v > (~0UL - digit) / 10u)
+			return 0;
+		v = v * 10u + digit;
 	}
 	*out = v;
 	return 1;

--- a/kmod/shared/vpnhide_logic.h
+++ b/kmod/shared/vpnhide_logic.h
@@ -37,6 +37,107 @@ enum vpnhide_iface_field {
 		1, /* /proc/net/ipv6_route    — last ws field      */
 };
 
+/* ====================================================================== */
+/*  Public-host-route concealment predicates (shared by .ko + KPM).        */
+/*                                                                          */
+/*  A VPN client pins a host-route to the server's PUBLIC address on the    */
+/*  PHYSICAL uplink so tunnel packets can escape. That route leaks the      */
+/*  server's address through a routing-table dump even when the tun iface   */
+/*  is hidden, so both backends hide it. The byte/address logic below is    */
+/*  pure (no kernel types); each backend supplies the kernel-struct reads.  */
+/* ====================================================================== */
+
+/* Case-insensitive ASCII prefix test. Self-contained (freestanding): the
+ * generated iface_lists.h has an equivalent, but this header must not depend
+ * on it (or on libc). */
+static inline int vpnhide_str_starts_with_ci(const char *s, const char *prefix)
+{
+	unsigned int i;
+
+	if (!s || !prefix)
+		return 0;
+	for (i = 0; prefix[i]; i++) {
+		char a = s[i];
+		char b = prefix[i];
+
+		if (a >= 'A' && a <= 'Z')
+			a = (char)(a + ('a' - 'A'));
+		if (b >= 'A' && b <= 'Z')
+			b = (char)(b + ('a' - 'A'));
+		if (a != b)
+			return 0;
+	}
+	return 1;
+}
+
+/* A physical (non-tunnel) uplink by name prefix: the only device the
+ * host-route concealment fires on (a public route pinned to a tun is left to
+ * the normal VPN-iface matcher). rmnet/ccmni/ccemni/seth are cellular, wlan
+ * Wi-Fi, eth wired/tethering. */
+static inline int vpnhide_iface_is_physical(const char *name)
+{
+	if (!name)
+		return 0;
+	return vpnhide_str_starts_with_ci(name, "rmnet") ||
+	       vpnhide_str_starts_with_ci(name, "wlan") ||
+	       vpnhide_str_starts_with_ci(name, "eth") ||
+	       vpnhide_str_starts_with_ci(name, "ccmni") ||
+	       vpnhide_str_starts_with_ci(name, "ccemni") ||
+	       vpnhide_str_starts_with_ci(name, "seth");
+}
+
+/* Public-IPv4 test on the 4 network-order bytes of an address (be[0] is the
+ * first octet, so this is endianness-explicit — no host byte-swap needed).
+ * Rejects 0/8, 10/8, 127/8, 224/4+, 100.64/10, 169.254/16, 172.16/12,
+ * 192.168/16, and the 192.0.0/24, 192.0.2/24, 198.18/15, 198.51.100/24,
+ * 203.0.113/24 special blocks. */
+static inline int vpnhide_is_public_ipv4(const unsigned char *be)
+{
+	unsigned int a, b, c;
+
+	if (!be)
+		return 0;
+	a = be[0];
+	b = be[1];
+	c = be[2];
+	if (a == 0 || a == 10 || a == 127 || a >= 224)
+		return 0;
+	if (a == 100 && b >= 64 && b <= 127)
+		return 0;
+	if (a == 169 && b == 254)
+		return 0;
+	if (a == 172 && b >= 16 && b <= 31)
+		return 0;
+	if (a == 192 && b == 168)
+		return 0;
+	if (a == 192 && b == 0 && c == 0)
+		return 0;
+	if (a == 192 && b == 0 && c == 2)
+		return 0;
+	if (a == 198 && (b == 18 || b == 19))
+		return 0;
+	if (a == 198 && b == 51 && c == 100)
+		return 0;
+	if (a == 203 && b == 0 && c == 113)
+		return 0;
+	return 1;
+}
+
+/* Public-IPv6 test on the 16 address bytes (network order). Global unicast
+ * 2000::/3 only — excludes ::/::1 (unspec/loopback), fe80::/10 (link-local),
+ * fc00::/7 (ULA), ff00::/8 (multicast), and 2001:db8::/32 (documentation). */
+static inline int vpnhide_is_public_ipv6(const unsigned char *addr)
+{
+	if (!addr)
+		return 0;
+	if ((addr[0] & 0xe0) != 0x20)
+		return 0;
+	if (addr[0] == 0x20 && addr[1] == 0x01 && addr[2] == 0x0d &&
+	    addr[3] == 0xb8)
+		return 0;
+	return 1;
+}
+
 /*
  * Compact VPN lines out of a /proc/net seq-file buffer in place.
  *

--- a/kmod/test/init-kpm.sh
+++ b/kmod/test/init-kpm.sh
@@ -40,14 +40,29 @@ ip -6 addr add fd00:9::1/64 dev vpn0 2>/dev/null
 ip -6 route add fd00:99::/64 dev vpn0 2>/dev/null
 ip rule add uidrange 0-0 table 199 2>/dev/null
 
-# Public /32 host-route pinned to the physical uplink (eth0) — the route a VPN
-# client installs so tunnel packets reach the server. It leaks the server's
-# public IP through an RTM_GETROUTE dump even though vpn0 is hidden, so it must
-# be hidden for a target the same way the .ko hides it. eth0 is not a VPN iface,
-# so this exercises the public-host-route path, not iface_is_vpn.
-ip route add 1.2.3.4/32 dev eth0 2>/dev/null
-# IPv6 analogue: a public /128 host-route pinned to the physical uplink.
-ip -6 route add 2001:4860:4860::8888/128 dev eth0 2>/dev/null
+# Public host-route concealment is a GKI 5.6+ feature in the KPM: IPv4 uses the
+# constant fib_rt_info offsets (5.6+ fib_dump_info), IPv6 the per-kver fib6_dst
+# offset (only populated for GKI). On the legacy non-GKI kernels (<5.6: 4.14/
+# 4.19/5.4 the legacy job boots) it is intentionally disabled, so set up + assert
+# those vectors only when the running kernel actually supports them.
+KVER_MM=$(uname -r | sed 's/^\([0-9]*\.[0-9]*\).*/\1/')
+KVER_MAJ=${KVER_MM%.*}
+KVER_MIN=${KVER_MM#*.}
+if [ "$KVER_MAJ" -gt 5 ] || { [ "$KVER_MAJ" -eq 5 ] && [ "$KVER_MIN" -ge 6 ]; }; then
+	HOSTROUTE_OK=1
+else
+	HOSTROUTE_OK=0
+fi
+
+if [ "$HOSTROUTE_OK" = 1 ]; then
+	# Public /32 + /128 host-routes pinned to the physical uplink (eth0) — the
+	# routes a VPN client installs so tunnel packets reach the server. They
+	# leak the server's public IP through an RTM_GETROUTE dump even though vpn0
+	# is hidden, so they must be hidden for a target the way the .ko hides them.
+	# eth0 is not a VPN iface, so this exercises the public-host-route path.
+	ip route add 1.2.3.4/32 dev eth0 2>/dev/null
+	ip -6 route add 2001:4860:4860::8888/128 dev eth0 2>/dev/null
+fi
 
 # Vectors covered by the wired hooks. Count vpn0 hits as seen by root, then
 # count stable non-VPN entries so an over-trimmed empty dump fails loudly.
@@ -62,8 +77,13 @@ echo "VEC dev_ioctl=$(ifconfig vpn0 2>/dev/null | grep -c vpn0)"                
 echo "VEC keep_dev_ioctl=$(ifconfig eth0 2>/dev/null | grep -c '^eth0')"
 echo "VEC netlink_route4=$(ip route show table all 2>/dev/null | grep -c vpn0)"     # fib_dump_info (#86)
 echo "VEC keep_netlink_route4=$(ip route show table all 2>/dev/null | grep -c 'dev eth0')"
-echo "VEC hostroute4=$(ip route show table all 2>/dev/null | grep -c '1\.2\.3\.4')" # fib_dump_info public host-route
-echo "VEC hostroute6=$(ip -6 route show table all 2>/dev/null | grep -c '2001:4860')" # rt6_fill_node public host-route
+if [ "$HOSTROUTE_OK" = 1 ]; then
+	echo "VEC hostroute4=$(ip route show table all 2>/dev/null | grep -c '1\.2\.3\.4')" # fib_dump_info public host-route
+	echo "VEC hostroute6=$(ip -6 route show table all 2>/dev/null | grep -c '2001:4860')" # rt6_fill_node public host-route
+else
+	echo "VEC hostroute4=SKIP" # host-route disabled on non-GKI <5.6 kernels
+	echo "VEC hostroute6=SKIP"
+fi
 echo "VEC netlink_route6=$(ip -6 route show table all 2>/dev/null | grep -c vpn0)"  # rt6_fill_node
 echo "VEC policy_rule=$(ip rule show 2>/dev/null | grep -c 199)"                    # fib_nl_fill_rule
 echo "VEC keep_policy_rule=$(ip rule show 2>/dev/null | grep -c 'lookup main')"

--- a/kmod/test/init-kpm.sh
+++ b/kmod/test/init-kpm.sh
@@ -40,6 +40,13 @@ ip -6 addr add fd00:9::1/64 dev vpn0 2>/dev/null
 ip -6 route add fd00:99::/64 dev vpn0 2>/dev/null
 ip rule add uidrange 0-0 table 199 2>/dev/null
 
+# Public /32 host-route pinned to the physical uplink (eth0) — the route a VPN
+# client installs so tunnel packets reach the server. It leaks the server's
+# public IP through an RTM_GETROUTE dump even though vpn0 is hidden, so it must
+# be hidden for a target the same way the .ko hides it. eth0 is not a VPN iface,
+# so this exercises the public-host-route path, not iface_is_vpn.
+ip route add 1.2.3.4/32 dev eth0 2>/dev/null
+
 # Vectors covered by the wired hooks. Count vpn0 hits as seen by root, then
 # count stable non-VPN entries so an over-trimmed empty dump fails loudly.
 echo "VEC proc_route_v4=$(grep -c vpn0 /proc/net/route 2>/dev/null)"        # fib_route_seq_show
@@ -53,6 +60,7 @@ echo "VEC dev_ioctl=$(ifconfig vpn0 2>/dev/null | grep -c vpn0)"                
 echo "VEC keep_dev_ioctl=$(ifconfig eth0 2>/dev/null | grep -c '^eth0')"
 echo "VEC netlink_route4=$(ip route show table all 2>/dev/null | grep -c vpn0)"     # fib_dump_info (#86)
 echo "VEC keep_netlink_route4=$(ip route show table all 2>/dev/null | grep -c 'dev eth0')"
+echo "VEC hostroute4=$(ip route show table all 2>/dev/null | grep -c '1\.2\.3\.4')" # fib_dump_info public host-route
 echo "VEC netlink_route6=$(ip -6 route show table all 2>/dev/null | grep -c vpn0)"  # rt6_fill_node
 echo "VEC policy_rule=$(ip rule show 2>/dev/null | grep -c 199)"                    # fib_nl_fill_rule
 echo "VEC keep_policy_rule=$(ip rule show 2>/dev/null | grep -c 'lookup main')"

--- a/kmod/test/init-kpm.sh
+++ b/kmod/test/init-kpm.sh
@@ -46,6 +46,8 @@ ip rule add uidrange 0-0 table 199 2>/dev/null
 # be hidden for a target the same way the .ko hides it. eth0 is not a VPN iface,
 # so this exercises the public-host-route path, not iface_is_vpn.
 ip route add 1.2.3.4/32 dev eth0 2>/dev/null
+# IPv6 analogue: a public /128 host-route pinned to the physical uplink.
+ip -6 route add 2001:4860:4860::8888/128 dev eth0 2>/dev/null
 
 # Vectors covered by the wired hooks. Count vpn0 hits as seen by root, then
 # count stable non-VPN entries so an over-trimmed empty dump fails loudly.
@@ -61,6 +63,7 @@ echo "VEC keep_dev_ioctl=$(ifconfig eth0 2>/dev/null | grep -c '^eth0')"
 echo "VEC netlink_route4=$(ip route show table all 2>/dev/null | grep -c vpn0)"     # fib_dump_info (#86)
 echo "VEC keep_netlink_route4=$(ip route show table all 2>/dev/null | grep -c 'dev eth0')"
 echo "VEC hostroute4=$(ip route show table all 2>/dev/null | grep -c '1\.2\.3\.4')" # fib_dump_info public host-route
+echo "VEC hostroute6=$(ip -6 route show table all 2>/dev/null | grep -c '2001:4860')" # rt6_fill_node public host-route
 echo "VEC netlink_route6=$(ip -6 route show table all 2>/dev/null | grep -c vpn0)"  # rt6_fill_node
 echo "VEC policy_rule=$(ip rule show 2>/dev/null | grep -c 199)"                    # fib_nl_fill_rule
 echo "VEC keep_policy_rule=$(ip rule show 2>/dev/null | grep -c 'lookup main')"

--- a/kmod/test/init.sh
+++ b/kmod/test/init.sh
@@ -50,6 +50,12 @@ ip -6 addr add fd00:9::1/64 dev vpn0 2>/dev/null
 ip -6 route add fd00:99::/64 dev vpn0 2>/dev/null
 ip rule add uidrange 0-0 table 199 2>/dev/null
 
+# Public /32 host-route pinned to the physical uplink (eth0) — the route a VPN
+# client installs so tunnel packets reach the server. eth0 is not a VPN iface,
+# so hiding it from a target exercises is_public_host_route_via_physical, not
+# the VPN-name matcher.
+ip route add 1.2.3.4/32 dev eth0 2>/dev/null
+
 PASS=0
 FAIL=0
 
@@ -152,6 +158,7 @@ check_hide dev_ioctl       "ifconfig vpn0"                "vpn0"   # dev_ioctl
 check_hide proc_route_v4   "cat /proc/net/route"          "vpn0"   # fib_route_seq_show
 check_hide proc_route_v6   "cat /proc/net/ipv6_route"     "vpn0"   # ipv6_route_seq_show
 check_hide netlink_route4  "ip route show table all"      "vpn0"   # fib_dump_info
+check_hide hostroute4      "ip route show table all"      "1\.2\.3\.4" # fib_dump_info public host-route
 check_hide netlink_route6  "ip -6 route show table all"   "vpn0"   # rt6_fill_node
 check_hide policy_rule     "ip rule show"                 "199"    # fib_nl_fill_rule
 check_gai

--- a/kmod/test/init.sh
+++ b/kmod/test/init.sh
@@ -55,6 +55,8 @@ ip rule add uidrange 0-0 table 199 2>/dev/null
 # so hiding it from a target exercises is_public_host_route_via_physical, not
 # the VPN-name matcher.
 ip route add 1.2.3.4/32 dev eth0 2>/dev/null
+# IPv6 analogue: a public /128 host-route pinned to the physical uplink.
+ip -6 route add 2001:4860:4860::8888/128 dev eth0 2>/dev/null
 
 PASS=0
 FAIL=0
@@ -160,6 +162,7 @@ check_hide proc_route_v6   "cat /proc/net/ipv6_route"     "vpn0"   # ipv6_route_
 check_hide netlink_route4  "ip route show table all"      "vpn0"   # fib_dump_info
 check_hide hostroute4      "ip route show table all"      "1\.2\.3\.4" # fib_dump_info public host-route
 check_hide netlink_route6  "ip -6 route show table all"   "vpn0"   # rt6_fill_node
+check_hide hostroute6      "ip -6 route show table all"   "2001:4860" # rt6_fill_node public host-route
 check_hide policy_rule     "ip rule show"                 "199"    # fib_nl_fill_rule
 check_gai
 

--- a/kmod/test/run-kpm.sh
+++ b/kmod/test/run-kpm.sh
@@ -180,6 +180,11 @@ for vec in proc_route_v4 getifaddrs proc_route_v6 siocgifconf dev_ioctl netlink_
 	if [ "$vec" = gai_getifaddrs ] && [ -z "$GAI" ]; then
 		echo "RESULT $vec=SKIP (no bionic getifaddrs probe available)"; continue
 	fi
+	# init-kpm.sh emits `VEC <name>=SKIP` for a vector that doesn't apply to the
+	# running kernel (e.g. the host-route on non-GKI <5.6 kernels).
+	if grep -q "VEC $vec=SKIP" "$NT_LOG"; then
+		echo "RESULT $vec=SKIP (not supported on this kernel)"; continue
+	fi
 	nt="$(vec_count "$vec" "$NT_LOG")"
 	tg="$(vec_count "$vec" "$TG_LOG")"
 	if [ "$nt" -gt 0 ] && [ "$tg" -eq 0 ]; then

--- a/kmod/test/run-kpm.sh
+++ b/kmod/test/run-kpm.sh
@@ -173,7 +173,7 @@ echo "-------------------------------------------------------------------"
 [ "$(kpmload "$TG_LOG")" = ok ] || { echo "ERROR: KPM did not load (target boot)"; tail -20 "$TG_LOG"; exit 1; }
 
 PASS=0; FAIL=0
-for vec in proc_route_v4 getifaddrs proc_route_v6 siocgifconf dev_ioctl netlink_route4 hostroute4 netlink_route6 policy_rule gai_getifaddrs; do
+for vec in proc_route_v4 getifaddrs proc_route_v6 siocgifconf dev_ioctl netlink_route4 hostroute4 netlink_route6 hostroute6 policy_rule gai_getifaddrs; do
 	# The gai_getifaddrs vector only exists when the bionic probe is available
 	# (baked VPNHIDE_GAI_BIN, or built from an NDK on this host). If neither is
 	# present the probe can't run, so skip the vector instead of failing it.

--- a/kmod/test/run-kpm.sh
+++ b/kmod/test/run-kpm.sh
@@ -173,7 +173,7 @@ echo "-------------------------------------------------------------------"
 [ "$(kpmload "$TG_LOG")" = ok ] || { echo "ERROR: KPM did not load (target boot)"; tail -20 "$TG_LOG"; exit 1; }
 
 PASS=0; FAIL=0
-for vec in proc_route_v4 getifaddrs proc_route_v6 siocgifconf dev_ioctl netlink_route4 netlink_route6 policy_rule gai_getifaddrs; do
+for vec in proc_route_v4 getifaddrs proc_route_v6 siocgifconf dev_ioctl netlink_route4 hostroute4 netlink_route6 policy_rule gai_getifaddrs; do
 	# The gai_getifaddrs vector only exists when the bionic probe is available
 	# (baked VPNHIDE_GAI_BIN, or built from an NDK on this host). If neither is
 	# present the probe can't run, so skip the vector instead of failing it.

--- a/kmod/vpnhide_kmod.c
+++ b/kmod/vpnhide_kmod.c
@@ -859,8 +859,8 @@ static int fib_route_ret(struct kretprobe_instance *ri, struct pt_regs *regs)
 	 * Uses the shared compactor — the single implementation the KPM also
 	 * calls — instead of an open-coded copy.
 	 */
-	newc = vpnhide_compact_seq_lines(seq->buf, data->start_count, seq->count,
-					 VPNHIDE_FIELD_FIRST,
+	newc = vpnhide_compact_seq_lines(seq->buf, data->start_count,
+					 seq->count, VPNHIDE_FIELD_FIRST,
 					 vpnhide_iface_is_vpn);
 	if (newc != seq->count) {
 		seq->count = newc;
@@ -917,8 +917,8 @@ static int ipv6_route_ret(struct kretprobe_instance *ri, struct pt_regs *regs)
 	/* Same as fib_route_ret but the iface name is the LAST whitespace field
 	 * of each /proc/net/ipv6_route line — the shared compactor handles both
 	 * via the field selector. */
-	newc = vpnhide_compact_seq_lines(seq->buf, data->start_count, seq->count,
-					 VPNHIDE_FIELD_LAST,
+	newc = vpnhide_compact_seq_lines(seq->buf, data->start_count,
+					 seq->count, VPNHIDE_FIELD_LAST,
 					 vpnhide_iface_is_vpn);
 	if (newc != seq->count) {
 		seq->count = newc;

--- a/kmod/vpnhide_kmod.c
+++ b/kmod/vpnhide_kmod.c
@@ -997,71 +997,22 @@ static bool copy_dev_name(struct net_device *dev, char name[IFNAMSIZ])
 	return true;
 }
 
-static bool is_physical_ifname(const char *name)
-{
-	return vpnhide_iface_starts_with_ci(name, "rmnet") ||
-	       vpnhide_iface_starts_with_ci(name, "wlan") ||
-	       vpnhide_iface_starts_with_ci(name, "eth") ||
-	       vpnhide_iface_starts_with_ci(name, "ccmni") ||
-	       vpnhide_iface_starts_with_ci(name, "ccemni") ||
-	       vpnhide_iface_starts_with_ci(name, "seth");
-}
-
-static bool is_public_ipv4(__be32 addr)
-{
-	u32 host = be32_to_cpu(addr);
-	u8 a = (host >> 24) & 0xff;
-	u8 b = (host >> 16) & 0xff;
-	u8 c = (host >> 8) & 0xff;
-
-	if (a == 0 || a == 10 || a == 127 || a >= 224)
-		return false;
-	if (a == 100 && b >= 64 && b <= 127)
-		return false;
-	if (a == 169 && b == 254)
-		return false;
-	if (a == 172 && b >= 16 && b <= 31)
-		return false;
-	if (a == 192 && b == 168)
-		return false;
-	if (a == 192 && b == 0 && c == 0)
-		return false;
-	if (a == 192 && b == 0 && c == 2)
-		return false;
-	if (a == 198 && (b == 18 || b == 19))
-		return false;
-	if (a == 198 && b == 51 && c == 100)
-		return false;
-	if (a == 203 && b == 0 && c == 113)
-		return false;
-	return true;
-}
-
+/* A public /32 host-route pinned to a physical uplink — the route a VPN client
+ * installs so tunnel packets reach the server, leaking the server's IPv4 even
+ * when the tun iface is hidden. The address/iface logic is shared with the KPM
+ * (vpnhide_is_public_ipv4 / vpnhide_iface_is_physical in shared/vpnhide_logic.h);
+ * &fri->dst is the __be32's 4 network-order bytes. */
 static bool is_public_host_route_via_physical(const struct fib_rt_info *fri,
 					      struct net_device *dev)
 {
 	char name[IFNAMSIZ];
 
-	if (!fri || !dev || fri->dst_len != 32 || !is_public_ipv4(fri->dst))
+	if (!fri || !dev || fri->dst_len != 32 ||
+	    !vpnhide_is_public_ipv4((const unsigned char *)&fri->dst))
 		return false;
 	if (!copy_dev_name(dev, name))
 		return false;
-	return is_physical_ifname(name);
-}
-
-static bool is_public_ipv6(const struct in6_addr *addr)
-{
-	u8 b0 = addr->s6_addr[0];
-
-	/* Global unicast 2000::/3 only. Excludes ::/:: 1 (unspec/loopback),
-	 * fe80::/10 (link-local), fc00::/7 (ULA), ff00::/8 (multicast). */
-	if ((b0 & 0xe0) != 0x20)
-		return false;
-	/* 2001:db8::/32 documentation range. */
-	if (addr->s6_addr[0] == 0x20 && addr->s6_addr[1] == 0x01 &&
-	    addr->s6_addr[2] == 0x0d && addr->s6_addr[3] == 0xb8)
-		return false;
-	return true;
+	return vpnhide_iface_is_physical(name);
 }
 
 /* IPv6 analogue of is_public_host_route_via_physical: a /128 route to a
@@ -1069,7 +1020,8 @@ static bool is_public_ipv6(const struct in6_addr *addr)
  * client installs so tunnel packets can reach the server — it leaks the
  * server's IPv6 even when the tun interface itself is hidden. fib6_dst
  * (struct rt6key { struct in6_addr addr; int plen; }) is stable across
- * GKI 5.10..6.12; read it fault-safe since `rt` comes from a raw reg. */
+ * GKI 5.10..6.12; read it fault-safe since `rt` comes from a raw reg. The
+ * address/iface logic is shared with the KPM (shared/vpnhide_logic.h). */
 static bool is_public_host_route6_via_physical(struct fib6_info *rt,
 					       struct net_device *dev)
 {
@@ -1085,11 +1037,11 @@ static bool is_public_host_route6_via_physical(struct fib6_info *rt,
 		return false;
 	if (copy_from_kernel_nofault(&addr, &rt->fib6_dst.addr, sizeof(addr)) !=
 		    0 ||
-	    !is_public_ipv6(&addr))
+	    !vpnhide_is_public_ipv6(addr.s6_addr))
 		return false;
 	if (!copy_dev_name(dev, name))
 		return false;
-	return is_physical_ifname(name);
+	return vpnhide_iface_is_physical(name);
 }
 
 static struct net_device *dev_from_nexthop(struct nexthop *nh)

--- a/kmod/vpnhide_kmod.c
+++ b/kmod/vpnhide_kmod.c
@@ -119,6 +119,13 @@ static bool debug_enabled;
 static struct vpnhide_target targets[MAX_TARGET_UIDS];
 static int nr_targets;
 static DEFINE_SPINLOCK(targets_lock);
+/* OR of every target's hookmask — a lock-free fast-path gate so hook_active()
+ * can reject the common case (a hook enabled for nobody, e.g. no targets yet)
+ * with a single atomic-free read instead of acquiring targets_lock on every
+ * hooked syscall. Recomputed under targets_lock on each config apply; a torn
+ * read only costs a brief over- or under-filter around a (rare) config change.
+ * Mirrors the KPM's active_hook_mask. */
+static u32 active_hook_mask;
 
 /* The enabled-hook mask for the calling UID (0 if it is not a target). */
 static u32 target_mask(void)
@@ -139,9 +146,12 @@ static u32 target_mask(void)
 }
 
 /* True if `hook_id` is enabled for the calling UID (per-hook gate, §4.3).
- * The .ko owns the full kernel hook mask, so it never masks foreign bits. */
+ * The .ko owns the full kernel hook mask, so it never masks foreign bits.
+ * Fast path: if no target enables this hook, skip the per-uid lock+scan. */
 static bool hook_active(u32 hook_id)
 {
+	if (!(READ_ONCE(active_hook_mask) & (1u << hook_id)))
+		return false;
 	return (target_mask() & (1u << hook_id)) != 0;
 }
 
@@ -246,6 +256,14 @@ static ssize_t ctl_write(struct file *file, const char __user *ubuf,
 	spin_lock(&targets_lock);
 	memcpy(targets, newt, (size_t)n * sizeof(*targets));
 	nr_targets = n;
+	{
+		u32 mask = 0;
+		int i;
+
+		for (i = 0; i < n; i++)
+			mask |= newt[i].hookmask & VPNHIDE_KERNEL_HOOK_MASK;
+		WRITE_ONCE(active_hook_mask, mask);
+	}
 	spin_unlock(&targets_lock);
 	WRITE_ONCE(debug_enabled, dbg ? true : false);
 
@@ -828,58 +846,26 @@ static int fib_route_ret(struct kretprobe_instance *ri, struct pt_regs *regs)
 {
 	struct fib_route_data *data = (void *)ri->data;
 	struct seq_file *seq = data->seq;
-	char *buf, *src, *dst, *end;
-	char ifname[IFNAMSIZ];
-	int j;
+	unsigned long newc;
 
 	if (!data->target || !seq || !seq->buf)
 		return 0;
-
 	if (seq->count <= data->start_count)
 		return 0;
 
 	/*
-	 * Scan the region [start_count, seq->count) for lines whose
-	 * first tab-separated field is a VPN interface name. Compact
-	 * out matching lines in place and adjust seq->count.
-	 *
-	 * Each route line looks like: "tun0\t08000000\t...\n"
+	 * Compact out lines whose FIRST tab-separated field (each route line is
+	 * "tun0\t08000000\t...\n") is a VPN iface name, in [start_count, count).
+	 * Uses the shared compactor — the single implementation the KPM also
+	 * calls — instead of an open-coded copy.
 	 */
-	buf = seq->buf;
-	src = buf + data->start_count;
-	dst = src;
-	end = buf + seq->count;
-
-	while (src < end) {
-		char *nl = memchr(src, '\n', end - src);
-		char *line_end = nl ? nl + 1 : end;
-		size_t line_len = line_end - src;
-
-		/* Extract the interface name (first field, tab-delimited) */
-		for (j = 0; j < IFNAMSIZ - 1 && j < (int)line_len &&
-			    src[j] != '\t' && src[j] != '\n';
-		     j++)
-			ifname[j] = src[j];
-		ifname[j] = '\0';
-
-		if (is_vpn_ifname(ifname)) {
-			vpnhide_dbg("fib_route_ret: hiding route for %s\n",
-				    ifname);
-			/* Skip this line */
-			src = line_end;
-			continue;
-		}
-
-		/* Keep this line — move it down if there's a gap */
-		if (dst != src)
-			memmove(dst, src, line_len);
-		dst += line_len;
-		src = line_end;
-	}
-
-	seq->count = dst - buf;
-	if (seq->count != (size_t)(end - buf))
+	newc = vpnhide_compact_seq_lines(seq->buf, data->start_count, seq->count,
+					 VPNHIDE_FIELD_FIRST,
+					 vpnhide_iface_is_vpn);
+	if (newc != seq->count) {
+		seq->count = newc;
 		record_hook_hit(VPNHIDE_HOOK_FIB_ROUTE_SEQ_SHOW);
+	}
 	return 0;
 }
 
@@ -921,57 +907,23 @@ static int ipv6_route_ret(struct kretprobe_instance *ri, struct pt_regs *regs)
 {
 	struct fib_route_data *data = (void *)ri->data;
 	struct seq_file *seq = data->seq;
-	char *buf, *src, *dst, *end;
-	char ifname[IFNAMSIZ];
-	int j;
+	unsigned long newc;
 
 	if (!data->target || !seq || !seq->buf)
 		return 0;
 	if (seq->count <= data->start_count)
 		return 0;
 
-	buf = seq->buf;
-	src = buf + data->start_count;
-	dst = src;
-	end = buf + seq->count;
-
-	while (src < end) {
-		char *nl = memchr(src, '\n', end - src);
-		char *line_end = nl ? nl + 1 : end;
-		size_t line_len = line_end - src;
-		char *field_start;
-		char *field_end = line_end;
-
-		while (field_end > src &&
-		       (field_end[-1] == '\n' || field_end[-1] == '\r' ||
-			field_end[-1] == ' ' || field_end[-1] == '\t'))
-			field_end--;
-		field_start = field_end;
-		while (field_start > src && field_start[-1] != ' ' &&
-		       field_start[-1] != '\t')
-			field_start--;
-
-		for (j = 0; j < IFNAMSIZ - 1 && (field_start + j) < field_end;
-		     j++)
-			ifname[j] = field_start[j];
-		ifname[j] = '\0';
-
-		if (is_vpn_ifname(ifname)) {
-			vpnhide_dbg("ipv6_route_ret: hiding route for %s\n",
-				    ifname);
-			src = line_end;
-			continue;
-		}
-
-		if (dst != src)
-			memmove(dst, src, line_len);
-		dst += line_len;
-		src = line_end;
-	}
-
-	seq->count = dst - buf;
-	if (seq->count != (size_t)(end - buf))
+	/* Same as fib_route_ret but the iface name is the LAST whitespace field
+	 * of each /proc/net/ipv6_route line — the shared compactor handles both
+	 * via the field selector. */
+	newc = vpnhide_compact_seq_lines(seq->buf, data->start_count, seq->count,
+					 VPNHIDE_FIELD_LAST,
+					 vpnhide_iface_is_vpn);
+	if (newc != seq->count) {
+		seq->count = newc;
 		record_hook_hit(VPNHIDE_HOOK_IPV6_ROUTE_SEQ_SHOW);
+	}
 	return 0;
 }
 


### PR DESCRIPTION
The kmod kernel-behavior batch from the codebase audit (`.ko` + KPM). Stacked on #202; retarget to main once that merges. Every change validated A/B in the local QEMU harness and (on push) by CI's per-KMI `kmod-qemu` + `kpm-qemu` matrix across all 7 KMIs.

**Fixed**

- **Public host-route parity (HIGH).** The KPM only hid a route whose output device was a VPN iface, missing the public `/32`·`/128` host-route a VPN client pins to the *physical* uplink to reach the server — the `.ko` hides it, the KPM didn't, leaking the server's address through a route dump even with the tun hidden. The pure predicates (`vpnhide_is_public_ipv4/ipv6`, `vpnhide_iface_is_physical`) are now **shared** in `shared/vpnhide_logic.h` and used by both backends; each keeps only its own kernel-struct read. IPv4 needs no offset (constant `fib_rt_info` +12/+16); IPv6 uses a per-kver `fib6_info.fib6_dst` offset (64 on 5.10/5.15/6.1/6.6, 80 on 6.12; disabled on non-GKI). Host unit tests + `hostroute4`/`hostroute6` vectors on both harnesses.
- **KPM config race.** `ctl0` parsed a CONFIG straight into the live `targets[]` while hooks read it lock-free on other CPUs. Now double-buffered: parse into a staging set, publish with one release-store; readers acquire-load one consistent snapshot.
- **`.ko` shared compactor.** `fib_route_ret`/`ipv6_route_ret` hand-rolled the seq-line compaction the shared `vpnhide_compact_seq_lines` (which the KPM already calls) provides; replaced with the shared call.
- **`.ko` lock-free `hook_active` gate.** Added an `active_hook_mask` fast-path so a hooked syscall skips the `targets_lock` acquire when no target enables the hook, matching the KPM.
- **KPM stats-slot race.** `stats_slot_for_uid` could give one uid two slots (split counters) by skipping a mid-init slot or moving on after a lost CAS; now waits out the init window and re-examines on a lost CAS.

**Documented as known narrow gaps** (need a dedicated probe + atomic-context kernel changes; both `SIOCGIFCONF` subcases, both offered as "document" by the audit): the size-query (`ifc_req == NULL`) length leak and the 32-bit `compat_sock_ioctl` path — see `docs/detection-vectors.md`.