### PR TITLE
kmod host-route: cover the legacy kernels (4.14/4.19/5.4), document the 32-bit SIOCGIFCONF gap

### DIFF
--- a/changelog.d/added-kpm-public-host-route-concealment-ipv4-ee6f.md
+++ b/changelog.d/added-kpm-public-host-route-concealment-ipv4-ee6f.md
@@ -1,0 +1,9 @@
+_2026-06-30_
+
+## English
+
+KPM: public host-route concealment (IPv4 /32 and IPv6 /128 routes to the VPN server, pinned to a physical interface) now also covers the legacy kernels 4.14, 4.19, and 5.4
+
+## Русский
+
+KPM: скрытие публичного host-route VPN-сервера (маршруты IPv4 /32 и IPv6 /128 на физическом интерфейсе) теперь работает и на устаревших ядрах 4.14, 4.19 и 5.4

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -81,6 +81,27 @@ Follow-up work (low priority):
   the reply skb to a physical ifindex, instead of reading a fixed register
   off the static `rt_fill_info`.
 
+### 32-bit (compat) SIOCGIFCONF enumeration (low priority)
+
+The kmod `.ko` filters `SIOCGIFCONF` interface enumeration via a kretprobe on
+`sock_ioctl`. A **32-bit** app's `SIOCGIFCONF` enters the kernel through
+`compat_sock_ioctl` → `compat_dev_ifconf` and never reaches `sock_ioctl`, so its
+enumeration is not filtered (it sees VPN interfaces). The size-query subcase of
+the 64-bit path (the `ifc_req == NULL` length query) is likewise unfiltered.
+Both are tracked in [detection-vectors.md](detection-vectors.md) (the SIOCGIFCONF
+notes).
+
+This is **low priority**: most current Android apps are 64-bit, and modern
+interface enumeration uses netlink `getifaddrs` (covered by the rtnl/inet fill
+hooks), not the legacy `SIOCGIFCONF`. zygisk (its own `getifaddrs`/procfs
+filtering) is unaffected.
+
+Follow-up work (low priority — may revisit):
+
+- Register a second kretprobe on `compat_sock_ioctl` and filter `SIOCGIFCONF`
+  there using the compat `struct ifconf` / `struct ifreq` layout (32-bit
+  pointers and `ifr_name` offset), mirroring the `sock_ioctl_ret` compaction.
+
 ## Diagnostics And Observability
 
 - Add optional per-hook interception counters so users can see which apps are

--- a/kmod/kpm/kver_offsets.h
+++ b/kmod/kpm/kver_offsets.h
@@ -85,9 +85,13 @@ struct vpnhide_offsets {
 
 	/* Pre-fib6_info kernels (<= 4.14): rt6_fill_node takes a struct rt6_info*
 	 * (which begins with a struct dst_entry), not a fib6_info. When
-	 * rt6_via_dst is set, dev = *(rt + rt6_dst_dev) (dst_entry.dev). */
+	 * rt6_via_dst is set, dev = *(rt + rt6_dst_dev) (dst_entry.dev), and the
+	 * route's destination is rt6_info.rt6i_dst (a rt6key) at rt6_dst (the
+	 * fib6_info_fib6_dst above is for the fib6_info path; 0 disables the v6
+	 * host-route check). */
 	int rt6_via_dst;
 	unsigned int rt6_dst_dev;
+	unsigned int rt6_dst;
 
 	/* Policy rules (fib_nl_fill_rule -> struct fib_rule). */
 	unsigned int fib_rule_table;
@@ -379,6 +383,11 @@ static const struct vpnhide_offsets vpnhide_off_4_x = {
 	.fib6_info_fib6_nh = 0,
 	.rt6_via_dst = 1,
 	.rt6_dst_dev = 0,
+	/* rt6_info.rt6i_dst (rt6key) is ____cacheline_aligned_in_smp: dst_entry is
+	 * 160B (config-independent — the __pads keep it constant), the rt6_info
+	 * prefix runs to +220, rounded up to a cacheline -> @256 (same for 64- or
+	 * 128-byte lines). QEMU-validated on the legacy 4.14 image. */
+	.rt6_dst = 256,
 	/* struct fib_rule layout matches 5.10; the symbol is fib_nl_fill_rule
 	 * .isra.N under gcc — the fuzzy resolver finds it. */
 	.fib_rule_table = 36,

--- a/kmod/kpm/kver_offsets.h
+++ b/kmod/kpm/kver_offsets.h
@@ -285,12 +285,11 @@ static const struct vpnhide_offsets vpnhide_off_5_4 = {
 	.fib_dump_fi_arg = 9,
 	.fib_dump_fi_via_fri = 0,
 	/* fib6_info: rt6key=20, NO KABI reserve -> nh@152, fib6_nh[]@160. fib6_dst
-	 * is almost certainly @64 (same head as 5.10), but 5.4 is not in the QEMU
-	 * matrix, so leave the public-/128-host-route check disabled here (0) rather
-	 * than ship an unvalidated offset — the .ko covers 5.4-class devices anyway. */
+	 * is the first rt6key after fib6_metrics@56 -> @64 (head identical to 5.10);
+	 * QEMU-validated on the legacy 5.4 image (kpm-qemu-legacy). */
 	.fib6_info_nh = 152,
 	.fib6_info_fib6_nh = 160,
-	.fib6_info_fib6_dst = 0,
+	.fib6_info_fib6_dst = 64,
 	/* struct fib_rule layout identical to 5.10. */
 	.fib_rule_table = 36,
 	.fib_rule_iifname = 88,
@@ -333,9 +332,10 @@ static const struct vpnhide_offsets vpnhide_off_4_19 = {
 	 * (Without ROUTER_PREF it would be @168 — config-sensitive.) */
 	.fib6_info_nh = 0,
 	.fib6_info_fib6_nh = 176,
-	/* 4.19's fib6_info head differs (config-sensitive) and is not in the QEMU
-	 * matrix, so leave the public-/128-host-route check disabled (0). */
-	.fib6_info_fib6_dst = 0,
+	/* 4.19 fib6_info: list_head fib6_siblings (16, no union) then nsiblings/
+	 * ref/expires/metrics -> fib6_dst, the first rt6key, lands @64 (same as 5.4/
+	 * 5.10). QEMU-validated on the legacy 4.19 image. */
+	.fib6_info_fib6_dst = 64,
 	/* struct fib_rule layout identical to 5.4/5.10. */
 	.fib_rule_table = 36,
 	.fib_rule_iifname = 88,

--- a/kmod/kpm/vpnhide_kpm.c
+++ b/kmod/kpm/vpnhide_kpm.c
@@ -320,20 +320,25 @@ static int kpm_is_public_host_route4(hook_fargs12_t *fargs, const void *p,
 /* IPv6 analogue of kpm_is_public_host_route4: a public /128 host-route pinned to
  * a physical uplink (the route a VPN client installs to reach the server, which
  * leaks its IPv6 even when the tun is hidden — the .ko's
- * is_public_host_route6_via_physical). Reads fib6_info.fib6_dst (rt6key { addr@0;
- * int plen@16 }) at the per-kver offset; off->fib6_info_fib6_dst == 0 disables
- * it (the pre-fib6_info 4.14 rt6_info path, and non-GKI kernels the QEMU matrix
- * can't validate). `rt` is the fib6_info* arg to rt6_fill_node and fib6_dst sits
- * before fib6_nh — which dev_from_fib6_info already reads — so it is in-bounds.
- * The address/iface logic is shared with the .ko (shared/vpnhide_logic.h). */
+ * is_public_host_route6_via_physical). The route's destination is a rt6key
+ * { in6_addr addr@0; int plen@16 } whose offset depends on the kernel's IPv6
+ * route model: in fib6_info at off->fib6_info_fib6_dst (5.x/6.x), or in the
+ * embedded rt6_info at off->rt6_dst on the pre-fib6_info rt6_via_dst path (4.14).
+ * A 0 offset for the active model disables the check. `rt` is the route arg to
+ * rt6_fill_node; the rt6key sits within the struct dev_from_fib6_info already
+ * reads, so it is in-bounds. Address/iface logic shared with the .ko. */
 static int kpm_is_public_host_route6(void *rt, void *dev)
 {
 	const unsigned char *dst;
+	unsigned int dst_off;
 	int plen;
 
-	if (!rt || !dev || !off->fib6_info_fib6_dst)
+	if (!rt || !dev)
 		return 0;
-	dst = (const unsigned char *)rt + off->fib6_info_fib6_dst;
+	dst_off = off->rt6_via_dst ? off->rt6_dst : off->fib6_info_fib6_dst;
+	if (!dst_off)
+		return 0;
+	dst = (const unsigned char *)rt + dst_off;
 	plen = *(const int *)(dst + 16); /* rt6key.plen */
 	if (plen != 128)
 		return 0;
@@ -869,20 +874,18 @@ static void fib_rule_after(hook_fargs8_t *fargs, void *udata)
  *                                                   public /128 host-route via a
  *                                                   physical uplink, the .ko's
  *                                                   is_public_host_route6_via_
- *                                                   physical — per-kver
- *                                                   fib6_info.fib6_dst offset,
- *                                                   A/B on 5.10/5.15/6.1/6.12 +
- *                                                   legacy 5.4/4.19; NOT 4.14,
- *                                                   which uses rt6_info)
+ *                                                   physical — A/B on every kver
+ *                                                   5.10/5.15/6.1/6.12 + legacy
+ *                                                   5.4/4.19/4.14)
  *   fib_nl_fill_rule       RTM_GETRULE            ✓ (fib_rule iif/oif/uid)
  *   ( rt_fill_info — intentionally NOT hooked; unstable arg->reg ABI )
  *
  * Both host-route predicates (v4 + v6) and their address/iface logic are now
- * shared with the .ko via shared/vpnhide_logic.h. The IPv4 path needs no offset
- * (fib_rt_info.dst/dst_len at a constant +12/+16 on 5.6+; dst/dst_len passed as
- * args 6/7 on <5.6); the IPv6 path reads fib6_info.fib6_dst at the per-kver
- * offset (64 on 5.4/4.19/5.10..6.6, 80 on 6.12; 0/disabled on 4.14, which uses
- * rt6_info with a cacheline-aligned rt6i_dst we carry no offset for).
+ * shared with the .ko via shared/vpnhide_logic.h, and cover EVERY supported kver.
+ * IPv4 needs no offset (fib_rt_info.dst/dst_len at a constant +12/+16 on 5.6+;
+ * dst/dst_len passed as args 6/7 on <5.6). IPv6 reads the route's rt6key from
+ * fib6_info.fib6_dst (64 on 5.4/4.19/5.10..6.6, 80 on 6.12) or, on the 4.14
+ * rt6_via_dst path, rt6_info.rt6i_dst (rt6_dst @256).
  */
 
 /* ------------------------------------------------------------------ */

--- a/kmod/kpm/vpnhide_kpm.c
+++ b/kmod/kpm/vpnhide_kpm.c
@@ -287,16 +287,32 @@ static const char *netdev_name(void *dev)
  * dst_len (int) at +16 (struct fib_rt_info is stable across GKI 5.10..6.12,
  * verified against the kernel sources). The fri is stack-resident in the
  * caller, so reading those two fields is in-bounds. */
-static int kpm_is_public_host_route4(const void *fri, void *dev)
+static int kpm_is_public_host_route4(hook_fargs12_t *fargs, const void *p,
+				     void *dev)
 {
+	const unsigned char *dst_be;
+	uint32_t dst_val = 0;
 	int dst_len;
 
-	if (!fri || !dev)
+	if (!dev)
 		return 0;
-	dst_len = *(const int *)((const char *)fri + 16);
+	if (off->fib_dump_fi_via_fri) {
+		/* 5.6+: p is a fib_rt_info* with __be32 dst @+12, int dst_len
+		 * @+16 (constant across GKI 5.10..6.12). */
+		dst_len = *(const int *)((const char *)p + 16);
+		dst_be = (const unsigned char *)p + 12;
+	} else {
+		/* <5.6 (5.4/4.19/4.14): fib_dump_info(skb,...,tb_id,type,dst,
+		 * dst_len,...) passes the __be32 dst by value in arg 6 and
+		 * dst_len in arg 7. The register holds the network-order value,
+		 * so the in-memory bytes of a local copy are the octets a.b.c.d. */
+		dst_val = (uint32_t)fargs->args[6];
+		dst_len = (int)fargs->args[7];
+		dst_be = (const unsigned char *)&dst_val;
+	}
 	if (dst_len != 32)
 		return 0;
-	if (!vpnhide_is_public_ipv4((const unsigned char *)fri + 12))
+	if (!vpnhide_is_public_ipv4(dst_be))
 		return 0;
 	return vpnhide_iface_is_physical(netdev_name(dev));
 }
@@ -680,12 +696,12 @@ static void fib_dump_before(hook_fargs12_t *fargs, void *udata)
 	dev = dev_from_fib_info(fi);
 	if (!dev)
 		return;
-	/* Hide the route if its output dev is a VPN iface, OR (5.6+ only, where
-	 * dst/dst_len live at fixed offsets in the fib_rt_info) it is a public
-	 * /32 host-route pinned to a physical uplink — the .ko hides both, so the
-	 * KPM must too for backend parity. */
+	/* Hide the route if its output dev is a VPN iface, OR it is a public /32
+	 * host-route pinned to a physical uplink — the .ko hides both, so the KPM
+	 * must too for backend parity. Works on both the 5.6+ fib_rt_info ABI and
+	 * the <5.6 (5.4/4.19/4.14) dst/dst_len-as-args ABI. */
 	if (!iface_is_vpn(netdev_name(dev)) &&
-	    !(off->fib_dump_fi_via_fri && kpm_is_public_host_route4(p, dev)))
+	    !kpm_is_public_host_route4(fargs, p, dev))
 		return;
 
 	fargs->local.data0 = 1;
@@ -846,24 +862,27 @@ static void fib_rule_after(hook_fargs8_t *fargs, void *udata)
  *                                                   public /32 host-route via a
  *                                                   physical uplink, the .ko's
  *                                                   is_public_host_route_via_
- *                                                   physical — constant
- *                                                   fib_rt_info offsets, A/B on
- *                                                   5.10 + 6.12)
+ *                                                   physical — A/B on every kver
+ *                                                   5.10/5.15/6.1/6.12 + legacy
+ *                                                   5.4/4.19/4.14)
  *   rt6_fill_node          RTM_GETROUTE v6 dump   ✓ (fib6_info nexthop +
  *                                                   public /128 host-route via a
  *                                                   physical uplink, the .ko's
  *                                                   is_public_host_route6_via_
  *                                                   physical — per-kver
  *                                                   fib6_info.fib6_dst offset,
- *                                                   A/B on 5.10/5.15/6.1/6.12)
+ *                                                   A/B on 5.10/5.15/6.1/6.12 +
+ *                                                   legacy 5.4/4.19; NOT 4.14,
+ *                                                   which uses rt6_info)
  *   fib_nl_fill_rule       RTM_GETRULE            ✓ (fib_rule iif/oif/uid)
  *   ( rt_fill_info — intentionally NOT hooked; unstable arg->reg ABI )
  *
  * Both host-route predicates (v4 + v6) and their address/iface logic are now
  * shared with the .ko via shared/vpnhide_logic.h. The IPv4 path needs no offset
- * (fib_rt_info.dst/dst_len are at a constant +12/+16 on 5.6+); the IPv6 path
- * reads fib6_info.fib6_dst at the per-kver offset (64 on 5.10..6.6, 80 on 6.12),
- * disabled (0) on the non-GKI kernels the QEMU matrix can't validate.
+ * (fib_rt_info.dst/dst_len at a constant +12/+16 on 5.6+; dst/dst_len passed as
+ * args 6/7 on <5.6); the IPv6 path reads fib6_info.fib6_dst at the per-kver
+ * offset (64 on 5.4/4.19/5.10..6.6, 80 on 6.12; 0/disabled on 4.14, which uses
+ * rt6_info with a cacheline-aligned rt6i_dst we carry no offset for).
  */
 
 /* ------------------------------------------------------------------ */

--- a/kmod/test/init-kpm.sh
+++ b/kmod/test/init-kpm.sh
@@ -40,27 +40,30 @@ ip -6 addr add fd00:9::1/64 dev vpn0 2>/dev/null
 ip -6 route add fd00:99::/64 dev vpn0 2>/dev/null
 ip rule add uidrange 0-0 table 199 2>/dev/null
 
-# Public host-route concealment is a GKI 5.6+ feature in the KPM: IPv4 uses the
-# constant fib_rt_info offsets (5.6+ fib_dump_info), IPv6 the per-kver fib6_dst
-# offset (only populated for GKI). On the legacy non-GKI kernels (<5.6: 4.14/
-# 4.19/5.4 the legacy job boots) it is intentionally disabled, so set up + assert
-# those vectors only when the running kernel actually supports them.
+# Public host-route concealment in the KPM: IPv4 works on EVERY supported kernel
+# (5.6+ via the fib_rt_info ABI, <5.6 via the dst/dst_len args). IPv6 needs
+# fib6_info.fib6_dst, populated for every kver EXCEPT 4.14 (which uses rt6_info,
+# whose cacheline-aligned rt6i_dst we carry no offset for). So always test
+# hostroute4; skip hostroute6 only on 4.14.
 KVER_MM=$(uname -r | sed 's/^\([0-9]*\.[0-9]*\).*/\1/')
 KVER_MAJ=${KVER_MM%.*}
 KVER_MIN=${KVER_MM#*.}
-if [ "$KVER_MAJ" -gt 5 ] || { [ "$KVER_MAJ" -eq 5 ] && [ "$KVER_MIN" -ge 6 ]; }; then
-	HOSTROUTE_OK=1
+HOSTROUTE4_OK=1
+if [ "$KVER_MAJ" -eq 4 ] && [ "$KVER_MIN" -eq 14 ]; then
+	HOSTROUTE6_OK=0
 else
-	HOSTROUTE_OK=0
+	HOSTROUTE6_OK=1
 fi
 
-if [ "$HOSTROUTE_OK" = 1 ]; then
-	# Public /32 + /128 host-routes pinned to the physical uplink (eth0) — the
-	# routes a VPN client installs so tunnel packets reach the server. They
-	# leak the server's public IP through an RTM_GETROUTE dump even though vpn0
-	# is hidden, so they must be hidden for a target the way the .ko hides them.
-	# eth0 is not a VPN iface, so this exercises the public-host-route path.
+# Public /32 + /128 host-routes pinned to the physical uplink (eth0) — the routes
+# a VPN client installs so tunnel packets reach the server. They leak the server's
+# public IP through an RTM_GETROUTE dump even though vpn0 is hidden, so they must
+# be hidden for a target the way the .ko hides them. eth0 is not a VPN iface, so
+# this exercises the public-host-route path, not iface_is_vpn.
+if [ "$HOSTROUTE4_OK" = 1 ]; then
 	ip route add 1.2.3.4/32 dev eth0 2>/dev/null
+fi
+if [ "$HOSTROUTE6_OK" = 1 ]; then
 	ip -6 route add 2001:4860:4860::8888/128 dev eth0 2>/dev/null
 fi
 
@@ -77,12 +80,15 @@ echo "VEC dev_ioctl=$(ifconfig vpn0 2>/dev/null | grep -c vpn0)"                
 echo "VEC keep_dev_ioctl=$(ifconfig eth0 2>/dev/null | grep -c '^eth0')"
 echo "VEC netlink_route4=$(ip route show table all 2>/dev/null | grep -c vpn0)"     # fib_dump_info (#86)
 echo "VEC keep_netlink_route4=$(ip route show table all 2>/dev/null | grep -c 'dev eth0')"
-if [ "$HOSTROUTE_OK" = 1 ]; then
+if [ "$HOSTROUTE4_OK" = 1 ]; then
 	echo "VEC hostroute4=$(ip route show table all 2>/dev/null | grep -c '1\.2\.3\.4')" # fib_dump_info public host-route
+else
+	echo "VEC hostroute4=SKIP"
+fi
+if [ "$HOSTROUTE6_OK" = 1 ]; then
 	echo "VEC hostroute6=$(ip -6 route show table all 2>/dev/null | grep -c '2001:4860')" # rt6_fill_node public host-route
 else
-	echo "VEC hostroute4=SKIP" # host-route disabled on non-GKI <5.6 kernels
-	echo "VEC hostroute6=SKIP"
+	echo "VEC hostroute6=SKIP" # 4.14 uses rt6_info; no fib6_dst offset carried
 fi
 echo "VEC netlink_route6=$(ip -6 route show table all 2>/dev/null | grep -c vpn0)"  # rt6_fill_node
 echo "VEC policy_rule=$(ip rule show 2>/dev/null | grep -c 199)"                    # fib_nl_fill_rule

--- a/kmod/test/init-kpm.sh
+++ b/kmod/test/init-kpm.sh
@@ -40,32 +40,15 @@ ip -6 addr add fd00:9::1/64 dev vpn0 2>/dev/null
 ip -6 route add fd00:99::/64 dev vpn0 2>/dev/null
 ip rule add uidrange 0-0 table 199 2>/dev/null
 
-# Public host-route concealment in the KPM: IPv4 works on EVERY supported kernel
-# (5.6+ via the fib_rt_info ABI, <5.6 via the dst/dst_len args). IPv6 needs
-# fib6_info.fib6_dst, populated for every kver EXCEPT 4.14 (which uses rt6_info,
-# whose cacheline-aligned rt6i_dst we carry no offset for). So always test
-# hostroute4; skip hostroute6 only on 4.14.
-KVER_MM=$(uname -r | sed 's/^\([0-9]*\.[0-9]*\).*/\1/')
-KVER_MAJ=${KVER_MM%.*}
-KVER_MIN=${KVER_MM#*.}
-HOSTROUTE4_OK=1
-if [ "$KVER_MAJ" -eq 4 ] && [ "$KVER_MIN" -eq 14 ]; then
-	HOSTROUTE6_OK=0
-else
-	HOSTROUTE6_OK=1
-fi
-
 # Public /32 + /128 host-routes pinned to the physical uplink (eth0) — the routes
 # a VPN client installs so tunnel packets reach the server. They leak the server's
 # public IP through an RTM_GETROUTE dump even though vpn0 is hidden, so they must
 # be hidden for a target the way the .ko hides them. eth0 is not a VPN iface, so
-# this exercises the public-host-route path, not iface_is_vpn.
-if [ "$HOSTROUTE4_OK" = 1 ]; then
-	ip route add 1.2.3.4/32 dev eth0 2>/dev/null
-fi
-if [ "$HOSTROUTE6_OK" = 1 ]; then
-	ip -6 route add 2001:4860:4860::8888/128 dev eth0 2>/dev/null
-fi
+# this exercises the public-host-route path, not iface_is_vpn. The KPM now covers
+# both v4 and v6 on every supported kernel (5.x/6.x fib6_info + 4.14 rt6_info), so
+# no per-kver gate is needed here.
+ip route add 1.2.3.4/32 dev eth0 2>/dev/null
+ip -6 route add 2001:4860:4860::8888/128 dev eth0 2>/dev/null
 
 # Vectors covered by the wired hooks. Count vpn0 hits as seen by root, then
 # count stable non-VPN entries so an over-trimmed empty dump fails loudly.
@@ -80,16 +63,8 @@ echo "VEC dev_ioctl=$(ifconfig vpn0 2>/dev/null | grep -c vpn0)"                
 echo "VEC keep_dev_ioctl=$(ifconfig eth0 2>/dev/null | grep -c '^eth0')"
 echo "VEC netlink_route4=$(ip route show table all 2>/dev/null | grep -c vpn0)"     # fib_dump_info (#86)
 echo "VEC keep_netlink_route4=$(ip route show table all 2>/dev/null | grep -c 'dev eth0')"
-if [ "$HOSTROUTE4_OK" = 1 ]; then
-	echo "VEC hostroute4=$(ip route show table all 2>/dev/null | grep -c '1\.2\.3\.4')" # fib_dump_info public host-route
-else
-	echo "VEC hostroute4=SKIP"
-fi
-if [ "$HOSTROUTE6_OK" = 1 ]; then
-	echo "VEC hostroute6=$(ip -6 route show table all 2>/dev/null | grep -c '2001:4860')" # rt6_fill_node public host-route
-else
-	echo "VEC hostroute6=SKIP" # 4.14 uses rt6_info; no fib6_dst offset carried
-fi
+echo "VEC hostroute4=$(ip route show table all 2>/dev/null | grep -c '1\.2\.3\.4')" # fib_dump_info public host-route
+echo "VEC hostroute6=$(ip -6 route show table all 2>/dev/null | grep -c '2001:4860')" # rt6_fill_node public host-route
 echo "VEC netlink_route6=$(ip -6 route show table all 2>/dev/null | grep -c vpn0)"  # rt6_fill_node
 echo "VEC policy_rule=$(ip rule show 2>/dev/null | grep -c 199)"                    # fib_nl_fill_rule
 echo "VEC keep_policy_rule=$(ip rule show 2>/dev/null | grep -c 'lookup main')"


### PR DESCRIPTION
Follow-up to #210 (which landed the host-route on GKI). The host-route concealment now covers **every** supported KPM kernel, and the one SIOCGIFCONF gap that's genuinely low-value is moved to the roadmap.

Context: #210 disabled the host-route on the non-GKI kernels on the mistaken belief they weren't QEMU-tested — but `kpm-qemu-legacy` covers exactly 4.14/4.19/5.4, and those are the kernels the KPM exists to serve.

- **IPv4 on every kernel.** On `<5.6` (5.4/4.19/4.14), `fib_dump_info` passes the `__be32 dst` and `dst_len` as args 6/7 rather than a `fib_rt_info*`, so the predicate reads them per ABI (the arg-register value stores to network-order bytes, so the shared `vpnhide_is_public_ipv4` applies unchanged).
- **IPv6 on 5.4/4.19** via `fib6_info.fib6_dst @64` (head identical to 5.10, derived from the AOSP/vanilla sources).
- **IPv6 on 4.14** via `rt6_info.rt6i_dst`. 4.14 predates `fib6_info`; the route's dest is in the embedded `rt6_info`. `rt6i_dst` is `____cacheline_aligned_in_smp` — `dst_entry` is 160B (config-independent via its `__pad`s), the prefix runs to +220, rounded up to **+256** (same for a 64- or 128-byte cacheline).
- **32-bit (compat) `SIOCGIFCONF`** → `docs/ROADMAP.md` as low-priority (may revisit): a 32-bit app's enumeration enters via `compat_sock_ioctl` and isn't filtered; most apps are 64-bit and use netlink `getifaddrs` (covered). Cross-linked from `detection-vectors.md`.

**Validated A/B in QEMU locally** on 4.14, 4.19, 5.4 (extracted legacy images, cortex-a57) and 5.10 GKI (no regression): both host-routes hidden for the target, 18/18, no panic. CI's `kpm-qemu-legacy` matrix now exercises the host-route vectors there too (the per-kver harness gate is dropped — every kver covers v4 + v6).