### PR TITLE
refactor(zygisk): dedup line-filter loop, saved-original blocks, and hook install table

### DIFF
--- a/zygisk/src/filter.rs
+++ b/zygisk/src/filter.rs
@@ -27,22 +27,16 @@ pub fn is_vpn_iface_cstr(name: &CStr) -> bool {
     is_vpn_iface_bytes(name.to_bytes())
 }
 
-/// Filter `/proc/net/route` content in-place, removing lines whose
-/// first tab-separated field is a VPN interface name.
-/// Returns the new length of the valid data in `data`.
+/// Walk `data` line by line, keeping every line for which `hide(line)` is
+/// false and compacting the kept lines toward the front in place. Returns the
+/// new valid length.
 ///
-/// Format:
-/// ```text
-/// Iface   Destination Gateway     Flags RefCnt Use Metric Mask     MTU Window IRTT
-/// wlan0   00000000    0101A8C0    0003  0      0   0      00000000 0   0      0
-/// tun0    00000000    010010AC    0003  0      0   0      00000000 0   0      0
-/// ```
-/// The header line (starting with "Iface") is always kept.
-pub fn filter_route_buf(data: &mut [u8]) -> usize {
-    if data.is_empty() {
-        return 0;
-    }
-
+/// Each `line` passed to `hide` spans from the start of the line through and
+/// including its terminating `'\n'` (or to end-of-buffer for an unterminated
+/// final line) — the same span that gets copied down, so a predicate can look
+/// at the whole record. Empty input yields 0 (the loop never runs). This is
+/// the shared skeleton behind every `/proc/net/*` line filter below.
+fn compact_lines(data: &mut [u8], mut hide: impl FnMut(&[u8]) -> bool) -> usize {
     let len = data.len();
     let mut read_pos = 0usize;
     let mut write_pos = 0usize;
@@ -55,17 +49,7 @@ pub fn filter_route_buf(data: &mut [u8]) -> usize {
             .map(|p| read_pos + p + 1)
             .unwrap_or(len);
 
-        // Extract first field (up to '\t').
-        let line = &data[read_pos..line_end];
-        let field_len = line
-            .iter()
-            .position(|&b| b == b'\t' || b == b'\n')
-            .unwrap_or(line.len());
-        let ifname = &line[..field_len];
-
-        let hide = !ifname.is_empty() && is_vpn_iface_bytes(ifname);
-
-        if !hide {
+        if !hide(&data[read_pos..line_end]) {
             let line_len = line_end - read_pos;
             if write_pos != read_pos {
                 data.copy_within(read_pos..line_end, write_pos);
@@ -77,6 +61,29 @@ pub fn filter_route_buf(data: &mut [u8]) -> usize {
     }
 
     write_pos
+}
+
+/// Filter `/proc/net/route` content in-place, removing lines whose
+/// first tab-separated field is a VPN interface name.
+/// Returns the new length of the valid data in `data`.
+///
+/// Format:
+/// ```text
+/// Iface   Destination Gateway     Flags RefCnt Use Metric Mask     MTU Window IRTT
+/// wlan0   00000000    0101A8C0    0003  0      0   0      00000000 0   0      0
+/// tun0    00000000    010010AC    0003  0      0   0      00000000 0   0      0
+/// ```
+/// The header line (starting with "Iface") is always kept.
+pub fn filter_route_buf(data: &mut [u8]) -> usize {
+    compact_lines(data, |line| {
+        // Extract first field (up to '\t').
+        let field_len = line
+            .iter()
+            .position(|&b| b == b'\t' || b == b'\n')
+            .unwrap_or(line.len());
+        let ifname = &line[..field_len];
+        !ifname.is_empty() && is_vpn_iface_bytes(ifname)
+    })
 }
 
 /// Filter `/proc/net/ipv6_route` in-place. Interface name is the LAST
@@ -89,42 +96,13 @@ pub fn filter_ipv6_route_buf(data: &mut [u8]) -> usize {
 /// drop lines whose interface name (trimmed, before the first ':') is a VPN
 /// interface. The two header lines have no `name:` token and are kept.
 pub fn filter_dev_buf(data: &mut [u8]) -> usize {
-    if data.is_empty() {
-        return 0;
-    }
-
-    let len = data.len();
-    let mut read_pos = 0usize;
-    let mut write_pos = 0usize;
-
-    while read_pos < len {
-        let line_end = data[read_pos..]
-            .iter()
-            .position(|&b| b == b'\n')
-            .map(|p| read_pos + p + 1)
-            .unwrap_or(len);
-
-        let line = &data[read_pos..line_end];
-        let hide = match line.iter().position(|&b| b == b':') {
-            Some(colon) => {
-                let name = trim_ascii_ws(&line[..colon]);
-                !name.is_empty() && is_vpn_iface_bytes(name)
-            }
-            None => false,
-        };
-
-        if !hide {
-            let line_len = line_end - read_pos;
-            if write_pos != read_pos {
-                data.copy_within(read_pos..line_end, write_pos);
-            }
-            write_pos += line_len;
+    compact_lines(data, |line| match line.iter().position(|&b| b == b':') {
+        Some(colon) => {
+            let name = trim_ascii_ws(&line[..colon]);
+            !name.is_empty() && is_vpn_iface_bytes(name)
         }
-
-        read_pos = line_end;
-    }
-
-    write_pos
+        None => false,
+    })
 }
 
 /// Trim leading and trailing ASCII whitespace from a byte slice.
@@ -155,37 +133,10 @@ pub fn filter_if_inet6_buf(data: &mut [u8]) -> usize {
 /// Shared logic: filter lines where the LAST whitespace-delimited field
 /// is a VPN interface name (used by ipv6_route and if_inet6).
 fn filter_by_last_field(data: &mut [u8]) -> usize {
-    if data.is_empty() {
-        return 0;
-    }
-
-    let len = data.len();
-    let mut read_pos = 0usize;
-    let mut write_pos = 0usize;
-
-    while read_pos < len {
-        let line_end = data[read_pos..]
-            .iter()
-            .position(|&b| b == b'\n')
-            .map(|p| read_pos + p + 1)
-            .unwrap_or(len);
-
-        let line = &data[read_pos..line_end];
+    compact_lines(data, |line| {
         let ifname = extract_last_field(line);
-        let hide = !ifname.is_empty() && is_vpn_iface_bytes(ifname);
-
-        if !hide {
-            let line_len = line_end - read_pos;
-            if write_pos != read_pos {
-                data.copy_within(read_pos..line_end, write_pos);
-            }
-            write_pos += line_len;
-        }
-
-        read_pos = line_end;
-    }
-
-    write_pos
+        !ifname.is_empty() && is_vpn_iface_bytes(ifname)
+    })
 }
 
 /// Extract the last whitespace-delimited field from a line (trimming
@@ -214,7 +165,7 @@ pub fn filter_tcp4_buf(data: &mut [u8], vpn_addrs: &[u32], n_addrs: usize) -> us
     if data.is_empty() || n_addrs == 0 {
         return data.len();
     }
-    filter_tcp_generic(data, &vpn_addrs[..n_addrs], 8, parse_hex_u32)
+    filter_tcp_addr(data, &vpn_addrs[..n_addrs], 8, parse_hex_u32)
 }
 
 /// Filter `/proc/net/tcp6` in-place. Removes lines whose local address
@@ -225,92 +176,30 @@ pub fn filter_tcp6_buf(data: &mut [u8], vpn_addrs: &[[u32; 4]], n_addrs: usize) 
     if data.is_empty() || n_addrs == 0 {
         return data.len();
     }
-    filter_tcp6_inner(data, &vpn_addrs[..n_addrs])
+    filter_tcp_addr(data, &vpn_addrs[..n_addrs], 32, parse_hex_addr6)
 }
 
-/// Generic TCP filter: for each line, find ": ", parse `hex_len` hex
-/// chars as an address, check against `vpn_addrs`.
-fn filter_tcp_generic(
+/// Generic TCP filter, shared by tcp4 (`Addr = u32`) and tcp6
+/// (`Addr = [u32; 4]`): for each line find ": ", parse `hex_len` hex chars
+/// into an `Addr`, and drop the line if it matches any of `vpn_addrs`.
+fn filter_tcp_addr<Addr: PartialEq>(
     data: &mut [u8],
-    vpn_addrs: &[u32],
+    vpn_addrs: &[Addr],
     hex_len: usize,
-    parse: fn(&[u8]) -> Option<u32>,
+    parse: fn(&[u8]) -> Option<Addr>,
 ) -> usize {
-    let len = data.len();
-    let mut read_pos = 0usize;
-    let mut write_pos = 0usize;
-
-    while read_pos < len {
-        let line_end = data[read_pos..]
-            .iter()
-            .position(|&b| b == b'\n')
-            .map(|p| read_pos + p + 1)
-            .unwrap_or(len);
-
-        let line = &data[read_pos..line_end];
-        let mut hide = false;
-
+    compact_lines(data, |line| {
         // Find ": " separator, then parse hex address after it.
         if let Some(colon_pos) = find_colon_space(line) {
             let addr_start = colon_pos + 2;
             if addr_start + hex_len <= line.len() {
                 if let Some(addr) = parse(&line[addr_start..addr_start + hex_len]) {
-                    hide = vpn_addrs.contains(&addr);
+                    return vpn_addrs.contains(&addr);
                 }
             }
         }
-
-        if !hide {
-            let line_len = line_end - read_pos;
-            if write_pos != read_pos {
-                data.copy_within(read_pos..line_end, write_pos);
-            }
-            write_pos += line_len;
-        }
-
-        read_pos = line_end;
-    }
-
-    write_pos
-}
-
-/// TCP6 filter: parse 32-char hex as 4×u32 and compare against VPN addrs.
-fn filter_tcp6_inner(data: &mut [u8], vpn_addrs: &[[u32; 4]]) -> usize {
-    let len = data.len();
-    let mut read_pos = 0usize;
-    let mut write_pos = 0usize;
-
-    while read_pos < len {
-        let line_end = data[read_pos..]
-            .iter()
-            .position(|&b| b == b'\n')
-            .map(|p| read_pos + p + 1)
-            .unwrap_or(len);
-
-        let line = &data[read_pos..line_end];
-        let mut hide = false;
-
-        if let Some(colon_pos) = find_colon_space(line) {
-            let addr_start = colon_pos + 2;
-            if addr_start + 32 <= line.len() {
-                if let Some(addr) = parse_hex_addr6(&line[addr_start..addr_start + 32]) {
-                    hide = vpn_addrs.contains(&addr);
-                }
-            }
-        }
-
-        if !hide {
-            let line_len = line_end - read_pos;
-            if write_pos != read_pos {
-                data.copy_within(read_pos..line_end, write_pos);
-            }
-            write_pos += line_len;
-        }
-
-        read_pos = line_end;
-    }
-
-    write_pos
+        false
+    })
 }
 
 fn find_colon_space(line: &[u8]) -> Option<usize> {

--- a/zygisk/src/hooks.rs
+++ b/zygisk/src/hooks.rs
@@ -93,32 +93,58 @@ fn set_errno(val: c_int) {
 //  Saved originals
 // ============================================================================
 
-/// Pointer to the real `ioctl` entrypoint, captured by `pltHookRegister`.
-/// Stored as `AtomicPtr<c_void>` so the hook can load it with a relaxed
-/// atomic read — no locks.
-static REAL_IOCTL: AtomicPtr<c_void> = AtomicPtr::new(core::ptr::null_mut());
+/// Declare a saved-original slot for one PLT-hooked libc function.
+///
+/// Each hook needs the same four items to call through to the function it
+/// replaced, so we generate them from one declaration instead of hand-copying
+/// the block seven times:
+///   - `static $slot: AtomicPtr<c_void>` — the captured original pointer,
+///   - `type $ty` — its function-pointer shape (doc comments carry through),
+///   - `fn $getter() -> Option<$ty>` — None before install or if somehow null,
+///   - `pub fn $setter(p: *const ())` — what `pltHookRegister` feeds the
+///     original into.
+///
+/// The slot is read/written with relaxed atomics: install happens-before any
+/// hook fires, so no stronger ordering is needed and no locks are taken.
+macro_rules! saved_original {
+    (
+        $(#[$tymeta:meta])*
+        type $ty:ident = $sig:ty;
+        static $slot:ident;
+        fn $getter:ident;
+        pub fn $setter:ident;
+    ) => {
+        static $slot: AtomicPtr<c_void> = AtomicPtr::new(core::ptr::null_mut());
 
-/// Raw function type for the slice of ioctl variants we care about.
-/// Matches the three-argument C signature `int ioctl(int, unsigned long, void*)`.
-type IoctlFn = unsafe extern "C" fn(c_int, libc::c_ulong, *mut c_void) -> c_int;
+        $(#[$tymeta])*
+        type $ty = $sig;
 
-/// Safely fetch the saved original ioctl. Returns None if for some reason
-/// the pointer is null (should never happen after install, but defensive).
-#[inline(always)]
-fn real_ioctl() -> Option<IoctlFn> {
-    let raw = REAL_IOCTL.load(Ordering::Relaxed);
-    if raw.is_null() {
-        None
-    } else {
-        // SAFETY: we only ever store a valid function pointer of this shape
-        // in this slot via set_real_ioctl_ptr.
-        Some(unsafe { core::mem::transmute::<*mut c_void, IoctlFn>(raw) })
-    }
+        #[inline(always)]
+        fn $getter() -> Option<$ty> {
+            let raw = $slot.load(Ordering::Relaxed);
+            if raw.is_null() {
+                None
+            } else {
+                // SAFETY: the slot only ever holds a valid pointer of this
+                // exact shape, stored once at install via the setter below.
+                Some(unsafe { core::mem::transmute::<*mut c_void, $ty>(raw) })
+            }
+        }
+
+        /// Stash the original pointer returned by `pltHookRegister`.
+        pub fn $setter(p: *const ()) {
+            $slot.store(p as *mut c_void, Ordering::Relaxed);
+        }
+    };
 }
 
-/// Stash the original pointer we got back from `pltHookRegister`.
-pub fn set_real_ioctl_ptr(p: *const ()) {
-    REAL_IOCTL.store(p as *mut c_void, Ordering::Relaxed);
+saved_original! {
+    /// Raw function type for the slice of ioctl variants we care about.
+    /// Matches the three-argument C signature `int ioctl(int, unsigned long, void*)`.
+    type IoctlFn = unsafe extern "C" fn(c_int, libc::c_ulong, *mut c_void) -> c_int;
+    static REAL_IOCTL;
+    fn real_ioctl;
+    pub fn set_real_ioctl_ptr;
 }
 
 // ============================================================================
@@ -258,26 +284,12 @@ unsafe fn filter_ifconf(ifc: *mut ifconf) {
 //  Hook: getifaddrs
 // ============================================================================
 
-/// Pointer to the real `getifaddrs`, captured at install time.
-static REAL_GETIFADDRS: AtomicPtr<c_void> = AtomicPtr::new(core::ptr::null_mut());
-
-type GetifaddrsFn = unsafe extern "C" fn(*mut *mut libc::ifaddrs) -> c_int;
-
-#[inline(always)]
-fn real_getifaddrs() -> Option<GetifaddrsFn> {
-    let raw = REAL_GETIFADDRS.load(Ordering::Relaxed);
-    if raw.is_null() {
-        None
-    } else {
-        // SAFETY: we only ever store a valid `getifaddrs` pointer in this
-        // slot via `set_real_getifaddrs_ptr`.
-        Some(unsafe { core::mem::transmute::<*mut c_void, GetifaddrsFn>(raw) })
-    }
-}
-
-/// Stash the trampoline returned by shadowhook for `libc.so!getifaddrs`.
-pub fn set_real_getifaddrs_ptr(p: *const ()) {
-    REAL_GETIFADDRS.store(p as *mut c_void, Ordering::Relaxed);
+saved_original! {
+    /// Raw function type for `getifaddrs`.
+    type GetifaddrsFn = unsafe extern "C" fn(*mut *mut libc::ifaddrs) -> c_int;
+    static REAL_GETIFADDRS;
+    fn real_getifaddrs;
+    pub fn set_real_getifaddrs_ptr;
 }
 
 /// Replacement for `libc::getifaddrs`.
@@ -350,23 +362,12 @@ pub unsafe extern "C" fn hooked_getifaddrs(ifap: *mut *mut libc::ifaddrs) -> c_i
 //  Hook: openat — intercept /proc/net/* reads
 // ============================================================================
 
-/// Pointer to the real `openat` entrypoint, captured at install time.
-static REAL_OPENAT: AtomicPtr<c_void> = AtomicPtr::new(core::ptr::null_mut());
-
-type OpenatFn = unsafe extern "C" fn(c_int, *const libc::c_char, c_int, libc::mode_t) -> c_int;
-
-#[inline(always)]
-fn real_openat() -> Option<OpenatFn> {
-    let raw = REAL_OPENAT.load(Ordering::Relaxed);
-    if raw.is_null() {
-        None
-    } else {
-        Some(unsafe { core::mem::transmute::<*mut c_void, OpenatFn>(raw) })
-    }
-}
-
-pub fn set_real_openat_ptr(p: *const ()) {
-    REAL_OPENAT.store(p as *mut c_void, Ordering::Relaxed);
+saved_original! {
+    /// Raw function type for `openat`.
+    type OpenatFn = unsafe extern "C" fn(c_int, *const libc::c_char, c_int, libc::mode_t) -> c_int;
+    static REAL_OPENAT;
+    fn real_openat;
+    pub fn set_real_openat_ptr;
 }
 
 /// Which /proc/net file was matched.
@@ -783,22 +784,12 @@ fn collect_vpn_addrs() -> (
 //  Hook: recvmsg — filter netlink RTM_NEWADDR / RTM_NEWLINK responses
 // ============================================================================
 
-static REAL_RECVMSG: AtomicPtr<c_void> = AtomicPtr::new(core::ptr::null_mut());
-
-type RecvmsgFn = unsafe extern "C" fn(c_int, *mut libc::msghdr, c_int) -> isize;
-
-#[inline(always)]
-fn real_recvmsg() -> Option<RecvmsgFn> {
-    let raw = REAL_RECVMSG.load(Ordering::Relaxed);
-    if raw.is_null() {
-        None
-    } else {
-        Some(unsafe { core::mem::transmute::<*mut c_void, RecvmsgFn>(raw) })
-    }
-}
-
-pub fn set_real_recvmsg_ptr(p: *const ()) {
-    REAL_RECVMSG.store(p as *mut c_void, Ordering::Relaxed);
+saved_original! {
+    /// Raw function type for `recvmsg`.
+    type RecvmsgFn = unsafe extern "C" fn(c_int, *mut libc::msghdr, c_int) -> isize;
+    static REAL_RECVMSG;
+    fn real_recvmsg;
+    pub fn set_real_recvmsg_ptr;
 }
 
 /// Replacement for `libc::recvmsg`.
@@ -912,22 +903,12 @@ unsafe fn maybe_filter_netlink_buf(fd: c_int, buf: *mut u8, ret: isize) -> isize
 // hook only has to handle the bare `recv` symbol. (Hooking `recvfrom`
 // turned out to be fine in practice — see the recvfrom hook block.)
 
-static REAL_RECV: AtomicPtr<c_void> = AtomicPtr::new(core::ptr::null_mut());
-
-type RecvFn = unsafe extern "C" fn(c_int, *mut c_void, usize, c_int) -> isize;
-
-#[inline(always)]
-fn real_recv() -> Option<RecvFn> {
-    let raw = REAL_RECV.load(Ordering::Relaxed);
-    if raw.is_null() {
-        None
-    } else {
-        Some(unsafe { core::mem::transmute::<*mut c_void, RecvFn>(raw) })
-    }
-}
-
-pub fn set_real_recv_ptr(p: *const ()) {
-    REAL_RECV.store(p as *mut c_void, Ordering::Relaxed);
+saved_original! {
+    /// Raw function type for `recv`.
+    type RecvFn = unsafe extern "C" fn(c_int, *mut c_void, usize, c_int) -> isize;
+    static REAL_RECV;
+    fn real_recv;
+    pub fn set_real_recv_ptr;
 }
 
 /// Replacement for `libc::recv`.
@@ -971,23 +952,13 @@ pub unsafe extern "C" fn hooked_recv(
 // `is_netlink_fd` in `maybe_filter_netlink_buf` keeps TCP/UDP/Unix recvfrom
 // traffic untouched, so hooking these high-traffic symbols is safe.
 
-static REAL_RECVFROM: AtomicPtr<c_void> = AtomicPtr::new(core::ptr::null_mut());
-
-type RecvfromFn =
-    unsafe extern "C" fn(c_int, *mut c_void, usize, c_int, *mut c_void, *mut c_void) -> isize;
-
-#[inline(always)]
-fn real_recvfrom() -> Option<RecvfromFn> {
-    let raw = REAL_RECVFROM.load(Ordering::Relaxed);
-    if raw.is_null() {
-        None
-    } else {
-        Some(unsafe { core::mem::transmute::<*mut c_void, RecvfromFn>(raw) })
-    }
-}
-
-pub fn set_real_recvfrom_ptr(p: *const ()) {
-    REAL_RECVFROM.store(p as *mut c_void, Ordering::Relaxed);
+saved_original! {
+    /// Raw function type for `recvfrom`.
+    type RecvfromFn =
+        unsafe extern "C" fn(c_int, *mut c_void, usize, c_int, *mut c_void, *mut c_void) -> isize;
+    static REAL_RECVFROM;
+    fn real_recvfrom;
+    pub fn set_real_recvfrom_ptr;
 }
 
 /// Replacement for `libc::recvfrom`. Filters the flat buffer like `recv`.
@@ -1012,32 +983,21 @@ pub unsafe extern "C" fn hooked_recvfrom(
     ret - (in_buf - filtered)
 }
 
-static REAL_RECVFROM_CHK: AtomicPtr<c_void> = AtomicPtr::new(core::ptr::null_mut());
-
-/// `ssize_t __recvfrom_chk(int, void*, size_t len, size_t buf_size, int flags,
-///                         const struct sockaddr*, socklen_t*)` — bionic FORTIFY.
-type RecvfromChkFn = unsafe extern "C" fn(
-    c_int,
-    *mut c_void,
-    usize,
-    usize,
-    c_int,
-    *mut c_void,
-    *mut c_void,
-) -> isize;
-
-#[inline(always)]
-fn real_recvfrom_chk() -> Option<RecvfromChkFn> {
-    let raw = REAL_RECVFROM_CHK.load(Ordering::Relaxed);
-    if raw.is_null() {
-        None
-    } else {
-        Some(unsafe { core::mem::transmute::<*mut c_void, RecvfromChkFn>(raw) })
-    }
-}
-
-pub fn set_real_recvfrom_chk_ptr(p: *const ()) {
-    REAL_RECVFROM_CHK.store(p as *mut c_void, Ordering::Relaxed);
+saved_original! {
+    /// `ssize_t __recvfrom_chk(int, void*, size_t len, size_t buf_size, int flags,
+    ///                         const struct sockaddr*, socklen_t*)` — bionic FORTIFY.
+    type RecvfromChkFn = unsafe extern "C" fn(
+        c_int,
+        *mut c_void,
+        usize,
+        usize,
+        c_int,
+        *mut c_void,
+        *mut c_void,
+    ) -> isize;
+    static REAL_RECVFROM_CHK;
+    fn real_recvfrom_chk;
+    pub fn set_real_recvfrom_chk_ptr;
 }
 
 /// Replacement for bionic's `__recvfrom_chk`. Same filtering as `recvfrom`.

--- a/zygisk/src/lib.rs
+++ b/zygisk/src/lib.rs
@@ -375,54 +375,73 @@ fn mark_cleanup(api: &mut ZygiskApi<'_, V2>) {
 fn install_hooks(hookmask: u32) -> Result<(), String> {
     shadowhook::init_once().map_err(|rc| format!("shadowhook_init: rc={rc}"))?;
 
-    // (sym, replacement, stash-original-via). Install order is the
-    // order we'll roll back in on failure (LIFO).
+    // Every libc symbol the Zygisk backend can hook, in install order (we roll
+    // back LIFO on failure). Each row is gated by its per-hook bit in
+    // `hookmask`; adding a hook is one row here plus a `saved_original!` block
+    // and a `hooked_*` fn — no parallel match arms to keep in sync.
     //
-    // recv is hooked directly because bionic's `recv()` tail-calls
-    // recvfrom via a bare `b` branch — patching recvfrom's prologue
-    // would break recv. recv itself is 12 bytes (3 instructions),
-    // safe for island-mode hooking.
-    type StoreFn = fn(*const ());
-    let mut plan: Vec<(&core::ffi::CStr, *mut core::ffi::c_void, StoreFn)> = Vec::new();
-    if zygisk_hook_enabled(hookmask, Hook::ZygiskIoctl) {
-        plan.push((c"ioctl", hooked_ioctl as *mut _, set_real_ioctl_ptr));
+    // recv is hooked directly because bionic's `recv()` tail-calls recvfrom via
+    // a bare `b` branch — patching recvfrom's prologue would break recv. recv
+    // itself is 12 bytes (3 instructions), safe for island-mode hooking.
+    // recvfrom + __recvfrom_chk catch FORTIFY'd / direct callers that never
+    // touch the `recv` symbol (issue #86 native route dump).
+    struct HookDesc {
+        sym: &'static core::ffi::CStr,
+        hook_id: Hook,
+        replacement: *mut core::ffi::c_void,
+        store_orig: fn(*const ()),
     }
-    if zygisk_hook_enabled(hookmask, Hook::ZygiskGetifaddrs) {
-        plan.push((
-            c"getifaddrs",
-            hooked_getifaddrs as *mut _,
-            set_real_getifaddrs_ptr,
-        ));
-    }
-    if zygisk_hook_enabled(hookmask, Hook::ZygiskOpenat) {
-        plan.push((c"openat", hooked_openat as *mut _, set_real_openat_ptr));
-    }
-    if zygisk_hook_enabled(hookmask, Hook::ZygiskRecvmsg) {
-        plan.push((c"recvmsg", hooked_recvmsg as *mut _, set_real_recvmsg_ptr));
-    }
-    if zygisk_hook_enabled(hookmask, Hook::ZygiskRecv) {
-        plan.push((c"recv", hooked_recv as *mut _, set_real_recv_ptr));
-    }
-    // recvfrom + __recvfrom_chk catch FORTIFY'd / direct callers that
-    // never touch the `recv` symbol (issue #86 native route dump).
-    if zygisk_hook_enabled(hookmask, Hook::ZygiskRecvfrom) {
-        plan.push((
-            c"recvfrom",
-            hooked_recvfrom as *mut _,
-            set_real_recvfrom_ptr,
-        ));
-    }
-    if zygisk_hook_enabled(hookmask, Hook::ZygiskRecvfromChk) {
-        plan.push((
-            c"__recvfrom_chk",
-            hooked_recvfrom_chk as *mut _,
-            set_real_recvfrom_chk_ptr,
-        ));
-    }
+    let table = [
+        HookDesc {
+            sym: c"ioctl",
+            hook_id: Hook::ZygiskIoctl,
+            replacement: hooked_ioctl as *mut _,
+            store_orig: set_real_ioctl_ptr,
+        },
+        HookDesc {
+            sym: c"getifaddrs",
+            hook_id: Hook::ZygiskGetifaddrs,
+            replacement: hooked_getifaddrs as *mut _,
+            store_orig: set_real_getifaddrs_ptr,
+        },
+        HookDesc {
+            sym: c"openat",
+            hook_id: Hook::ZygiskOpenat,
+            replacement: hooked_openat as *mut _,
+            store_orig: set_real_openat_ptr,
+        },
+        HookDesc {
+            sym: c"recvmsg",
+            hook_id: Hook::ZygiskRecvmsg,
+            replacement: hooked_recvmsg as *mut _,
+            store_orig: set_real_recvmsg_ptr,
+        },
+        HookDesc {
+            sym: c"recv",
+            hook_id: Hook::ZygiskRecv,
+            replacement: hooked_recv as *mut _,
+            store_orig: set_real_recv_ptr,
+        },
+        HookDesc {
+            sym: c"recvfrom",
+            hook_id: Hook::ZygiskRecvfrom,
+            replacement: hooked_recvfrom as *mut _,
+            store_orig: set_real_recvfrom_ptr,
+        },
+        HookDesc {
+            sym: c"__recvfrom_chk",
+            hook_id: Hook::ZygiskRecvfromChk,
+            replacement: hooked_recvfrom_chk as *mut _,
+            store_orig: set_real_recvfrom_chk_ptr,
+        },
+    ];
 
-    let mut installed: Vec<*mut core::ffi::c_void> = Vec::with_capacity(plan.len());
-    for (sym, new_fn, store_orig) in plan {
-        match hook_libc_sym(sym, new_fn, store_orig) {
+    let mut installed: Vec<*mut core::ffi::c_void> = Vec::with_capacity(table.len());
+    for desc in table {
+        if !zygisk_hook_enabled(hookmask, desc.hook_id) {
+            continue;
+        }
+        match hook_libc_sym(desc.sym, desc.replacement, desc.store_orig) {
             Ok(stub) => installed.push(stub),
             Err(err) => {
                 // Roll back any hooks already installed before this


### PR DESCRIPTION
Three behaviour-preserving cleanups in the Zygisk backend, all driven by the codebase audit.

The `/proc/net/*` filters in `filter.rs` each repeated the same line-by-line read/write compaction skeleton, the seven libc hooks in `hooks.rs` each hand-copied a four-item saved-original block, and `install_hooks` in `lib.rs` had seven near-identical `if zygisk_hook_enabled { plan.push(..) }` arms. This collapses each of those into one shared abstraction so adding or changing a hook touches one place instead of three.

- `filter.rs`: extract a shared `compact_lines(data, hide)` helper that owns the read/write line-compaction loop every filter repeated; make the TCP filter generic over the address type (`u32` / `[u32; 4]`) so tcp6 reuses one code path instead of a near-identical copy.
- `hooks.rs`: replace the seven saved-original blocks (static slot + fn type + getter + setter) with a single `saved_original!` macro; public setter names and fn-pointer types are unchanged.
- `lib.rs`: collapse the seven `if`/`plan.push` install arms into one `HookDesc` table walked by a data-driven install loop (same install order, same LIFO rollback).

Net -132 lines. No behaviour change: all unit tests, clippy, rustfmt and the cargo-ndk cdylib build pass unchanged.