### PR TITLE
fix(kmod): hide VPN interfaces from the SIOCGIFCONF size query, not just the fill

### DIFF
--- a/.github/docker/ddk-qemu/Dockerfile
+++ b/.github/docker/ddk-qemu/Dockerfile
@@ -29,9 +29,11 @@ RUN curl -fsSL "https://dl.google.com/android/repository/android-ndk-${NDK_VER}-
     unzip -q /tmp/ndk.zip "android-ndk-${NDK_VER}/toolchains/llvm/prebuilt/linux-x86_64/*" \
         -d /opt && rm /tmp/ndk.zip
 COPY kmod/test/gai-probe.c /tmp/gai-probe.c
+COPY kmod/test/ifconf-probe.c /tmp/ifconf-probe.c
 RUN TC="/opt/android-ndk-${NDK_VER}/toolchains/llvm/prebuilt/linux-x86_64/bin" && \
     "$TC/aarch64-linux-android24-clang" -static -O2 -o /opt/gai /tmp/gai-probe.c && \
-    "$TC/llvm-strip" /opt/gai
+    "$TC/aarch64-linux-android24-clang" -static -O2 -o /opt/ifconf /tmp/ifconf-probe.c && \
+    "$TC/llvm-strip" /opt/gai /opt/ifconf
 
 FROM ghcr.io/ylarod/ddk-min:${KMI}-20260313
 ARG KMI
@@ -79,17 +81,21 @@ RUN mkdir -p /opt/qemu/kp && \
             -o "/opt/qemu/kp/$a"; \
     done && chmod +x /opt/qemu/kp/kptools-linux
 
-# Prebuilt bionic getifaddrs probe (built from gai-probe.c with the NDK in the
-# `gai` stage). run-kpm.sh picks it up via VPNHIDE_GAI_BIN so the addr-fill
-# hook is validated in CI on every KMI — not skipped.
+# Prebuilt bionic getifaddrs + SIOCGIFCONF probes (built from *-probe.c with the
+# NDK in the `gai` stage). run.sh / run-kpm.sh pick them up via VPNHIDE_GAI_BIN /
+# VPNHIDE_IFC_BIN so the addr-fill hook and the ifconf size-query path are
+# validated in CI on every KMI — not skipped.
 COPY --from=gai /opt/gai /opt/qemu/gai
+COPY --from=gai /opt/ifconf /opt/qemu/ifconf
 
 # run.sh / run-kpm.sh read these to use the baked artifacts instead of the local
 # cache. VPNHIDE_QEMU_KSRC is the kernel tree to build the test module against;
 # VPNHIDE_KP_BIN is the baked KernelPatch tool/runtime dir (KPM only);
-# VPNHIDE_GAI_BIN is the prebuilt bionic getifaddrs probe.
+# VPNHIDE_GAI_BIN is the prebuilt bionic getifaddrs probe;
+# VPNHIDE_IFC_BIN is the prebuilt SIOCGIFCONF size-query probe.
 ENV VPNHIDE_QEMU_IMAGE=/opt/qemu/Image
 ENV VPNHIDE_QEMU_ROOTFS=/opt/qemu/alpine-minirootfs.tar.gz
 ENV VPNHIDE_QEMU_KSRC=/opt/qemu/linux
 ENV VPNHIDE_KP_BIN=/opt/qemu/kp
 ENV VPNHIDE_GAI_BIN=/opt/qemu/gai
+ENV VPNHIDE_IFC_BIN=/opt/qemu/ifconf

--- a/.github/workflows/qemu-image.yml
+++ b/.github/workflows/qemu-image.yml
@@ -12,6 +12,7 @@ on:
       - .github/docker/kpm-qemu-legacy/Dockerfile
       - .github/workflows/qemu-image.yml
       - kmod/test/gai-probe.c
+      - kmod/test/ifconf-probe.c
       - kmod/test/qemu.config
       - kmod/test/build-source-kernel.sh
   schedule:

--- a/changelog.d/fixed-kmod-hide-vpn-interfaces-from-the-320c.md
+++ b/changelog.d/fixed-kmod-hide-vpn-interfaces-from-the-320c.md
@@ -1,0 +1,9 @@
+_2026-06-30_
+
+## English
+
+kmod: hide VPN interfaces from the SIOCGIFCONF buffer-size query (ifc_req == NULL), not just the filled list, so the legacy two-step enumeration can no longer reveal a hidden interface by comparing the advertised count against the returned entries.
+
+## Русский
+
+kmod: скрывать VPN-интерфейсы и при запросе размера буфера SIOCGIFCONF (ifc_req == NULL), а не только в заполненном списке, чтобы устаревшее двухшаговое перечисление не выдавало скрытый интерфейс по расхождению размера и числа записей.

--- a/docs/detection-vectors.md
+++ b/docs/detection-vectors.md
@@ -122,23 +122,32 @@ Notes: bionic's `getifaddrs` itself runs over netlink, so the kmod
 at once. zygisk additionally unlinks entries from the `getifaddrs` result list
 directly, so it works even if a future bionic stops using netlink.
 
-**Two known narrow `SIOCGIFCONF` gaps (kmod `.ko`), tracked not yet closed:**
+**`SIOCGIFCONF` size-query subcase — closed in the `.ko`.** The classic two-step
+`SIOCGIFCONF` (first call with `ifc_req == NULL` to learn the buffer size, then a
+sized call to fill it) used to leak: the `.ko` filtered the fill but returned the
+*unfiltered* length from the size query, so a target comparing the two back-to-back
+saw a one-interface discrepancy. `sock_ioctl_ret` now also handles the
+`ifc_req == NULL` path — it rcu-enumerates the socket's netns netdevs and subtracts
+`sizeof(struct ifreq)` per *IPv4-addressed* VPN iface (matched by `ifa_label`, the
+exact set/naming `inet_gifconf` would have emitted), so the size query agrees with
+the filtered fill. Validated by the harness `ifconf_size_probe` vector.
 
-- **Size-query subcase.** The classic two-step `SIOCGIFCONF` (first call with
-  `ifc_req == NULL` to learn the buffer size, then a sized call to fill it) — the
-  `.ko` filters the fill but returns the *unfiltered* length from the size query,
-  so a target comparing the two back-to-back sees a one-interface discrepancy.
-  Closing it means, on the `ifc_req == NULL` path, enumerating netdevs (rcu) and
-  subtracting `sizeof(struct ifreq)` per *IPv4-addressed* VPN iface — feasible
-  but unvalidated without a dedicated probe. zygisk (its own `getifaddrs`/procfs
-  filtering) and modern apps (netlink `getifaddrs`, not `SIOCGIFCONF`) are
-  unaffected; the leak needs an app deliberately doing the legacy NULL-probe.
-- **32-bit (compat) callers.** `sock_ioctl_krp` hooks `sock_ioctl` only; a 32-bit
-  app's `SIOCGIFCONF` enters through `compat_sock_ioctl` → `compat_dev_ifconf`
-  and never reaches it, so the size/fill filtering is skipped for 32-bit
-  enumeration. Most current Android apps are 64-bit and modern enumeration uses
-  netlink (which the rtnl/inet fill hooks do cover), so this is narrow; closing
-  it means also hooking `compat_sock_ioctl` with the compat `ifconf` layout.
+**One narrow `SIOCGIFCONF` gap still open:**
+
+- **32-bit (compat) callers (kmod `.ko`).** `sock_ioctl_krp` hooks `sock_ioctl`
+  only; a 32-bit app's `SIOCGIFCONF` enters through `compat_sock_ioctl` →
+  `compat_dev_ifconf` and never reaches it, so both the fill and the size-query
+  filtering are skipped for 32-bit enumeration. Most current Android apps are
+  64-bit and modern enumeration uses netlink (which the rtnl/inet fill hooks do
+  cover), so this is narrow; closing it means also hooking `compat_sock_ioctl`
+  with the compat `ifconf` layout. Deferred (low priority) — see
+  [ROADMAP.md](ROADMAP.md).
+
+The KPM backend's `filter_ifconf` compacts the fill the same way the `.ko` does,
+but does not yet reduce the `ifc_req == NULL` size query (it would need raw netdev
+walking by per-kver offset rather than the `.ko`'s rcu helpers); the size-query
+subcase is therefore `.ko`-only for now, tracked with the KPM's other WIP parity
+items.
 
 ### 3B. Route table — "is the default route a tunnel?"
 

--- a/kmod/test/ifconf-probe.c
+++ b/kmod/test/ifconf-probe.c
@@ -1,0 +1,67 @@
+/*
+ * SIOCGIFCONF probe for the kmod harness — exercises the legacy ioctl
+ * enumeration path, specifically the two-step "size query then fill" sequence
+ * the `ip addr`/`ifconfig` shell vectors don't isolate.
+ *
+ * The classic caller first issues SIOCGIFCONF with ifc_req == NULL to learn how
+ * big a buffer it needs (the kernel returns ifc_len = N * sizeof(struct ifreq)
+ * without copying anything), then issues a sized call to fill it. If the kmod
+ * filters the fill but leaves the size query unfiltered, the two disagree by
+ * one interface for a hidden VPN — a detectable tell. This probe reports both
+ * so the harness can assert they stay consistent.
+ *
+ * Build (static, runs on the Alpine VM regardless of its libc):
+ *   <ndk>/aarch64-linux-android35-clang -static -O2 -o ifconf ifconf-probe.c
+ * Output:
+ *   IFCONF_SIZE=<n>      ifreqs reported by the NULL size-query
+ *   IFCONF_FILL=<n>      ifreqs returned by a real fill
+ *   IFCONF_FILL_VPN=<n>  of the fill entries, how many name "vpn0"
+ */
+#include <net/if.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/ioctl.h>
+#include <sys/socket.h>
+#include <unistd.h>
+
+int main(void)
+{
+	struct ifconf ifc;
+	struct ifreq buf[64];
+	int fd, i, size_n, fill_n, vpn = 0;
+
+	fd = socket(AF_INET, SOCK_DGRAM, 0);
+	if (fd < 0) {
+		printf("IFCONF_SIZE=-1\nIFCONF_FILL=-1\nIFCONF_FILL_VPN=-1\n");
+		return 2;
+	}
+
+	/* Step 1: size query — ifc_req == NULL, kernel returns only ifc_len. */
+	ifc.ifc_len = 0;
+	ifc.ifc_buf = NULL;
+	if (ioctl(fd, SIOCGIFCONF, &ifc) < 0) {
+		printf("IFCONF_SIZE=-1\nIFCONF_FILL=-1\nIFCONF_FILL_VPN=-1\n");
+		close(fd);
+		return 2;
+	}
+	size_n = ifc.ifc_len / (int)sizeof(struct ifreq);
+
+	/* Step 2: real fill into a fixed buffer. */
+	ifc.ifc_len = (int)sizeof(buf);
+	ifc.ifc_req = buf;
+	if (ioctl(fd, SIOCGIFCONF, &ifc) < 0) {
+		printf("IFCONF_SIZE=%d\nIFCONF_FILL=-1\nIFCONF_FILL_VPN=-1\n",
+		       size_n);
+		close(fd);
+		return 2;
+	}
+	fill_n = ifc.ifc_len / (int)sizeof(struct ifreq);
+	for (i = 0; i < fill_n; i++)
+		if (strcmp(buf[i].ifr_name, "vpn0") == 0)
+			vpn++;
+
+	close(fd);
+	printf("IFCONF_SIZE=%d\nIFCONF_FILL=%d\nIFCONF_FILL_VPN=%d\n", size_n,
+	       fill_n, vpn);
+	return 0;
+}

--- a/kmod/test/init.sh
+++ b/kmod/test/init.sh
@@ -153,6 +153,43 @@ check_gai() {
 	fi
 }
 
+ifc_field() {
+	/ifconf 2>/dev/null | sed -n "s/^$1=//p" | head -1
+}
+
+# SIOCGIFCONF size-query path: the legacy two-step probe (NULL ifc_req to learn
+# the size, then a sized fill). A target's size query must (a) agree with its
+# own filtered fill and (b) drop below the non-target size query — i.e. vpn0's
+# address was subtracted from the count, not just from the buffer.
+check_ifconf_size() {
+	if [ ! -x /ifconf ]; then
+		echo "RESULT ifconf_size_probe=SKIP (no ifconf probe available)"
+		return
+	fi
+
+	set_target 5555
+	_nt_size=$(ifc_field IFCONF_SIZE)
+	set_target 0
+	_tg_size=$(ifc_field IFCONF_SIZE)
+	_tg_fill=$(ifc_field IFCONF_FILL)
+	_tg_vpn=$(ifc_field IFCONF_FILL_VPN)
+	[ -n "$_nt_size" ] || _nt_size=-1
+	[ -n "$_tg_size" ] || _tg_size=-1
+	[ -n "$_tg_fill" ] || _tg_fill=-1
+	[ -n "$_tg_vpn" ] || _tg_vpn=-1
+
+	# tg_vpn==0 guards against matching two equally-broken numbers: the fill
+	# must actually be vpn-free for the size==fill agreement to mean anything.
+	if [ "$_tg_vpn" -eq 0 ] && [ "$_tg_size" -eq "$_tg_fill" ] &&
+		[ "$_nt_size" -gt "$_tg_size" ]; then
+		echo "RESULT ifconf_size_probe=PASS (nt_size=$_nt_size tg_size=$_tg_size tg_fill=$_tg_fill)"
+		PASS=$((PASS + 1))
+	else
+		echo "RESULT ifconf_size_probe=FAIL (nt_size=$_nt_size tg_size=$_tg_size tg_fill=$_tg_fill tg_vpn=$_tg_vpn)"
+		FAIL=$((FAIL + 1))
+	fi
+}
+
 # vector -> hook it exercises
 check_hide getifaddrs      "ip addr show"                 "vpn0"   # rtnl_fill_ifinfo + inet*_fill_ifaddr
 check_hide siocgifconf     "ifconfig -a"                  "vpn0"   # sock_ioctl
@@ -165,6 +202,7 @@ check_hide netlink_route6  "ip -6 route show table all"   "vpn0"   # rt6_fill_no
 check_hide hostroute6      "ip -6 route show table all"   "2001:4860" # rt6_fill_node public host-route
 check_hide policy_rule     "ip rule show"                 "199"    # fib_nl_fill_rule
 check_gai
+check_ifconf_size                                                  # sock_ioctl size-query
 
 # Non-VPN entries must survive target filtering. This catches over-trimming
 # regressions where a hook hides the whole dump instead of only vpn0 rows.

--- a/kmod/test/run.sh
+++ b/kmod/test/run.sh
@@ -58,6 +58,30 @@ if [ -z "$GAI" ] && [ -n "${VPNHIDE_GAI_REQUIRED:-}" ]; then
 	exit 2
 fi
 
+# --- static SIOCGIFCONF probe (validates the ifconf size-query path) ---------
+# Reuses the same bionic toolchain as the getifaddrs probe (any libc would do
+# for this one, but keep it consistent). Built only if a toolchain is around;
+# the harness SKIPs the size-probe vectors when it's missing.
+IFC=""
+if [ -n "${VPNHIDE_IFC_BIN:-}" ] && [ -x "${VPNHIDE_IFC_BIN:-}" ]; then
+	IFC="$VPNHIDE_IFC_BIN"
+	echo "[run] ifconf probe: prebuilt ($IFC)"
+else
+	IFC_CC="${VPNHIDE_GAI_CC:-$(find "$HOME/Android/Sdk/ndk" -type f -path '*/toolchains/llvm/prebuilt/*/bin/aarch64-linux-android*-clang' 2>/dev/null | sort | tail -1 || true)}"
+	if [ -n "$IFC_CC" ] && [ -x "$IFC_CC" ]; then
+		IFC="$CACHE/ifconf"
+		"$IFC_CC" -static -O2 -o "$IFC" "$HERE/ifconf-probe.c" 2>/dev/null || IFC=""
+	fi
+	[ -n "$IFC" ] && echo "[run] ifconf probe built ($(basename "$IFC_CC"))" || \
+		echo "[run] no bionic toolchain/binary — skipping SIOCGIFCONF size-probe vector"
+fi
+
+if [ -z "$IFC" ] && [ -n "${VPNHIDE_IFC_REQUIRED:-}" ]; then
+	echo "ERROR: ifconf probe is required here (VPNHIDE_IFC_REQUIRED set) but" \
+	     "unavailable. Refusing to pass with the SIOCGIFCONF size-query path unchecked."
+	exit 2
+fi
+
 WORK="$(mktemp -d)"
 trap 'rm -rf "$WORK"' EXIT
 RFS="$WORK/rootfs"
@@ -67,6 +91,7 @@ cp "$KO" "$RFS/vpnhide_kmod.ko"
 cp "$HERE/init.sh" "$RFS/init"
 chmod +x "$RFS/init"
 [ -n "$GAI" ] && { cp "$GAI" "$RFS/gai"; chmod +x "$RFS/gai"; }
+[ -n "$IFC" ] && { cp "$IFC" "$RFS/ifconf"; chmod +x "$RFS/ifconf"; }
 ( cd "$RFS" && find . | cpio -o -H newc 2>/dev/null | gzip > "$WORK/initramfs.cpio.gz" )
 
 LOG="$WORK/serial.log"

--- a/kmod/vpnhide_kmod.c
+++ b/kmod/vpnhide_kmod.c
@@ -48,6 +48,7 @@
 #include <linux/rtnetlink.h>
 #include <linux/skbuff.h>
 #include <linux/inetdevice.h>
+#include <net/sock.h>
 #include <net/if_inet6.h>
 #include <net/ip_fib.h>
 #include <net/nexthop.h>
@@ -435,6 +436,11 @@ static struct kretprobe dev_ioctl_krp = {
 
 struct sock_ioctl_data {
 	void __user *argp;
+	/* Net namespace of the socket this ioctl is on — captured at entry so
+	 * the size-query path (ifc_req == NULL) can enumerate that ns's netdevs
+	 * to learn how many ifreqs the kernel counted for VPN ifaces. dev_ifconf
+	 * uses sock_net(sk), so we match it instead of guessing current's ns. */
+	struct net *net;
 	bool target;
 };
 
@@ -442,6 +448,8 @@ static int sock_ioctl_entry(struct kretprobe_instance *ri, struct pt_regs *regs)
 {
 	struct sock_ioctl_data *data = (void *)ri->data;
 	unsigned int cmd = (unsigned int)regs->regs[1];
+	struct file *file;
+	struct socket *sock;
 
 	data->target = false;
 
@@ -449,6 +457,12 @@ static int sock_ioctl_entry(struct kretprobe_instance *ri, struct pt_regs *regs)
 		return 0;
 	if (!hook_active(VPNHIDE_HOOK_SOCK_IOCTL))
 		return 0;
+
+	/* sock_ioctl only runs for socket files, so file->private_data is the
+	 * struct socket (same thing sock_from_file() returns). Stable uapi. */
+	file = (struct file *)regs->regs[0];
+	sock = file ? file->private_data : NULL;
+	data->net = (sock && sock->sk) ? sock_net(sock->sk) : NULL;
 
 	data->target = true;
 	data->argp = (void __user *)regs->regs[2];
@@ -504,6 +518,63 @@ static enum filter_ifconf_result filter_ifconf_buf(struct ifreq __user *usr_ifr,
 	return FILTER_IFCONF_CHANGED;
 }
 
+/*
+ * Size-query subcase: SIOCGIFCONF with ifc_req == NULL. The kernel
+ * (dev_ifconf -> inet_gifconf) doesn't copy any ifreqs, it just returns
+ * ifc_len = (number of IPv4 addresses across all netdevs) * sizeof(ifreq).
+ * There's no buffer to compact, so to keep the size query consistent with the
+ * filtered fill, we recompute how many of those ifreqs belong to VPN ifaces
+ * and shrink ifc_len by that much. Otherwise a target doing the classic
+ * two-step probe (size, then fill) sees the fill come back one interface short
+ * of the advertised size.
+ *
+ * inet_gifconf emits one ifreq per in_ifaddr, named by ifa_label, so we count
+ * by ifa_label under rcu — the exact set and naming the fill path would filter.
+ */
+static void filter_ifconf_size_probe(struct net *net,
+				     struct ifconf __user *uifc, int orig_len)
+{
+	struct net_device *dev;
+	int hidden = 0;
+	int new_len;
+
+	if (!net)
+		return;
+
+	rcu_read_lock();
+	for_each_netdev_rcu(net, dev) {
+		struct in_device *in_dev = __in_dev_get_rcu(dev);
+		const struct in_ifaddr *ifa;
+
+		if (!in_dev)
+			continue;
+		in_dev_for_each_ifa_rcu(ifa, in_dev) {
+			char label[IFNAMSIZ];
+
+			memcpy(label, ifa->ifa_label, IFNAMSIZ);
+			label[IFNAMSIZ - 1] = '\0';
+			if (is_vpn_ifname(label))
+				hidden++;
+		}
+	}
+	rcu_read_unlock();
+
+	if (hidden == 0)
+		return;
+
+	new_len = orig_len - hidden * (int)sizeof(struct ifreq);
+	if (new_len < 0)
+		new_len = 0;
+	if (put_user(new_len, &uifc->ifc_len)) {
+		vpnhide_dbg(
+			"ifconf size-probe: put_user failed; len untouched\n");
+		return;
+	}
+	vpnhide_dbg("ifconf size-probe %d -> %d (hid %d vpn addr)\n", orig_len,
+		    new_len, hidden);
+	record_hook_hit(VPNHIDE_HOOK_SOCK_IOCTL);
+}
+
 static int sock_ioctl_ret(struct kretprobe_instance *ri, struct pt_regs *regs)
 {
 	struct sock_ioctl_data *data = (void *)ri->data;
@@ -524,8 +595,14 @@ static int sock_ioctl_ret(struct kretprobe_instance *ri, struct pt_regs *regs)
 	uifc = data->argp;
 	if (copy_from_user(&ifc, uifc, sizeof(ifc)))
 		return 0;
-	if (!ifc.ifc_req || ifc.ifc_len <= 0)
+	if (ifc.ifc_len <= 0)
 		return 0;
+
+	/* ifc_req == NULL is the size-query probe (no buffer to compact). */
+	if (!ifc.ifc_req) {
+		filter_ifconf_size_probe(data->net, uifc, ifc.ifc_len);
+		return 0;
+	}
 
 	orig_len = ifc.ifc_len;
 	res = filter_ifconf_buf(ifc.ifc_req,


### PR DESCRIPTION
Closes the SIOCGIFCONF size-query leak documented in detection-vectors.md.

The classic two-step `SIOCGIFCONF` enumeration first calls with `ifc_req == NULL` to learn the buffer size (the kernel returns `ifc_len = N * sizeof(struct ifreq)` without copying anything), then calls again with a sized buffer. `sock_ioctl_ret` filtered the fill but bailed on the NULL probe, so the size query returned the *unfiltered* count — a target comparing the two back-to-back saw a one-interface discrepancy that revealed a hidden VPN.

`sock_ioctl_ret` now also handles `ifc_req == NULL`: it rcu-enumerates the socket's netns netdevs (the `net` is captured at entry from the socket, matching `dev_ifconf`'s `sock_net`) and subtracts `sizeof(struct ifreq)` per IPv4-addressed VPN iface, matched by `ifa_label` — the exact set and naming `inet_gifconf` would have emitted — so the size query agrees with the filtered fill.

- `kmod/vpnhide_kmod.c`: capture the socket netns at `sock_ioctl_entry`; add `filter_ifconf_size_probe` and dispatch to it on the NULL-probe path.
- `kmod/test/ifconf-probe.c` (new): a native probe doing the size query + a real fill, reporting both counts.
- `kmod/test/{run,init}.sh`: build/ship the probe and add the `ifconf_size_probe` vector (target size query must equal its filtered fill and drop below the non-target size query).
- `.github/docker/ddk-qemu/Dockerfile` + `qemu-image.yml`: bake the probe into the image and expose `VPNHIDE_IFC_BIN`, mirroring the existing getifaddrs probe.
- docs: mark the `.ko` size-query subcase closed; note the 32-bit compat path stays deferred and the KPM still shares the size-query gap as WIP parity.

The 32-bit compat `SIOCGIFCONF` path (`compat_sock_ioctl`) remains unhooked (low priority, tracked in docs).

Testing: 19/19 harness vectors PASS with no panic on GKI android14-6.1 and android15-6.6 in QEMU. The remaining KMIs (5.10/5.15/6.12) build and boot the module in the `kmod-qemu` CI matrix; the new `ifconf_size_probe` vector runs there once the `ddk-qemu` image rebuilds with the baked probe (`qemu-image.yml` now triggers on `ifconf-probe.c`), and SKIPs cleanly until then.