### PR TITLE
feat(lsposed): keep configured apps visible under all Protection filters

### DIFF
--- a/changelog.d/changed-the-protection-tab-s-app-filters-a045.md
+++ b/changelog.d/changed-the-protection-tab-s-app-filters-a045.md
@@ -1,0 +1,9 @@
+_2026-06-30_
+
+## English
+
+The Protection tab's app filters (system apps, Russian apps only) no longer hide apps you have already configured — configured apps stay visible under any filter. The redundant configured-only filter is removed, since configured apps already group at the top of the list.
+
+## Русский
+
+Фильтры приложений на вкладке «Защита» (системные, только российские) больше не скрывают уже настроенные приложения — они остаются видимыми при любом фильтре. Избыточный фильтр «только настроенные» удалён: настроенные приложения и так сгруппированы вверху списка.

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/AppPickerScreen.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/AppPickerScreen.kt
@@ -91,7 +91,6 @@ internal fun AppPickerScreen(
     searchQuery: String,
     showSystem: Boolean,
     showRussianOnly: Boolean,
-    showConfiguredOnly: Boolean,
     sortMode: TargetListSortMode,
     modifier: Modifier = Modifier,
 ) {
@@ -99,7 +98,6 @@ internal fun AppPickerScreen(
         searchQuery = searchQuery,
         showSystem = showSystem,
         showRussianOnly = showRussianOnly,
-        showConfiguredOnly = showConfiguredOnly,
         sortMode = sortMode,
         modifier = modifier,
         helpPrefKey = "apps_unified",

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/MainActivity.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/MainActivity.kt
@@ -217,7 +217,6 @@ private fun MainScreen() {
     var searchActive by remember { mutableStateOf(false) }
     var showSystem by remember { mutableStateOf(false) }
     var showRussianOnly by remember { mutableStateOf(false) }
-    var showConfiguredOnly by remember { mutableStateOf(false) }
     var targetSortMode by remember { mutableStateOf(TargetListSortMode.ConfiguredFirst) }
     var showFilterMenu by remember { mutableStateOf(false) }
     val appListLoading by AppListCache.loading.collectAsState()
@@ -400,7 +399,6 @@ private fun MainScreen() {
                                     val anyFilterActive =
                                         showSystem ||
                                             showRussianOnly ||
-                                            showConfiguredOnly ||
                                             targetSortMode != TargetListSortMode.ConfiguredFirst
                                     TopBarActionButton(
                                         onClick = { showFilterMenu = true },
@@ -431,16 +429,6 @@ private fun MainScreen() {
                                             leadingIcon = {
                                                 Checkbox(
                                                     checked = showRussianOnly,
-                                                    onCheckedChange = null,
-                                                )
-                                            },
-                                        )
-                                        DropdownMenuItem(
-                                            text = { Text(stringResource(R.string.filter_configured_only)) },
-                                            onClick = { showConfiguredOnly = !showConfiguredOnly },
-                                            leadingIcon = {
-                                                Checkbox(
-                                                    checked = showConfiguredOnly,
                                                     onCheckedChange = null,
                                                 )
                                             },
@@ -595,7 +583,6 @@ private fun MainScreen() {
                             searchQuery = searchQuery,
                             showSystem = showSystem,
                             showRussianOnly = showRussianOnly,
-                            showConfiguredOnly = showConfiguredOnly,
                             sortMode = targetSortMode,
                             modifier = Modifier.padding(innerPadding),
                         )

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/ProtectionScreen.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/ProtectionScreen.kt
@@ -14,7 +14,6 @@ internal fun ProtectionScreen(
     searchQuery: String,
     showSystem: Boolean,
     showRussianOnly: Boolean,
-    showConfiguredOnly: Boolean,
     sortMode: TargetListSortMode,
     modifier: Modifier = Modifier,
 ) {
@@ -22,7 +21,6 @@ internal fun ProtectionScreen(
         searchQuery = searchQuery,
         showSystem = showSystem,
         showRussianOnly = showRussianOnly,
-        showConfiguredOnly = showConfiguredOnly,
         sortMode = sortMode,
         modifier = modifier,
     )

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/TargetPickerData.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/TargetPickerData.kt
@@ -20,15 +20,17 @@ internal fun <T : TargetEntry> visibleTargetEntries(
     searchQuery: String,
     showSystem: Boolean,
     showRussianOnly: Boolean,
-    showConfiguredOnly: Boolean,
     sortMode: TargetListSortMode,
 ): List<T> {
     val query = searchQuery.trim().lowercase()
     return entries
         .filter { app ->
+            // The system and Russian filters narrow the discovery set for
+            // *new* apps; they never hide an already-configured app (anySelected) —
+            // its roles are set, so the user must always be able to see and edit
+            // it. Search is explicit intent, so it still applies to everything.
             (showSystem || !app.isSystem || app.anySelected) &&
-                (!showRussianOnly || isRussianApp(app.packageName, app.label)) &&
-                (!showConfiguredOnly || app.anySelected) &&
+                (!showRussianOnly || isRussianApp(app.packageName, app.label) || app.anySelected) &&
                 (
                     query.isEmpty() ||
                         app.label.lowercase().contains(query) ||

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/TargetPickerScaffold.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/TargetPickerScaffold.kt
@@ -126,7 +126,6 @@ internal fun <T : TargetEntry> TargetPickerScreen(
     searchQuery: String,
     showSystem: Boolean,
     showRussianOnly: Boolean,
-    showConfiguredOnly: Boolean,
     sortMode: TargetListSortMode,
     modifier: Modifier,
     helpPrefKey: String,
@@ -211,13 +210,12 @@ internal fun <T : TargetEntry> TargetPickerScreen(
     }
 
     val visibleApps =
-        remember(allApps, searchQuery, showSystem, showRussianOnly, showConfiguredOnly, sortMode) {
+        remember(allApps, searchQuery, showSystem, showRussianOnly, sortMode) {
             visibleTargetEntries(
                 entries = allApps,
                 searchQuery = searchQuery,
                 showSystem = showSystem,
                 showRussianOnly = showRussianOnly,
-                showConfiguredOnly = showConfiguredOnly,
                 sortMode = sortMode,
             )
         }

--- a/lsposed/app/src/main/res/values-ru/strings.xml
+++ b/lsposed/app/src/main/res/values-ru/strings.xml
@@ -15,7 +15,6 @@
     <string name="search_placeholder">Поиск приложений&#8230;</string>
     <string name="filter_show_system">Показать системные приложения</string>
     <string name="filter_russian_only">Только российские</string>
-    <string name="filter_configured_only">Только настроенные</string>
     <string name="sort_configured_first">Сначала настроенные</string>
     <string name="sort_alphabetical">По алфавиту</string>
     <string name="target_group_configured">Настроенные</string>

--- a/lsposed/app/src/main/res/values/strings.xml
+++ b/lsposed/app/src/main/res/values/strings.xml
@@ -15,7 +15,6 @@
     <string name="search_placeholder">Search apps&#8230;</string>
     <string name="filter_show_system">Show system apps</string>
     <string name="filter_russian_only">Russian apps only</string>
-    <string name="filter_configured_only">Configured only</string>
     <string name="sort_configured_first">Configured first</string>
     <string name="sort_alphabetical">Alphabetical</string>
     <string name="target_group_configured">Configured</string>

--- a/lsposed/app/src/test/kotlin/dev/okhsunrog/vpnhide/TargetPickerDataTest.kt
+++ b/lsposed/app/src/test/kotlin/dev/okhsunrog/vpnhide/TargetPickerDataTest.kt
@@ -19,7 +19,6 @@ class TargetPickerDataTest {
                 searchQuery = "",
                 showSystem = false,
                 showRussianOnly = false,
-                showConfiguredOnly = false,
                 sortMode = TargetListSortMode.ConfiguredFirst,
             )
 
@@ -44,7 +43,6 @@ class TargetPickerDataTest {
                 searchQuery = "",
                 showSystem = false,
                 showRussianOnly = false,
-                showConfiguredOnly = false,
                 sortMode = TargetListSortMode.Alphabetical,
             )
 
@@ -53,24 +51,24 @@ class TargetPickerDataTest {
     }
 
     @Test
-    fun `configured only filters unselected apps`() {
+    fun `configured apps stay visible when russian-only is on`() {
         val visible =
             visibleTargetEntries(
                 entries =
                     listOf(
-                        target("com.alpha", "Alpha"),
-                        target("com.beta", "Beta", selected = true),
-                        target("com.gamma", "Gamma"),
+                        target("com.foreign.unselected", "Foreign unselected"),
+                        target("com.foreign.selected", "Foreign selected", selected = true),
+                        target("ru.bank", "Russian bank"),
                     ),
                 searchQuery = "",
                 showSystem = false,
-                showRussianOnly = false,
-                showConfiguredOnly = true,
+                showRussianOnly = true,
                 sortMode = TargetListSortMode.ConfiguredFirst,
             )
 
-        assertEquals(listOf("Beta"), visible.map { it.label })
-        assertEquals(TargetListGroup.Configured, targetListSections(visible, TargetListSortMode.ConfiguredFirst).single().group)
+        // Russian-only narrows discovery to ru.* apps, but a configured foreign
+        // app is never hidden — it stays so the user can still see and edit it.
+        assertEquals(listOf("Foreign selected", "Russian bank"), visible.map { it.label })
     }
 
     @Test
@@ -86,7 +84,6 @@ class TargetPickerDataTest {
                 searchQuery = "",
                 showSystem = false,
                 showRussianOnly = false,
-                showConfiguredOnly = false,
                 sortMode = TargetListSortMode.ConfiguredFirst,
             )
 


### PR DESCRIPTION
The Protection tab's app filters could hide apps the user had already configured. The **system-apps** filter already exempted configured apps (`showSystem || !isSystem || anySelected`), but **Russian apps only** did not — turning it on hid a configured non-Russian app. This makes the Russian filter consistent: like the system filter, it narrows the discovery set for *new* apps but never hides one you've already configured. Search still applies to everything (it's explicit intent).

It also removes the now-redundant **Configured only** filter. The default `ConfiguredFirst` sort already groups configured apps into a "Configured" section at the top, alphabetised within the group — so "Configured only" only collapsed the "Other apps" section below it. Staying on `ConfiguredFirst` gives the same alphabetical configured list, so nothing is lost.

- `TargetPickerData.visibleTargetEntries`: add the `anySelected` exemption to the Russian clause; drop the `showConfiguredOnly` param and clause.
- Remove `showConfiguredOnly` threading through `MainActivity` -> `ProtectionScreen` -> `AppPickerScreen` -> `TargetPickerScreen`, the filter menu item, and the `filter_configured_only` string (en + ru).
- Replace the unit test for the removed configured-only behaviour with one asserting configured apps survive the Russian filter.

detekt, ktlint, `lintDebug`, and unit tests pass.