### PR TITLE
fix(kpm): KPM install warning should respect a disabled .ko (disable, not uninstall)

### DIFF
--- a/changelog.d/fixed-kpm-install-now-warns-about-a-cb91.md
+++ b/changelog.d/fixed-kpm-install-now-warns-about-a-cb91.md
@@ -1,0 +1,9 @@
+_2026-06-30_
+
+## English
+
+KPM install now warns about a conflicting kmod (.ko) backend only when that .ko is actually enabled, matching the boot loader — and clarifies that disabling vpnhide_kmod (not only uninstalling it) is enough to let the KPM load.
+
+## Русский
+
+Установка KPM теперь предупреждает о конфликте с kmod (.ko) только когда .ko реально включён — как и загрузчик — и уточняет, что для загрузки KPM достаточно отключить vpnhide_kmod, а не удалять его.

--- a/kmod/kpm/module/customize.sh
+++ b/kmod/kpm/module/customize.sh
@@ -19,11 +19,14 @@ set_perm "$MODPATH/uninstall.sh" 0 0 0755
 
 # Single-active warning (protocol §1.5): the .ko and KPM wrap the SAME kernel
 # functions; running both freezes the device. The boot loader refuses to load
-# the KPM when the .ko module is present, but warn at install time too.
-if [ -d /data/adb/modules/vpnhide_kmod ]; then
-    ui_print "! WARNING: the .ko backend (vpnhide_kmod) is installed."
+# the KPM while the .ko module is present AND enabled (post-fs-data.sh /
+# service.sh check the same `disable` flag), so warn here in exactly that case —
+# a vpnhide_kmod that is merely disabled is fine and lets the KPM load.
+if [ -d /data/adb/modules/vpnhide_kmod ] &&
+    [ ! -f /data/adb/modules/vpnhide_kmod/disable ]; then
+    ui_print "! WARNING: the .ko backend (vpnhide_kmod) is installed and enabled."
     ui_print "! Only one native backend may be active — the KPM will NOT load"
-    ui_print "! while it is present. Uninstall vpnhide_kmod to use the KPM."
+    ui_print "! until you disable (or uninstall) vpnhide_kmod."
 fi
 
 ui_print "- Config: /data/system/vpnhide_config.json (managed by the app)"


### PR DESCRIPTION
The KPM install-time single-active warning disagreed with the runtime guard.

`customize.sh` warned about a conflicting `.ko` backend whenever the `vpnhide_kmod` module directory merely **existed** (`[ -d ... ]`), and told the user to **uninstall** it. But the boot loader (`post-fs-data.sh` / `service.sh`) only refuses to load the KPM when `vpnhide_kmod` is present **AND not disabled** (`[ ! -f .../disable ]`) — a *disabled* `.ko` is fine and lets the KPM load.

This makes the install check mirror the runtime guard (present **and** no `disable` flag) and rewords the message to say disabling is sufficient. So a user who disabled (not uninstalled) the `.ko` to switch to the KPM no longer sees a misleading warning telling them to uninstall.

Verified on a real device (Pixel 8 Pro, KernelSU-Next + KPatch-Next): with `vpnhide_kmod` **disabled** (not uninstalled), the KPM loads and configures (`load_status: loaded=1 detail=configured`, `kpatch kpm list` shows `vpnhide`) and the `.ko` is absent from `lsmod`.

shellcheck passes (the same `-x -e SC2034,SC3043` CI uses).