### PR TITLE
fix(kpm): make the ctl0 status/stats channel reliable on real devices

### DIFF
--- a/changelog.d/fixed-kpm-backend-fix-garbled-status-stats-f1f9.md
+++ b/changelog.d/fixed-kpm-backend-fix-garbled-status-stats-f1f9.md
@@ -1,0 +1,9 @@
+_2026-06-30_
+
+## English
+
+KPM backend: fix garbled status/stats control-channel replies on APatch (KernelPatch) devices that could make the app fail to start with 'Startup preparation failed'. The .kpm is now built with the large code model (-mcmodel=large) so its string-literal addressing stays correct when KernelPatch loads the module far from the kernel.
+
+## Русский
+
+KPM-бэкенд: исправлены искажённые ответы канала управления (status/stats) на устройствах APatch (KernelPatch), из-за которых приложение могло не запускаться с ошибкой «Startup preparation failed». Модуль .kpm теперь собирается с большой моделью кода (-mcmodel=large), чтобы адресация строковых литералов оставалась корректной при загрузке модуля далеко от ядра.

--- a/changelog.d/fixed-kpm-interception-stats-now-appear-on-8ecb.md
+++ b/changelog.d/fixed-kpm-interception-stats-now-appear-on-8ecb.md
@@ -1,0 +1,9 @@
+_2026-06-30_
+
+## English
+
+KPM interception stats now appear on KernelSU / KPatch-Next setups. The activator treated the kpatch CLI's exit status (which is the reply byte count for a ctl0 read, not 0) as a read failure, so the dashboard's KPM status/stats came back empty.
+
+## Русский
+
+Статистика перехватов KPM теперь отображается на KernelSU / KPatch-Next. Активатор воспринимал код выхода CLI kpatch (для чтения ctl0 это число байт ответа, а не 0) как ошибку чтения, из-за чего статус/статистика KPM на дашборде были пустыми.

--- a/crates/activator/src/lib.rs
+++ b/crates/activator/src/lib.rs
@@ -869,11 +869,15 @@ fn run_kpatch_kpm_ctl0_read(kpatch: &Path, wire: &str) -> Result<String> {
     let mut cmd = Command::new(kpatch);
     cmd.args(["kpm", "ctl0", KPM_NAME, wire]);
     let out = cmd.output()?;
-    if out.status.success() {
-        Ok(String::from_utf8(out.stdout)?)
-    } else {
-        Err(format!("kpm ctl0 read failed with status {}", out.status).into())
-    }
+    // The kpatch CLI prints the reply to stdout (`fprintf(stdout, "%s", buf)`)
+    // and exits with the supercall's return value — for a READ that is the reply
+    // BYTE COUNT (e.g. 64), NOT 0. So a non-zero exit is the normal success case
+    // here; treating it as failure (the old behaviour) dropped every status/stats
+    // read on KPatch-Next, leaving the dashboard with no KPM stats. On a real
+    // error the supercall returns a negative rc and never fills the buffer, so
+    // stdout is empty. Trust stdout: the reply text is authoritative, the exit
+    // code is not (it can't even round-trip a reply longer than 255 bytes).
+    Ok(String::from_utf8_lossy(&out.stdout).into_owned())
 }
 
 fn kpatch_ctl0_config_status_ok(status: std::process::ExitStatus, wire: &str) -> bool {

--- a/kmod/Makefile
+++ b/kmod/Makefile
@@ -27,8 +27,15 @@ KPM_INCLUDES := $(foreach d,$(KPM_INCLUDE_DIRS),-I$(KP_DIR)/kernel/$(d))
 # -nostdlib: this is a freestanding relocatable kernel object; older Android
 # clang drivers (e.g. clang-12 on android12-5.10) otherwise add CRT startup
 # files + -lc/-ldl to the `-r` link and fail (crtbegin_dynamic.o / -lc not found).
+# -mcmodel=large: REQUIRED, do not change to small. KernelPatch loads the .kpm
+# in a vmalloc region that can sit >4 GB from where ADRP-relative literals were
+# assumed, so -mcmodel=small's ADR_PREL_PG_HI21 relocations for .rodata (string
+# literals) overflow and resolve to garbage addresses — the ctl0 status/stats
+# replies came back corrupted on a real APatch device until this was switched to
+# large (absolute MOVW_UABS materialisation, no ±4 GB range limit). The .ko is
+# unaffected because Kbuild handles module addressing itself.
 KPM_CFLAGS := -target aarch64-linux-android -fuse-ld=lld -nostdlib \
-	-O2 -fno-pic -fno-pie -fno-plt -mcmodel=small \
+	-O2 -fno-pic -fno-pie -fno-plt -mcmodel=large \
 	-fvisibility=hidden -mno-outline-atomics \
 	-fno-stack-protector -fno-common -fno-builtin -ffreestanding \
 	-fno-asynchronous-unwind-tables -fno-unwind-tables -nostdinc \


### PR DESCRIPTION
The KPM control channel (`ctl0` status/stats) was broken on real devices in two distinct, runtime-specific ways. Both are fixed here; both were validated on hardware (Pixel 4a / APatch / 4.14 and Pixel 8 Pro / KernelSU-Next + KPatch-Next / 6.1).

## 1. APatch: `.kpm` built with `-mcmodel=large` (was app-breaking)

On APatch the `ctl0` replies came back **corrupted** — garbled/duplicated string literals (`vpnhide vpnhide`, `backendr`, a stray `1 stats` prefix). The app's root snapshot couldn't parse the `kpm_state` section, so it showed **"Startup preparation failed."**

Root cause: `-mcmodel=small` emits `ADRP` (`ADR_PREL_PG_HI21`, PC-relative ±4 GB) relocations for `.rodata` string literals. KernelPatch loads the module in a vmalloc region that can sit **more than 4 GB** from where those literals were assumed, so the relocations overflow → garbage string addresses. The shared formatter is correct (clean on host and under qemu-user with the exact `.kpm` flags); only the in-kernel address materialisation breaks. The `.ko` is unaffected (Kbuild handles addressing). Fix: `-mcmodel=large` → absolute `MOVW_UABS`, no range limit. One-line flag change in `kmod/Makefile` + a comment.

## 2. KernelSU/KPatch-Next: trust the kpatch CLI stdout, not its exit status (stats were empty)

On KSU the activator reads `ctl0` via the `kpatch` CLI, which prints the reply to stdout and **exits with the reply byte count** (e.g. 64), not 0. `run_kpatch_kpm_ctl0_read` treated any non-zero exit as failure, so every KPM status/stats read failed → the dashboard showed **no KPM counters**. (This masked bug #1 on KSU: the read errored out before the corrupt reply was ever parsed.) Fix: capture stdout regardless of exit code; on a real error the CLI leaves its buffer empty so stdout is empty. Matches what the config path already tolerates.

## Testing
- **Pixel 4a (APatch, 4.14)**: `ctl0` status/stats decode cleanly; app starts (`dashboard_ready`, no `*_failed`).
- **Pixel 8 Pro (KSU-Next + KPatch-Next, 6.1)**: `activator state` now returns the clean reply instead of erroring; KPM stats populate.
- **QEMU KPM harness**: 18/18 PASS, panic=0 on android16-6.12 (confirms the larger `.kpm` still boots KernelPatch) and android14-6.1. CI covers the full matrix.

How #1 was found: instrumented the `.kpm` `ctl0` handler in-kernel — the formatter's byte counter advanced correctly while the bytes landed wrong → an addressing/relocation problem, confirmed by the relocation histogram flipping `ADR_PREL_PG_HI21` → `MOVW_UABS` after the model switch.