### PR TITLE
feat(lsposed): show the real cause on the startup-preparation error screen

### DIFF
--- a/changelog.d/changed-the-startup-preparation-failed-screen-now-e50c.md
+++ b/changelog.d/changed-the-startup-preparation-failed-screen-now-e50c.md
@@ -1,0 +1,9 @@
+_2026-06-30_
+
+## English
+
+The 'Startup preparation failed' screen now explains the actual cause (root unavailable, incomplete root data, or a config-write failure) and shows the underlying error detail, instead of always telling you to check root permissions.
+
+## Русский
+
+Экран «Подготовка запуска не удалась» теперь объясняет настоящую причину (нет root, неполные root-данные или ошибка записи конфига) и показывает техническую деталь ошибки, вместо того чтобы всегда советовать проверить права root.

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/MainActivity.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/MainActivity.kt
@@ -32,6 +32,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
@@ -229,8 +230,7 @@ private fun MainScreen() {
     val selfTargetState by startupCoordinator.selfTargetState.collectAsState()
     val selfNeedsRestart =
         (selfTargetState as? StartupSelfTargetState.Ready)?.selfNeedsRestart
-    val selfTargetError =
-        (selfTargetState as? StartupSelfTargetState.Failed)?.message
+    val selfTargetFailure = selfTargetState as? StartupSelfTargetState.Failed
     val refreshRestart = selfNeedsRestart ?: false
 
     LaunchedEffect(startupCoordinator) {
@@ -533,9 +533,11 @@ private fun MainScreen() {
         },
     ) { innerPadding ->
         val restart = selfNeedsRestart
-        val preparationError = selfTargetError
-        if (preparationError != null) {
+        val preparationFailure = selfTargetFailure
+        if (preparationFailure != null) {
             RootPreparationErrorScreen(
+                kind = preparationFailure.kind,
+                detail = preparationFailure.detail,
                 modifier = Modifier.padding(innerPadding),
                 onRetry = { startupCoordinator.retrySelfTargets(scope) },
             )
@@ -614,8 +616,18 @@ private fun StartupLoadingScreen() {
     }
 }
 
+private fun selfTargetErrorBodyRes(kind: SelfTargetFailureKind): Int =
+    when (kind) {
+        SelfTargetFailureKind.RootUnavailable -> R.string.self_targets_error_body_root
+        SelfTargetFailureKind.IncompleteData -> R.string.self_targets_error_body_incomplete
+        SelfTargetFailureKind.ConfigWriteFailed -> R.string.self_targets_error_body_write
+        SelfTargetFailureKind.Unknown -> R.string.self_targets_error_body_unknown
+    }
+
 @Composable
 private fun RootPreparationErrorScreen(
+    kind: SelfTargetFailureKind,
+    detail: String,
     onRetry: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
@@ -642,10 +654,20 @@ private fun RootPreparationErrorScreen(
                 )
                 Spacer(Modifier.height(12.dp))
                 Text(
-                    text = stringResource(R.string.self_targets_error_message),
+                    text = stringResource(selfTargetErrorBodyRes(kind)),
                     style = MaterialTheme.typography.bodyMedium,
                     textAlign = TextAlign.Center,
                 )
+                if (detail.isNotBlank()) {
+                    Spacer(Modifier.height(10.dp))
+                    Text(
+                        text = detail,
+                        style = MaterialTheme.typography.bodySmall,
+                        fontFamily = FontFamily.Monospace,
+                        textAlign = TextAlign.Center,
+                        color = MaterialTheme.colorScheme.onErrorContainer.copy(alpha = 0.75f),
+                    )
+                }
                 Spacer(Modifier.height(16.dp))
                 EnhancedButton(onClick = onRetry) {
                     Text(stringResource(R.string.vpn_off_retry))

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/ShellUtils.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/ShellUtils.kt
@@ -212,12 +212,32 @@ internal fun isVpnActiveBlocking(): Boolean {
     return isVpnActiveFromSnapshot(output)
 }
 
+/**
+ * Why startup root-state preparation failed, so the UI can tell the user the
+ * truth instead of always blaming root permissions. The distinction is known at
+ * the point of failure (not parsed back out of a string).
+ */
+internal enum class SelfTargetFailureKind {
+    /** The root command didn't run: denied, su prompt interrupted, non-zero exit. */
+    RootUnavailable,
+
+    /** Root worked, but the state probe returned incomplete data (a backend's
+     *  section was missing — e.g. a broken/garbled KPM control reply). */
+    IncompleteData,
+
+    /** Root worked, but writing the updated config back failed. */
+    ConfigWriteFailed,
+
+    Unknown,
+}
+
 internal data class SelfTargetPreparation(
     val rootAvailable: Boolean,
     val selfNeedsRestart: Boolean,
     val currentBootId: String?,
     val pmPackages: String? = null,
     val error: String? = null,
+    val failureKind: SelfTargetFailureKind = SelfTargetFailureKind.Unknown,
 )
 
 internal fun cleanupStaleZygiskStatus(
@@ -268,11 +288,16 @@ internal fun ensureSelfInTargets(
     selfPkg: String,
     timeoutSec: Long = SELF_TARGETS_TIMEOUT_SEC,
 ): SelfTargetPreparation {
-    val (sections, loadError) = loadStartupRootSections(timeoutSec)
-    if (sections == null) return selfTargetPreparationFailure(loadError ?: "snapshot load failed")
+    val (sections, loadFailure) = loadStartupRootSections(timeoutSec)
+    if (sections == null) {
+        val failure = loadFailure ?: SelfTargetFailureDetail(SelfTargetFailureKind.Unknown, "snapshot load failed")
+        return selfTargetPreparationFailure(failure.kind, failure.detail)
+    }
     val update = buildCanonicalSelfUpdate(sections, selfPkg)
     if (update.writeRequired) {
-        writeStartupCanonical(update.canonical, timeoutSec)?.let { return selfTargetPreparationFailure(it) }
+        writeStartupCanonical(update.canonical, timeoutSec)?.let {
+            return selfTargetPreparationFailure(SelfTargetFailureKind.ConfigWriteFailed, it)
+        }
         RootSnapshotCache.invalidate()
     }
     cleanupLegacyConfigInputs(timeoutSec)
@@ -293,17 +318,27 @@ private data class CanonicalSelfUpdate(
     val writeRequired: Boolean,
 )
 
-private fun loadStartupRootSections(timeoutSec: Long): Pair<Map<String, String>?, String?> {
+private data class SelfTargetFailureDetail(
+    val kind: SelfTargetFailureKind,
+    val detail: String,
+)
+
+private fun loadStartupRootSections(timeoutSec: Long): Pair<Map<String, String>?, SelfTargetFailureDetail?> {
     val (exitCode, out) = suExec(buildRootShellSnapshotCommand(includePmPackages = true), timeoutSec = timeoutSec)
     if (exitCode != 0) {
         VpnHideLog.w(TAG, "ensureSelfInTargets: root snapshot failed (exit=$exitCode): ${out.trim()}")
-        return null to "exit=$exitCode"
+        return null to SelfTargetFailureDetail(SelfTargetFailureKind.RootUnavailable, "exit=$exitCode")
     }
     return try {
         parseRootShellSnapshot(out).also(::validateRootSnapshotSections) to null
+    } catch (e: RootSnapshotException) {
+        // Root worked, but a required section was missing (incomplete probe — e.g.
+        // a backend's control reply didn't come back). Distinct from no-root.
+        VpnHideLog.w(TAG, "ensureSelfInTargets: snapshot parse failed: ${e.message}")
+        null to SelfTargetFailureDetail(SelfTargetFailureKind.IncompleteData, e.message ?: "incomplete root snapshot")
     } catch (e: Exception) {
         VpnHideLog.w(TAG, "ensureSelfInTargets: snapshot parse failed: ${e.message}")
-        null to (e.message ?: "snapshot parse failed")
+        null to SelfTargetFailureDetail(SelfTargetFailureKind.Unknown, e.message ?: "snapshot parse failed")
     }
 }
 
@@ -353,10 +388,14 @@ private fun cleanupLegacyConfigInputs(timeoutSec: Long) {
     }
 }
 
-private fun selfTargetPreparationFailure(error: String): SelfTargetPreparation =
+private fun selfTargetPreparationFailure(
+    kind: SelfTargetFailureKind,
+    error: String,
+): SelfTargetPreparation =
     SelfTargetPreparation(
         rootAvailable = false,
         selfNeedsRestart = false,
         currentBootId = null,
         error = error,
+        failureKind = kind,
     )

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/StartupCoordinator.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/StartupCoordinator.kt
@@ -17,7 +17,8 @@ internal sealed interface StartupSelfTargetState {
     ) : StartupSelfTargetState
 
     data class Failed(
-        val message: String,
+        val kind: SelfTargetFailureKind,
+        val detail: String,
     ) : StartupSelfTargetState
 }
 
@@ -59,7 +60,8 @@ internal class StartupCoordinator(
             markStartupEvent("self_targets_failed")
             _selfTargetState.value =
                 StartupSelfTargetState.Failed(
-                    preparation.error ?: "root preparation failed",
+                    kind = preparation.failureKind,
+                    detail = preparation.error ?: "root preparation failed",
                 )
         }
     }

--- a/lsposed/app/src/main/res/values-ru/strings.xml
+++ b/lsposed/app/src/main/res/values-ru/strings.xml
@@ -66,7 +66,10 @@
     <string name="dashboard_load_failed_message">VPN Hide не смог собрать root-состояние для этого экрана. Проверьте менеджер root, если разрешение было прервано, затем нажмите «Повторить».</string>
     <string name="dashboard_refresh_failed_message">Обновление не удалось. Показываются предыдущие данные обзора.</string>
     <string name="self_targets_error_title">Подготовка запуска не удалась</string>
-    <string name="self_targets_error_message">VPN Hide не смог обновить root-конфиг. Проверьте менеджер root, если разрешение было прервано, затем нажмите «Повторить».</string>
+    <string name="self_targets_error_body_root">VPN Hide не смог выполнить root-команду. Если вы отклонили или прервали запрос root, выдайте доступ в менеджере root и нажмите «Повторить».</string>
+    <string name="self_targets_error_body_incomplete">Root-доступ сработал, но VPN Hide не смог прочитать часть стартового состояния (показано ниже). Обычно это временно — нажмите «Повторить».</string>
+    <string name="self_targets_error_body_write">Root-доступ сработал, но VPN Hide не смог сохранить обновлённый конфиг (показано ниже). Нажмите «Повторить».</string>
+    <string name="self_targets_error_body_unknown">VPN Hide не смог завершить root-часть запуска (показано ниже). Нажмите «Повторить».</string>
     <string name="targets_load_failed_title">Данные защиты недоступны</string>
     <string name="targets_load_failed_message">VPN Hide не смог собрать root-состояние для этой вкладки. Проверьте менеджер root, если разрешение было прервано, затем нажмите «Повторить».</string>
     <string name="dashboard_ports">Модуль скрытия портов</string>

--- a/lsposed/app/src/main/res/values/strings.xml
+++ b/lsposed/app/src/main/res/values/strings.xml
@@ -97,7 +97,10 @@
     <string name="dashboard_load_failed_message">VPN Hide could not collect the root state needed for this screen. Check your root manager if permission was interrupted, then tap Retry.</string>
     <string name="dashboard_refresh_failed_message">Refresh failed. Showing the previous dashboard data.</string>
     <string name="self_targets_error_title">Startup preparation failed</string>
-    <string name="self_targets_error_message">VPN Hide could not update its root config. Check your root manager if permission was interrupted, then tap Retry.</string>
+    <string name="self_targets_error_body_root">VPN Hide could not run a root command. If you denied or interrupted the root prompt, grant access in your root manager, then tap Retry.</string>
+    <string name="self_targets_error_body_incomplete">Root access worked, but VPN Hide could not read part of its startup state (shown below). This is usually temporary — tap Retry.</string>
+    <string name="self_targets_error_body_write">Root access worked, but VPN Hide could not save its updated config (shown below). Tap Retry.</string>
+    <string name="self_targets_error_body_unknown">VPN Hide could not finish its root-side startup (shown below). Tap Retry.</string>
     <string name="targets_load_failed_title">Protection data unavailable</string>
     <string name="targets_load_failed_message">VPN Hide could not collect the root state needed for this tab. Check your root manager if permission was interrupted, then tap Retry.</string>
     <string name="dashboard_ports">Ports hiding module</string>

--- a/lsposed/app/src/test/kotlin/dev/okhsunrog/vpnhide/StartupCoordinatorTest.kt
+++ b/lsposed/app/src/test/kotlin/dev/okhsunrog/vpnhide/StartupCoordinatorTest.kt
@@ -53,6 +53,7 @@ class StartupCoordinatorTest {
                             selfNeedsRestart = false,
                             currentBootId = null,
                             error = "exit=-1",
+                            failureKind = SelfTargetFailureKind.RootUnavailable,
                         )
                     },
                     cleanupZygiskStatus = { _, bootId -> cleanupBootId = bootId },
@@ -62,7 +63,10 @@ class StartupCoordinatorTest {
 
             coordinator.prepareSelfTargets()
 
-            assertEquals(StartupSelfTargetState.Failed("exit=-1"), coordinator.selfTargetState.value)
+            assertEquals(
+                StartupSelfTargetState.Failed(SelfTargetFailureKind.RootUnavailable, "exit=-1"),
+                coordinator.selfTargetState.value,
+            )
             assertNull(seededPackages)
             assertNull(cleanupBootId)
             assertEquals(


### PR DESCRIPTION
The "Startup preparation failed" card always told the user to *"check your root manager if permission was interrupted"* — even when root was perfectly fine. For the case I actually hit (a backend's section missing from the root snapshot, e.g. a garbled KPM control reply → `missing sections: kpm_state`) that message **actively misleads**: root WAS granted, nothing was interrupted, and it sent me chasing a permissions ghost.

Worse, the real reason was already carried all the way up to the composable (`SelfTargetPreparation.error` → `StartupSelfTargetState.Failed` → `MainActivity`) and then **dropped at the render call** — `RootPreparationErrorScreen` neither accepted nor showed it.

This:
- Models the failure cause where it's actually known: `SelfTargetFailureKind` = `RootUnavailable` / `IncompleteData` / `ConfigWriteFailed` / `Unknown` (set at the point of failure, not string-parsed back out).
- Threads it through `SelfTargetPreparation` → `StartupSelfTargetState.Failed(kind, detail)` → the card.
- Renders a **cause-appropriate body** (e.g. for incomplete data: "Root access worked, but VPN Hide could not read part of its startup state… usually temporary — tap Retry") **plus the underlying detail string** in monospace. It's the app's own screen, so the technical detail leaks nothing.

**Behaviour by cause:**
| cause | body |
|---|---|
| root command failed / denied / interrupted | the (now correct) "grant access in your root manager" message |
| **root worked, snapshot incomplete** | "Root access worked, but VPN Hide could not read part of its startup state…" — **no permission blame** |
| config write failed | "Root access worked, but VPN Hide could not save its updated config…" |
| unknown | neutral |

Plus the raw detail (e.g. `root snapshot incomplete, missing sections: kpm_state`) shown verbatim.

Testing: verified on a real Pixel 8 Pro by temporarily forcing the `IncompleteData` path — the card shows the accurate body and the detail verbatim. ktlint, detekt, `lintDebug`, and unit tests pass (the StartupCoordinator test now asserts both kind and detail propagate). Installed clean on both test devices.