### PR TITLE
feat(lsposed): modernize the no-root screen + add a 'Check again' recheck

### DIFF
--- a/changelog.d/changed-modernized-the-root-access-required-screen-04a2.md
+++ b/changelog.d/changed-modernized-the-root-access-required-screen-04a2.md
@@ -1,0 +1,9 @@
+_2026-06-30_
+
+## English
+
+Modernized the 'Root access required' screen to match the app's redesigned look (icon + themed error card, consistent in light and dark) and added a 'Check again' button so you can re-probe root after granting it, instead of having to reopen the app.
+
+## Русский
+
+Экран «Требуется root-доступ» обновлён под новый дизайн приложения (иконка + тематическая карточка ошибки, корректно в светлой и тёмной теме) и получил кнопку «Проверить снова» — теперь можно перепроверить root после выдачи, не переоткрывая приложение.

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/MainActivity.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/MainActivity.kt
@@ -20,8 +20,10 @@ import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.automirrored.filled.List
 import androidx.compose.material.icons.filled.BarChart
 import androidx.compose.material.icons.filled.Clear
+import androidx.compose.material.icons.filled.ErrorOutline
 import androidx.compose.material.icons.filled.FilterList
 import androidx.compose.material.icons.filled.Home
+import androidx.compose.material.icons.filled.Lock
 import androidx.compose.material.icons.filled.Refresh
 import androidx.compose.material.icons.filled.Search
 import androidx.compose.material.icons.filled.Settings
@@ -44,6 +46,7 @@ import dev.okhsunrog.vpnhide.settings.LocalSettingsInteractor
 import dev.okhsunrog.vpnhide.settings.LocalSettingsState
 import dev.okhsunrog.vpnhide.settings.RepositorySettingsInteractor
 import dev.okhsunrog.vpnhide.settings.SettingsRepository
+import dev.okhsunrog.vpnhide.ui.components.BlockingErrorCard
 import dev.okhsunrog.vpnhide.ui.components.EnhancedButton
 import dev.okhsunrog.vpnhide.ui.components.EnhancedCard
 import dev.okhsunrog.vpnhide.ui.components.pulse
@@ -104,14 +107,20 @@ fun VpnHideApp() {
     ) {
         VpnHideTheme {
             var rootState by remember { mutableStateOf<RootState?>(null) }
-
-            LaunchedEffect(Unit) {
-                rootState =
-                    withContext(Dispatchers.IO) {
-                        if (checkRootAccess()) RootState.Granted else RootState.Denied
-                    }
-                StartupTrace.mark("root_check_done")
+            val rootCheckScope = rememberCoroutineScope()
+            // Re-probe root without relaunching the app: clears to the loading
+            // state, then re-runs the check. Lets the no-root gate offer a
+            // "Check again" button after the user grants root in their manager.
+            val probeRoot: () -> Unit = {
+                rootState = null
+                rootCheckScope.launch {
+                    val granted = withContext(Dispatchers.IO) { checkRootAccess() }
+                    rootState = if (granted) RootState.Granted else RootState.Denied
+                    StartupTrace.mark("root_check_done")
+                }
             }
+
+            LaunchedEffect(Unit) { probeRoot() }
 
             when (rootState) {
                 null -> {
@@ -120,7 +129,7 @@ fun VpnHideApp() {
 
                 RootState.Denied -> {
                     LaunchedEffect(Unit) { StartupTrace.rootDeniedReady() }
-                    RootDeniedScreen()
+                    RootDeniedScreen(onRecheck = probeRoot)
                 }
 
                 RootState.Granted -> {
@@ -638,56 +647,29 @@ private fun RootPreparationErrorScreen(
                 .padding(24.dp),
         contentAlignment = Alignment.Center,
     ) {
-        EnhancedCard(
-            color = MaterialTheme.colorScheme.errorContainer,
-            contentColor = MaterialTheme.colorScheme.onErrorContainer,
-        ) {
-            Column(
-                modifier = Modifier.padding(24.dp),
-                horizontalAlignment = Alignment.CenterHorizontally,
-            ) {
-                Text(
-                    text = stringResource(R.string.self_targets_error_title),
-                    style = MaterialTheme.typography.titleMedium,
-                    fontWeight = FontWeight.Bold,
-                    textAlign = TextAlign.Center,
-                )
-                Spacer(Modifier.height(12.dp))
-                Text(
-                    text = stringResource(selfTargetErrorBodyRes(kind)),
-                    style = MaterialTheme.typography.bodyMedium,
-                    textAlign = TextAlign.Center,
-                )
-                if (detail.isNotBlank()) {
-                    Spacer(Modifier.height(10.dp))
-                    Text(
-                        text = detail,
-                        style = MaterialTheme.typography.bodySmall,
-                        fontFamily = FontFamily.Monospace,
-                        textAlign = TextAlign.Center,
-                        color = MaterialTheme.colorScheme.onErrorContainer.copy(alpha = 0.75f),
-                    )
-                }
-                Spacer(Modifier.height(16.dp))
-                EnhancedButton(onClick = onRetry) {
-                    Text(stringResource(R.string.vpn_off_retry))
-                }
-            }
-        }
+        BlockingErrorCard(
+            icon = Icons.Default.ErrorOutline,
+            title = stringResource(R.string.self_targets_error_title),
+            body = stringResource(selfTargetErrorBodyRes(kind)),
+            detail = detail.takeIf { it.isNotBlank() },
+            actionLabel = stringResource(R.string.vpn_off_retry),
+            onAction = onRetry,
+        )
     }
 }
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-private fun RootDeniedScreen() {
+private fun RootDeniedScreen(onRecheck: () -> Unit) {
     Scaffold(
+        containerColor = AppColors.screenBackground,
         topBar = {
             TopAppBar(
                 title = { Text(stringResource(R.string.app_name)) },
                 colors =
                     TopAppBarDefaults.topAppBarColors(
-                        containerColor = MaterialTheme.colorScheme.errorContainer,
-                        titleContentColor = MaterialTheme.colorScheme.onErrorContainer,
+                        containerColor = AppColors.topBarContainer,
+                        titleContentColor = MaterialTheme.colorScheme.onSurface,
                     ),
             )
         },
@@ -700,28 +682,13 @@ private fun RootDeniedScreen() {
                     .padding(32.dp),
             contentAlignment = Alignment.Center,
         ) {
-            EnhancedCard(
-                color = MaterialTheme.colorScheme.errorContainer,
-            ) {
-                Column(
-                    modifier = Modifier.padding(24.dp),
-                    horizontalAlignment = Alignment.CenterHorizontally,
-                ) {
-                    Text(
-                        text = stringResource(R.string.root_error_title),
-                        style = MaterialTheme.typography.headlineSmall,
-                        fontWeight = FontWeight.Bold,
-                        color = MaterialTheme.colorScheme.onErrorContainer,
-                    )
-                    Spacer(Modifier.height(16.dp))
-                    Text(
-                        text = stringResource(R.string.root_error_message),
-                        style = MaterialTheme.typography.bodyLarge,
-                        color = MaterialTheme.colorScheme.onErrorContainer,
-                        textAlign = TextAlign.Center,
-                    )
-                }
-            }
+            BlockingErrorCard(
+                icon = Icons.Default.Lock,
+                title = stringResource(R.string.root_error_title),
+                body = stringResource(R.string.root_error_message),
+                actionLabel = stringResource(R.string.root_error_recheck),
+                onAction = onRecheck,
+            )
         }
     }
 }

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/ui/components/BlockingErrorCard.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/ui/components/BlockingErrorCard.kt
@@ -1,0 +1,92 @@
+package dev.okhsunrog.vpnhide.ui.components
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.Icon
+import androidx.compose.material3.LocalContentColor
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+
+/**
+ * The shared "can't proceed" card. Every full-screen blocking state in the app
+ * (no root, startup-prep failure, …) renders through this one composable so they
+ * stay visually consistent and a redesign updates all of them at once — instead
+ * of each gate hand-rolling its own slightly-different `errorContainer` card and
+ * one getting forgotten on the next redesign.
+ *
+ * Styled with the theme's error container, so it reads correctly in both light
+ * and dark themes (and under dynamic / amoled) without hardcoded colours.
+ *
+ * @param icon optional leading icon (tinted to match the card's content colour).
+ * @param detail optional raw/technical detail line, shown monospace and dimmed.
+ * @param actionLabel + onAction optional button (e.g. Retry / Check again).
+ */
+@Composable
+fun BlockingErrorCard(
+    title: String,
+    body: String,
+    modifier: Modifier = Modifier,
+    icon: ImageVector? = null,
+    detail: String? = null,
+    actionLabel: String? = null,
+    onAction: (() -> Unit)? = null,
+) {
+    EnhancedCard(
+        modifier = modifier,
+        color = MaterialTheme.colorScheme.errorContainer,
+        contentColor = MaterialTheme.colorScheme.onErrorContainer,
+    ) {
+        Column(
+            modifier = Modifier.padding(24.dp),
+            horizontalAlignment = Alignment.CenterHorizontally,
+        ) {
+            if (icon != null) {
+                Icon(
+                    imageVector = icon,
+                    contentDescription = null,
+                    modifier = Modifier.size(40.dp),
+                )
+                Spacer(Modifier.height(12.dp))
+            }
+            Text(
+                text = title,
+                style = MaterialTheme.typography.titleMedium,
+                fontWeight = FontWeight.Bold,
+                textAlign = TextAlign.Center,
+            )
+            Spacer(Modifier.height(12.dp))
+            Text(
+                text = body,
+                style = MaterialTheme.typography.bodyMedium,
+                textAlign = TextAlign.Center,
+            )
+            if (!detail.isNullOrBlank()) {
+                Spacer(Modifier.height(10.dp))
+                Text(
+                    text = detail,
+                    style = MaterialTheme.typography.bodySmall,
+                    fontFamily = FontFamily.Monospace,
+                    textAlign = TextAlign.Center,
+                    color = LocalContentColor.current.copy(alpha = 0.75f),
+                )
+            }
+            if (actionLabel != null && onAction != null) {
+                Spacer(Modifier.height(16.dp))
+                EnhancedButton(onClick = onAction) {
+                    Text(actionLabel)
+                }
+            }
+        }
+    }
+}

--- a/lsposed/app/src/main/res/values-ru/strings.xml
+++ b/lsposed/app/src/main/res/values-ru/strings.xml
@@ -52,7 +52,8 @@
 
     <!-- Root status -->
     <string name="root_error_title">Требуется root-доступ</string>
-    <string name="root_error_message">VPN Hide необходим root-доступ для управления целевыми приложениями. Предоставьте root-права этому приложению в менеджере root (Magisk, KernelSU и т.д.) и откройте приложение заново.</string>
+    <string name="root_error_message">VPN Hide нужен root-доступ для управления защищёнными приложениями. Выдайте его в менеджере root (Magisk, KernelSU, APatch) и нажмите «Проверить снова».</string>
+    <string name="root_error_recheck">Проверить снова</string>
 
     <!-- Save feedback -->
     <string name="save_success">Сохранено целей: %d</string>

--- a/lsposed/app/src/main/res/values/strings.xml
+++ b/lsposed/app/src/main/res/values/strings.xml
@@ -60,7 +60,8 @@
 
     <!-- Root status -->
     <string name="root_error_title">Root access required</string>
-    <string name="root_error_message">VPN Hide needs root access to manage target apps. Grant root permissions to this app in your root manager (Magisk, KernelSU, etc.) and reopen the app.</string>
+    <string name="root_error_message">VPN Hide needs root access to manage protected apps. Grant it in your root manager (Magisk, KernelSU, APatch), then tap Check again.</string>
+    <string name="root_error_recheck">Check again</string>
 
     <!-- Save feedback -->
     <string name="save_success">Saved %d target(s)</string>


### PR DESCRIPTION
The "Root access required" gate was the most stripped-down of the app's "can't proceed" cards — no icon, no button, an all-red top bar — and the root probe ran once in `LaunchedEffect(Unit)`, so after granting root the user had to **fully kill and reopen the app**. (It wasn't a dated separate Activity, as feared — it was already Compose and nav was already blocked; it had just been skipped in the redesign.)

- **Extract a shared `BlockingErrorCard`** (`ui/components/`): icon + title + body + optional monospace detail + optional action button, styled with the theme's `errorContainer`. Every full-screen blocking state now renders through this one composable, so they stay consistent and a future redesign can't miss one.
- **Modernize `RootDeniedScreen`**: lock icon, neutral app-chrome top bar + screen background (only the card carries the error colour, matching the rest of the app), and a **"Check again"** button that re-probes root **without relaunching** (the gate's `probeRoot` is now reusable).
- **Migrate `RootPreparationErrorScreen`** onto the same shared card.

Navigation stays blocked by construction: the no-root branch shows only this screen; the bottom-nav tabs live in `MainScreen`, reachable only in the `RootState.Granted` branch.

Testing: verified on a real **Pixel 4a in both light and dark themes** (forced the no-root state) — `errorContainer`/`onErrorContainer` adapt per theme, the top bar/background match the app chrome, and icon/title/body/button render correctly in both. ktlint, detekt, `lintDebug`, and unit tests pass.

Note: this was branched while #217 was open and is now rebased onto main (which has #217).