### PR TITLE
feat(lsposed): add background update checks

### DIFF
--- a/changelog.d/added-added-optional-daily-background-update-checks-cd82.md
+++ b/changelog.d/added-added-optional-daily-background-update-checks-cd82.md
@@ -1,0 +1,9 @@
+_2026-07-01_
+
+## English
+
+Added optional daily background update checks with notifications.
+
+## Русский
+
+Добавлена опциональная ежедневная фоновая проверка обновлений с уведомлениями.

--- a/lsposed/app/build.gradle.kts
+++ b/lsposed/app/build.gradle.kts
@@ -238,6 +238,7 @@ dependencies {
     // Reactive theme/settings store (replaces ad-hoc SharedPreferences for UI prefs).
     implementation(libs.datastore.preferences)
     implementation(libs.kotlinx.serialization.json)
+    implementation(libs.work.runtime.ktx)
     // Material You color-scheme generation + harmonization (seed -> full M3 scheme,
     // AMOLED, contrast, palette styles). Powers VpnHideTheme.
     implementation(libs.material.kolor)

--- a/lsposed/app/src/main/AndroidManifest.xml
+++ b/lsposed/app/src/main/AndroidManifest.xml
@@ -6,6 +6,7 @@
         tools:ignore="QueryAllPackagesPermission" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
 
     <application
         android:label="@string/app_name"

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/BackgroundUpdateChecks.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/BackgroundUpdateChecks.kt
@@ -1,0 +1,184 @@
+package dev.okhsunrog.vpnhide
+
+import android.Manifest
+import android.annotation.SuppressLint
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.app.PendingIntent
+import android.content.Context
+import android.content.Intent
+import android.content.pm.PackageManager
+import android.net.Uri
+import android.os.Build
+import androidx.core.app.NotificationCompat
+import androidx.core.app.NotificationManagerCompat
+import androidx.core.content.ContextCompat
+import androidx.work.Constraints
+import androidx.work.ExistingPeriodicWorkPolicy
+import androidx.work.NetworkType
+import androidx.work.PeriodicWorkRequestBuilder
+import androidx.work.WorkManager
+import androidx.work.Worker
+import androidx.work.WorkerParameters
+import dev.okhsunrog.vpnhide.settings.AppSettings
+import dev.okhsunrog.vpnhide.settings.SettingsRepository
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.runBlocking
+import java.util.concurrent.TimeUnit
+
+private const val TAG = "VpnHide-Update"
+private const val UPDATE_WORK_NAME = "vpnhide_background_update_check"
+private const val UPDATE_NOTIFICATION_CHANNEL_ID = "vpnhide_updates"
+private const val UPDATE_NOTIFICATION_ID = 1001
+private const val UPDATE_PREFS_NAME = "vpnhide_prefs"
+private const val KEY_LAST_NOTIFIED_UPDATE_VERSION = "last_notified_update_version"
+
+internal object BackgroundUpdateChecks {
+    fun sync(
+        context: Context,
+        settings: AppSettings,
+    ) {
+        val appContext = context.applicationContext
+        if (settings.backgroundUpdateChecksConfigured && settings.backgroundUpdateChecksEnabled) {
+            schedule(appContext)
+        } else {
+            cancel(appContext)
+        }
+    }
+
+    fun schedule(context: Context) {
+        val request =
+            PeriodicWorkRequestBuilder<BackgroundUpdateCheckWorker>(1, TimeUnit.DAYS)
+                .setConstraints(
+                    Constraints
+                        .Builder()
+                        .setRequiredNetworkType(NetworkType.CONNECTED)
+                        .build(),
+                ).build()
+
+        WorkManager
+            .getInstance(context.applicationContext)
+            .enqueueUniquePeriodicWork(
+                UPDATE_WORK_NAME,
+                ExistingPeriodicWorkPolicy.UPDATE,
+                request,
+            )
+    }
+
+    fun cancel(context: Context) {
+        WorkManager
+            .getInstance(context.applicationContext)
+            .cancelUniqueWork(UPDATE_WORK_NAME)
+    }
+}
+
+internal fun shouldRequestUpdateNotificationPermission(context: Context): Boolean =
+    Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU &&
+        ContextCompat.checkSelfPermission(context, Manifest.permission.POST_NOTIFICATIONS) !=
+        PackageManager.PERMISSION_GRANTED
+
+internal fun canPostUpdateNotifications(context: Context): Boolean =
+    !shouldRequestUpdateNotificationPermission(context) &&
+        NotificationManagerCompat.from(context).areNotificationsEnabled()
+
+class BackgroundUpdateCheckWorker(
+    appContext: Context,
+    params: WorkerParameters,
+) : Worker(appContext, params) {
+    override fun doWork(): Result {
+        if (!backgroundChecksEnabled()) return Result.success()
+
+        return when (val result = checkForUpdate(BuildConfig.VERSION_NAME)) {
+            is UpdateCheckResult.Available -> {
+                notifyIfNeeded(applicationContext, result.info)
+                Result.success()
+            }
+
+            UpdateCheckResult.UpToDate -> {
+                Result.success()
+            }
+
+            UpdateCheckResult.Failed -> {
+                Result.success()
+            }
+        }
+    }
+
+    private fun backgroundChecksEnabled(): Boolean =
+        runCatching {
+            runBlocking {
+                SettingsRepository(applicationContext).settings.first().backgroundUpdateChecksEnabled
+            }
+        }.getOrDefault(false)
+}
+
+private fun notifyIfNeeded(
+    context: Context,
+    info: UpdateInfo,
+) {
+    if (!canPostUpdateNotifications(context)) {
+        VpnHideLog.d(TAG, "Update ${info.latestVersion} available, but notifications are disabled")
+        return
+    }
+    val prefs = context.getSharedPreferences(UPDATE_PREFS_NAME, Context.MODE_PRIVATE)
+    if (prefs.getString(KEY_LAST_NOTIFIED_UPDATE_VERSION, null) == info.latestVersion) return
+    if (showUpdateNotification(context, info)) {
+        prefs
+            .edit()
+            .putString(KEY_LAST_NOTIFIED_UPDATE_VERSION, info.latestVersion)
+            .apply()
+    }
+}
+
+@SuppressLint("MissingPermission")
+private fun showUpdateNotification(
+    context: Context,
+    info: UpdateInfo,
+): Boolean {
+    ensureUpdateNotificationChannel(context)
+    val intent =
+        Intent(Intent.ACTION_VIEW, Uri.parse(info.downloadUrl))
+            .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+    val pendingIntent =
+        PendingIntent.getActivity(
+            context,
+            0,
+            intent,
+            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE,
+        )
+    val notification =
+        NotificationCompat
+            .Builder(context, UPDATE_NOTIFICATION_CHANNEL_ID)
+            .setSmallIcon(R.mipmap.ic_launcher_monochrome)
+            .setContentTitle(context.getString(R.string.update_notification_title))
+            .setContentText(context.getString(R.string.update_notification_body, info.latestVersion))
+            .setStyle(
+                NotificationCompat.BigTextStyle().bigText(
+                    context.getString(R.string.update_notification_body, info.latestVersion),
+                ),
+            ).setContentIntent(pendingIntent)
+            .setAutoCancel(true)
+            .setPriority(NotificationCompat.PRIORITY_DEFAULT)
+            .build()
+
+    return runCatching {
+        NotificationManagerCompat.from(context).notify(UPDATE_NOTIFICATION_ID, notification)
+        true
+    }.getOrElse { error ->
+        VpnHideLog.d(TAG, "Failed to show update notification: ${error.message}")
+        false
+    }
+}
+
+private fun ensureUpdateNotificationChannel(context: Context) {
+    val manager = context.getSystemService(NotificationManager::class.java)
+    val channel =
+        NotificationChannel(
+            UPDATE_NOTIFICATION_CHANNEL_ID,
+            context.getString(R.string.update_notification_channel_name),
+            NotificationManager.IMPORTANCE_DEFAULT,
+        ).apply {
+            description = context.getString(R.string.update_notification_channel_description)
+        }
+    manager.createNotificationChannel(channel)
+}

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/BackgroundUpdateChecks.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/BackgroundUpdateChecks.kt
@@ -30,8 +30,6 @@ private const val TAG = "VpnHide-Update"
 private const val UPDATE_WORK_NAME = "vpnhide_background_update_check"
 private const val UPDATE_NOTIFICATION_CHANNEL_ID = "vpnhide_updates"
 private const val UPDATE_NOTIFICATION_ID = 1001
-private const val UPDATE_PREFS_NAME = "vpnhide_prefs"
-private const val KEY_LAST_NOTIFIED_UPDATE_VERSION = "last_notified_update_version"
 
 internal object BackgroundUpdateChecks {
     fun sync(
@@ -86,11 +84,12 @@ class BackgroundUpdateCheckWorker(
     params: WorkerParameters,
 ) : Worker(appContext, params) {
     override fun doWork(): Result {
-        if (!backgroundChecksEnabled()) return Result.success()
+        val repository = SettingsRepository(applicationContext)
+        if (!backgroundChecksEnabled(repository)) return Result.success()
 
         return when (val result = checkForUpdate(BuildConfig.VERSION_NAME)) {
             is UpdateCheckResult.Available -> {
-                notifyIfNeeded(applicationContext, result.info)
+                notifyIfNeeded(applicationContext, repository, result.info)
                 Result.success()
             }
 
@@ -104,29 +103,35 @@ class BackgroundUpdateCheckWorker(
         }
     }
 
-    private fun backgroundChecksEnabled(): Boolean =
+    private fun backgroundChecksEnabled(repository: SettingsRepository): Boolean =
         runCatching {
             runBlocking {
-                SettingsRepository(applicationContext).settings.first().backgroundUpdateChecksEnabled
+                repository.settings.first().backgroundUpdateChecksEnabled
             }
         }.getOrDefault(false)
 }
 
 private fun notifyIfNeeded(
     context: Context,
+    repository: SettingsRepository,
     info: UpdateInfo,
 ) {
     if (!canPostUpdateNotifications(context)) {
         VpnHideLog.d(TAG, "Update ${info.latestVersion} available, but notifications are disabled")
         return
     }
-    val prefs = context.getSharedPreferences(UPDATE_PREFS_NAME, Context.MODE_PRIVATE)
-    if (prefs.getString(KEY_LAST_NOTIFIED_UPDATE_VERSION, null) == info.latestVersion) return
-    if (showUpdateNotification(context, info)) {
-        prefs
-            .edit()
-            .putString(KEY_LAST_NOTIFIED_UPDATE_VERSION, info.latestVersion)
-            .apply()
+    runCatching {
+        runBlocking {
+            if (repository.lastNotifiedUpdateVersion() == info.latestVersion) return@runBlocking
+            if (showUpdateNotification(context, info)) {
+                // Persist through the app's DataStore with a suspend write that
+                // completes before doWork() returns — not SharedPreferences.apply().
+                // The OS can tear this worker's process down the moment work
+                // finishes, dropping a fire-and-forget async write and re-notifying
+                // for the same version on the next run.
+                repository.setLastNotifiedUpdateVersion(info.latestVersion)
+            }
+        }
     }
 }
 

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/MainActivity.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/MainActivity.kt
@@ -1,10 +1,13 @@
 package dev.okhsunrog.vpnhide
 
+import android.Manifest
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.BackHandler
+import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.animation.AnimatedContent
 import androidx.compose.animation.EnterTransition
 import androidx.compose.animation.ExitTransition
@@ -83,21 +86,68 @@ private fun checkRootAccess(): Boolean {
     return exitCode == 0 && stdout.contains("uid=0")
 }
 
+@Composable
+private fun BackgroundUpdatePromptDialog(
+    onEnable: () -> Unit,
+    onDismiss: () -> Unit,
+) {
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text(stringResource(R.string.background_update_prompt_title)) },
+        text = { Text(stringResource(R.string.background_update_prompt_body)) },
+        confirmButton = {
+            TextButton(onClick = onEnable) {
+                Text(stringResource(R.string.background_update_prompt_enable))
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) {
+                Text(stringResource(R.string.background_update_prompt_not_now))
+            }
+        },
+    )
+}
+
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun VpnHideApp() {
     val context = LocalContext.current
     val settingsRepository = remember(context) { SettingsRepository(context.applicationContext) }
-    val settings by settingsRepository.settings.collectAsState(initial = AppSettings())
+    val loadedSettings by settingsRepository.settings.collectAsState(initial = null)
+    val settingsLoaded = loadedSettings != null
+    val settings = loadedSettings ?: AppSettings()
     val settingsScope = rememberCoroutineScope()
     val settingsInteractor =
         remember(settingsRepository, settingsScope) {
             RepositorySettingsInteractor(settingsRepository, settingsScope)
         }
+    val notificationPermissionLauncher =
+        rememberLauncherForActivityResult(ActivityResultContracts.RequestPermission()) {
+            // Work scheduling is controlled by the DataStore setting. If the user
+            // denies notifications, the worker still runs but skips notification
+            // delivery until permission is granted later.
+        }
+
+    fun requestUpdateNotificationsIfNeeded() {
+        if (shouldRequestUpdateNotificationPermission(context)) {
+            notificationPermissionLauncher.launch(Manifest.permission.POST_NOTIFICATIONS)
+        }
+    }
 
     LaunchedEffect(settings.agentControlEnabled) {
         withContext(Dispatchers.IO) {
             AgentControlBridge.setEnabled(context.applicationContext, settings.agentControlEnabled)
+        }
+    }
+    LaunchedEffect(
+        settingsLoaded,
+        settings.backgroundUpdateChecksConfigured,
+        settings.backgroundUpdateChecksEnabled,
+    ) {
+        if (settingsLoaded) {
+            withContext(Dispatchers.IO) {
+                BackgroundUpdateChecks.sync(context.applicationContext, settings)
+            }
         }
     }
 
@@ -106,6 +156,24 @@ fun VpnHideApp() {
         LocalSettingsInteractor provides settingsInteractor,
     ) {
         VpnHideTheme {
+            var showBackgroundUpdatePrompt by remember { mutableStateOf(false) }
+            LaunchedEffect(settingsLoaded, settings.backgroundUpdateChecksConfigured) {
+                showBackgroundUpdatePrompt =
+                    settingsLoaded && !settings.backgroundUpdateChecksConfigured
+            }
+            if (showBackgroundUpdatePrompt) {
+                BackgroundUpdatePromptDialog(
+                    onEnable = {
+                        showBackgroundUpdatePrompt = false
+                        settingsInteractor.setBackgroundUpdateChecksEnabled(true)
+                        requestUpdateNotificationsIfNeeded()
+                    },
+                    onDismiss = {
+                        showBackgroundUpdatePrompt = false
+                        settingsInteractor.setBackgroundUpdateChecksEnabled(false)
+                    },
+                )
+            }
             var rootState by remember { mutableStateOf<RootState?>(null) }
             val rootCheckScope = rememberCoroutineScope()
             // Re-probe root without relaunching the app: clears to the loading

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/MainActivity.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/MainActivity.kt
@@ -156,24 +156,6 @@ fun VpnHideApp() {
         LocalSettingsInteractor provides settingsInteractor,
     ) {
         VpnHideTheme {
-            var showBackgroundUpdatePrompt by remember { mutableStateOf(false) }
-            LaunchedEffect(settingsLoaded, settings.backgroundUpdateChecksConfigured) {
-                showBackgroundUpdatePrompt =
-                    settingsLoaded && !settings.backgroundUpdateChecksConfigured
-            }
-            if (showBackgroundUpdatePrompt) {
-                BackgroundUpdatePromptDialog(
-                    onEnable = {
-                        showBackgroundUpdatePrompt = false
-                        settingsInteractor.setBackgroundUpdateChecksEnabled(true)
-                        requestUpdateNotificationsIfNeeded()
-                    },
-                    onDismiss = {
-                        showBackgroundUpdatePrompt = false
-                        settingsInteractor.setBackgroundUpdateChecksEnabled(false)
-                    },
-                )
-            }
             var rootState by remember { mutableStateOf<RootState?>(null) }
             val rootCheckScope = rememberCoroutineScope()
             // Re-probe root without relaunching the app: clears to the loading
@@ -201,6 +183,27 @@ fun VpnHideApp() {
                 }
 
                 RootState.Granted -> {
+                    // Only prompt about background update checks once the app is
+                    // actually usable (root granted) — not over the loading or
+                    // no-root gate, where nothing else works yet.
+                    var showBackgroundUpdatePrompt by remember { mutableStateOf(false) }
+                    LaunchedEffect(settingsLoaded, settings.backgroundUpdateChecksConfigured) {
+                        showBackgroundUpdatePrompt =
+                            settingsLoaded && !settings.backgroundUpdateChecksConfigured
+                    }
+                    if (showBackgroundUpdatePrompt) {
+                        BackgroundUpdatePromptDialog(
+                            onEnable = {
+                                showBackgroundUpdatePrompt = false
+                                settingsInteractor.setBackgroundUpdateChecksEnabled(true)
+                                requestUpdateNotificationsIfNeeded()
+                            },
+                            onDismiss = {
+                                showBackgroundUpdatePrompt = false
+                                settingsInteractor.setBackgroundUpdateChecksEnabled(false)
+                            },
+                        )
+                    }
                     MainScreen()
                 }
             }

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/SettingsScreen.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/SettingsScreen.kt
@@ -1,5 +1,6 @@
 package dev.okhsunrog.vpnhide
 
+import android.Manifest
 import android.content.ClipData
 import android.content.ClipboardManager
 import android.net.Uri
@@ -228,6 +229,7 @@ fun SettingsScreen(
                 )
             }
 
+            UpdatesSettingsSection()
             AutoHideSettingsSection()
             DiagnosticsSettingsSection(onOpen = { diagnosticsOpen = true })
             DebugToolsSettingsSection(selfNeedsRestart = selfNeedsRestart)
@@ -237,6 +239,33 @@ fun SettingsScreen(
             ResetSettingsSection(selfNeedsRestart = selfNeedsRestart)
             DeveloperSettingsSection()
         }
+    }
+}
+
+@Composable
+private fun UpdatesSettingsSection() {
+    val settings = LocalSettingsState.current
+    val interactor = LocalSettingsInteractor.current
+    val context = LocalContext.current
+    val notificationPermissionLauncher =
+        rememberLauncherForActivityResult(ActivityResultContracts.RequestPermission()) {
+            // The switch reflects the user's preference. If Android denies the
+            // notification permission, the worker still runs and skips delivery.
+        }
+    Column(verticalArrangement = Arrangement.spacedBy(3.dp)) {
+        SettingsSectionHeader(stringResource(R.string.settings_updates_section))
+        PreferenceRowSwitch(
+            title = stringResource(R.string.settings_background_update_checks),
+            subtitle = stringResource(R.string.settings_background_update_checks_sub),
+            icon = Icons.Default.Update,
+            checked = settings.backgroundUpdateChecksEnabled,
+            onCheckedChange = { enabled ->
+                interactor.setBackgroundUpdateChecksEnabled(enabled)
+                if (enabled && shouldRequestUpdateNotificationPermission(context)) {
+                    notificationPermissionLauncher.launch(Manifest.permission.POST_NOTIFICATIONS)
+                }
+            },
+        )
     }
 }
 

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/UpdateCheckCache.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/UpdateCheckCache.kt
@@ -21,9 +21,9 @@ import kotlinx.coroutines.withContext
  *    keep the app minimized for a day still see a fresh state when
  *    they come back.
  *
- * No WorkManager, no background alarms, no notifications — this is
- * purely reactive to app lifecycle. If the app is actually killed the
- * cache dies with it and the next launch re-checks as usual.
+ * This cache is purely reactive to app lifecycle. Optional background checks
+ * live in [BackgroundUpdateChecks] and report through system notifications,
+ * not through this in-memory state.
  */
 internal object UpdateCheckCache {
     /** 6 hours. Arbitrary — roughly matches how often a release cadence

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/settings/AppSettings.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/settings/AppSettings.kt
@@ -43,6 +43,10 @@ data class AppSettings(
     val hapticsEnabled: Boolean = true,
     /** Use full role labels in the unified Apps picker instead of single-letter chips. */
     val fullProtectionRoleLabels: Boolean = true,
+    /** Whether the user has explicitly accepted or declined daily background update checks. */
+    val backgroundUpdateChecksConfigured: Boolean = false,
+    /** Check GitHub Releases in the background and notify when a newer APK is available. */
+    val backgroundUpdateChecksEnabled: Boolean = false,
     /** Expose UI-equivalent state/control through the debug host bridge for agent-driven development. */
     val agentControlEnabled: Boolean = false,
     /** Whether the user has opened Settings at least once (gates the gear hint). */

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/settings/SettingsInteractor.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/settings/SettingsInteractor.kt
@@ -38,6 +38,8 @@ interface SettingsInteractor {
 
     fun setFullProtectionRoleLabels(value: Boolean)
 
+    fun setBackgroundUpdateChecksEnabled(value: Boolean)
+
     fun setAgentControlEnabled(value: Boolean)
 
     fun setSettingsHintSeen(value: Boolean)
@@ -70,6 +72,8 @@ class RepositorySettingsInteractor(
     override fun setHapticsEnabled(value: Boolean) = launch { repository.setHapticsEnabled(value) }
 
     override fun setFullProtectionRoleLabels(value: Boolean) = launch { repository.setFullProtectionRoleLabels(value) }
+
+    override fun setBackgroundUpdateChecksEnabled(value: Boolean) = launch { repository.setBackgroundUpdateChecksEnabled(value) }
 
     override fun setAgentControlEnabled(value: Boolean) = launch { repository.setAgentControlEnabled(value) }
 

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/settings/SettingsRepository.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/settings/SettingsRepository.kt
@@ -34,6 +34,7 @@ class SettingsRepository(
         val ANIMATIONS = booleanPreferencesKey("animations_enabled")
         val HAPTICS = booleanPreferencesKey("haptics_enabled")
         val FULL_PROTECTION_ROLE_LABELS = booleanPreferencesKey("full_protection_role_labels")
+        val BACKGROUND_UPDATE_CHECKS = booleanPreferencesKey("background_update_checks")
         val AGENT_CONTROL = booleanPreferencesKey("agent_control_enabled")
         val SETTINGS_HINT_SEEN = booleanPreferencesKey("settings_hint_seen")
         val SUPPRESS_VERSION_WARNINGS = booleanPreferencesKey("suppress_version_warnings")
@@ -53,6 +54,9 @@ class SettingsRepository(
                 hapticsEnabled = p[Keys.HAPTICS] ?: defaults.hapticsEnabled,
                 fullProtectionRoleLabels =
                     p[Keys.FULL_PROTECTION_ROLE_LABELS] ?: defaults.fullProtectionRoleLabels,
+                backgroundUpdateChecksConfigured = Keys.BACKGROUND_UPDATE_CHECKS in p,
+                backgroundUpdateChecksEnabled =
+                    p[Keys.BACKGROUND_UPDATE_CHECKS] ?: defaults.backgroundUpdateChecksEnabled,
                 agentControlEnabled = p[Keys.AGENT_CONTROL] ?: defaults.agentControlEnabled,
                 settingsHintSeen = p[Keys.SETTINGS_HINT_SEEN] ?: defaults.settingsHintSeen,
                 suppressVersionWarnings =
@@ -77,6 +81,8 @@ class SettingsRepository(
     suspend fun setHapticsEnabled(value: Boolean) = edit { it[Keys.HAPTICS] = value }
 
     suspend fun setFullProtectionRoleLabels(value: Boolean) = edit { it[Keys.FULL_PROTECTION_ROLE_LABELS] = value }
+
+    suspend fun setBackgroundUpdateChecksEnabled(value: Boolean) = edit { it[Keys.BACKGROUND_UPDATE_CHECKS] = value }
 
     suspend fun setAgentControlEnabled(value: Boolean) = edit { it[Keys.AGENT_CONTROL] = value }
 

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/settings/SettingsRepository.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/settings/SettingsRepository.kt
@@ -8,8 +8,10 @@ import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.floatPreferencesKey
 import androidx.datastore.preferences.core.intPreferencesKey
 import androidx.datastore.preferences.core.longPreferencesKey
+import androidx.datastore.preferences.core.stringPreferencesKey
 import androidx.datastore.preferences.preferencesDataStore
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
 
 /**
@@ -38,6 +40,11 @@ class SettingsRepository(
         val AGENT_CONTROL = booleanPreferencesKey("agent_control_enabled")
         val SETTINGS_HINT_SEEN = booleanPreferencesKey("settings_hint_seen")
         val SUPPRESS_VERSION_WARNINGS = booleanPreferencesKey("suppress_version_warnings")
+
+        // Worker-internal state (not a user-facing setting, so not surfaced in
+        // AppSettings): the last release the background update worker already
+        // notified about, so it doesn't re-notify for the same version.
+        val LAST_NOTIFIED_UPDATE_VERSION = stringPreferencesKey("last_notified_update_version")
     }
 
     val settings: Flow<AppSettings> =
@@ -89,6 +96,14 @@ class SettingsRepository(
     suspend fun setSettingsHintSeen(value: Boolean) = edit { it[Keys.SETTINGS_HINT_SEEN] = value }
 
     suspend fun setSuppressVersionWarnings(value: Boolean) = edit { it[Keys.SUPPRESS_VERSION_WARNINGS] = value }
+
+    /** Last release the background update worker has already notified about, if any. */
+    suspend fun lastNotifiedUpdateVersion(): String? =
+        context.uiSettingsStore.data
+            .map { it[Keys.LAST_NOTIFIED_UPDATE_VERSION] }
+            .first()
+
+    suspend fun setLastNotifiedUpdateVersion(value: String) = edit { it[Keys.LAST_NOTIFIED_UPDATE_VERSION] = value }
 
     private suspend fun edit(block: (androidx.datastore.preferences.core.MutablePreferences) -> Unit) {
         context.uiSettingsStore.edit(block)

--- a/lsposed/app/src/main/res/values-ru/strings.xml
+++ b/lsposed/app/src/main/res/values-ru/strings.xml
@@ -303,6 +303,14 @@
     <string name="update_available_title">Доступно обновление</string>
     <string name="update_available_subtitle">Доступна версия %1$s</string>
     <string name="update_download">Скачать</string>
+    <string name="update_notification_channel_name">Обновления</string>
+    <string name="update_notification_channel_description">Уведомления о новых версиях VPN Hide</string>
+    <string name="update_notification_title">Доступно обновление</string>
+    <string name="update_notification_body">Доступна версия %1$s. Нажмите, чтобы скачать.</string>
+    <string name="background_update_prompt_title">Проверять обновления автоматически?</string>
+    <string name="background_update_prompt_body">VPN Hide может раз в сутки проверять GitHub и присылать уведомление, когда доступна новая версия. Android может задерживать фоновую проверку ради экономии батареи.</string>
+    <string name="background_update_prompt_enable">Включить</string>
+    <string name="background_update_prompt_not_now">Не сейчас</string>
 
     <!-- Changelog -->
     <string name="changelog_title">Что нового в v%1$s</string>
@@ -356,6 +364,9 @@
     <string name="settings_animations_sub">Пружинные переходы и плавное изменение формы</string>
     <string name="settings_full_role_labels">Полные названия ролей</string>
     <string name="settings_full_role_labels_sub">Показывать Java / Native / Apps / Ports вместо J / N / A / P</string>
+    <string name="settings_updates_section">Обновления</string>
+    <string name="settings_background_update_checks">Автоматическая проверка обновлений</string>
+    <string name="settings_background_update_checks_sub">Раз в сутки проверять новые релизы в фоне и уведомлять, когда доступна новая версия.</string>
     <string name="settings_diagnostics_section">Диагностика</string>
     <string name="settings_diagnostics_title">Подробная диагностика</string>
     <string name="settings_diagnostics_sub">Полный набор проверок скрытия</string>

--- a/lsposed/app/src/main/res/values/strings.xml
+++ b/lsposed/app/src/main/res/values/strings.xml
@@ -325,6 +325,14 @@
     <string name="update_available_title">Update available</string>
     <string name="update_available_subtitle">Version %1$s is available</string>
     <string name="update_download">Download</string>
+    <string name="update_notification_channel_name">Updates</string>
+    <string name="update_notification_channel_description">VPN Hide release notifications</string>
+    <string name="update_notification_title">Update available</string>
+    <string name="update_notification_body">Version %1$s is available. Tap to download.</string>
+    <string name="background_update_prompt_title">Check for updates automatically?</string>
+    <string name="background_update_prompt_body">VPN Hide can check GitHub once a day and notify you when a new version is available. Android may delay background checks to save battery.</string>
+    <string name="background_update_prompt_enable">Enable</string>
+    <string name="background_update_prompt_not_now">Not now</string>
 
     <!-- Changelog -->
     <string name="changelog_title">What\'s new in v%1$s</string>
@@ -384,6 +392,9 @@
     <string name="settings_animations_sub">Springy transitions and shape morphing</string>
     <string name="settings_full_role_labels">Full role labels</string>
     <string name="settings_full_role_labels_sub">Show Java / Native / Apps / Ports instead of J / N / A / P</string>
+    <string name="settings_updates_section">Updates</string>
+    <string name="settings_background_update_checks">Automatic update checks</string>
+    <string name="settings_background_update_checks_sub">Check once a day in the background and notify when a new release is available.</string>
     <string name="settings_diagnostics_section">Diagnostics</string>
     <string name="settings_diagnostics_title">Detailed diagnostics</string>
     <string name="settings_diagnostics_sub">Run the full hiding check suite</string>

--- a/lsposed/gradle/libs.versions.toml
+++ b/lsposed/gradle/libs.versions.toml
@@ -15,6 +15,7 @@ gobley = "0.3.8-agp9.1.okhsunrog1"
 detekt = "1.23.8"
 cpd = "3.5"
 kotlinx-serialization-json = "1.9.0"
+work = "2.11.2"
 
 [libraries]
 core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "core-ktx" }
@@ -28,6 +29,7 @@ datastore-preferences = { group = "androidx.datastore", name = "datastore-prefer
 kotlinx-serialization-json = { group = "org.jetbrains.kotlinx", name = "kotlinx-serialization-json", version.ref = "kotlinx-serialization-json" }
 material-kolor = { group = "com.materialkolor", name = "material-kolor", version.ref = "material-kolor" }
 squircle-shape = { group = "com.stoyanvuchev", name = "squircle-shape-android", version.ref = "squircle-shape" }
+work-runtime-ktx = { group = "androidx.work", name = "work-runtime-ktx", version.ref = "work" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
## What changed

- Added an optional daily background update check backed by WorkManager.
- Added a first-run/migration prompt so users explicitly choose whether to enable background checks.
- Added a Settings toggle for automatic update checks and Android notification permission request flow.
- Added update notifications that open the latest release/APK URL and avoid notifying repeatedly for the same version.

## Why

Update checks were previously foreground-only: the app checked GitHub when Dashboard was opened or resumed after the in-memory cache went stale. Users who did not open VPN Hide would not learn about new releases.

## Validation

- `xmllint --noout lsposed/app/src/main/res/values/strings.xml lsposed/app/src/main/res/values-ru/strings.xml lsposed/app/src/main/AndroidManifest.xml`
- `git diff --check`
- `./gradlew :app:ktlintCheck :app:detekt cpdCheck :app:lintDebug :app:compileDebugKotlin`
- `./gradlew :app:testDebugUnitTest`
