### PR TITLE
feat(lsposed): drop the duplicate per-level protection status on the Dashboard

### DIFF
--- a/changelog.d/added-dashboard-shows-a-warning-with-a-840f.md
+++ b/changelog.d/added-dashboard-shows-a-warning-with-a-840f.md
@@ -1,0 +1,9 @@
+_2026-07-01_
+
+## English
+
+Dashboard shows a warning with a Details button (opens the full diagnostics) when a hiding layer is active but some of its runtime checks still fail
+
+## Русский
+
+На «Обзоре» показывается предупреждение с кнопкой «Подробности» (открывает полную диагностику), когда слой скрытия активен, но часть его проверок не проходит

--- a/changelog.d/changed-dashboard-drops-the-redundant-per-level-0379.md
+++ b/changelog.d/changed-dashboard-drops-the-redundant-per-level-0379.md
@@ -1,0 +1,9 @@
+_2026-07-01_
+
+## English
+
+Dashboard drops the redundant per-level protection status section (it just repeated the summary card); the VPN-off and restart prompts now sit directly under the summary
+
+## Русский
+
+На «Обзоре» убрана дублирующая секция статуса по уровням — она просто повторяла верхнюю карточку; подсказки «VPN выключен» и «нужен перезапуск» теперь сразу под ней

--- a/changelog.d/changed-dashboard-drops-the-redundant-per-level-0379.md
+++ b/changelog.d/changed-dashboard-drops-the-redundant-per-level-0379.md
@@ -2,8 +2,8 @@ _2026-07-01_
 
 ## English
 
-Dashboard drops the redundant per-level protection status section (it just repeated the summary card); the VPN-off and restart prompts now sit directly under the summary
+Dashboard declutter: drops the redundant per-level protection status section (it just repeated the summary card), so the VPN-off and restart prompts now sit directly under the summary; the status card also no longer repeats its verdict in a coloured pill
 
 ## Русский
 
-На «Обзоре» убрана дублирующая секция статуса по уровням — она просто повторяла верхнюю карточку; подсказки «VPN выключен» и «нужен перезапуск» теперь сразу под ней
+Расхламление «Обзора»: убрана дублирующая секция статуса по уровням (она просто повторяла верхнюю карточку), а подсказки «VPN выключен» и «нужен перезапуск» теперь сразу под ней; сама карточка статуса больше не дублирует свой вердикт в цветной пилюле

--- a/changelog.d/changed-reworded-the-debug-logging-setting-it-c2ef.md
+++ b/changelog.d/changed-reworded-the-debug-logging-setting-it-c2ef.md
@@ -1,0 +1,9 @@
+_2026-07-01_
+
+## English
+
+Reworded the Debug logging setting: it's off by default to keep logcat quiet and save resources, not 'for stealth' (apps can't read another app's logcat anyway)
+
+## Русский
+
+Переписана подпись «Отладочные логи»: выключены по умолчанию, чтобы не засорять logcat и не тратить ресурсы, а не «ради скрытности» (обычные приложения всё равно не видят чужой logcat)

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DashboardData.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DashboardData.kt
@@ -214,8 +214,9 @@ internal sealed interface LsposedConfig {
 internal enum class DashboardMessageSeverity { ERROR, WARNING, INFO }
 
 // Optional call-to-action rendered on a message banner. ContactAuthor opens the
-// shared community/feedback modal (GitHub / Telegram / 4PDA).
-internal enum class DashboardMessageAction { ContactAuthor, }
+// shared community/feedback modal (GitHub / Telegram / 4PDA); OpenDiagnostics
+// opens the detailed diagnostics screen.
+internal enum class DashboardMessageAction { ContactAuthor, OpenDiagnostics }
 
 internal data class DashboardMessage(
     val severity: DashboardMessageSeverity,
@@ -1532,6 +1533,21 @@ internal suspend fun loadDashboardState(
         } else {
             warn(text)
         }
+    }
+
+    // A hiding layer is active but some of its runtime probes still leak (native
+    // partial/full, or a Java probe fails). Without this the state shows only as
+    // an amber hero/tile with no explanation — surface a warning that links to
+    // the full diagnostics for the per-check breakdown.
+    if (protection is ProtectionCheck.Checked &&
+        (protection.native is NativeResult.Fail || protection.java is JavaResult.Fail)
+    ) {
+        messages +=
+            DashboardMessage(
+                DashboardMessageSeverity.WARNING,
+                res.getString(R.string.dashboard_issue_checks_failed),
+                DashboardMessageAction.OpenDiagnostics,
+            )
     }
 
     StartupTrace.mark("dashboard_messages_done")

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DashboardScreen.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DashboardScreen.kt
@@ -165,6 +165,39 @@ fun DashboardScreen(
 
         // Hero: the whole setup's health at a glance.
         DashboardHeroCard(state = loadedState, errorCount = errors.size, warningCount = warnings.size)
+
+        // Critical protection states sit right under the hero (not in a separate
+        // mid-screen section): the VPN needs turning on, or a self-restart is
+        // pending. The all-good "Checked" state renders nothing here — the hero's
+        // per-level tiles already carry that status, so the old duplicate per-level
+        // cards (Native / Java «OK», which just restated those tiles) are gone.
+        when (loadedState.protection) {
+            is ProtectionCheck.NoVpn -> {
+                Spacer(Modifier.height(12.dp))
+                VpnOffPrompt(
+                    onRetry = {
+                        // Re-read dashboard state (re-runs its own VPN + protection
+                        // probes) and re-run the diag cache so both screens move to
+                        // "Ready" when VPN is back.
+                        DashboardCache.refresh(scope, context, selfNeedsRestart)
+                        DiagnosticsCache.retry(scope, context)
+                    },
+                )
+            }
+
+            is ProtectionCheck.NeedsRestart -> {
+                Spacer(Modifier.height(12.dp))
+                StatusBanner(
+                    text = stringResource(R.string.dashboard_needs_restart),
+                    containerColor = warningBg,
+                    contentColor = onBannerColor,
+                )
+            }
+
+            is ProtectionCheck.Checked -> {
+                Unit
+            }
+        }
         Spacer(Modifier.height(20.dp))
 
         // Module status cards — one grouped block (byIndex corners).
@@ -185,41 +218,6 @@ fun DashboardScreen(
         updateInfo?.let { info ->
             Spacer(Modifier.height(8.dp))
             UpdateAvailableCard(info)
-        }
-
-        // Protection status
-        Spacer(Modifier.height(20.dp))
-        SectionHeader(stringResource(R.string.dashboard_protection))
-        Spacer(Modifier.height(8.dp))
-
-        when (val p = loadedState.protection) {
-            is ProtectionCheck.NoVpn -> {
-                VpnOffPrompt(
-                    onRetry = {
-                        // Re-read dashboard state (re-runs its own VPN
-                        // + protection probes) and re-run the diag
-                        // cache so both screens move to "Ready" when
-                        // VPN is back.
-                        DashboardCache.refresh(scope, context, selfNeedsRestart)
-                        DiagnosticsCache.retry(scope, context)
-                    },
-                )
-            }
-
-            is ProtectionCheck.NeedsRestart -> {
-                StatusBanner(
-                    text = stringResource(R.string.dashboard_needs_restart),
-                    containerColor = warningBg,
-                    contentColor = onBannerColor,
-                )
-            }
-
-            is ProtectionCheck.Checked -> {
-                Column(verticalArrangement = Arrangement.spacedBy(3.dp)) {
-                    NativeProtectionCard(p.native, index = 0, count = 2)
-                    JavaProtectionCard(p.java, index = 1, count = 2)
-                }
-            }
         }
 
         if (errors.isNotEmpty()) {
@@ -1129,156 +1127,6 @@ private fun NativeInstallRecommendationCard(recommendation: NativeInstallRecomme
                 style = MaterialTheme.typography.bodySmall,
                 color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.8f),
             )
-        }
-    }
-}
-
-@Composable
-private fun NativeProtectionCard(
-    result: NativeResult,
-    index: Int = -1,
-    count: Int = 1,
-) {
-    val (statusContainerColor, statusText, statusColor) =
-        when (result) {
-            is NativeResult.Ok -> {
-                Triple(
-                    StatusColors.successContainer(),
-                    stringResource(R.string.dashboard_protection_ok),
-                    StatusColors.successDot,
-                )
-            }
-
-            is NativeResult.Fail -> {
-                val text =
-                    if (result.passed > 0) {
-                        stringResource(R.string.dashboard_protection_partial)
-                    } else {
-                        stringResource(R.string.dashboard_protection_fail)
-                    }
-                val color = if (result.passed > 0) StatusColors.warningAccent else StatusColors.errorAccent
-                val bg = if (result.passed > 0) StatusColors.warningContainer() else StatusColors.errorContainer()
-                Triple(bg, text, color)
-            }
-
-            is NativeResult.NoModule -> {
-                Triple(
-                    MaterialTheme.colorScheme.surfaceVariant,
-                    stringResource(R.string.dashboard_protection_no_module),
-                    MaterialTheme.colorScheme.onSurfaceVariant,
-                )
-            }
-        }
-    ProtectionCardShell(
-        badgeText = "N",
-        label = stringResource(R.string.dashboard_native_protection),
-        statusText = statusText,
-        statusColor = statusColor,
-        statusContainerColor = statusContainerColor,
-        pulsing = result is NativeResult.Ok,
-        index = index,
-        count = count,
-    )
-}
-
-@Composable
-private fun JavaProtectionCard(
-    result: JavaResult,
-    index: Int = -1,
-    count: Int = 1,
-) {
-    val (statusContainerColor, statusText, statusColor) =
-        when (result) {
-            is JavaResult.Ok -> {
-                Triple(
-                    StatusColors.successContainer(),
-                    stringResource(R.string.dashboard_protection_ok),
-                    StatusColors.successDot,
-                )
-            }
-
-            is JavaResult.Fail -> {
-                Triple(
-                    StatusColors.errorContainer(),
-                    stringResource(R.string.dashboard_protection_fail),
-                    StatusColors.errorAccent,
-                )
-            }
-
-            is JavaResult.HooksInactive -> {
-                Triple(
-                    MaterialTheme.colorScheme.surfaceVariant,
-                    stringResource(R.string.dashboard_protection_hooks_inactive),
-                    MaterialTheme.colorScheme.onSurfaceVariant,
-                )
-            }
-        }
-    ProtectionCardShell(
-        badgeText = "J",
-        label = stringResource(R.string.dashboard_java_protection),
-        statusText = statusText,
-        statusColor = statusColor,
-        statusContainerColor = statusContainerColor,
-        pulsing = result is JavaResult.Ok,
-        index = index,
-        count = count,
-    )
-}
-
-@Composable
-private fun ProtectionCardShell(
-    badgeText: String,
-    label: String,
-    statusText: String,
-    statusColor: Color,
-    statusContainerColor: Color,
-    pulsing: Boolean = false,
-    index: Int = -1,
-    count: Int = 1,
-) {
-    val animations = LocalSettingsState.current.animationsEnabled
-    GroupedCard(
-        index = index,
-        count = count,
-        modifier = Modifier.fillMaxWidth(),
-        color = AppColors.cardContainer,
-    ) {
-        Row(
-            modifier = Modifier.padding(16.dp).fillMaxWidth(),
-            horizontalArrangement = Arrangement.SpaceBetween,
-            verticalAlignment = Alignment.CenterVertically,
-        ) {
-            ModuleBadge(text = badgeText, accentColor = statusColor, containerColor = statusContainerColor)
-            Spacer(Modifier.width(14.dp))
-            Text(
-                text = label,
-                style = MaterialTheme.typography.bodyLarge,
-                fontWeight = FontWeight.Medium,
-                maxLines = 1,
-                overflow = TextOverflow.Ellipsis,
-                modifier = Modifier.weight(1f),
-            )
-            Spacer(Modifier.width(10.dp))
-            Row(
-                verticalAlignment = Alignment.CenterVertically,
-                horizontalArrangement = Arrangement.spacedBy(8.dp),
-            ) {
-                if (pulsing) {
-                    Box(
-                        modifier =
-                            Modifier
-                                .size(9.dp)
-                                .pulse(enabled = animations, min = 0.55f, max = 1f, durationMillis = 1100)
-                                .clip(CircleShape)
-                                .background(statusColor),
-                    )
-                }
-                StatusPill(
-                    text = statusText,
-                    contentColor = statusColor,
-                    containerColor = statusContainerColor,
-                )
-            }
         }
     }
 }

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DashboardScreen.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DashboardScreen.kt
@@ -40,6 +40,7 @@ import dev.okhsunrog.vpnhide.settings.LocalSettingsState
 import dev.okhsunrog.vpnhide.settings.SettingsRepository
 import dev.okhsunrog.vpnhide.ui.components.EnhancedButton
 import dev.okhsunrog.vpnhide.ui.components.EnhancedCard
+import dev.okhsunrog.vpnhide.ui.components.EnhancedOutlinedButton
 import dev.okhsunrog.vpnhide.ui.components.GroupedCard
 import dev.okhsunrog.vpnhide.ui.components.IconBubble
 import dev.okhsunrog.vpnhide.ui.components.MetricTile
@@ -53,6 +54,7 @@ import dev.okhsunrog.vpnhide.ui.components.SectionHeader as SharedSectionHeader
 @Composable
 fun DashboardScreen(
     selfNeedsRestart: Boolean,
+    onOpenDiagnostics: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     val context = LocalContext.current
@@ -229,6 +231,7 @@ fun DashboardScreen(
                     text = issue.text,
                     containerColor = errorBg,
                     contentColor = onBannerColor,
+                    action = messageActionSlot(issue.action, onOpenDiagnostics) { showContact = true },
                 )
                 Spacer(Modifier.height(6.dp))
             }
@@ -243,6 +246,7 @@ fun DashboardScreen(
                     text = issue.text,
                     containerColor = warningBg,
                     contentColor = onBannerColor,
+                    action = messageActionSlot(issue.action, onOpenDiagnostics) { showContact = true },
                 )
                 Spacer(Modifier.height(6.dp))
             }
@@ -257,12 +261,7 @@ fun DashboardScreen(
                     text = message.text,
                     containerColor = infoBg,
                     contentColor = onBannerColor,
-                    action =
-                        if (message.action == DashboardMessageAction.ContactAuthor) {
-                            { ContactAuthorButton(onClick = { showContact = true }) }
-                        } else {
-                            null
-                        },
+                    action = messageActionSlot(message.action, onOpenDiagnostics) { showContact = true },
                 )
                 Spacer(Modifier.height(6.dp))
             }
@@ -273,6 +272,27 @@ fun DashboardScreen(
 }
 
 // ── UI Components ────────────────────────────────────────────────────────
+
+// Maps a message's data-layer action tag to the actual button + handler in ONE
+// place, so a new action is an enum case + one branch here — not an edit in
+// every message loop. The data layer stays UI-free (it only emits the tag).
+private fun messageActionSlot(
+    action: DashboardMessageAction?,
+    onOpenDiagnostics: () -> Unit,
+    onContactAuthor: () -> Unit,
+): (@Composable () -> Unit)? =
+    when (action) {
+        DashboardMessageAction.ContactAuthor -> ({ ContactAuthorButton(onClick = onContactAuthor) })
+        DashboardMessageAction.OpenDiagnostics -> ({ DetailsButton(onClick = onOpenDiagnostics) })
+        null -> null
+    }
+
+@Composable
+private fun DetailsButton(onClick: () -> Unit) {
+    EnhancedOutlinedButton(onClick = onClick) {
+        Text(stringResource(R.string.dashboard_action_details))
+    }
+}
 
 @Composable
 internal fun DashboardLoadingState(modifier: Modifier = Modifier) {

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DashboardScreen.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DashboardScreen.kt
@@ -555,11 +555,6 @@ private fun DashboardHeroCard(
                         color = MaterialTheme.colorScheme.onSurfaceVariant,
                     )
                 }
-                StatusPill(
-                    text = stringResource(visual.titleRes),
-                    contentColor = visual.accent,
-                    containerColor = visual.container,
-                )
             }
             Spacer(Modifier.height(16.dp))
             Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
@@ -598,33 +593,6 @@ private fun DashboardHeroCard(
                 }
             }
         }
-    }
-}
-
-@Composable
-private fun StatusPill(
-    text: String,
-    contentColor: Color,
-    containerColor: Color,
-    modifier: Modifier = Modifier,
-) {
-    Box(
-        modifier =
-            modifier
-                .widthIn(max = 160.dp)
-                .clip(MaterialTheme.shapes.medium)
-                .background(containerColor)
-                .padding(horizontal = 10.dp, vertical = 6.dp),
-        contentAlignment = Alignment.Center,
-    ) {
-        Text(
-            text = text,
-            style = MaterialTheme.typography.labelMedium,
-            fontWeight = FontWeight.Bold,
-            color = contentColor,
-            maxLines = 1,
-            overflow = TextOverflow.Ellipsis,
-        )
     }
 }
 

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/MainActivity.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/MainActivity.kt
@@ -315,6 +315,17 @@ private fun MainScreen() {
         return
     }
 
+    // Full-screen diagnostics overlay, reachable from a Dashboard message's
+    // "Details" button (the same screen Settings → Diagnostics opens).
+    var showDiagnostics by remember { mutableStateOf(false) }
+    if (showDiagnostics) {
+        DiagnosticsSettingsScreen(
+            selfNeedsRestart = selfNeedsRestart,
+            onBack = { showDiagnostics = false },
+        )
+        return
+    }
+
     Scaffold(
         containerColor = AppColors.screenBackground,
         topBar = {
@@ -579,6 +590,7 @@ private fun MainScreen() {
                     Tab.Dashboard -> {
                         DashboardScreen(
                             selfNeedsRestart = restart,
+                            onOpenDiagnostics = { showDiagnostics = true },
                             modifier = Modifier.padding(innerPadding),
                         )
                     }

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/SettingsScreen.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/SettingsScreen.kt
@@ -276,7 +276,7 @@ private fun CommunitySettingsSection() {
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-private fun DiagnosticsSettingsScreen(
+internal fun DiagnosticsSettingsScreen(
     selfNeedsRestart: Boolean?,
     onBack: () -> Unit,
 ) {

--- a/lsposed/app/src/main/res/values-ru/strings.xml
+++ b/lsposed/app/src/main/res/values-ru/strings.xml
@@ -254,6 +254,8 @@
     <string name="dashboard_issues">Ошибки (%d)</string>
     <string name="dashboard_warnings">Предупреждения (%d)</string>
     <string name="dashboard_info">Информация (%d)</string>
+    <string name="dashboard_issue_checks_failed">Не все проверки скрытия пройдены.</string>
+    <string name="dashboard_action_details">Подробности</string>
     <string name="dashboard_issue_kmod_capable_but_zygisk">Ваше ядро поддерживает модуль ядра — он работает в пространстве ядра и невидим для анти-тампер проверок. Zygisk тоже работает, но банковские и платёжные приложения могут обнаружить его хуки, если для них включён Native. Установите %1$s и удалите Zygisk-модуль.</string>
     <string name="dashboard_issue_native_conflict_kernel">Модуль ядра (.ko) и KPM установлены одновременно. Они перехватывают одни и те же функции ядра, и при одновременной работе устройство может полностью зависнуть. Оставьте только один — удалите либо модуль ядра, либо KPM.</string>
     <string name="dashboard_issue_native_conflict_deferred">Модуль ядра (.ko) и KPM установлены одновременно. KPM отключился при загрузке, чтобы не подвесить устройство, и сейчас бездействует. Оставьте только один — удалите KPM (или модуль ядра).</string>
@@ -315,7 +317,7 @@
     <string name="btn_save_debug">Сохранить</string>
     <string name="btn_share_debug">Поделиться</string>
     <string name="diag_debug_logging_title">Отладочные логи</string>
-    <string name="settings_debug_logging_sub">По умолчанию выключено ради скрытности. Инструменты захвата в «Отладке» включают его автоматически — этот переключатель нужен только для постоянных логов во всех компонентах.</string>
+    <string name="settings_debug_logging_sub">По умолчанию выключено, чтобы не засорять logcat и не тратить ресурсы. Инструменты захвата в «Отладке» включают его автоматически — вручную нужен только для постоянных логов во всех компонентах.</string>
     <string name="logcat_card_title">Полный системный logcat</string>
     <string name="logcat_card_description">Записывает неотфильтрованные логи из всех буферов (main/system/crash/events/radio) для диагностики проблем, которые не видны в стандартных проверках. Начните запись, воспроизведите ошибку, затем остановите.</string>
     <string name="logcat_btn_start">Начать запись</string>

--- a/lsposed/app/src/main/res/values-ru/strings.xml
+++ b/lsposed/app/src/main/res/values-ru/strings.xml
@@ -92,7 +92,6 @@
     <string name="dashboard_kmod_broken_signature_enforced">Установлен, ядро отклоняет неподписанные модули</string>
     <string name="dashboard_active_targets">Активен · целей: %d</string>
     <string name="dashboard_reboot_needed">Требуется перезагрузка устройства</string>
-    <string name="dashboard_protection">Статус скрытия</string>
     <string name="dashboard_hero_protected_title">VPN скрыт</string>
     <string name="dashboard_hero_protected_subtitle">Все уровни скрытия активны</string>
     <string name="dashboard_hero_attention_title">Требует внимания</string>

--- a/lsposed/app/src/main/res/values-ru/strings.xml
+++ b/lsposed/app/src/main/res/values-ru/strings.xml
@@ -111,7 +111,7 @@
     <string name="dashboard_protection_no_module">Нет модуля</string>
     <string name="dashboard_protection_hooks_inactive">Хуки неактивны</string>
     <string name="dashboard_needs_restart">VPN Hide только что включил скрытие для самого себя. Принудительно остановите VPN Hide и откройте снова, чтобы проверить скрытие — перезагрузка устройства не нужна.</string>
-    <string name="vpn_off_prompt">VPN не активен. Включите его и нажмите «Повторить», чтобы проверить скрытие. Результаты кэшируются до перезапуска VPN Hide — повторно запускать проверку в этой сессии не нужно.</string>
+    <string name="vpn_off_prompt">VPN не активен. Включите его и нажмите «Повторить», чтобы проверить скрытие.</string>
     <string name="vpn_off_retry">Повторить</string>
     <string name="diag_failed_prompt">Не удалось выполнить проверку скрытия — возможно, отклонён root-доступ или команда завершилась с ошибкой. Нажмите «Повторить». Обычно это временно.</string>
 

--- a/lsposed/app/src/main/res/values/strings.xml
+++ b/lsposed/app/src/main/res/values/strings.xml
@@ -123,7 +123,6 @@
     <string name="dashboard_kmod_broken_signature_enforced">Installed, kernel rejects unsigned modules</string>
     <string name="dashboard_active_targets">Active · %d target(s)</string>
     <string name="dashboard_reboot_needed">Device reboot needed</string>
-    <string name="dashboard_protection">Hiding status</string>
     <string name="dashboard_hero_protected_title">VPN hidden</string>
     <string name="dashboard_hero_protected_subtitle">All hiding layers are active</string>
     <string name="dashboard_hero_attention_title">Needs attention</string>

--- a/lsposed/app/src/main/res/values/strings.xml
+++ b/lsposed/app/src/main/res/values/strings.xml
@@ -142,7 +142,7 @@
     <string name="dashboard_protection_no_module">No module</string>
     <string name="dashboard_protection_hooks_inactive">Hooks inactive</string>
     <string name="dashboard_needs_restart">VPN Hide just enabled hiding for itself. Restart VPN Hide (force-stop and reopen) to check hiding — no device reboot needed.</string>
-    <string name="vpn_off_prompt">No active VPN. Turn it on, then tap Retry to run the hiding checks. Results are cached until VPN Hide is restarted — no need to re-run later in the same session.</string>
+    <string name="vpn_off_prompt">No active VPN. Turn it on, then tap Retry to run the hiding checks.</string>
     <string name="vpn_off_retry">Retry</string>
     <string name="diag_failed_prompt">The hiding checks couldn\'t run — root access may have been denied or a command failed. Tap Retry. This is usually transient.</string>
 

--- a/lsposed/app/src/main/res/values/strings.xml
+++ b/lsposed/app/src/main/res/values/strings.xml
@@ -76,7 +76,7 @@
     <string name="btn_save_debug">Save</string>
     <string name="btn_share_debug">Share</string>
     <string name="diag_debug_logging_title">Debug logging</string>
-    <string name="settings_debug_logging_sub">Off by default for stealth. The capture tools in Debugging enable it automatically — turn this on only for continuous logs across every component.</string>
+    <string name="settings_debug_logging_sub">Off by default to keep logcat quiet and avoid the overhead. The capture tools in Debugging enable it automatically — turn this on only for continuous logs across every component.</string>
     <string name="logcat_card_title">Full system logcat</string>
     <string name="logcat_card_description">Records unfiltered logs from all buffers (main/system/crash/events/radio) for debugging issues that aren\'t visible in the standard checks. Start recording, reproduce the bug, then stop.</string>
     <string name="logcat_btn_start">Start recording</string>
@@ -276,6 +276,8 @@
     <string name="dashboard_issues">Errors (%d)</string>
     <string name="dashboard_warnings">Warnings (%d)</string>
     <string name="dashboard_info">Info (%d)</string>
+    <string name="dashboard_issue_checks_failed">Not all hiding checks passed.</string>
+    <string name="dashboard_action_details">Details</string>
     <string name="dashboard_issue_kmod_capable_but_zygisk">Your kernel supports the kernel module — it hooks in kernel space and is invisible to anti-tamper checks. Zygisk works too, but banking and payment apps may detect its hooks when Native is enabled for them. Install %1$s and uninstall the Zygisk module for cleaner coverage.</string>
     <string name="dashboard_issue_native_conflict_kernel">The kernel module (.ko) and the KPM are both installed. They hook the same kernel functions, and having both active can hard-freeze the device. Keep only one — uninstall either the kernel module or the KPM.</string>
     <string name="dashboard_issue_native_conflict_deferred">The kernel module (.ko) and the KPM are both installed. The KPM stood down at boot to avoid a freeze, so it isn\'t doing anything. Keep only one — uninstall the KPM (or the kernel module).</string>


### PR DESCRIPTION
The Dashboard's «Статус скрытия» section restated the hero card's «Нативный уровень» / «Java API уровень» tiles verbatim — same label, same status text, same colour, since both derive from the same `nativeSummaryText`/`javaSummaryText` helpers — so it added no information in any state (OK, partial, fail, no-module). It's removed. The section's critical branches — the VPN-off prompt and the needs-restart banner — move to a slot directly under the hero, so they're more prominent instead of buried mid-screen. In the all-good state the Dashboard is now just the hero card + the Модули list.

- Removed the «Статус скрытия» section (header + the per-level `NativeProtectionCard` / `JavaProtectionCard`).
- Moved the `NoVpn` (VpnOffPrompt) and `NeedsRestart` (banner) states to right under the hero card.
- The hero card is unchanged — it already carries the per-level status tiles.
- Deleted the now-dead `NativeProtectionCard` / `JavaProtectionCard` / `ProtectionCardShell` composables and the unused `dashboard_protection` string (both locales).

Testing: builds a signed release; ktlint / detekt / lintRelease / unit tests pass. On-device visual confirmation pending (test phone was locked at PR time).