### PR TITLE
fix(lsposed): reconcile auto-hidden VPN apps on startup and Refresh

### DIFF
--- a/changelog.d/fixed-auto-hidden-vpn-apps-are-now-66d4.md
+++ b/changelog.d/fixed-auto-hidden-vpn-apps-are-now-66d4.md
@@ -1,0 +1,9 @@
+_2026-07-02_
+
+## English
+
+Auto-hidden VPN apps are now re-detected on startup and when you tap Refresh, so a VPN app installed after the app list was cached gets hidden from detector apps without re-saving the hiding list.
+
+## Русский
+
+Список автоматически скрываемых VPN-приложений теперь обновляется при запуске и по кнопке «Обновить»: VPN-приложение, установленное уже после загрузки списка, прячется от приложений-детекторов без повторного сохранения на вкладке «Скрытие».

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/AppPickerData.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/AppPickerData.kt
@@ -139,6 +139,21 @@ internal fun applyAutoHiddenPackages(
     )
 }
 
+/**
+ * Whether re-materializing the auto-hidden set against fresh [signals] would
+ * change the set persisted for [config] — i.e. whether the startup / Refresh
+ * reconcile needs to write. The reconcile write-guard: a newly-installed VPN
+ * app that isn't in `autoHiddenPackages` yet flips this true; an unchanged set
+ * keeps it false so the reconcile is a no-op.
+ */
+internal fun autoHiddenPackagesNeedReconcile(
+    config: CanonicalConfig,
+    selfPkg: String,
+    signals: Collection<AppAutoHideSignal>,
+): Boolean =
+    applyAutoHiddenPackages(config, selfPkg, signals).settings.autoHiddenPackages !=
+        config.settings.autoHiddenPackages
+
 internal fun manualHiddenPackages(
     config: CanonicalConfig,
     selfPkg: String,

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/ConfigChannels.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/ConfigChannels.kt
@@ -78,3 +78,44 @@ internal fun runRuntimeConfigReconcile(
     val (exit, _) = suExec(cmd)
     if (exit != 0) VpnHideLog.w("VpnHide-Startup", "runtime config reconcile failed (exit=$exit)")
 }
+
+/**
+ * Re-materialize `settings.autoHiddenPackages` for the on-disk [config] against
+ * fresh VpnService [signals], and persist it iff the auto-hidden set changed.
+ * This keeps a newly-installed VPN app hidden from observers after a Hiding-tab
+ * Refresh or a cold start, without the user having to open the picker and Save.
+ *
+ * Idempotent: [applyAutoHiddenPackages] only touches the auto-hidden set and the
+ * hidden flags derived from it — every manual role (Java / Native / Apps / Ports
+ * and manually-hidden packages) is preserved — so an unchanged set writes
+ * nothing. Best-effort, blocking; call from a background dispatcher. Returns
+ * true when it wrote (and re-activated) a new config.
+ */
+internal fun reconcileAutoHiddenPackages(
+    context: Context,
+    config: CanonicalConfig,
+    signals: Collection<AppAutoHideSignal>,
+): Boolean {
+    val selfPkg = context.packageName
+    if (!autoHiddenPackagesNeedReconcile(config, selfPkg, signals)) return false
+    val next = applyAutoHiddenPackages(config, selfPkg, signals)
+    val cmd =
+        listOf(
+            buildCanonicalConfigWriteCommand(next),
+            ConfigChannels.reconcileCommand(),
+        ).joinToString(" ; ")
+    val (exit, output) = suExec(cmd)
+    if (exit != 0) {
+        VpnHideLog.w("VpnHide-Startup", "auto-hide reconcile failed (exit=$exit): ${output.trim()}")
+        return false
+    }
+    RootSnapshotCache.invalidate()
+    TargetsCache.invalidate()
+    DashboardCache.invalidate()
+    StatisticsCache.invalidate()
+    VpnHideLog.i(
+        "VpnHide-Startup",
+        "auto-hide reconcile: ${next.settings.autoHiddenPackages.size} auto-hidden package(s)",
+    )
+    return true
+}

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DebugLoggingPrefs.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DebugLoggingPrefs.kt
@@ -62,6 +62,30 @@ internal fun applyDebugLoggingRuntime(enabled: Boolean) {
     writeDebugFlagFiles(enabled)
 }
 
+/**
+ * Startup safety-net: re-propagate the persisted debug flag to the on-disk
+ * config + native sinks only if they've drifted from [enabled]. This runs on
+ * every cold start; without the drift check it would rewrite the canonical
+ * config (and re-run the native activator) with byte-identical content on every
+ * launch. Capture paths (LogcatRecorder / debug export) do not go through here —
+ * they already gate their own [applyDebugLoggingRuntime] calls on
+ * [VpnHideLog.enabled] and must always write both directions.
+ *
+ * When the snapshot isn't loaded yet the flag is treated as drifted, so the
+ * safety-net still fires once.
+ */
+internal fun reapplyDebugLoggingIfDrifted(enabled: Boolean) {
+    val onDiskDebug =
+        TargetsCache.snapshot.value
+            ?.canonicalConfig
+            ?.debug
+    if (onDiskDebug == enabled) {
+        VpnHideLog.enabled = enabled
+        return
+    }
+    applyDebugLoggingRuntime(enabled)
+}
+
 private fun writeDebugFlagFiles(enabled: Boolean) {
     val parts = mutableListOf<String>()
 

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/MainActivity.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/MainActivity.kt
@@ -348,8 +348,10 @@ private fun MainScreen() {
             StartupTrace.dashboardReady()
             scope.launch(Dispatchers.IO) {
                 // Re-propagate the persisted flag to the on-disk sinks as a
-                // safety-net, but keep it off the cold-start critical path.
-                applyDebugLoggingRuntime(VpnHideLog.enabled)
+                // safety-net, but only if they've drifted — otherwise a cold
+                // start needlessly rewrites the canonical config every launch.
+                // Kept off the cold-start critical path.
+                reapplyDebugLoggingIfDrifted(VpnHideLog.enabled)
             }
         }
     }

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/StartupCoordinator.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/StartupCoordinator.kt
@@ -6,6 +6,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 
@@ -30,6 +31,10 @@ internal class StartupCoordinator(
     private val seedRootSnapshotPackages: (String?) -> Unit = RootSnapshotCache::seedPmPackages,
     private val markStartupEvent: (String) -> Unit = StartupTrace::mark,
     private val reconcileRuntimeConfig: (RootSnapshot) -> Unit = { runRuntimeConfigReconcile(appContext, it) },
+    private val reconcileAutoHidden: (CanonicalConfig, List<AppAutoHideSignal>) -> Unit =
+        { config, signals -> reconcileAutoHiddenPackages(appContext, config, signals) },
+    private val loadCanonicalConfig: suspend () -> CanonicalConfig? =
+        { parseTargetsSnapshot(RootSnapshotCache.getOrLoad()).canonicalConfig },
 ) {
     private val _selfTargetState = MutableStateFlow<StartupSelfTargetState>(StartupSelfTargetState.Preparing)
     val selfTargetState: StateFlow<StartupSelfTargetState> = _selfTargetState.asStateFlow()
@@ -38,6 +43,12 @@ internal class StartupCoordinator(
     // activator from canonical JSON. A once-per-session reconcile is enough
     // (Save / the debug toggle re-run the activator on their own afterwards).
     private val reconcileStarted =
+        java.util.concurrent.atomic
+            .AtomicBoolean(false)
+
+    // The auto-hide reconcile observer is a single session-long collector; guard
+    // against starting a second one if ensureInitialCaches re-runs.
+    private val autoHideReconcileStarted =
         java.util.concurrent.atomic
             .AtomicBoolean(false)
 
@@ -77,6 +88,29 @@ internal class StartupCoordinator(
         AppListCache.ensureLoaded(scope, appContext)
         DashboardCache.ensureLoaded(scope, appContext, selfNeedsRestart)
         if (!selfNeedsRestart) DiagnosticsCache.run(scope, appContext)
+        startAutoHideReconcile(scope)
+    }
+
+    /**
+     * Once per session, watch the installed-app list and re-materialize the
+     * auto-hidden VPN-app set whenever it (re)loads — at cold start and after a
+     * Hiding-tab Refresh (which force-reloads [AppListCache]). This keeps a
+     * newly-installed VPN app hidden from observers without the user having to
+     * open the picker and Save. The write itself is idempotent: it only touches
+     * disk when the auto-hidden set actually changed.
+     *
+     * Self-target preparation runs first and always writes the canonical config,
+     * so by the time the app list emits, the config is non-null — a null read
+     * means no root, and the reconcile is simply skipped.
+     */
+    private fun startAutoHideReconcile(scope: CoroutineScope) {
+        if (!autoHideReconcileStarted.compareAndSet(false, true)) return
+        scope.launch(Dispatchers.IO) {
+            AppListCache.apps.filterNotNull().collect { apps ->
+                val config = loadCanonicalConfig() ?: return@collect
+                reconcileAutoHidden(config, apps.map { it.toAutoHideSignal() })
+            }
+        }
     }
 
     fun ensureProtectionCacheAfterRootSnapshot(

--- a/lsposed/app/src/test/kotlin/dev/okhsunrog/vpnhide/AppPickerDataTest.kt
+++ b/lsposed/app/src/test/kotlin/dev/okhsunrog/vpnhide/AppPickerDataTest.kt
@@ -522,6 +522,45 @@ class AppPickerDataTest {
         assertEquals(emptySet<String>(), manualHiddenPackages(updated, self))
     }
 
+    @Test
+    fun `reconcile needed when a newly installed vpn app is missing from auto hidden set`() {
+        val config = CanonicalConfig()
+        val signals = listOf(AppAutoHideSignal(packageName = "com.happproxy", declaresVpnService = true))
+
+        assertEquals(true, autoHiddenPackagesNeedReconcile(config, self, signals))
+    }
+
+    @Test
+    fun `reconcile is a no op when the auto hidden set already matches the signals`() {
+        val config =
+            CanonicalConfig(
+                apps = mapOf("com.happproxy" to CanonicalApp(hidden = true)),
+                settings = CanonicalSettings(autoHiddenPackages = setOf("com.happproxy")),
+            )
+        val signals = listOf(AppAutoHideSignal(packageName = "com.happproxy", declaresVpnService = true))
+
+        assertEquals(false, autoHiddenPackagesNeedReconcile(config, self, signals))
+    }
+
+    @Test
+    fun `reconcile needed when an auto hidden vpn app is no longer present`() {
+        val config =
+            CanonicalConfig(
+                apps = mapOf("com.gone" to CanonicalApp(hidden = true)),
+                settings = CanonicalSettings(autoHiddenPackages = setOf("com.gone")),
+            )
+
+        assertEquals(true, autoHiddenPackagesNeedReconcile(config, self, emptyList()))
+    }
+
+    @Test
+    fun `reconcile is a no op when auto hide is disabled and the set is already empty`() {
+        val config = CanonicalConfig(settings = CanonicalSettings(autoHideVpnServices = false))
+        val signals = listOf(AppAutoHideSignal(packageName = "com.happproxy", declaresVpnService = true))
+
+        assertEquals(false, autoHiddenPackagesNeedReconcile(config, self, signals))
+    }
+
     private fun snapshotWithCanonical(
         vararg apps: Pair<String, CanonicalApp>,
         settings: CanonicalSettings = CanonicalSettings(),


### PR DESCRIPTION
Two related startup fixes for the auto-hidden VPN-app set and cold-start config writes.

Newly-installed VPN apps stayed visible to detector apps until the user re-opened the Hiding tab and saved, because the auto-hidden VPN-app set was only re-materialized on an explicit Save — and toggling auto-hide off/on re-derived it from the same stale cached app list. This watches the installed-app list and re-derives the auto-hidden set whenever it (re)loads, so a VPN app installed after the app list was cached is hidden on the next cold start or Hiding-tab Refresh, without a manual Save.

While validating that on-device, the config turned out to be rewritten with byte-identical content on every cold start: the debug-logging safety-net re-propagated the persisted flag unconditionally. That is now guarded too.

- Add `reconcileAutoHiddenPackages` (ConfigChannels): re-materialize `settings.autoHiddenPackages` against fresh VpnService signals and persist only when the set changed; reuses the canonical write + activator path and preserves every manual role.
- Add the `autoHiddenPackagesNeedReconcile` write-guard (AppPickerData) so the reconcile is idempotent.
- Start a once-per-session observer in `StartupCoordinator` that reconciles on each `AppListCache` (re)load — covering cold start and Hiding-tab Refresh.
- Guard the cold-start debug-flag safety-net (`reapplyDebugLoggingIfDrifted`): only re-propagate to the on-disk config + native activator when the flag has drifted from the persisted preference, instead of rewriting identical content every launch. Capture paths are unaffected (they gate their own calls on `VpnHideLog.enabled`).
- Unit tests for the auto-hide write-guard: newly-installed VPN app, idempotent no-op, uninstalled app, and auto-hide-disabled cases.

Testing:
- `:app:testDebugUnitTest`, `ktlintCheck`, `detekt`, and `:app:assembleRelease` all pass locally.
- On-device on a Pixel 8 Pro (KernelSU-Next, GKI 6.1): recreated the stale state by dropping `com.happproxy` (a VpnService provider) from the on-disk `autoHiddenPackages`, then cold-started. The startup reconcile re-added it with `hidden: true` in ~3s, no manual Save, and the app started cleanly. Confirmed idempotent: with the set already correct, three consecutive cold-starts left the config's mtime unchanged (no rewrite, no activator churn).