### PR TITLE
Diagnose broken KPM installs, surface kmod GKI variant

### DIFF
--- a/changelog.d/added-the-dashboard-now-diagnoses-a-kpm-9d4f.md
+++ b/changelog.d/added-the-dashboard-now-diagnoses-a-kpm-9d4f.md
@@ -1,0 +1,9 @@
+_2026-07-02_
+
+## English
+
+The dashboard now diagnoses a KPM install stuck without loading (corrupted activator or a generic activator failure), showing which one and how to fix it — previously it silently sat inactive with no explanation.
+
+## Русский
+
+Дашборд теперь диагностирует KPM, который установлен, но не загрузился (повреждён активатор или его сбой по другой причине), и показывает, что именно случилось и как это исправить — раньше он просто оставался неактивным без объяснений.

--- a/changelog.d/added-the-dashboard-now-shows-the-installed-62db.md
+++ b/changelog.d/added-the-dashboard-now-shows-the-installed-62db.md
@@ -1,0 +1,9 @@
+_2026-07-02_
+
+## English
+
+The dashboard now shows the installed kernel module's GKI variant on its card, and update warnings for an outdated kmod name the exact recommended zip to grab — so updating over an old kmod install no longer means guessing which variant you originally flashed.
+
+## Русский
+
+Дашборд теперь показывает GKI-вариант установленного модуля ядра прямо на карточке, а предупреждение об устаревшей версии kmod называет конкретный рекомендуемый zip-файл — обновление старого kmod больше не требует угадывать, какой вариант был установлен изначально.

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DashboardData.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DashboardData.kt
@@ -24,29 +24,34 @@ sealed interface ModuleState {
         // Non-null when the module is installed but the installation itself
         // is permanently broken (distinct from "active=false" which usually
         // just means a reboot is pending). UI colors the card red.
-        val brokenReason: KmodBrokenReason? = null,
+        val brokenReason: ModuleBrokenReason? = null,
     ) : ModuleState
 }
 
-enum class KmodBrokenReason {
+// Shared across every flashable module kind (kmod, KPM, ...) that stamps
+// ModuleState.Installed.brokenReason — not just kmod, despite the name
+// prefixes on the individual kmod-only cases below.
+enum class ModuleBrokenReason {
     WrongVariant,
     UnsupportedKernel,
     MissingKprobes,
     UnknownVariantInactive,
     AmbiguousLoadFailed,
     SignatureEnforced,
+    KpmActivatorMissing,
 }
 
 /**
- * The single kmod problem to surface. [reason] drives the red module-card
+ * The single module problem to surface. [reason] drives the red module-card
  * color; [text] drives the dashboard error banner. Computed once (see
  * `loadDashboardState`) so the card and the banner can never disagree —
  * previously the priority order was hand-mirrored in two separate `when`
- * blocks. [reason] is null for a generic insmod failure where we only have
- * raw stderr to show, not a named diagnosis.
+ * blocks. [reason] is null for a generic load failure where we only have raw
+ * stderr/exit-status text to show, not a named diagnosis. Shared by the kmod
+ * (`classifyKmodProblem`) and KPM (`classifyKpmProblem`) diagnosis paths.
  */
-internal data class KmodProblem(
-    val reason: KmodBrokenReason?,
+internal data class ModuleProblem(
+    val reason: ModuleBrokenReason?,
     val text: String,
 )
 
@@ -587,10 +592,10 @@ internal fun readKmodLoadStatus(
  * to be hand-mirrored across two `when` blocks.
  */
 internal sealed interface KmodProblemKind {
-    val reason: KmodBrokenReason?
+    val reason: ModuleBrokenReason?
 
     data object KprobesMissing : KmodProblemKind {
-        override val reason get() = KmodBrokenReason.MissingKprobes
+        override val reason get() = ModuleBrokenReason.MissingKprobes
     }
 
     // The kernel enforces module signature verification and refused our
@@ -598,14 +603,14 @@ internal sealed interface KmodProblemKind {
     // such a kernel, so the only fix is removing the enforcement — KernelSU
     // Next (GKI mode) does that. See issue #132.
     data object SignatureEnforced : KmodProblemKind {
-        override val reason get() = KmodBrokenReason.SignatureEnforced
+        override val reason get() = ModuleBrokenReason.SignatureEnforced
     }
 
     data class UnsupportedKernel(
         val unameR: String,
         val recommendedArtifact: String,
     ) : KmodProblemKind {
-        override val reason get() = KmodBrokenReason.UnsupportedKernel
+        override val reason get() = ModuleBrokenReason.UnsupportedKernel
     }
 
     data class WrongVariant(
@@ -613,27 +618,27 @@ internal sealed interface KmodProblemKind {
         val recommendedKmi: String,
         val recommendedArtifact: String,
     ) : KmodProblemKind {
-        override val reason get() = KmodBrokenReason.WrongVariant
+        override val reason get() = ModuleBrokenReason.WrongVariant
     }
 
     data class UnknownVariant(
         val recommendedArtifact: String,
     ) : KmodProblemKind {
-        override val reason get() = KmodBrokenReason.UnknownVariantInactive
+        override val reason get() = ModuleBrokenReason.UnknownVariantInactive
     }
 
     data class AmbiguousLoadFailed(
         val installedVariant: String,
         val tryArtifact: String,
     ) : KmodProblemKind {
-        override val reason get() = KmodBrokenReason.AmbiguousLoadFailed
+        override val reason get() = ModuleBrokenReason.AmbiguousLoadFailed
     }
 
     // Generic insmod failure where we only have raw stderr, no named diagnosis.
     data class LoadFailed(
         val insmodStderr: String,
     ) : KmodProblemKind {
-        override val reason: KmodBrokenReason? get() = null
+        override val reason: ModuleBrokenReason? get() = null
     }
 }
 
@@ -733,8 +738,8 @@ internal fun KmodLoadStatus.isModuleSignatureRejected(): Boolean {
 private fun renderKmodProblem(
     kind: KmodProblemKind,
     res: android.content.res.Resources,
-): KmodProblem =
-    KmodProblem(
+): ModuleProblem =
+    ModuleProblem(
         reason = kind.reason,
         text =
             when (kind) {
@@ -773,6 +778,85 @@ private fun renderKmodProblem(
 
                 is KmodProblemKind.LoadFailed -> {
                     res.getString(R.string.dashboard_issue_kmod_load_failed, kind.insmodStderr)
+                }
+            },
+    )
+
+internal sealed interface KpmProblemKind {
+    val reason: ModuleBrokenReason?
+
+    // The activator binary itself is missing from the module directory — a
+    // corrupted or partial KPM install (see kmod/kpm/module/service.sh).
+    // [path] is the path the boot script tried to exec.
+    data class ActivatorMissing(
+        val path: String,
+    ) : KpmProblemKind {
+        override val reason get() = ModuleBrokenReason.KpmActivatorMissing
+    }
+
+    // The activator ran but exited non-zero for a reason we don't have a
+    // named diagnosis for. [detail] is the raw `rc=<code> <captured output>`
+    // the boot script wrote — the KPM analogue of kmod's raw insmod stderr.
+    // Null reason (mirrors KmodProblemKind.LoadFailed): an untriaged exit
+    // code isn't a confident enough diagnosis to paint the module card red.
+    data class LoadFailed(
+        val detail: String,
+    ) : KpmProblemKind {
+        override val reason: ModuleBrokenReason? get() = null
+    }
+}
+
+/**
+ * Diagnose a KPM install that's present but didn't load, for the
+ * `runtime=activator` outcomes the boot script (kmod/kpm/module/service.sh)
+ * writes. The other two runtimes it can write — `conflict` (a co-installed
+ * .ko took the single-active slot) and `apatch` (dormant, awaiting a saved
+ * superkey) — are expected, recoverable states already handled separately as
+ * warnings by [kpmDeferredForConflict] / [kpmAwaitingSuperkey]; this function
+ * only fires for `runtime=activator`, so it can never double up with those.
+ * `runtime=activator` itself covers both the success case (`loaded=1`, which
+ * the `!kpm.active` guard below already excludes) and the failure cases this
+ * diagnoses — the KPM analogue of classifyKmodProblem's LoadFailed fallback,
+ * sourced from the activator's own captured detail instead of insmod stderr.
+ */
+internal fun classifyKpmProblem(
+    kpm: ModuleState,
+    loadStatusSection: String,
+    currentBootId: String,
+): KpmProblemKind? {
+    if (kpm !is ModuleState.Installed || kpm.active) return null
+    val load = parseKeyValueLines(loadStatusSection)
+    val bootId = load["boot_id"]?.trim()
+    if (load["runtime"]?.trim() != "activator" ||
+        load["loaded"]?.trim() != "0" ||
+        bootId.isNullOrEmpty() ||
+        bootId != currentBootId.trim()
+    ) {
+        return null
+    }
+    val detail = load["detail"]?.trim().orEmpty()
+    val missingPrefix = "activator missing at "
+    return if (detail.startsWith(missingPrefix)) {
+        KpmProblemKind.ActivatorMissing(detail.removePrefix(missingPrefix))
+    } else {
+        KpmProblemKind.LoadFailed(detail)
+    }
+}
+
+private fun renderKpmProblem(
+    kind: KpmProblemKind,
+    res: android.content.res.Resources,
+): ModuleProblem =
+    ModuleProblem(
+        reason = kind.reason,
+        text =
+            when (kind) {
+                is KpmProblemKind.ActivatorMissing -> {
+                    res.getString(R.string.dashboard_issue_kpm_activator_missing, kind.path)
+                }
+
+                is KpmProblemKind.LoadFailed -> {
+                    res.getString(R.string.dashboard_issue_kpm_load_failed, kind.detail)
                 }
             },
     )
@@ -912,6 +996,11 @@ private fun buildModuleVersionIssue(
     kind: FlashableModuleKind,
     moduleVersion: String,
     appVersion: String,
+    // Only meaningful for FlashableModuleKind.Kmod: the GKI-specific zip the
+    // kernel recommends, so an "update the module" nudge can name the exact
+    // file instead of sending the user back to KernelSU/Magisk to guess
+    // which variant they originally flashed (issue #225).
+    recommendedArtifact: String? = null,
 ): String =
     when (compareSemver(normalizeVersion(moduleVersion), normalizeVersion(appVersion))) {
         null, 0 -> {
@@ -928,16 +1017,20 @@ private fun buildModuleVersionIssue(
         }
 
         in Int.MIN_VALUE..-1 -> {
-            res.getString(
-                when (kind) {
-                    FlashableModuleKind.Kmod -> R.string.dashboard_issue_update_kmod
-                    FlashableModuleKind.Kpm -> R.string.dashboard_issue_update_kpm
-                    FlashableModuleKind.Zygisk -> R.string.dashboard_issue_update_zygisk
-                    FlashableModuleKind.Ports -> R.string.dashboard_issue_update_ports
-                },
-                moduleVersion,
-                appVersion,
-            )
+            if (kind == FlashableModuleKind.Kmod && recommendedArtifact != null) {
+                res.getString(R.string.dashboard_issue_update_kmod_named, moduleVersion, appVersion, recommendedArtifact)
+            } else {
+                res.getString(
+                    when (kind) {
+                        FlashableModuleKind.Kmod -> R.string.dashboard_issue_update_kmod
+                        FlashableModuleKind.Kpm -> R.string.dashboard_issue_update_kpm
+                        FlashableModuleKind.Zygisk -> R.string.dashboard_issue_update_zygisk
+                        FlashableModuleKind.Ports -> R.string.dashboard_issue_update_ports
+                    },
+                    moduleVersion,
+                    appVersion,
+                )
+            }
         }
 
         else -> {
@@ -1132,12 +1225,12 @@ internal suspend fun loadDashboardState(
     val kmodRaw = rawNativeBackends.kmod.withTargetCount(nativeTargetCount)
     val zygiskStatusRaw = shellSnapshot["zygisk_status"].orEmpty()
     val zygisk = rawNativeBackends.zygisk.withTargetCount(nativeTargetCount)
-    val kpm = rawNativeBackends.kpm.withTargetCount(nativeTargetCount)
+    val kpmRaw = rawNativeBackends.kpm.withTargetCount(nativeTargetCount)
     val ports = detectPortsModule(shellSnapshot, selfPkg).withTargetCount(countPackages(targetsSnapshot.portsObservers))
     val kmodTargetCount = (kmodRaw as? ModuleState.Installed)?.targetCount ?: 0
-    val kpmTargetCount = (kpm as? ModuleState.Installed)?.targetCount ?: 0
+    val kpmTargetCount = (kpmRaw as? ModuleState.Installed)?.targetCount ?: 0
     val zygiskTargetCount = (zygisk as? ModuleState.Installed)?.targetCount ?: 0
-    VpnHideLog.i(TAG, "modules: kmodRaw=$kmodRaw kpm=$kpm zygisk=$zygisk ports=$ports")
+    VpnHideLog.i(TAG, "modules: kmodRaw=$kmodRaw kpmRaw=$kpmRaw zygisk=$zygisk ports=$ports")
     StartupTrace.mark("dashboard_modules_done")
 
     // Recommendation based purely on the kernel — used by the install card,
@@ -1160,34 +1253,47 @@ internal suspend fun loadDashboardState(
     // diagnosis; renderKmodProblem maps it to the localized banner text.
     // [reason] colors the card, [text] is the banner — both derive from the
     // one classification so they can't disagree.
-    val kmodProblem: KmodProblem? =
+    val kmodProblem: ModuleProblem? =
         classifyKmodProblem(kmodRaw, kernelRecommendation, kmodLoadStatus)
             ?.let { renderKmodProblem(it, res) }
-    val kmodBrokenReason = kmodProblem?.reason
     val kmod: ModuleState =
-        if (kmodRaw is ModuleState.Installed && kmodBrokenReason != null) {
-            kmodRaw.copy(brokenReason = kmodBrokenReason)
+        if (kmodRaw is ModuleState.Installed && kmodProblem?.reason != null) {
+            kmodRaw.copy(brokenReason = kmodProblem.reason)
         } else {
             kmodRaw
         }
     VpnHideLog.i(TAG, "kmod (with brokenReason): $kmod")
+
+    // Same single-source-of-truth pattern as kmod above, for the KPM
+    // runtime=activator failure cases classifyKpmProblem diagnoses (the
+    // conflict / awaiting-superkey cases stay separate warnings below).
+    val kpmProblem: ModuleProblem? =
+        classifyKpmProblem(kpmRaw, shellSnapshot["kpm_load_status"].orEmpty(), currentBootId)
+            ?.let { renderKpmProblem(it, res) }
+    val kpm: ModuleState =
+        if (kpmRaw is ModuleState.Installed && kpmProblem?.reason != null) {
+            kpmRaw.copy(brokenReason = kpmProblem.reason)
+        } else {
+            kpmRaw
+        }
+    VpnHideLog.i(TAG, "kpm (with brokenReason): $kpm")
+
+    // The one place all three backends are grouped together — every
+    // "is anything installed / active" gate below reads from this instead of
+    // re-deriving its own kmod/kpm/zygisk boolean combination.
+    val backends = NativeBackendStates(kmod = kmod, kpm = kpm, zygisk = zygisk)
     // The single native backend the dashboard shows (kmod > KPM > Zygisk).
-    val nativeBackend = displayNativeBackend(NativeBackendStates(kmod = kmod, kpm = kpm, zygisk = zygisk))
+    val nativeBackend = displayNativeBackend(backends)
     VpnHideLog.i(TAG, "nativeBackend=$nativeBackend")
     // Only surface the blue "what to install" card when nothing is
     // installed yet. Wrong-variant / broken / unsupported-kernel cases
     // already emit a red error below with the same CTA — showing both
     // duplicates the instruction.
-    val nativeInstallRecommendation =
-        kernelRecommendation?.takeIf {
-            kmod is ModuleState.NotInstalled &&
-                kpm is ModuleState.NotInstalled &&
-                zygisk is ModuleState.NotInstalled
-        }
+    val nativeInstallRecommendation = kernelRecommendation?.takeIf { backends.noneInstalled }
     VpnHideLog.i(
         TAG,
         "nativeInstallRecommendation=$nativeInstallRecommendation " +
-            "(raw=$kernelRecommendation kmodProblem=$kmodProblem)",
+            "(raw=$kernelRecommendation kmodProblem=$kmodProblem kpmProblem=$kpmProblem)",
     )
     StartupTrace.mark("dashboard_kernel_done")
 
@@ -1243,10 +1349,7 @@ internal suspend fun loadDashboardState(
     StartupTrace.mark("dashboard_lsposed_done")
 
     // ── Messages ──
-    val hasNative =
-        kmod is ModuleState.Installed ||
-            kpm is ModuleState.Installed ||
-            zygisk is ModuleState.Installed
+    val hasNative = backends.anyInstalled
     if (!hasNative) {
         err(res.getString(R.string.dashboard_issue_no_native))
     }
@@ -1318,7 +1421,13 @@ internal suspend fun loadDashboardState(
             appVersion,
         )
     moduleMismatches.forEach { mismatch ->
-        warn(buildModuleVersionIssue(res, mismatch.kind, mismatch.moduleVersion, mismatch.appVersion))
+        val recommendedArtifact =
+            if (mismatch.kind == FlashableModuleKind.Kmod && kernelRecommendation?.preferKmod == true) {
+                kernelRecommendation.recommendedArtifact
+            } else {
+                null
+            }
+        warn(buildModuleVersionIssue(res, mismatch.kind, mismatch.moduleVersion, mismatch.appVersion, recommendedArtifact))
     }
     val totalTargets = lsposedTargetCount + kmodTargetCount + kpmTargetCount + zygiskTargetCount
     if (totalTargets == 0) {
@@ -1481,12 +1590,15 @@ internal suspend fun loadDashboardState(
         warn(res.getString(R.string.dashboard_issue_self_multi_profile, selfUidCount))
     }
 
-    // ── Errors: kmod variant / load problems ──
-    // The diagnosis (reason + banner text) was computed once above as
-    // `kmodProblem`; emit its text here. Only one kmod-failure banner fires,
-    // and its priority can't drift from the card color because both come
-    // from the same value.
+    // ── Errors: kmod / KPM variant / load problems ──
+    // Each diagnosis (reason + banner text) was computed once above as
+    // `kmodProblem` / `kpmProblem`; emit their text here. Only one banner per
+    // backend fires, and its priority can't drift from the card color
+    // because both come from the same value. classifyKpmProblem only matches
+    // runtime=activator, so this can never double up with the
+    // conflict/awaiting-superkey warnings below.
     kmodProblem?.let { err(it.text) }
+    kpmProblem?.let { err(it.text) }
 
     // ── Protection checks ──
     StartupTrace.mark("dashboard_protection_start")

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DashboardScreen.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DashboardScreen.kt
@@ -740,21 +740,27 @@ private fun installedVisual(
     val broken = state.brokenReason
     val brokenSubtitleRes =
         when (broken) {
-            KmodBrokenReason.WrongVariant -> R.string.dashboard_kmod_broken_wrong_variant
-            KmodBrokenReason.UnsupportedKernel -> R.string.dashboard_kmod_broken_unsupported_kernel
-            KmodBrokenReason.MissingKprobes -> R.string.dashboard_kmod_broken_no_kprobes
-            KmodBrokenReason.UnknownVariantInactive -> R.string.dashboard_kmod_broken_unknown_variant
-            KmodBrokenReason.AmbiguousLoadFailed -> R.string.dashboard_kmod_broken_ambiguous
-            KmodBrokenReason.SignatureEnforced -> R.string.dashboard_kmod_broken_signature_enforced
+            ModuleBrokenReason.WrongVariant -> R.string.dashboard_kmod_broken_wrong_variant
+            ModuleBrokenReason.UnsupportedKernel -> R.string.dashboard_kmod_broken_unsupported_kernel
+            ModuleBrokenReason.MissingKprobes -> R.string.dashboard_kmod_broken_no_kprobes
+            ModuleBrokenReason.UnknownVariantInactive -> R.string.dashboard_kmod_broken_unknown_variant
+            ModuleBrokenReason.AmbiguousLoadFailed -> R.string.dashboard_kmod_broken_ambiguous
+            ModuleBrokenReason.SignatureEnforced -> R.string.dashboard_kmod_broken_signature_enforced
+            ModuleBrokenReason.KpmActivatorMissing -> R.string.dashboard_kpm_broken_activator_missing
             null -> null
         }
+    // Stamped GKI variant (kmod builds from v0.6.3+ only — see ModuleState.gkiVariant),
+    // appended so the card itself answers "which zip did I install", without
+    // sending the user hunting through KernelSU/Magisk's module list (which
+    // shows only the generic module name, not the GKI variant — issue #225).
+    val variantSuffix = state.gkiVariant?.let { " · $it" }.orEmpty()
     return InstalledVisual(
         subtitle =
             when {
                 brokenSubtitleRes != null -> stringResource(brokenSubtitleRes)
-                active -> stringResource(R.string.dashboard_active_targets, state.targetCount)
+                active -> stringResource(R.string.dashboard_active_targets, state.targetCount) + variantSuffix
                 selfNeedsRestart -> stringResource(R.string.dashboard_installed_restart_app)
-                else -> stringResource(R.string.dashboard_installed_inactive)
+                else -> stringResource(R.string.dashboard_installed_inactive) + variantSuffix
             },
         accentColor =
             when {

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/NativeBackendData.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/NativeBackendData.kt
@@ -12,6 +12,17 @@ internal data class NativeBackendStates(
         get() = activeNativeBackendId(this)
 }
 
+// Single source of truth for "is anything installed at all" — reused by both
+// the install-recommendation gate (noneInstalled) and the missing-native
+// error (anyInstalled) so the two checks can't independently drift out of
+// sync the way two hand-written `kmod is X || kpm is X || zygisk is X`
+// expressions could.
+internal val NativeBackendStates.anyInstalled: Boolean
+    get() = kmod is ModuleState.Installed || kpm is ModuleState.Installed || zygisk is ModuleState.Installed
+
+internal val NativeBackendStates.noneInstalled: Boolean
+    get() = !anyInstalled
+
 /**
  * The one native backend to surface on the dashboard. This is display state:
  * an active backend wins, otherwise the highest-priority installed backend is

--- a/lsposed/app/src/main/res/values-ru/strings.xml
+++ b/lsposed/app/src/main/res/values-ru/strings.xml
@@ -90,6 +90,7 @@
     <string name="dashboard_kmod_broken_unknown_variant">Установлен, не загрузился</string>
     <string name="dashboard_kmod_broken_ambiguous">Установлен, не загрузился — попробуйте второй GKI-вариант</string>
     <string name="dashboard_kmod_broken_signature_enforced">Установлен, ядро отклоняет неподписанные модули</string>
+    <string name="dashboard_kpm_broken_activator_missing">Установлен, отсутствует активатор</string>
     <string name="dashboard_active_targets">Активен · целей: %d</string>
     <string name="dashboard_reboot_needed">Требуется перезагрузка устройства</string>
     <string name="dashboard_hero_protected_title">VPN скрыт</string>
@@ -260,6 +261,8 @@
     <string name="dashboard_issue_native_conflict_kernel">Модуль ядра (.ko) и KPM установлены одновременно. Они перехватывают одни и те же функции ядра, и при одновременной работе устройство может полностью зависнуть. Оставьте только один — удалите либо модуль ядра, либо KPM.</string>
     <string name="dashboard_issue_native_conflict_deferred">Модуль ядра (.ko) и KPM установлены одновременно. KPM отключился при загрузке, чтобы не подвесить устройство, и сейчас бездействует. Оставьте только один — удалите KPM (или модуль ядра).</string>
     <string name="dashboard_issue_kpm_awaiting_superkey">KPM установлен, но не активен: APatch нужен суперключ, чтобы его загрузить. Сохраните его в Настройки → Безопасность и перезагрузитесь для активации нативного скрытия.</string>
+    <string name="dashboard_issue_kpm_activator_missing">Модуль KPM повреждён: отсутствует бинарник активатора (%1$s). Переустановите vpnhide-kpm.zip из последнего релиза.</string>
+    <string name="dashboard_issue_kpm_load_failed">KPM установлен, но не загрузился: %1$s. Чтобы приложить полный лог загрузки к отчёту об ошибке, нажмите Настройки → Отладка → Собрать отладочный лог, либо переустановите vpnhide-kpm.zip из последнего релиза.</string>
     <string name="dashboard_issue_multiple_native">Установлено больше одного Native-бэкенда. Активным может быть только один (приоритет: модуль ядра, затем KPM, затем Zygisk), остальные простаивают. Удалите неиспользуемые, чтобы не засорять систему.</string>
     <string name="dashboard_issue_debug_logging_on">Отладочные логи включены. VPN Hide пишет подробные строки в logcat, которые может прочитать любой с root-доступом. Выключите переключатель в Настройки → Отладка после сбора отчёта об ошибке.</string>
     <string name="dashboard_issue_agent_bridge_on">Agent control включён. VPN Hide запускает локальный отладочный мост; по открытому порту другие приложения на устройстве могут обнаружить VPN Hide. Выключите его в Настройки → Для разработчиков, когда закончите.</string>
@@ -277,6 +280,7 @@
     <string name="dashboard_issue_ports_no_observers">Модуль скрытия портов установлен, но Ports не включён ни для одного приложения. Откройте вкладку «Скрытие» и включите Ports для нужных приложений.</string>
     <string name="dashboard_issue_version_mismatch">Несоответствие версий LSPosed модуля: запущена %1$s, установлена %2$s. Перезагрузите устройство для обновления.</string>
     <string name="dashboard_issue_update_kmod">Версия модуля ядра %1$s старее версии приложения %2$s. Откройте KernelSU/Magisk → Модули для обновления.</string>
+    <string name="dashboard_issue_update_kmod_named">Версия модуля ядра %1$s старее версии приложения %2$s. Установите %3$s из последнего релиза через KernelSU/Magisk → Модули.</string>
     <string name="dashboard_issue_update_zygisk">Версия модуля Zygisk %1$s старее версии приложения %2$s. Откройте KernelSU/Magisk → Модули для обновления.</string>
     <string name="dashboard_issue_update_app_for_kmod">Версия модуля ядра %1$s новее версии приложения %2$s. Обновите приложение VPN Hide.</string>
     <string name="dashboard_issue_update_app_for_zygisk">Версия модуля Zygisk %1$s новее версии приложения %2$s. Обновите приложение VPN Hide.</string>

--- a/lsposed/app/src/main/res/values/strings.xml
+++ b/lsposed/app/src/main/res/values/strings.xml
@@ -121,6 +121,7 @@
     <string name="dashboard_kmod_broken_unknown_variant">Installed, did not load</string>
     <string name="dashboard_kmod_broken_ambiguous">Installed, did not load — try the other GKI variant</string>
     <string name="dashboard_kmod_broken_signature_enforced">Installed, kernel rejects unsigned modules</string>
+    <string name="dashboard_kpm_broken_activator_missing">Installed, activator missing</string>
     <string name="dashboard_active_targets">Active · %d target(s)</string>
     <string name="dashboard_reboot_needed">Device reboot needed</string>
     <string name="dashboard_hero_protected_title">VPN hidden</string>
@@ -282,6 +283,8 @@
     <string name="dashboard_issue_native_conflict_kernel">The kernel module (.ko) and the KPM are both installed. They hook the same kernel functions, and having both active can hard-freeze the device. Keep only one — uninstall either the kernel module or the KPM.</string>
     <string name="dashboard_issue_native_conflict_deferred">The kernel module (.ko) and the KPM are both installed. The KPM stood down at boot to avoid a freeze, so it isn\'t doing anything. Keep only one — uninstall the KPM (or the kernel module).</string>
     <string name="dashboard_issue_kpm_awaiting_superkey">The KPM is installed but inactive: APatch needs your superkey to load it. Save it in Settings → Security, then reboot to activate native hiding.</string>
+    <string name="dashboard_issue_kpm_activator_missing">KPM module is corrupted: the activator binary is missing (%1$s). Reinstall vpnhide-kpm.zip from the latest release.</string>
+    <string name="dashboard_issue_kpm_load_failed">KPM installed but failed to load: %1$s. Use Settings → Debugging → Collect debug log to attach the full boot-time output to a bug report, or reinstall vpnhide-kpm.zip from the latest release.</string>
     <string name="dashboard_issue_multiple_native">More than one native backend is installed. Only one can be active at a time (priority: kernel module, then KPM, then Zygisk); the others sit idle. Uninstall the ones you don\'t use to keep things clean.</string>
     <string name="dashboard_issue_debug_logging_on">Debug logging is enabled. VPN Hide is writing verbose lines to logcat that anyone with root can read. Turn it off in Settings → Debugging after you\'ve finished collecting a bug report.</string>
     <string name="dashboard_issue_agent_bridge_on">Agent control is enabled. VPN Hide is running a local debug bridge whose open port lets other apps on this device detect VPN Hide. Turn it off in Settings → Developer when you\'re done.</string>
@@ -299,6 +302,7 @@
     <string name="dashboard_issue_ports_no_observers">Ports hiding module is installed, but no apps have Ports enabled. Open Hiding and enable Ports for the apps you need.</string>
     <string name="dashboard_issue_version_mismatch">LSPosed module version mismatch: running %1$s, installed %2$s. Reboot the device to apply the update.</string>
     <string name="dashboard_issue_update_kmod">Kernel module version %1$s is older than app version %2$s. Open KernelSU/Magisk → Modules to update.</string>
+    <string name="dashboard_issue_update_kmod_named">Kernel module version %1$s is older than app version %2$s. Install %3$s from the latest release via KernelSU/Magisk → Modules to update.</string>
     <string name="dashboard_issue_update_zygisk">Zygisk version %1$s is older than app version %2$s. Open KernelSU/Magisk → Modules to update.</string>
     <string name="dashboard_issue_update_app_for_kmod">Kernel module version %1$s is newer than app version %2$s. Update the VPN Hide app.</string>
     <string name="dashboard_issue_update_app_for_zygisk">Zygisk version %1$s is newer than app version %2$s. Update the VPN Hide app.</string>

--- a/lsposed/app/src/test/kotlin/dev/okhsunrog/vpnhide/ClassifyKmodProblemTest.kt
+++ b/lsposed/app/src/test/kotlin/dev/okhsunrog/vpnhide/ClassifyKmodProblemTest.kt
@@ -72,7 +72,7 @@ class ClassifyKmodProblemTest {
                 loadStatus(fresh = true, kretprobes = "n"),
             )
         assertEquals(KmodProblemKind.KprobesMissing, kind)
-        assertEquals(KmodBrokenReason.MissingKprobes, kind?.reason)
+        assertEquals(ModuleBrokenReason.MissingKprobes, kind?.reason)
     }
 
     @Test
@@ -178,7 +178,7 @@ class ClassifyKmodProblemTest {
                 loadStatus(fresh = true, insmodStderr = "Key was rejected by service", insmodExit = 129),
             )
         assertEquals(KmodProblemKind.SignatureEnforced, kind)
-        assertEquals(KmodBrokenReason.SignatureEnforced, kind?.reason)
+        assertEquals(ModuleBrokenReason.SignatureEnforced, kind?.reason)
     }
 
     @Test

--- a/lsposed/app/src/test/kotlin/dev/okhsunrog/vpnhide/ClassifyKpmProblemTest.kt
+++ b/lsposed/app/src/test/kotlin/dev/okhsunrog/vpnhide/ClassifyKpmProblemTest.kt
@@ -1,0 +1,71 @@
+package dev.okhsunrog.vpnhide
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class ClassifyKpmProblemTest {
+    private fun installed(active: Boolean) = ModuleState.Installed(version = "1.0", active = active, targetCount = 0)
+
+    @Test
+    fun `not installed produces no problem`() {
+        assertNull(classifyKpmProblem(ModuleState.NotInstalled, "runtime=activator\nloaded=0\nboot_id=boot-1\n", "boot-1"))
+    }
+
+    @Test
+    fun `active kpm is fine regardless of load status`() {
+        assertNull(classifyKpmProblem(installed(active = true), "runtime=activator\nloaded=1\nboot_id=boot-1\n", "boot-1"))
+    }
+
+    @Test
+    fun `conflict runtime is not diagnosed here — handled by kpmDeferredForConflict`() {
+        val status = "runtime=conflict\nloaded=0\nboot_id=boot-1\ndetail=vpnhide_kmod present\n"
+        assertNull(classifyKpmProblem(installed(active = false), status, "boot-1"))
+    }
+
+    @Test
+    fun `apatch awaiting-superkey runtime is not diagnosed here — handled by kpmAwaitingSuperkey`() {
+        val status = "runtime=apatch\nloaded=0\nboot_id=boot-1\ndetail=awaiting_superkey\n"
+        assertNull(classifyKpmProblem(installed(active = false), status, "boot-1"))
+    }
+
+    @Test
+    fun `missing activator binary is a named diagnosis with a red card`() {
+        val status = "runtime=activator\nloaded=0\nboot_id=boot-1\ndetail=activator missing at /data/adb/modules/vpnhide_kpm/activator\n"
+        val kind = classifyKpmProblem(installed(active = false), status, "boot-1")
+        assertEquals(KpmProblemKind.ActivatorMissing("/data/adb/modules/vpnhide_kpm/activator"), kind)
+        assertEquals(ModuleBrokenReason.KpmActivatorMissing, kind?.reason)
+    }
+
+    @Test
+    fun `generic activator failure surfaces the raw detail with no card color`() {
+        val status = "runtime=activator\nloaded=0\nboot_id=boot-1\ndetail=rc=1 supercall failed: ENOENT\n"
+        val kind = classifyKpmProblem(installed(active = false), status, "boot-1")
+        assertEquals(KpmProblemKind.LoadFailed("rc=1 supercall failed: ENOENT"), kind)
+        assertNull(kind?.reason)
+    }
+
+    @Test
+    fun `stale boot id is ignored`() {
+        val status = "runtime=activator\nloaded=0\nboot_id=boot-0\ndetail=rc=1 boom\n"
+        assertNull(classifyKpmProblem(installed(active = false), status, "boot-1"))
+    }
+
+    @Test
+    fun `missing boot id is ignored`() {
+        val status = "runtime=activator\nloaded=0\ndetail=rc=1 boom\n"
+        assertNull(classifyKpmProblem(installed(active = false), status, "boot-1"))
+    }
+
+    @Test
+    fun `empty load status is ignored`() {
+        assertNull(classifyKpmProblem(installed(active = false), "", "boot-1"))
+    }
+
+    @Test
+    fun `inactive with fresh configured status but stale active flag is not diagnosed`() {
+        // loaded=1 on runtime=activator means "configured" per service.sh, not a failure.
+        val status = "runtime=activator\nloaded=1\nboot_id=boot-1\ndetail=configured\n"
+        assertNull(classifyKpmProblem(installed(active = false), status, "boot-1"))
+    }
+}

--- a/lsposed/app/src/test/kotlin/dev/okhsunrog/vpnhide/NativeBackendTest.kt
+++ b/lsposed/app/src/test/kotlin/dev/okhsunrog/vpnhide/NativeBackendTest.kt
@@ -105,6 +105,22 @@ class NativeBackendTest {
         assertEquals(NativeBackendId.Kmod, states.activeId)
     }
 
+    // ── anyInstalled / noneInstalled ─────────────────────────────────────
+
+    @Test
+    fun `none installed is the only state where noneInstalled is true`() {
+        val none = states(ModuleState.NotInstalled, ModuleState.NotInstalled, ModuleState.NotInstalled)
+        assertEquals(false, none.anyInstalled)
+        assertEquals(true, none.noneInstalled)
+    }
+
+    @Test
+    fun `a single installed backend flips anyInstalled regardless of which one`() {
+        val kpmOnly = states(ModuleState.NotInstalled, installed(active = false), ModuleState.NotInstalled)
+        assertEquals(true, kpmOnly.anyInstalled)
+        assertEquals(false, kpmOnly.noneInstalled)
+    }
+
     // ── classifyMultiNative ──────────────────────────────────────────────
 
     @Test


### PR DESCRIPTION
Closes #225. A KPM install whose activator failed to load (corrupted binary, or any other activator exit failure) sat inactive with zero explanation — no card color, no banner — unlike kmod, which already has a full failure-diagnosis cascade. Separately, once a kmod is already installed, the dashboard gave no way to see which GKI variant it was, and the "update your module" warning for an outdated kmod didn't name which zip to grab, forcing a re-install to be a guessing game.

- Add `classifyKpmProblem`, mirroring `classifyKmodProblem`'s single-source-of-truth pattern: diagnoses `ActivatorMissing` (red card) and a generic `LoadFailed` (banner only) from the boot script's `detail` status field, which was previously parsed only for the conflict/awaiting-superkey cases
- Rename `KmodBrokenReason`/`KmodProblem` to `ModuleBrokenReason`/`ModuleProblem` since both are shared across module kinds, not kmod-only
- Add `NativeBackendStates.anyInstalled`/`.noneInstalled` and reuse them at the three call sites that used to hand-roll their own `kmod`/`kpm`/`zygisk` boolean combination
- Show the installed kmod's stamped GKI variant on its dashboard card
- Name the exact recommended zip in the "kmod is outdated" warning, when the kernel recommendation is known

Both fixes are additive (new optional params defaulting to `null`, new string resources); no existing behavior changes.