### PR TITLE
refactor(lsposed): canonical config is the single source of truth for debug logging

### DIFF
--- a/docs/state.md
+++ b/docs/state.md
@@ -241,10 +241,11 @@ and the app reruns the ports activator on Save.
 Accessed through `context.getSharedPreferences("vpnhide_prefs", MODE_PRIVATE)`.
 Keys currently in use:
 
-- `debug_logging: Boolean`: app-process preference backing Diagnostics debug
-  logging. The runtime/storage value is also mirrored into canonical JSON.
 - `last_seen_version: String`: changelog dialog.
 - `help_collapsed_*: Boolean`: help accordions.
+
+`debug` / `debugSwitch` are not stored here anymore. Diagnostics and debug
+capture state comes from canonical JSON (`/data/system/vpnhide_config.json`).
 
 Vector LSPosed redirects this storage to:
 

--- a/docs/storage.md
+++ b/docs/storage.md
@@ -55,9 +55,10 @@ The number-keying difference is deliberate and bridged by the activator:
 - **Readers:** the app (`su`), the LSPosed hook (directly, from `system_server`),
   the activator (root). **Not** readable by unprivileged apps or non-root `adb`
   (see §7).
-- **Holds:** schema version, the global `debug` flag, per-package roles + (optional)
-  per-hook selection, and app settings. It does **not** hold stats, status, or the
-  APatch superkey (those are runtime/secret — §5, §6).
+- **Holds:** schema version, the global `debug` flag (effective logging intent),
+  `debugSwitch` (user toggle intent), per-package roles + (optional) per-hook
+  selection, and app settings. It does **not** hold stats, status, or the APatch
+  superkey (those are runtime/secret — §5, §6).
 - **Import / export = copy this one file.** It contains no device-specific secret,
   so it is safe to back up / move / share. (This is *why* the superkey is **not**
   stored here — §6.)
@@ -68,6 +69,7 @@ Shape (illustrative):
 {
   "version": 1,
   "debug": false,
+  "debugSwitch": false,
   "apps": {
     "com.example.bank":  { "java": true, "native": true,  "appHiding": false, "ports": false },
     "org.example.proxy": {
@@ -90,6 +92,16 @@ Shape (illustrative):
   }
 }
 ```
+
+`debugSwitch` is the user intent stored by the app toggle; `debug` is the
+effective in-runtime value. On a capture path, `debug` may temporarily become
+`true` while `debugSwitch` remains `false`. Startup reconciliation restores
+`debug := debugSwitch` when they diverge.
+
+Migration from pre-switch configs:
+
+- If `debugSwitch` is missing, it is treated as `debug` while parsing so older
+  canonical JSONs keep working.
 
 Per-hook granularity ("раздельное управление хуками"): the coarse `"java": true`
 or `"native": true` is the common case (enable every hook in that role for the

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/AgentControl.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/AgentControl.kt
@@ -164,7 +164,7 @@ internal object AgentControl {
     ): AgentProtectionState =
         withAppContext(context) { context ->
             val snapshot = targetsSnapshot(refresh == true)
-            buildProtectionState(context, snapshot)
+            buildProtectionState(snapshot)
         }
 
     /**
@@ -183,7 +183,7 @@ internal object AgentControl {
         withAppContext(context) { context ->
             val apps = AppListCache.loadForAgent(context, force = refresh == true)
             val userNames = AppListCache.userNames.value
-            val protection = buildProtectionState(context, targetsSnapshot(refresh = false))
+            val protection = buildProtectionState(targetsSnapshot(refresh = false))
             val rolesByPackage = protection.configuredApps.associateBy { it.packageName }
             apps
                 .asSequence()
@@ -203,7 +203,7 @@ internal object AgentControl {
      */
     suspend fun exportCanonicalConfig(context: Context): String =
         withAppContext(context) { context ->
-            canonicalConfigJson(currentCanonicalConfig(context, refresh = false))
+            canonicalConfigJson(currentCanonicalConfig(refresh = false))
         }
 
     /**
@@ -219,11 +219,7 @@ internal object AgentControl {
             val canonical =
                 parseImportedCanonicalConfig(json, context.packageName)
                     ?: throw IllegalArgumentException("Invalid canonical JSON")
-            applyCanonicalConfig(
-                context = context,
-                canonical = canonical,
-                updateDebugPreference = true,
-            )
+            applyCanonicalConfig(context = context, canonical = canonical)
         }
 
     /**
@@ -247,7 +243,7 @@ internal object AgentControl {
     ): AgentMutationResult =
         withAppContext(context) { context ->
             val pkg = requirePackageName(packageName)
-            val base = currentCanonicalConfig(context, refresh = true)
+            val base = currentCanonicalConfig(refresh = true)
             val current = base.apps[pkg] ?: CanonicalApp()
             val nextPorts = ports ?: current.ports
             val next =
@@ -282,7 +278,7 @@ internal object AgentControl {
         withAppContext(context) { context ->
             val pkg = requirePackageName(packageName)
             val hooks = resolveHookIds(hookIds, LsposedJavaHookEntries)
-            val base = currentCanonicalConfig(context, refresh = true)
+            val base = currentCanonicalConfig(refresh = true)
             val current = base.apps[pkg] ?: CanonicalApp()
             val selected = resolveHookSelection(LsposedJavaHookEntries.map { it.hookName }, hooks.toSet())
             val next =
@@ -313,7 +309,7 @@ internal object AgentControl {
             val hookFamily = family?.let(::parseNativeHookFamily) ?: snapshot.nativeHookFamily
             val entries = nativeHookEntriesFor(hookFamily)
             val hooks = resolveHookIds(hookIds, entries)
-            val base = currentCanonicalConfig(context, refresh = false)
+            val base = currentCanonicalConfig(refresh = false)
             val current = base.apps[pkg] ?: CanonicalApp()
             val selected = resolveNativeHookSelection(entries.map { it.hookName }, hooks.toSet())
             val next =
@@ -349,7 +345,7 @@ internal object AgentControl {
         withAppContext(context) { context ->
             val pkg = requirePackageName(packageName)
             val policy = parseAgentPortPolicy(mode, preset, rules.orEmpty())
-            val base = currentCanonicalConfig(context, refresh = true)
+            val base = currentCanonicalConfig(refresh = true)
             val current = base.apps[pkg] ?: CanonicalApp()
             val next = current.copy(ports = true, portPolicy = policy)
             applyCanonicalConfig(context, base.withApp(pkg, next), targetRestartRecommended = true)
@@ -368,7 +364,7 @@ internal object AgentControl {
     ): AgentMutationResult =
         withAppContext(context) { context ->
             val apps = AppListCache.loadForAgent(context, force = true)
-            val base = currentCanonicalConfig(context, refresh = true)
+            val base = currentCanonicalConfig(refresh = true)
             val nextSettings =
                 base.settings.copy(
                     autoHideVpnServices = autoHideVpnServices ?: base.settings.autoHideVpnServices,
@@ -394,7 +390,7 @@ internal object AgentControl {
     ): AgentMutationResult =
         withAppContext(context) { context ->
             val apps = AppListCache.loadForAgent(context, force = true)
-            val base = currentCanonicalConfig(context, refresh = true)
+            val base = currentCanonicalConfig(refresh = true)
             val visiblePackages = apps.mapTo(mutableSetOf()) { it.packageName }
             val selected = packageNames.map(::requirePackageName).toSortedSet()
             val next =
@@ -420,7 +416,7 @@ internal object AgentControl {
         withAppContext(context) { context ->
             val packages = packageNames.map(::requirePackageName).toSortedSet()
             if (packages.isEmpty()) return@withAppContext AgentMutationResult(ok = true, message = "No packages to remove")
-            val base = currentCanonicalConfig(context, refresh = true)
+            val base = currentCanonicalConfig(refresh = true)
             applyCanonicalConfig(
                 context = context,
                 canonical = removeConfiguredPackages(base, packages, context.packageName),
@@ -437,7 +433,7 @@ internal object AgentControl {
         enabled: Boolean,
     ): AgentMutationResult =
         withAppContext(context) { context ->
-            setDebugLoggingEnabled(context, enabled)
+            setDebugLoggingEnabled(enabled)
             AgentMutationResult(ok = true, message = "Debug logging updated", changed = true)
         }
 
@@ -446,7 +442,7 @@ internal object AgentControl {
      */
     suspend fun activateConfig(context: Context): AgentMutationResult =
         withAppContext(context) { context ->
-            runActivation(context, changed = false)
+            runActivation(changed = false)
         }
 }
 
@@ -463,25 +459,20 @@ private suspend fun rootSnapshot(refresh: Boolean): RootSnapshot =
 
 private suspend fun targetsSnapshot(refresh: Boolean): TargetsSnapshot = parseTargetsSnapshot(rootSnapshot(refresh))
 
-private suspend fun currentCanonicalConfig(
-    context: Context,
-    refresh: Boolean,
-): CanonicalConfig {
+private suspend fun currentCanonicalConfig(refresh: Boolean): CanonicalConfig {
     val snapshot = targetsSnapshot(refresh)
     return snapshot.canonicalConfig
-        ?: buildCanonicalConfigFromTargetsSnapshot(snapshot, debug = isEnabledInPrefs(context))
+        ?: buildCanonicalConfigFromTargetsSnapshot(snapshot)
 }
 
 private fun applyCanonicalConfig(
     context: Context,
     canonical: CanonicalConfig,
-    updateDebugPreference: Boolean = false,
     targetRestartRecommended: Boolean = true,
 ): AgentMutationResult {
     val next = canonicalConfigWithSelfTarget(canonical, context.packageName)
     val result = runActivationCommand(buildCanonicalConfigWriteCommand(next), changed = true)
     if (result.ok) {
-        if (updateDebugPreference) storeDebugLoggingPreference(context, next.debug)
         RootSnapshotCache.invalidate()
         TargetsCache.invalidate()
         DashboardCache.invalidate()
@@ -490,10 +481,7 @@ private fun applyCanonicalConfig(
     return result.copy(targetRestartRecommended = result.ok && targetRestartRecommended)
 }
 
-private fun runActivation(
-    @Suppress("UNUSED_PARAMETER") context: Context,
-    changed: Boolean,
-): AgentMutationResult = runActivationCommand(prefix = null, changed = changed)
+private fun runActivation(changed: Boolean): AgentMutationResult = runActivationCommand(prefix = null, changed = changed)
 
 private fun runActivationCommand(
     prefix: String?,
@@ -517,13 +505,10 @@ private fun runActivationCommand(
     }
 }
 
-private fun buildProtectionState(
-    context: Context,
-    snapshot: TargetsSnapshot,
-): AgentProtectionState {
+private fun buildProtectionState(snapshot: TargetsSnapshot): AgentProtectionState {
     val canonical =
         snapshot.canonicalConfig
-            ?: buildCanonicalConfigFromTargetsSnapshot(snapshot, debug = isEnabledInPrefs(context))
+            ?: buildCanonicalConfigFromTargetsSnapshot(snapshot)
     return AgentProtectionState(
         canonicalConfigJson = canonicalConfigJson(canonical),
         activeNativeBackend = snapshot.activeNativeBackendId?.name,

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/AgentControlBridge.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/AgentControlBridge.kt
@@ -20,7 +20,7 @@ import java.security.SecureRandom
 import java.util.Base64
 import kotlin.concurrent.thread
 
-private const val TAG = "VpnHideAgentBridge"
+private const val TAG = LogTags.AGENT_BRIDGE
 private const val LOCALHOST = "127.0.0.1"
 
 // A stalled localhost peer must not wedge the single serve thread forever:
@@ -109,7 +109,7 @@ private class BridgeServer(
 
     fun start() {
         worker =
-            thread(name = "VpnHideAgentBridge", isDaemon = true) {
+            thread(name = LogTags.AGENT_BRIDGE, isDaemon = true) {
                 serveLoop()
             }
     }

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/AgentControlBridge.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/AgentControlBridge.kt
@@ -79,7 +79,7 @@ internal object AgentControlBridge {
                 )
             }
         }.onFailure { error ->
-            Log.e(TAG, "Failed to start agent bridge", error)
+            VpnHideLog.e(TAG, "Failed to start agent bridge", error)
         }.getOrNull()
 
     private fun generateToken(): String {
@@ -175,7 +175,7 @@ private class BridgeServer(
         } catch (e: SerializationException) {
             writeError(client, 400, "Bad Request", e.message ?: "Invalid JSON")
         } catch (e: Throwable) {
-            Log.e(TAG, "Agent bridge request failed", e)
+            VpnHideLog.e(TAG, "Agent bridge request failed", e)
             writeError(client, 500, "Internal Server Error", e.message ?: e::class.java.simpleName)
         }
     }

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/AppListCache.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/AppListCache.kt
@@ -76,7 +76,7 @@ internal fun labelWithUsers(
  */
 internal object AppListCache : StateCache<List<AppSummary>>(
     traceName = "app_list_cache",
-    logTag = "VpnHide-AppList",
+    logTag = LogTags.APP_LIST,
 ) {
     val apps: StateFlow<List<AppSummary>?> get() = value
 

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/AppPickerData.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/AppPickerData.kt
@@ -191,9 +191,20 @@ private fun canonicalBaseForSave(
     snapshot: TargetsSnapshot?,
 ): CanonicalConfig =
     when {
-        snapshot?.canonicalConfig != null -> snapshot.canonicalConfig.copy(debug = debug)
-        snapshot != null -> buildCanonicalConfigFromTargetsSnapshot(snapshot, debug = debug)
-        else -> CanonicalConfig(debug = debug)
+        snapshot?.canonicalConfig != null -> {
+            snapshot.canonicalConfig.copy(
+                debug = debug,
+                debugSwitch = snapshot.canonicalConfig.debugSwitch,
+            )
+        }
+
+        snapshot != null -> {
+            buildCanonicalConfigFromTargetsSnapshot(snapshot, debug = debug)
+        }
+
+        else -> {
+            CanonicalConfig(debug = debug)
+        }
     }
 
 private fun Collection<AppRoleSelection>.selectedPkgs(predicate: (AppRoleSelection) -> Boolean): Set<String> =

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/BackgroundUpdateChecks.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/BackgroundUpdateChecks.kt
@@ -26,7 +26,7 @@ import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.runBlocking
 import java.util.concurrent.TimeUnit
 
-private const val TAG = "VpnHide-Update"
+private const val TAG = LogTags.UPDATE
 private const val UPDATE_WORK_NAME = "vpnhide_background_update_check"
 private const val UPDATE_NOTIFICATION_CHANNEL_ID = "vpnhide_updates"
 private const val UPDATE_NOTIFICATION_ID = 1001

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/ConfigChannels.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/ConfigChannels.kt
@@ -66,7 +66,7 @@ internal fun runRuntimeConfigReconcile() {
     parts += ConfigChannels.reconcileCommand()
     val cmd = parts.joinToString(" ; ")
     val (exit, _) = suExec(cmd)
-    if (exit != 0) VpnHideLog.w("VpnHide-Startup", "runtime config reconcile failed (exit=$exit)")
+    if (exit != 0) VpnHideLog.w(LogTags.STARTUP, "runtime config reconcile failed (exit=$exit)")
 }
 
 /**
@@ -96,7 +96,7 @@ internal fun reconcileAutoHiddenPackages(
         ).joinToString(" ; ")
     val (exit, output) = suExec(cmd)
     if (exit != 0) {
-        VpnHideLog.w("VpnHide-Startup", "auto-hide reconcile failed (exit=$exit): ${output.trim()}")
+        VpnHideLog.w(LogTags.STARTUP, "auto-hide reconcile failed (exit=$exit): ${output.trim()}")
         return false
     }
     RootSnapshotCache.invalidate()
@@ -104,7 +104,7 @@ internal fun reconcileAutoHiddenPackages(
     DashboardCache.invalidate()
     StatisticsCache.invalidate()
     VpnHideLog.i(
-        "VpnHide-Startup",
+        LogTags.STARTUP,
         "auto-hide reconcile: ${next.settings.autoHiddenPackages.size} auto-hidden package(s)",
     )
     return true

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/ConfigChannels.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/ConfigChannels.kt
@@ -49,52 +49,24 @@ internal object ConfigChannels {
 }
 
 /**
- * Run the startup runtime-config reconcile over root: derive the targets from
- * [rootSnapshot], fold in the persisted debug flag, and (re-)write the
- * `vpnhide 1 config` snapshot to every live channel. Blocking — call from a
- * background dispatcher. Best-effort: a non-zero exit is logged, not fatal.
+ * If capture left debug enabled, return a canonical copy with effective debug
+ * snapped back to user intent for startup reconciliation.
  */
-internal fun runRuntimeConfigReconcile(
-    context: Context,
-    rootSnapshot: RootSnapshot,
-) {
-    val snapshot = parseTargetsSnapshot(rootSnapshot)
-    val persistedDebug = isEnabledInPrefs(context)
+internal fun canonicalConfigForStartupDebugReconcile(config: CanonicalConfig): CanonicalConfig? =
+    if (config.debug != config.debugSwitch) config.copy(debug = config.debugSwitch) else null
+
+/**
+ * Run the startup runtime-config reconcile. Canonical JSON already contains
+ * debug, so reconcile only needs to re-run activators to pick up the current
+ * file state. Blocking — call from a background dispatcher. Best-effort: a
+ * non-zero exit is logged, not fatal.
+ */
+internal fun runRuntimeConfigReconcile() {
     val parts = mutableListOf<String>()
-    runtimeReconcileCanonicalConfig(snapshot, persistedDebug)?.let { canonical ->
-        parts += buildCanonicalConfigWriteCommand(canonical)
-    }
     parts += ConfigChannels.reconcileCommand()
     val cmd = parts.joinToString(" ; ")
     val (exit, _) = suExec(cmd)
     if (exit != 0) VpnHideLog.w("VpnHide-Startup", "runtime config reconcile failed (exit=$exit)")
-}
-
-internal fun runtimeReconcileCanonicalConfig(
-    snapshot: TargetsSnapshot,
-    persistedDebug: Boolean,
-): CanonicalConfig? {
-    val existing = snapshot.canonicalConfig
-    return when {
-        existing == null -> {
-            buildCanonicalConfig(
-                debug = persistedDebug,
-                javaPkgs = snapshot.lsposedTargets,
-                nativePkgs = snapshot.nativeTargets,
-                hiddenPkgs = snapshot.hiddenPkgs,
-                observerPkgs = snapshot.observerNames,
-                portsPkgs = snapshot.portsObservers,
-            )
-        }
-
-        existing.debug != persistedDebug -> {
-            existing.copy(debug = persistedDebug)
-        }
-
-        else -> {
-            null
-        }
-    }
 }
 
 /**

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DashboardCache.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DashboardCache.kt
@@ -20,7 +20,7 @@ import kotlinx.coroutines.withContext
  */
 internal object DashboardCache : StateCache<DashboardState>(
     traceName = "dashboard_state",
-    logTag = "VpnHide-Dashboard",
+    logTag = LogTags.DASHBOARD,
 ) {
     val state: StateFlow<DashboardState?> get() = value
 

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DashboardData.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DashboardData.kt
@@ -385,7 +385,7 @@ internal data class KmodLoadStatus(
     val freshForCurrentBoot: Boolean,
 )
 
-private const val TAG = "VpnHide-Dashboard"
+private const val TAG = LogTags.DASHBOARD
 
 // Non-GKI kernel series KernelPatch (the KPM runtime) supports but the .ko does
 // not: no GKI KMI, no DDK build. Mirrors the sub-5.10 rows of the KPM kver

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DebugCaptureLogging.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DebugCaptureLogging.kt
@@ -1,6 +1,5 @@
 package dev.okhsunrog.vpnhide
 
-import android.content.Context
 import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.sync.Mutex
@@ -16,21 +15,19 @@ private val activeDebugCaptureSessions = linkedSetOf<Long>()
 
 internal data class DebugCaptureLoggingSession(
     val id: Long,
-    val persistedEnabled: Boolean,
-    val runtimeWasEnabled: Boolean,
+    val originalDebug: Boolean,
     val apply: DebugCaptureLoggingStep,
     val restore: DebugCaptureLoggingStep? = null,
 ) {
     val forced: Boolean
-        get() = !persistedEnabled || !runtimeWasEnabled
+        get() = !originalDebug
 
     fun withRestore(restore: DebugCaptureLoggingStep?): DebugCaptureLoggingSession = copy(restore = restore)
 
     fun toText(): String =
         buildString {
             appendLine("sessionId=$id")
-            appendLine("persistedEnabled=$persistedEnabled")
-            appendLine("runtimeWasEnabled=$runtimeWasEnabled")
+            appendLine("originalDebug=$originalDebug")
             appendLine("forced=$forced")
             appendLine()
             appendLine("=== apply ===")
@@ -68,54 +65,33 @@ internal data class DebugCaptureLoggingStep(
         }.trimEnd()
 }
 
-internal suspend fun beginDebugCaptureLogging(context: Context): DebugCaptureLoggingSession =
+internal suspend fun beginDebugCaptureLogging(): DebugCaptureLoggingSession =
     withContext(NonCancellable) {
         debugCaptureMutex.withLock {
             val sessionId = nextDebugCaptureSessionId.getAndIncrement()
-            val persisted = isEnabledInPrefs(context)
-            val runtime = VpnHideLog.enabled
-            val activeBeforeBegin = activeDebugCaptureSessions.size
+            val snapshot =
+                runCatching { RootSnapshotCache.getOrLoad() }.getOrNull()
+                    ?: RootSnapshotCache.snapshot.value
+            val originalDebug = debugFromCanonicalSnapshot(snapshot)
             activeDebugCaptureSessions += sessionId
-            try {
-                val apply =
-                    if (activeBeforeBegin == 0) {
-                        applyDebugLoggingForCapture(enabled = true)
-                    } else {
-                        VpnHideLog.enabled = true
-                        DebugCaptureLoggingStep(
-                            requestedEnabled = true,
-                            source = "already_forced_by_active_capture",
-                            rootSnapshotExit = null,
-                            commandExit = null,
-                            detail = "activeCaptureSessions=$activeBeforeBegin",
-                        )
-                    }
-                DebugCaptureLoggingSession(
-                    id = sessionId,
-                    persistedEnabled = persisted,
-                    runtimeWasEnabled = runtime,
-                    apply = apply,
-                )
-            } catch (t: Throwable) {
-                activeDebugCaptureSessions -= sessionId
-                if (activeDebugCaptureSessions.isEmpty()) {
-                    runCatching { applyDebugLoggingForCapture(enabled = isEnabledInPrefs(context)) }
-                }
-                throw t
-            }
+            val apply =
+                runCatching {
+                    applyCanonicalDebugToggle(enabled = true, sourceSnapshot = snapshot)
+                }.getOrElse { failureStep(requestedEnabled = true, detail = failureDetail(failure = it)) }
+            return@withLock DebugCaptureLoggingSession(
+                id = sessionId,
+                originalDebug = originalDebug,
+                apply = apply,
+            )
         }
     }
 
-internal suspend fun restoreDebugCaptureLogging(
-    context: Context,
-    session: DebugCaptureLoggingSession,
-): DebugCaptureLoggingStep? =
+internal suspend fun restoreDebugCaptureLogging(session: DebugCaptureLoggingSession): DebugCaptureLoggingStep? =
     withContext(NonCancellable) {
         debugCaptureMutex.withLock {
-            val target = isEnabledInPrefs(context)
             if (!activeDebugCaptureSessions.remove(session.id)) {
                 return@withLock DebugCaptureLoggingStep(
-                    requestedEnabled = target,
+                    requestedEnabled = session.originalDebug,
                     source = "capture_session_not_active",
                     rootSnapshotExit = null,
                     commandExit = null,
@@ -124,104 +100,101 @@ internal suspend fun restoreDebugCaptureLogging(
             }
 
             if (activeDebugCaptureSessions.isNotEmpty()) {
-                VpnHideLog.enabled = true
                 return@withLock DebugCaptureLoggingStep(
                     requestedEnabled = true,
                     source = "restore_deferred_active_capture",
                     rootSnapshotExit = null,
                     commandExit = null,
-                    detail =
-                        "targetAfterLastCapture=$target activeCaptureSessions=${activeDebugCaptureSessions.size}",
+                    detail = "activeCaptureSessions=${activeDebugCaptureSessions.size}",
                 )
             }
 
-            if (target == session.apply.requestedEnabled && VpnHideLog.enabled == target) {
-                null
-            } else {
-                applyDebugLoggingForCapture(enabled = target)
+            val restoreDebug =
+                RootSnapshotCache.snapshot.value
+                    ?.let { parseTargetsSnapshot(it).canonicalConfig?.debugSwitch }
+                    ?: session.originalDebug
+            if (restoreDebug == VpnHideLog.enabled && restoreDebug == session.apply.requestedEnabled) {
+                return@withLock null
             }
+            return@withLock runCatching {
+                applyCanonicalDebugToggle(enabled = restoreDebug, sourceSnapshot = RootSnapshotCache.snapshot.value)
+            }.getOrElse { failureStep(requestedEnabled = restoreDebug, detail = failureDetail(failure = it)) }
         }
     }
 
-private suspend fun applyDebugLoggingForCapture(enabled: Boolean): DebugCaptureLoggingStep {
-    VpnHideLog.enabled = enabled
-    val rootSnapshotResult = runCatching { RootSnapshotCache.refresh() }
-    val snapshot = rootSnapshotResult.getOrNull()
-    if (snapshot == null) {
-        val message = rootSnapshotResult.exceptionOrNull()?.message.orEmpty()
-        return fallbackDebugRuntimeApply(enabled, message)
-    }
+private fun failureStep(
+    requestedEnabled: Boolean,
+    detail: String,
+): DebugCaptureLoggingStep =
+    DebugCaptureLoggingStep(
+        requestedEnabled = requestedEnabled,
+        source = "canonical_missing_or_unavailable",
+        rootSnapshotExit = null,
+        commandExit = null,
+        detail = detail,
+    )
 
-    val canonical = debugToggledCanonicalConfig(snapshot, enabled)
+private fun failureDetail(failure: Throwable): String =
+    failure.message?.ifBlank { failure::class.java.simpleName } ?: failure::class.java.simpleName
+
+private suspend fun applyCanonicalDebugToggle(
+    enabled: Boolean,
+    sourceSnapshot: RootSnapshot?,
+): DebugCaptureLoggingStep {
+    val (snapshot, rootSnapshotExit) =
+        if (sourceSnapshot != null) {
+            sourceSnapshot to 0
+        } else {
+            runCatching { RootSnapshotCache.refresh() }.getOrNull() to null
+        }
+    val resolvedSnapshot = snapshot ?: RootSnapshotCache.snapshot.value
+    val canonical = debugToggledCanonicalConfig(resolvedSnapshot, enabled)
     if (canonical == null) {
-        return fallbackDebugRuntimeApply(enabled, "canonical config unavailable and target snapshot fallback failed")
+        VpnHideLog.enabled = enabled
+        invalidateDebugCaptureState()
+        delay(DEBUG_CAPTURE_OBSERVER_DELAY_MS)
+        return DebugCaptureLoggingStep(
+            requestedEnabled = enabled,
+            source = "canonical_unavailable",
+            rootSnapshotExit = rootSnapshotExit,
+            commandExit = null,
+            detail = "canonical config is unavailable or malformed",
+        )
     }
 
-    val cmd =
+    val (exit, out) =
         listOf(
-            buildCanonicalConfigWriteCommand(canonical.config),
+            buildCanonicalConfigWriteCommand(canonical),
             ConfigChannels.reconcileCommand(),
-        ).joinToString(" ; ")
-    val (exit, out) = suExec(cmd)
+        ).joinToString(" ; ").let(::suExec)
+
+    VpnHideLog.enabled = enabled
     invalidateDebugCaptureState()
     delay(DEBUG_CAPTURE_OBSERVER_DELAY_MS)
     return DebugCaptureLoggingStep(
         requestedEnabled = enabled,
-        source = canonical.source,
-        rootSnapshotExit = 0,
+        source = "canonical_debug_only",
+        rootSnapshotExit = rootSnapshotExit,
         commandExit = exit,
         detail = out.trim(),
     )
 }
 
-private suspend fun fallbackDebugRuntimeApply(
-    enabled: Boolean,
-    reason: String,
-): DebugCaptureLoggingStep {
-    VpnHideLog.enabled = enabled
-    invalidateDebugCaptureState()
-    delay(DEBUG_CAPTURE_OBSERVER_DELAY_MS)
-    return DebugCaptureLoggingStep(
-        requestedEnabled = enabled,
-        source = "app_process_only_fallback",
-        rootSnapshotExit = null,
-        commandExit = null,
-        detail = reason.ifBlank { "root snapshot unavailable" },
-    )
-}
-
-internal data class DebugCanonicalUpdate(
-    val config: CanonicalConfig,
-    val source: String,
-)
-
+/**
+ * Parse canonical config from snapshot and clone it with only [`debug`] changed.
+ * No rebuild from legacy target files happens here; callers are responsible for
+ * having canonical JSON available as the source of truth.
+ */
 internal fun debugToggledCanonicalConfig(
-    snapshot: RootSnapshot,
+    snapshot: RootSnapshot?,
     enabled: Boolean,
-): DebugCanonicalUpdate? {
-    val raw = snapshot.sections["canonical_config"].orEmpty()
-    val existing = runCatching { parseCanonicalConfig(raw) }.getOrNull()
-    if (existing != null) {
-        return DebugCanonicalUpdate(existing.copy(debug = enabled), "canonical_debug_only")
-    }
-
-    // A canonical config that is present but unparseable must NOT be rebuilt from
-    // the legacy targets snapshot: buildCanonicalConfig would reset settings to
-    // defaults and silently clear autoHiddenPackages / autoHideVpnName /
-    // rememberSuperkey. Refuse the rewrite (caller falls back to an app-process-
-    // only toggle) so a routine debug capture can't wipe the user's settings.
-    // Only rebuild when there is genuinely no canonical config on disk yet.
-    if (raw.isNotBlank()) {
-        return null
-    }
-
-    return runCatching {
-        DebugCanonicalUpdate(
-            buildCanonicalConfigFromTargetsSnapshot(parseTargetsSnapshot(snapshot), debug = enabled),
-            "targets_snapshot_fallback",
-        )
-    }.getOrNull()
-}
+): CanonicalConfig? =
+    snapshot
+        ?.sections
+        ?.get("canonical_config")
+        ?.let {
+            runCatching { parseCanonicalConfig(it) }.getOrNull()
+        }?.copy(debug = enabled)
 
 private fun invalidateDebugCaptureState() {
     RootSnapshotCache.invalidate()

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DebugExport.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DebugExport.kt
@@ -13,7 +13,7 @@ import java.util.Locale
 import java.util.zip.ZipEntry
 import java.util.zip.ZipOutputStream
 
-private const val TAG = "VPNHideTest"
+private const val TAG = LogTags.TEST
 
 internal data class DiagnosticFileEntry(
     val name: String,
@@ -364,7 +364,7 @@ internal fun buildBootLsposedLogcatCommand(): String {
 
 private val BOOT_LSPOSED_LOGCAT_PATTERNS =
     listOf(
-        "VpnHide-LSPosed",
+        LogTags.LSPOSED,
         "LSPosed-Bridge",
         "VectorNative",
         "VectorBridge",

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DebugExport.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DebugExport.kt
@@ -3,7 +3,6 @@ package dev.okhsunrog.vpnhide
 import android.content.Context
 import android.net.ConnectivityManager
 import android.os.Build
-import android.util.Log
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
@@ -35,7 +34,7 @@ internal suspend fun exportDebugZip(
         // native sinks while the capture runs. The helper records exactly what
         // it applied/restored so bug reports can distinguish "no logs" from
         // "debug propagation failed".
-        val loggingSession = beginDebugCaptureLogging(context)
+        val loggingSession = beginDebugCaptureLogging()
         var restoreAttempted = false
         try {
             val counterBaseline = collectHookCounterSnapshot()
@@ -51,7 +50,7 @@ internal suspend fun exportDebugZip(
             val shellSnapshot = collectDebugShellSnapshot()
 
             val logcat = captureDebugLogcat()
-            val restore = restoreDebugCaptureLogging(context, loggingSession)
+            val restore = restoreDebugCaptureLogging(loggingSession)
             restoreAttempted = true
             val completedLoggingSession = loggingSession.withRestore(restore)
 
@@ -100,11 +99,11 @@ internal suspend fun exportDebugZip(
             // concurrency (navigating away mid-capture must cancel cleanly).
             throw c
         } catch (e: Exception) {
-            Log.e(TAG, "Debug export failed", e)
+            VpnHideLog.e(TAG, "Debug export failed", e)
             null
         } finally {
             if (!restoreAttempted) {
-                restoreDebugCaptureLogging(context, loggingSession)
+                restoreDebugCaptureLogging(loggingSession)
             }
         }
     }

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DebugLoggingPrefs.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DebugLoggingPrefs.kt
@@ -1,109 +1,47 @@
 package dev.okhsunrog.vpnhide
 
-import android.content.Context
+private const val TAG = "VpnHideDebugConfig"
+
+private fun canonicalFromSnapshot(snapshot: RootSnapshot?): CanonicalConfig? =
+    snapshot
+        ?.let { parseTargetsSnapshot(it).canonicalConfig }
 
 /**
- * Persisted "debug logging" preference and its propagation. Debug is stored in
- * the canonical JSON and folded into the native control-config wire by the
- * activator, so every backend observes one source of truth. The sinks are:
+ * Canonical config is the only source of truth for debug logging state.
  *
- *  - App Kotlin code → [VpnHideLog.enabled] (volatile).
- *  - system_server LSPosed hooks → `/data/system/vpnhide_config.json`, watched
- *    by [HookLog].
- *  - native backends → [ConfigChannels.reconcileCommand], which runs the
- *    installed activator after the JSON update.
+ * Before a root snapshot exists this is `false`.
  */
-private const val PREFS_NAME = "vpnhide_prefs"
-private const val KEY_DEBUG_LOGGING = "debug_logging"
-
-/** Default is OFF — stealth-first matches the project's anti-detection stance. */
-internal fun isEnabledInPrefs(context: Context): Boolean =
-    context
-        .getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
-        .getBoolean(KEY_DEBUG_LOGGING, false)
+internal fun debugFromCanonicalSnapshot(rootSnapshot: RootSnapshot?): Boolean =
+    canonicalFromSnapshot(rootSnapshot)
+        ?.debug
+        ?: false
 
 /**
- * Flip the persisted preference and propagate it to every sink. Runs
- * SU commands, so callers should invoke from a background dispatcher.
- * Use this for the user-facing toggle in Diagnostics.
+ * Set debug on the canonical JSON and propagate it through the native activator.
+ * SU commands may fail on unusual root states, so callers should run this from
+ * an IO dispatcher and still tolerate a temporary mismatch if needed.
  */
-internal suspend fun setDebugLoggingEnabled(
-    context: Context,
-    enabled: Boolean,
-) {
-    storeDebugLoggingPreference(context, enabled)
-    writeDebugFlagFilesFromSnapshot(enabled)
+internal suspend fun setDebugLoggingEnabled(enabled: Boolean) {
+    val canonical =
+        canonicalFromSnapshot(RootSnapshotCache.snapshot.value)
+            ?.copy(
+                debug = enabled,
+                debugSwitch = enabled,
+            )
+            ?: return
+
+    val command =
+        listOf(
+            buildCanonicalConfigWriteCommand(canonical),
+            ConfigChannels.reconcileCommand(),
+        ).joinToString(" ; ")
+    val (exit, out) = suExec(command)
+    if (exit != 0) {
+        VpnHideLog.e(TAG, "write canonical debug command failed: exit=$exit: ${out.trim()}")
+    }
+
+    VpnHideLog.enabled = enabled
     RootSnapshotCache.invalidate()
     TargetsCache.invalidate()
     DashboardCache.invalidate()
-}
-
-internal fun storeDebugLoggingPreference(
-    context: Context,
-    enabled: Boolean,
-) {
-    context
-        .getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
-        .edit()
-        .putBoolean(KEY_DEBUG_LOGGING, enabled)
-        .apply()
-    VpnHideLog.enabled = enabled
-}
-
-/**
- * Startup safety-net: re-propagate the persisted debug flag to the canonical
- * config + native sinks only if they've drifted from [enabled]. This runs on
- * every cold start; without the drift check it would rewrite the canonical
- * config and re-run the native activator with byte-identical content on every
- * launch. Capture paths use [beginDebugCaptureLogging] and restore through
- * their own session cleanup.
- *
- * When the snapshot isn't loaded yet the flag is treated as drifted, so the
- * safety-net still fires once.
- */
-internal suspend fun reapplyDebugLoggingIfDrifted(enabled: Boolean) {
-    val onDiskDebug =
-        TargetsCache.snapshot.value
-            ?.canonicalConfig
-            ?.debug
-    if (onDiskDebug == enabled) {
-        VpnHideLog.enabled = enabled
-        return
-    }
-    writeDebugFlagFilesFromSnapshot(enabled)
-}
-
-private fun writeDebugFlagFiles(enabled: Boolean) {
-    val parts = mutableListOf<String>()
-
-    // Re-emit the runtime config with the new flag so a running native backend
-    // picks it up. Needs the current targets; if the snapshot isn't loaded yet,
-    // the next startup reconcile or Save carries the flag into the channels.
-    TargetsCache.snapshot.value?.let { snap ->
-        val canonical = buildCanonicalConfigFromTargetsSnapshot(snap, debug = enabled)
-        parts += buildCanonicalConfigWriteCommand(canonical)
-        parts += ConfigChannels.reconcileCommand()
-    }
-    parts += "true"
-
-    // Batched into one su invocation to keep the toggle UI snappy — each
-    // round-trip is ~50-100ms. Channels whose component isn't installed/loaded
-    // are skipped by the guards inside the config-write parts.
-    suExec(parts.joinToString(" ; "))
-}
-
-private suspend fun writeDebugFlagFilesFromSnapshot(enabled: Boolean) {
-    val snapshot = runCatching { RootSnapshotCache.refresh() }.getOrNull()
-    val canonical = snapshot?.let { debugToggledCanonicalConfig(it, enabled) }
-    if (canonical == null) {
-        writeDebugFlagFiles(enabled)
-        return
-    }
-
-    val cmd =
-        listOf(
-            buildCanonicalConfigWriteCommand(canonical.config),
-            ConfigChannels.reconcileCommand(),
-        ).joinToString(" ; ")
-    suExec(cmd)
 }

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DebugLoggingPrefs.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DebugLoggingPrefs.kt
@@ -1,6 +1,6 @@
 package dev.okhsunrog.vpnhide
 
-private const val TAG = "VpnHideDebugConfig"
+private const val TAG = LogTags.DEBUG_CONFIG
 
 private fun canonicalFromSnapshot(snapshot: RootSnapshot?): CanonicalConfig? =
     snapshot

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DebugLoggingPrefs.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DebugLoggingPrefs.kt
@@ -22,8 +22,15 @@ internal fun debugFromCanonicalSnapshot(rootSnapshot: RootSnapshot?): Boolean =
  * an IO dispatcher and still tolerate a temporary mismatch if needed.
  */
 internal suspend fun setDebugLoggingEnabled(enabled: Boolean) {
+    // Re-read canonical from disk rather than the cached StateFlow: a prior
+    // toggle in the same Settings visit invalidates RootSnapshotCache, and
+    // nothing on the Settings screen repopulates it, so `.snapshot.value` would
+    // be null and this write would silently no-op.
+    val snapshot =
+        runCatching { RootSnapshotCache.getOrLoad() }.getOrNull()
+            ?: RootSnapshotCache.snapshot.value
     val canonical =
-        canonicalFromSnapshot(RootSnapshotCache.snapshot.value)
+        canonicalFromSnapshot(snapshot)
             ?.copy(
                 debug = enabled,
                 debugSwitch = enabled,

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DiagnosticsCache.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DiagnosticsCache.kt
@@ -156,7 +156,7 @@ internal object DiagnosticsCache {
             // Both states offer a retry; these causes are usually transient.
             _state.value = State.Failed
             StartupTrace.mark("diagnostics_cache_failed")
-            VpnHideLog.w("VpnHide-Diag", "runAllChecks failed: ${e.message}")
+            VpnHideLog.w(LogTags.DIAG, "runAllChecks failed: ${e.message}")
         }
     }
 

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/GatedLogger.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/GatedLogger.kt
@@ -1,0 +1,42 @@
+package dev.okhsunrog.vpnhide
+
+import android.util.Log
+
+/**
+ * Shared gating core for the project's two logcat facades — [VpnHideLog] (app
+ * process) and [HookLog] (LSPosed hooks in `system_server`). Both apply the same
+ * policy — gate info/debug/warn behind a runtime "debug logging" flag, always
+ * emit errors — but they read that flag from different sources (the canonical
+ * snapshot vs. an inotify watcher) because they run in different processes. This
+ * base owns the single copy of the flag and the gate-and-level policy; each
+ * subclass only supplies the concrete sink and its own public method shape.
+ */
+internal abstract class GatedLogger {
+    /**
+     * Effective "debug logging" flag. A `@Volatile` plain boolean rather than a
+     * synchronized getter: info/debug/warn sit on hot paths (per-request hooks,
+     * Dashboard reload, suExec wrappers) and can't afford a monitor per call.
+     * Worst case a toggle flip costs one extra log line to take effect.
+     */
+    @Volatile
+    var enabled: Boolean = false
+
+    /** Write one line to the concrete sink(s). [tr], when present, is appended. */
+    protected abstract fun emit(
+        priority: Int,
+        tag: String,
+        msg: String,
+        tr: Throwable?,
+    )
+
+    /** Gate policy: info/debug/warn require [enabled]; error always prints. */
+    protected fun log(
+        priority: Int,
+        tag: String,
+        msg: String,
+        tr: Throwable? = null,
+    ) {
+        if (priority < Log.ERROR && !enabled) return
+        emit(priority, tag, msg, tr)
+    }
+}

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/HookLog.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/HookLog.kt
@@ -5,26 +5,18 @@ import android.util.Log
 import de.robv.android.xposed.XposedBridge
 
 /**
- * Log wrapper gated by a filesystem flag set from the app. Used by LSPosed
- * hooks running inside `system_server`, where we don't have access to the
- * app's SharedPreferences.
+ * system_server logcat facade for LSPosed hooks, which can't reach the app's
+ * canonical-snapshot cache. Same gate-and-level policy as [VpnHideLog] (see
+ * [GatedLogger]) — info is per-request/hot-path and gated, error always prints
+ * so "hooks didn't attach" reports stay diagnosable — but the flag is read
+ * straight from the canonical JSON on [install] and refreshed by an inotify
+ * watcher, so a toggle flip lands without restarting system_server.
  *
- * Source of truth is the canonical JSON config. We read it on [install] and via an
- * inotify watcher so a flip takes effect without restarting system_server.
- *
- * The logcat sink makes Settings → Debugging → Debug logging visible through
- * ordinary bug-report captures. The Xposed sink is kept for framework UIs /
- * files that expose `XposedBridge.log` separately.
- *
- * Only per-request / hot-path logs should go through [i]. Hook install failures
- * and other one-time errors use [e], which always prints — losing those would
- * make diagnosing "hooks didn't attach" reports impossible.
+ * Every line also goes to `XposedBridge.log`, keeping Settings → Debugging →
+ * Debug logging visible through framework UIs that surface the Xposed log
+ * separately from ordinary bug-report captures.
  */
-internal object HookLog {
-    private const val LOGCAT_TAG = "VpnHide-LSPosed"
-
-    @Volatile private var enabled: Boolean = false
-
+internal object HookLog : GatedLogger() {
     @Volatile private var watcher: FileObserver? = null
 
     fun install() {
@@ -45,15 +37,18 @@ internal object HookLog {
         enabled = SystemServerConfigCache.load().debug
     }
 
-    fun i(msg: String) {
-        if (!enabled) return
-        Log.i(LOGCAT_TAG, msg)
+    override fun emit(
+        priority: Int,
+        tag: String,
+        msg: String,
+        tr: Throwable?,
+    ) {
+        Log.println(priority, tag, if (tr == null) msg else "$msg\n${Log.getStackTraceString(tr)}")
         XposedBridge.log(msg)
     }
 
+    fun i(msg: String) = log(Log.INFO, LogTags.LSPOSED, msg)
+
     /** Always prints — used for install failures and other diagnostics we can't afford to lose. */
-    fun e(msg: String) {
-        Log.e(LOGCAT_TAG, msg)
-        XposedBridge.log(msg)
-    }
+    fun e(msg: String) = log(Log.ERROR, LogTags.LSPOSED, msg)
 }

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/JavaChecks.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/JavaChecks.kt
@@ -47,7 +47,7 @@ import java.util.concurrent.atomic.AtomicReference
 import java.util.zip.ZipEntry
 import java.util.zip.ZipOutputStream
 
-private const val TAG = "VPNHideTest"
+private const val TAG = LogTags.TEST
 
 data class CheckResult(
     val name: String,

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/JavaChecks.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/JavaChecks.kt
@@ -6,7 +6,6 @@ import android.net.Network
 import android.net.NetworkCapabilities
 import android.net.Uri
 import android.os.Build
-import android.util.Log
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.isSystemInDarkTheme
@@ -178,7 +177,7 @@ private fun nativeCheck(
         CheckResult(name, out.status.toPassed(), out.detail)
     } catch (e: Exception) {
         val detail = e.message ?: e.javaClass.simpleName
-        Log.e(TAG, "[$name] $detail", e)
+        VpnHideLog.e(TAG, "[$name] $detail", e)
         CheckResult(name, false, detail)
     }
 

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/LogTags.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/LogTags.kt
@@ -1,0 +1,56 @@
+package dev.okhsunrog.vpnhide
+
+/**
+ * Single registry of the logcat tags this project emits, so call sites, the
+ * [HookLog] system_server sink and the debug-capture logcat filter
+ * ([LogcatRecorder]) all agree on one spelling instead of re-typing string
+ * literals. Native-backend tags (kmod / ports / zygisk / shadowhook) are listed
+ * too — the app never logs under them, but the bundle filter needs them.
+ */
+internal object LogTags {
+    /** Generic app-process tag (shell helpers, LSPosed state writes). */
+    const val APP = "VpnHide"
+    const val STARTUP = "VpnHide-Startup"
+    const val DASHBOARD = "VpnHide-Dashboard"
+
+    /** system_server hooks ([HookLog]). */
+    const val LSPOSED = "VpnHide-LSPosed"
+    const val DIAG = "VpnHide-Diag"
+    const val LOGCAT = "VpnHide-Logcat"
+    const val UPDATE = "VpnHide-Update"
+    const val TARGETS = "VpnHide-Targets"
+    const val STATISTICS = "VpnHide-Statistics"
+    const val APP_LIST = "VpnHide-AppList"
+    const val DEBUG_CONFIG = "VpnHideDebugConfig"
+    const val AGENT_BRIDGE = "VpnHideAgentBridge"
+
+    /** Diagnostics self-test tag (distinct capitalisation, matched separately). */
+    const val TEST = "VPNHideTest"
+
+    /** App-process (and system_server) tags captured in debug bundles. */
+    val APP_TAGS =
+        listOf(
+            TEST,
+            APP,
+            STARTUP,
+            DASHBOARD,
+            LSPOSED,
+            DIAG,
+            LOGCAT,
+            UPDATE,
+            AGENT_BRIDGE,
+            TARGETS,
+            STATISTICS,
+            APP_LIST,
+            DEBUG_CONFIG,
+        )
+
+    /** Native-backend logcat tags (kmod / ports / zygisk / shadowhook). */
+    val NATIVE_TAGS =
+        listOf(
+            "vpnhide",
+            "vpnhide_ports",
+            "vpnhide-zygisk",
+            "shadowhook_tag",
+        )
+}

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/LogcatRecorder.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/LogcatRecorder.kt
@@ -105,7 +105,7 @@ internal object LogcatRecorder {
         var process: Process? = null
         var scope: CoroutineScope? = null
         try {
-            loggingSession = beginDebugCaptureLogging(context)
+            loggingSession = beginDebugCaptureLogging()
             val startMs = System.currentTimeMillis()
             // Step back one second so the start marker and any immediate debug
             // propagation lines are not lost to logcat timestamp rounding.
@@ -114,7 +114,7 @@ internal object LogcatRecorder {
 
             process = startLogcatProcess(logcatSince)
             if (process == null) {
-                restoreDebugCaptureLogging(context, loggingSession)
+                restoreDebugCaptureLogging(loggingSession)
                 runCatching { rawLogFile.delete() }
                 return null
             }
@@ -141,7 +141,7 @@ internal object LogcatRecorder {
         } catch (t: Throwable) {
             process?.destroyForcibly()
             scope?.cancel()
-            loggingSession?.let { restoreDebugCaptureLogging(context, it) }
+            loggingSession?.let { restoreDebugCaptureLogging(it) }
             runCatching { rawLogFile.delete() }
             throw t
         }
@@ -181,7 +181,7 @@ internal object LogcatRecorder {
 
             val dmesg = suExec("dmesg 2>/dev/null").second
             val shellSnapshot = collectDebugShellSnapshot()
-            val restore = restoreDebugCaptureLogging(context, recording.loggingSession)
+            val restore = restoreDebugCaptureLogging(recording.loggingSession)
             restoreAttempted = true
             val completedLoggingSession = recording.loggingSession.withRestore(restore)
 
@@ -211,7 +211,7 @@ internal object LogcatRecorder {
                         .onFailure { VpnHideLog.w(TAG, "failed to stop logcat process: ${it.message}") }
                 }
                 if (!restoreAttempted) {
-                    runCatching { restoreDebugCaptureLogging(context, recording.loggingSession) }
+                    runCatching { restoreDebugCaptureLogging(recording.loggingSession) }
                         .onFailure { VpnHideLog.w(TAG, "failed to restore debug logging: ${it.message}") }
                 }
                 if (zipFile == null) {

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/LogcatRecorder.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/LogcatRecorder.kt
@@ -32,7 +32,7 @@ import java.util.concurrent.TimeUnit
  * so reports about a third-party app still carry enough VPN Hide context.
  */
 internal object LogcatRecorder {
-    private const val TAG = "VpnHide-Logcat"
+    private const val TAG = LogTags.LOGCAT
     private const val LOGCAT_STOP_GRACE_MS = 200L
     private const val LOGCAT_PIPE_JOIN_MS = 2_000L
 
@@ -355,22 +355,7 @@ internal object LogcatRecorder {
             }
         }.trimEnd()
 
-    private fun isVpnHideLogcatLine(line: String): Boolean =
-        listOf(
-            "VPNHideTest",
-            "VpnHide",
-            "VpnHide-Dashboard",
-            "VpnHide-Startup",
-            "VpnHide-LSPosed",
-            "VpnHide-Diag",
-            "VpnHide-Logcat",
-            "VpnHide-Update",
-            "VpnHideAgentBridge",
-            "vpnhide",
-            "vpnhide_ports",
-            "vpnhide-zygisk",
-            "shadowhook_tag",
-        ).any { line.contains(it) }
+    private fun isVpnHideLogcatLine(line: String): Boolean = (LogTags.APP_TAGS + LogTags.NATIVE_TAGS).any { line.contains(it) }
 
     private fun formatLogcatSince(date: Date): String = SimpleDateFormat("MM-dd HH:mm:ss.SSS", Locale.US).format(date)
 

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/MainActivity.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/MainActivity.kt
@@ -66,9 +66,9 @@ class MainActivity : ComponentActivity() {
         StartupTrace.mark("activity_on_create")
         enableEdgeToEdge()
         super.onCreate(savedInstanceState)
-        // Load the user's debug-logging preference before anything else
-        // runs so the first suExec + Dashboard reload honor it.
-        VpnHideLog.init(applicationContext)
+        // Load debug state from the canonical snapshot before any runtime work.
+        // This keeps first suExec and dashboard bootstrap aligned.
+        VpnHideLog.init()
         setContent {
             VpnHideApp()
         }
@@ -334,6 +334,7 @@ private fun MainScreen() {
     // as that shared snapshot exists, TargetsCache parses it from memory and
     // Protection is still prewarmed before a normal tab switch.
     LaunchedEffect(selfNeedsRestart, rootSnapshot) {
+        VpnHideLog.setFromRootSnapshot(rootSnapshot)
         startupCoordinator.ensureProtectionCacheAfterRootSnapshot(scope, selfNeedsRestart, rootSnapshot)
     }
 
@@ -346,13 +347,6 @@ private fun MainScreen() {
         if (uiReady && !startupTraceMarked) {
             startupTraceMarked = true
             StartupTrace.dashboardReady()
-            scope.launch(Dispatchers.IO) {
-                // Re-propagate the persisted flag to the on-disk sinks as a
-                // safety-net, but only if they've drifted — otherwise a cold
-                // start needlessly rewrites the canonical config every launch.
-                // Kept off the cold-start critical path.
-                reapplyDebugLoggingIfDrifted(VpnHideLog.enabled)
-            }
         }
     }
 

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/SettingsScreen.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/SettingsScreen.kt
@@ -362,10 +362,10 @@ private fun DeveloperSettingsSection() {
     val interactor = LocalSettingsInteractor.current
     val context = LocalContext.current
     val scope = rememberCoroutineScope()
-    // Debug logging isn't a UI-DataStore setting — it's a stealth-sensitive runtime
-    // flag in its own prefs store (DebugLoggingPrefs), so it's driven by local state
-    // and a direct write rather than through the settings interactor.
-    var debugLogging by remember { mutableStateOf(VpnHideLog.enabled) }
+    val debugLoggingByCanonicalConfig by TargetsCache.snapshot.collectAsState()
+    val debugLogging =
+        debugLoggingByCanonicalConfig?.canonicalConfig?.debugSwitch
+            ?: VpnHideLog.enabled
     Column(verticalArrangement = Arrangement.spacedBy(3.dp)) {
         SettingsSectionHeader(stringResource(R.string.settings_developer_section))
         PreferenceRowSwitch(
@@ -397,8 +397,7 @@ private fun DeveloperSettingsSection() {
             count = 3,
             checked = debugLogging,
             onCheckedChange = { value ->
-                debugLogging = value
-                scope.launch(Dispatchers.IO) { setDebugLoggingEnabled(context, value) }
+                scope.launch(Dispatchers.IO) { setDebugLoggingEnabled(value) }
             },
         )
     }
@@ -511,7 +510,7 @@ private fun ConfigBackupSection() {
         ) {
             EnhancedOutlinedButton(
                 onClick = {
-                    pendingExport = buildConfigExportJson(context, targets)
+                    pendingExport = buildConfigExportJson(targets)
                     status = null
                     exportLauncher.launch("vpnhide_config.json")
                 },
@@ -581,7 +580,7 @@ private fun ConfigBackupSection() {
         }
     }
 
-    val packageListConfig = targets?.let { buildConfigExportCanonical(context, it) }
+    val packageListConfig = targets?.let(::buildConfigExportCanonical)
     if (packageListDialogOpen && packageListConfig != null) {
         PackageListExportDialog(
             config = packageListConfig,
@@ -781,7 +780,7 @@ private fun SuperkeySettingsSection() {
                     saving = true
                     status = null
                     scope.launch {
-                        val exit = withContext(Dispatchers.IO) { writeSuperkeySetting(context, remember = false, superkey = "") }
+                        val exit = withContext(Dispatchers.IO) { writeSuperkeySetting(remember = false, superkey = "") }
                         saving = false
                         status = if (exit == 0) clearedMessage else failedMessage
                         if (exit == 0) {
@@ -801,7 +800,7 @@ private fun SuperkeySettingsSection() {
                     status = null
                     val keyToWrite = superkey
                     scope.launch {
-                        val exit = withContext(Dispatchers.IO) { writeSuperkeySetting(context, remember = true, superkey = keyToWrite) }
+                        val exit = withContext(Dispatchers.IO) { writeSuperkeySetting(remember = true, superkey = keyToWrite) }
                         saving = false
                         status = if (exit == 0) storedMessage else failedMessage
                         if (exit == 0) {
@@ -835,14 +834,13 @@ private fun SuperkeySettingsSection() {
 }
 
 private fun writeSuperkeySetting(
-    context: android.content.Context,
     remember: Boolean,
     superkey: String,
 ): Int {
     val snapshot = TargetsCache.snapshot.value
     val base =
         snapshot?.let(::buildCanonicalConfigFromTargetsSnapshot)
-            ?: CanonicalConfig(debug = isEnabledInPrefs(context))
+            ?: CanonicalConfig()
     val canonical = base.copy(settings = base.settings.copy(rememberSuperkey = remember))
     val requiredParts =
         listOf(
@@ -876,20 +874,14 @@ private enum class ConfigOperation {
     PackageListSave,
 }
 
-private fun buildConfigExportCanonical(
-    context: android.content.Context,
-    snapshot: TargetsSnapshot?,
-): CanonicalConfig =
+private fun buildConfigExportCanonical(snapshot: TargetsSnapshot?): CanonicalConfig =
     when {
         snapshot?.canonicalConfig != null -> snapshot.canonicalConfig
         snapshot != null -> buildCanonicalConfigFromTargetsSnapshot(snapshot)
-        else -> CanonicalConfig(debug = isEnabledInPrefs(context))
+        else -> CanonicalConfig()
     }
 
-private fun buildConfigExportJson(
-    context: android.content.Context,
-    snapshot: TargetsSnapshot?,
-): String = canonicalConfigJson(buildConfigExportCanonical(context, snapshot))
+private fun buildConfigExportJson(snapshot: TargetsSnapshot?): String = canonicalConfigJson(buildConfigExportCanonical(snapshot))
 
 private fun writeTextToUri(
     context: android.content.Context,
@@ -922,7 +914,7 @@ private fun importConfigFromUri(
         ).joinToString(" ; ")
     val (exit, _) = suExec(cmd)
     if (exit != 0) return ConfigImportResult.RootFailed
-    storeDebugLoggingPreference(context, canonical.debug)
+    VpnHideLog.enabled = canonical.debug
     RootSnapshotCache.invalidate()
     DashboardCache.invalidate()
     return ConfigImportResult.Success
@@ -1193,7 +1185,7 @@ private fun writeAutoHideSetting(
     val snapshot = TargetsCache.snapshot.value
     val base =
         snapshot?.let(::buildCanonicalConfigFromTargetsSnapshot)
-            ?: CanonicalConfig(debug = isEnabledInPrefs(context))
+            ?: CanonicalConfig()
     val canonical =
         applyAutoHiddenPackages(
             config = base.copy(settings = transform(base.settings)),
@@ -1345,7 +1337,7 @@ private fun writeManualHiddenApps(
     val snapshot = TargetsCache.snapshot.value
     val base =
         snapshot?.let(::buildCanonicalConfigFromTargetsSnapshot)
-            ?: CanonicalConfig(debug = isEnabledInPrefs(context))
+            ?: CanonicalConfig()
     val canonical =
         updateManualHiddenPackages(
             config = base,

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/ShellUtils.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/ShellUtils.kt
@@ -96,7 +96,7 @@ internal fun suExec(
             proc.destroy()
         }
     } catch (e: Exception) {
-        Log.e(TAG, "su exec failed: ${e.message}")
+        VpnHideLog.e(TAG, "su exec failed: ${e.message}")
         -1 to ""
     }
 

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/ShellUtils.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/ShellUtils.kt
@@ -8,7 +8,7 @@ import java.io.File
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicReference
 
-private const val TAG = "VpnHide"
+private const val TAG = LogTags.APP
 
 // Legacy storage files retained as read-only migration inputs when canonical
 // JSON is absent. New writes go to CANONICAL_CONFIG_FILE only.

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/StartupCoordinator.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/StartupCoordinator.kt
@@ -129,24 +129,28 @@ internal class StartupCoordinator(
     private fun reconcileRuntimeConfigNow(rootSnapshot: RootSnapshot) {
         val canonicalConfig = parseTargetsSnapshot(rootSnapshot).canonicalConfig
         val reconciled = canonicalConfig?.let { canonicalConfigForStartupDebugReconcile(it) }
-        if (reconciled != null) {
-            val command =
-                listOf(
-                    buildCanonicalConfigWriteCommand(reconciled),
-                    ConfigChannels.reconcileCommand(),
-                ).joinToString(" ; ")
-            val (exit, output) = suExec(command)
-            if (exit != 0) {
-                VpnHideLog.w("VpnHide-Startup", "startup debug reconcile failed (exit=$exit): ${output.trim()}")
-                return
-            }
-            RootSnapshotCache.invalidate()
-            TargetsCache.invalidate()
-            DashboardCache.invalidate()
-            StatisticsCache.invalidate()
+        // A capture interrupted mid-flight left effective `debug` out of sync with
+        // the user's `debugSwitch`: write the healed config and run the activator
+        // once. Otherwise nothing needs writing — just re-run the activator to pick
+        // up the current file state. Never both (the write command already runs it).
+        if (reconciled == null) {
+            reconcileRuntimeConfig()
+            return
         }
-
-        reconcileRuntimeConfig()
+        val command =
+            listOf(
+                buildCanonicalConfigWriteCommand(reconciled),
+                ConfigChannels.reconcileCommand(),
+            ).joinToString(" ; ")
+        val (exit, output) = suExec(command)
+        if (exit != 0) {
+            VpnHideLog.w(LogTags.STARTUP, "startup debug reconcile failed (exit=$exit): ${output.trim()}")
+            return
+        }
+        RootSnapshotCache.invalidate()
+        TargetsCache.invalidate()
+        DashboardCache.invalidate()
+        StatisticsCache.invalidate()
     }
 
     fun ensureUpdateFresh(scope: CoroutineScope) {

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/StartupCoordinator.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/StartupCoordinator.kt
@@ -30,7 +30,7 @@ internal class StartupCoordinator(
     private val cleanupZygiskStatus: (Context, String?) -> Unit = ::cleanupStaleZygiskStatus,
     private val seedRootSnapshotPackages: (String?) -> Unit = RootSnapshotCache::seedPmPackages,
     private val markStartupEvent: (String) -> Unit = StartupTrace::mark,
-    private val reconcileRuntimeConfig: (RootSnapshot) -> Unit = { runRuntimeConfigReconcile(appContext, it) },
+    private val reconcileRuntimeConfig: () -> Unit = { runRuntimeConfigReconcile() },
     private val reconcileAutoHidden: (CanonicalConfig, List<AppAutoHideSignal>) -> Unit =
         { config, signals -> reconcileAutoHiddenPackages(appContext, config, signals) },
     private val loadCanonicalConfig: suspend () -> CanonicalConfig? =
@@ -121,9 +121,32 @@ internal class StartupCoordinator(
         if (selfNeedsRestart != null && rootSnapshot != null) {
             TargetsCache.ensureLoaded(scope, appContext)
             if (reconcileStarted.compareAndSet(false, true)) {
-                scope.launch(Dispatchers.IO) { reconcileRuntimeConfig(rootSnapshot) }
+                scope.launch(Dispatchers.IO) { reconcileRuntimeConfigNow(rootSnapshot) }
             }
         }
+    }
+
+    private fun reconcileRuntimeConfigNow(rootSnapshot: RootSnapshot) {
+        val canonicalConfig = parseTargetsSnapshot(rootSnapshot).canonicalConfig
+        val reconciled = canonicalConfig?.let { canonicalConfigForStartupDebugReconcile(it) }
+        if (reconciled != null) {
+            val command =
+                listOf(
+                    buildCanonicalConfigWriteCommand(reconciled),
+                    ConfigChannels.reconcileCommand(),
+                ).joinToString(" ; ")
+            val (exit, output) = suExec(command)
+            if (exit != 0) {
+                VpnHideLog.w("VpnHide-Startup", "startup debug reconcile failed (exit=$exit): ${output.trim()}")
+                return
+            }
+            RootSnapshotCache.invalidate()
+            TargetsCache.invalidate()
+            DashboardCache.invalidate()
+            StatisticsCache.invalidate()
+        }
+
+        reconcileRuntimeConfig()
     }
 
     fun ensureUpdateFresh(scope: CoroutineScope) {

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/StartupTrace.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/StartupTrace.kt
@@ -4,7 +4,7 @@ import android.os.SystemClock
 import android.util.Log
 import java.util.concurrent.atomic.AtomicBoolean
 
-private const val STARTUP_TAG = "VpnHide-Startup"
+private const val STARTUP_TAG = LogTags.STARTUP
 
 internal object StartupTrace {
     private val originMs = SystemClock.elapsedRealtime()

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/StatisticsCache.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/StatisticsCache.kt
@@ -7,7 +7,7 @@ import kotlinx.coroutines.withContext
 
 internal object StatisticsCache : StateCache<StatisticsState>(
     traceName = "statistics_state",
-    logTag = "VpnHide-Statistics",
+    logTag = LogTags.STATISTICS,
 ) {
     val state: StateFlow<StatisticsState?> get() = value
 

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/StorageConfig.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/StorageConfig.kt
@@ -10,6 +10,7 @@ internal const val SUPERKEY_FILE = "/data/adb/vpnhide/superkey"
 internal data class CanonicalConfig(
     val version: Int = 1,
     val debug: Boolean = false,
+    val debugSwitch: Boolean = false,
     val apps: Map<String, CanonicalApp> = emptyMap(),
     val settings: CanonicalSettings = CanonicalSettings(),
 )
@@ -122,6 +123,8 @@ internal fun parseCanonicalConfig(raw: String): CanonicalConfig? {
     val root = JSONObject(raw)
     val version = root.optInt("version", 1)
     if (version > 1) return null
+    val debug = root.optBoolean("debug", false)
+    val debugSwitch = root.optBoolean("debugSwitch", debug)
     val appsJson = root.optJSONObject("apps")
     val apps =
         appsJson
@@ -135,7 +138,8 @@ internal fun parseCanonicalConfig(raw: String): CanonicalConfig? {
     val defaultSettings = CanonicalSettings()
     return CanonicalConfig(
         version = version,
-        debug = root.optBoolean("debug", false),
+        debug = debug,
+        debugSwitch = debugSwitch,
         apps = apps,
         settings =
             CanonicalSettings(
@@ -272,6 +276,11 @@ private fun parseOptionalStringList(
 
 internal fun buildCanonicalConfig(
     debug: Boolean,
+    // null = inherit the user's toggle intent from [existing] (or fall back to
+    // [debug] on a first-write). Rebuild paths (Save / auto-hide / manual-hidden)
+    // must NOT reset debugSwitch to debug — the two diverge during a capture, and
+    // defaulting to debug would clobber the persisted intent.
+    debugSwitch: Boolean? = null,
     javaPkgs: Collection<String>,
     nativePkgs: Collection<String>,
     hiddenPkgs: Collection<String>,
@@ -303,6 +312,7 @@ internal fun buildCanonicalConfig(
     return CanonicalConfig(
         version = 1,
         debug = debug,
+        debugSwitch = debugSwitch ?: existing?.debugSwitch ?: debug,
         apps = apps,
         settings = existing?.settings ?: CanonicalSettings(),
     )
@@ -311,9 +321,11 @@ internal fun buildCanonicalConfig(
 internal fun buildCanonicalConfigFromTargetsSnapshot(
     snapshot: TargetsSnapshot,
     debug: Boolean = snapshot.canonicalConfig?.debug ?: false,
+    debugSwitch: Boolean = snapshot.canonicalConfig?.debugSwitch ?: debug,
 ): CanonicalConfig =
     buildCanonicalConfig(
         debug = debug,
+        debugSwitch = debugSwitch,
         javaPkgs = snapshot.lsposedTargets,
         nativePkgs = snapshot.nativeTargets,
         hiddenPkgs = snapshot.hiddenPkgs,
@@ -356,6 +368,9 @@ internal fun canonicalConfigJson(config: CanonicalConfig): String =
         append(",\n")
         append("  \"debug\": ")
         append(config.debug)
+        append(",\n")
+        append("  \"debugSwitch\": ")
+        append(config.debugSwitch)
         append(",\n")
         append("  \"apps\": {")
         val apps = config.apps.toSortedMap().filterValues { it.hasAnyRole }

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/TargetPickerScaffold.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/TargetPickerScaffold.kt
@@ -314,7 +314,11 @@ internal fun <T : TargetEntry> TargetPickerScreen(
         LaunchedEffect(Unit) {
             val entries = allApps
             val selfPkg = context.packageName
-            val ctx = SaveContext(selfPkg, isEnabledInPrefs(context))
+            val ctx =
+                SaveContext(
+                    selfPkg,
+                    targets?.canonicalConfig?.debugSwitch ?: (targets?.canonicalConfig?.debug ?: false),
+                )
             try {
                 val (exitCode, _) =
                     suExecAsync(buildSaveCommand(entries, ctx))

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/TargetsCache.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/TargetsCache.kt
@@ -72,7 +72,7 @@ internal data class TargetsSnapshot(
 
 internal object TargetsCache : StateCache<TargetsSnapshot>(
     traceName = "targets_cache",
-    logTag = "VpnHide-Targets",
+    logTag = LogTags.TARGETS,
 ) {
     val snapshot: StateFlow<TargetsSnapshot?> get() = value
 

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/UpdateCheckCache.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/UpdateCheckCache.kt
@@ -74,7 +74,7 @@ internal object UpdateCheckCache {
             // DON'T advance lastCheckMs, so the next ensureFresh retries instead
             // of caching the failure as a fresh "no update" for 6 hours.
             UpdateCheckResult.Failed -> {
-                VpnHideLog.d("VpnHide-Update", "update check failed; keeping prior state, will retry")
+                VpnHideLog.d(LogTags.UPDATE, "update check failed; keeping prior state, will retry")
             }
         }
     }

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/UpdateChecker.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/UpdateChecker.kt
@@ -5,7 +5,7 @@ import org.json.JSONObject
 import java.net.HttpURLConnection
 import java.net.URL
 
-private const val TAG = "VpnHide-Update"
+private const val TAG = LogTags.UPDATE
 private const val GITHUB_RELEASES_URL =
     "https://api.github.com/repos/okhsunrog/vpnhide/releases/latest"
 private const val PREFS_NAME = "vpnhide_prefs"

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/VpnHideLog.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/VpnHideLog.kt
@@ -3,25 +3,16 @@ package dev.okhsunrog.vpnhide
 import android.util.Log
 
 /**
- * Log wrapper gated by a runtime "debug logging" flag so users can
- * silence logcat output from the app process.
- *
- * Only i/d/w are gated. Error-level logs always pass through for crash
- * analysis.
- *
- * [enabled] is a volatile plain boolean rather than a synchronized
- * getter: i/d/w are on enough hot paths (Dashboard reload, suExec
- * wrappers, update checks) that we can't afford a monitor per call.
- * Worst case, a toggle flip takes one extra log line to take effect.
+ * App-process logcat facade. Info/debug/warn are gated by the runtime "debug
+ * logging" flag ([enabled]); error always prints for crash analysis. The
+ * gate-and-level policy lives in [GatedLogger]; this object only carries the app
+ * sink and the flag's source (the canonical config snapshot).
  */
-internal object VpnHideLog {
-    @Volatile
-    var enabled: Boolean = false
-
+internal object VpnHideLog : GatedLogger() {
     /**
-     * Load the persisted preference into [enabled] so the first log
-     * call after app start reflects the user's choice without waiting
-     * for the settings UI to be opened.
+     * Load the effective debug flag from the current root snapshot so the first
+     * log call after app start reflects the user's choice without waiting for
+     * the settings UI to be opened.
      */
     fun init() {
         enabled = debugFromCanonicalSnapshot(RootSnapshotCache.snapshot.value)
@@ -31,47 +22,44 @@ internal object VpnHideLog {
         enabled = debugFromCanonicalSnapshot(rootSnapshot)
     }
 
+    override fun emit(
+        priority: Int,
+        tag: String,
+        msg: String,
+        tr: Throwable?,
+    ) {
+        Log.println(priority, tag, if (tr == null) msg else "$msg\n${Log.getStackTraceString(tr)}")
+    }
+
     fun i(
         tag: String,
         msg: String,
-    ) {
-        if (enabled) Log.i(tag, msg)
-    }
+    ) = log(Log.INFO, tag, msg)
 
     fun d(
         tag: String,
         msg: String,
-    ) {
-        if (enabled) Log.d(tag, msg)
-    }
+    ) = log(Log.DEBUG, tag, msg)
 
     fun w(
         tag: String,
         msg: String,
-    ) {
-        if (enabled) Log.w(tag, msg)
-    }
+    ) = log(Log.WARN, tag, msg)
 
     fun w(
         tag: String,
         msg: String,
         tr: Throwable,
-    ) {
-        if (enabled) Log.w(tag, msg, tr)
-    }
+    ) = log(Log.WARN, tag, msg, tr)
 
     fun e(
         tag: String,
         msg: String,
-    ) {
-        Log.e(tag, msg)
-    }
+    ) = log(Log.ERROR, tag, msg)
 
     fun e(
         tag: String,
         msg: String,
         tr: Throwable,
-    ) {
-        Log.e(tag, msg, tr)
-    }
+    ) = log(Log.ERROR, tag, msg, tr)
 }

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/VpnHideLog.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/VpnHideLog.kt
@@ -1,15 +1,13 @@
 package dev.okhsunrog.vpnhide
 
-import android.content.Context
 import android.util.Log
 
 /**
  * Log wrapper gated by a runtime "debug logging" flag so users can
  * silence logcat output from the app process.
  *
- * Only i/d/w are gated. Error-level logs always pass through — losing
- * them would hurt crash analysis more than it helps stealth, and they
- * don't carry per-request details anyway.
+ * Only i/d/w are gated. Error-level logs always pass through for crash
+ * analysis.
  *
  * [enabled] is a volatile plain boolean rather than a synchronized
  * getter: i/d/w are on enough hot paths (Dashboard reload, suExec
@@ -25,8 +23,12 @@ internal object VpnHideLog {
      * call after app start reflects the user's choice without waiting
      * for the settings UI to be opened.
      */
-    fun init(context: Context) {
-        enabled = isEnabledInPrefs(context)
+    fun init() {
+        enabled = debugFromCanonicalSnapshot(RootSnapshotCache.snapshot.value)
+    }
+
+    fun setFromRootSnapshot(rootSnapshot: RootSnapshot?) {
+        enabled = debugFromCanonicalSnapshot(rootSnapshot)
     }
 
     fun i(
@@ -56,5 +58,20 @@ internal object VpnHideLog {
         tr: Throwable,
     ) {
         if (enabled) Log.w(tag, msg, tr)
+    }
+
+    fun e(
+        tag: String,
+        msg: String,
+    ) {
+        Log.e(tag, msg)
+    }
+
+    fun e(
+        tag: String,
+        msg: String,
+        tr: Throwable,
+    ) {
+        Log.e(tag, msg, tr)
     }
 }

--- a/lsposed/app/src/test/kotlin/dev/okhsunrog/vpnhide/AppPickerDataTest.kt
+++ b/lsposed/app/src/test/kotlin/dev/okhsunrog/vpnhide/AppPickerDataTest.kt
@@ -561,6 +561,26 @@ class AppPickerDataTest {
         assertEquals(false, autoHiddenPackagesNeedReconcile(config, self, signals))
     }
 
+    @Test
+    fun `auto-hide rebuild preserves debugSwitch when it differs from effective debug`() {
+        // While a capture forces logging, effective debug=true but the user's
+        // toggle intent debugSwitch=false. A rebuild (auto-hide reconcile) must
+        // keep debugSwitch, not reset it to debug — otherwise the interrupted-
+        // capture self-heal is defeated and the user's debug gets stuck on.
+        val config =
+            CanonicalConfig(
+                debug = true,
+                debugSwitch = false,
+            )
+        val signals = listOf(AppAutoHideSignal(packageName = "com.happproxy", declaresVpnService = true))
+
+        val result = applyAutoHiddenPackages(config, self, signals)
+
+        assertEquals(false, result.debugSwitch)
+        assertEquals(true, result.debug)
+        assertEquals(setOf("com.happproxy"), result.settings.autoHiddenPackages)
+    }
+
     private fun snapshotWithCanonical(
         vararg apps: Pair<String, CanonicalApp>,
         settings: CanonicalSettings = CanonicalSettings(),

--- a/lsposed/app/src/test/kotlin/dev/okhsunrog/vpnhide/DebugCaptureLoggingTest.kt
+++ b/lsposed/app/src/test/kotlin/dev/okhsunrog/vpnhide/DebugCaptureLoggingTest.kt
@@ -2,45 +2,66 @@ package dev.okhsunrog.vpnhide
 
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
 class DebugCaptureLoggingTest {
     @Test
-    fun `debug toggle updates only canonical debug flag when canonical config is valid`() {
-        val update = debugToggledCanonicalConfig(canonicalSnapshot(), enabled = true)
+    fun `debug toggle preserves debugSwitch when changing debug only`() {
+        val toggled = debugToggledCanonicalConfig(canonicalSnapshotWithSwitch(debug = true, debugSwitch = false), enabled = false)
 
-        assertEquals("canonical_debug_only", update?.source)
-        assertTrue(update?.config?.debug == true)
-        assertExampleBankRoles(update?.config?.apps?.get("com.example.bank"))
-        assertPreservedSettings(update?.config?.settings)
+        assertEquals(false, toggled?.debug)
+        assertEquals(false, toggled?.debugSwitch)
+        assertPreservedSettings(toggled?.settings)
     }
 
     @Test
-    fun `startup reconcile rewrites stale canonical debug from persisted preference`() {
-        val stale = canonicalConfig()
+    fun `debug toggle target updates debug only and preserves settings`() {
+        val toggled = debugToggledCanonicalConfig(canonicalSnapshot(), enabled = true)
 
-        val update =
-            runtimeReconcileCanonicalConfig(
-                targetsSnapshot(stale.copy(debug = true)),
-                persistedDebug = false,
-            )
-
-        assertEquals(false, update?.debug)
-        assertExampleBankRoles(update?.apps?.get("com.example.bank"))
-        assertPreservedSettings(update?.settings)
+        assertNotNull(toggled)
+        assertEquals(true, toggled?.debug)
+        assertExampleBankRoles(toggled?.apps?.get("com.example.bank"))
+        assertPreservedSettings(toggled?.settings)
     }
 
     @Test
-    fun `startup reconcile leaves canonical untouched when debug matches preference`() {
-        val update =
-            runtimeReconcileCanonicalConfig(
-                targetsSnapshot(canonicalConfig().copy(debug = false)),
-                persistedDebug = false,
-            )
+    fun `debug toggle false keeps canonical roles unchanged`() {
+        val toggled = debugToggledCanonicalConfig(canonicalSnapshot(), enabled = false)
 
-        assertNull(update)
+        assertEquals(false, toggled?.debug)
+        assertExampleBankRoles(toggled?.apps?.get("com.example.bank"))
+        assertPreservedSettings(toggled?.settings)
+    }
+
+    @Test
+    fun `debug toggle returns null when canonical config missing`() {
+        val toggled = debugToggledCanonicalConfig(RootSnapshot(mapOf("something_else" to "{}")), enabled = true)
+        assertNull(toggled)
+    }
+
+    @Test
+    fun `startup debug reconcile updates debug only when different from debugSwitch`() {
+        val canonical =
+            canonicalConfig(
+                debug = true,
+                debugSwitch = false,
+                canonicalApps = mapOf("com.example.bank" to canonicalSampleBankApp()),
+            )
+        val reconciled = canonicalConfigForStartupDebugReconcile(canonical)
+
+        assertEquals(false, reconciled?.debug)
+        assertEquals(false, reconciled?.debugSwitch)
+        assertEquals("com.example.bank", reconciled?.apps?.keys?.single())
+    }
+
+    @Test
+    fun `startup debug reconcile skips rewrite when already aligned`() {
+        val canonical = canonicalConfig(debug = true, debugSwitch = true)
+        val reconciled = canonicalConfigForStartupDebugReconcile(canonical)
+        assertNull(reconciled)
     }
 
     private fun assertExampleBankRoles(app: CanonicalApp?) {
@@ -68,38 +89,23 @@ class DebugCaptureLoggingTest {
         assertEquals(setOf("com.example.vpn"), settings?.autoHiddenPackages)
     }
 
-    private fun canonicalConfig(): CanonicalConfig =
-        parseCanonicalConfig(
-            """
-            {
-              "version": 1,
-              "debug": false,
-              "apps": {
-                "com.example.bank": {
-                  "java": true,
-                  "native": {
-                    "enabled": true,
-                    "kernel": ["dev_ioctl"],
-                    "zygisk": ["zygisk_ioctl"]
-                  },
-                  "appHiding": true,
-                  "ports": true,
-                  "portPolicy": {
-                    "mode": "custom",
-                    "rules": [{ "start": 8080, "protocol": "tcp" }]
-                  },
-                  "hidden": true
-                }
-              },
-              "settings": {
-                "rememberSuperkey": true,
-                "autoHideVpnServices": false,
-                "autoHideVpnName": true,
-                "autoHiddenPackages": ["com.example.vpn"]
-              }
-            }
-            """.trimIndent(),
-        ) ?: error("invalid test canonical config")
+    private fun canonicalConfig(
+        debug: Boolean = true,
+        debugSwitch: Boolean = debug,
+        canonicalApps: Map<String, CanonicalApp>? = null,
+    ): CanonicalConfig =
+        CanonicalConfig(
+            debug = debug,
+            debugSwitch = debugSwitch,
+            apps = canonicalApps ?: canonicalSampleApps(),
+            settings =
+                CanonicalSettings(
+                    rememberSuperkey = true,
+                    autoHideVpnServices = false,
+                    autoHideVpnName = true,
+                    autoHiddenPackages = setOf("com.example.vpn"),
+                ),
+        )
 
     private fun canonicalSnapshot(): RootSnapshot =
         RootSnapshot(
@@ -108,20 +114,41 @@ class DebugCaptureLoggingTest {
             ),
         )
 
-    private fun targetsSnapshot(canonical: CanonicalConfig): TargetsSnapshot =
-        TargetsSnapshot(
-            kmodModuleInstalled = false,
-            kpmModuleInstalled = false,
-            zygiskModuleInstalled = false,
-            portsModuleInstalled = false,
-            kmodTargets = emptySet(),
-            kpmTargets = emptySet(),
-            zygiskTargets = emptySet(),
-            lsposedTargets = emptySet(),
-            hiddenPkgs = emptySet(),
-            observerUids = emptySet(),
-            portsObservers = emptySet(),
-            uidToPkg = emptyMap(),
-            canonicalConfig = canonical,
+    private fun canonicalSnapshotWithSwitch(
+        debug: Boolean,
+        debugSwitch: Boolean,
+    ): RootSnapshot =
+        RootSnapshot(
+            mapOf(
+                "canonical_config" to
+                    canonicalConfigJson(canonicalConfig(debug = debug, debugSwitch = debugSwitch)),
+            ),
+        )
+
+    private fun canonicalSampleApps(): Map<String, CanonicalApp> =
+        mapOf(
+            "com.example.bank" to canonicalSampleBankApp(),
+        )
+
+    private fun canonicalSampleBankApp(): CanonicalApp =
+        CanonicalApp(
+            java = true,
+            native =
+                NativeRole(
+                    enabled = true,
+                    overrides =
+                        NativeHookOverrides(
+                            kernel = listOf("dev_ioctl"),
+                            zygisk = listOf("zygisk_ioctl"),
+                        ),
+                ),
+            appHiding = true,
+            ports = true,
+            portPolicy =
+                PortPolicy(
+                    mode = PortPolicyMode.Custom,
+                    rules = listOf(PortRule(start = 8080, end = 8080, protocol = PortProtocol.Tcp)),
+                ),
+            hidden = true,
         )
 }

--- a/lsposed/app/src/test/kotlin/dev/okhsunrog/vpnhide/StorageConfigTest.kt
+++ b/lsposed/app/src/test/kotlin/dev/okhsunrog/vpnhide/StorageConfigTest.kt
@@ -89,6 +89,45 @@ class StorageConfigTest {
     }
 
     @Test
+    fun `canonical config migrates debugSwitch from legacy debug`() {
+        val cfg =
+            requireNotNull(
+                parseCanonicalConfig(
+                    """
+                    {
+                      "version": 1,
+                      "debug": true,
+                      "apps": {}
+                    }
+                    """.trimIndent(),
+                ),
+            )
+
+        assertEquals(true, cfg.debug)
+        assertEquals(true, cfg.debugSwitch)
+    }
+
+    @Test
+    fun `canonical config reads explicit debugSwitch independently of debug`() {
+        val cfg =
+            requireNotNull(
+                parseCanonicalConfig(
+                    """
+                    {
+                      "version": 1,
+                      "debug": true,
+                      "debugSwitch": false,
+                      "apps": {}
+                    }
+                    """.trimIndent(),
+                ),
+            )
+
+        assertEquals(true, cfg.debug)
+        assertEquals(false, cfg.debugSwitch)
+    }
+
+    @Test
     fun `canonical config parses backend specific native hook overrides`() {
         val cfg =
             requireNotNull(
@@ -308,9 +347,11 @@ class StorageConfigTest {
         val cfg =
             CanonicalConfig(
                 debug = true,
+                debugSwitch = true,
                 apps =
                     buildCanonicalConfig(
                         debug = true,
+                        debugSwitch = true,
                         javaPkgs = setOf("com.java"),
                         nativePkgs = setOf("com.native"),
                         hiddenPkgs = setOf("dev.okhsunrog.vpnhide"),
@@ -329,6 +370,16 @@ class StorageConfigTest {
         val reparsed = requireNotNull(parseCanonicalConfig(canonicalConfigJson(cfg)))
 
         assertEquals(cfg, reparsed)
+    }
+
+    @Test
+    fun `canonical json serializes both debug flags`() {
+        val cfg = CanonicalConfig(debug = true, debugSwitch = false)
+        val json = canonicalConfigJson(cfg)
+
+        assertTrue(json.contains("\"debug\": true"))
+        assertTrue(json.contains("\"debugSwitch\": false"))
+        assertEquals(cfg, requireNotNull(parseCanonicalConfig(json)))
     }
 
     @Test


### PR DESCRIPTION
The debug-logging flag lived in two stores — the app's SharedPreferences and the canonical JSON — kept in sync by a startup reconcile and a drift safety-net, which was the source of a class of edge cases (including one where a routine debug capture could reset settings). This collapses it to a single store: the canonical JSON, with two distinct fields — `debug` (the effective flag every sink gates on: the app logger, the system_server LSPosed HookLog, and native backends) and `debugSwitch` (the user's toggle intent). The Settings toggle writes both; a debug capture temporarily forces only `debug` and restores it to `debugSwitch`; an interrupted capture self-heals on the next launch via a `debug <- debugSwitch` reconcile within the same store — no cross-process drift, no SharedPreferences.

- Add `debugSwitch` to the canonical config (migrates from `debug` when the field is absent); serialize both. `buildCanonicalConfig` inherits `debugSwitch` from the existing config, so rebuild paths (Save / auto-hide / manual-hidden) never clobber the user's intent when it diverges from the effective flag during a capture.
- The app reads the effective `debug` from the canonical snapshot; the Settings toggle reflects `debugSwitch`.
- Captures force only `debug` via a targeted copy of the parsed canonical config (never a rebuild from the legacy targets snapshot), so settings/autoHiddenPackages are preserved, and restore to `debugSwitch` in a finally.
- Replace the prefs<->canonical reconcile and the drift safety-net with a single startup `debug <- debugSwitch` reconcile; delete SharedPreferences, `runtimeReconcileCanonicalConfig`, and `reapplyDebugLoggingIfDrifted`.
- `VpnHideLog` gains an always-on `e()` for errors; stray `Log.e` routed through it.

Testing:
- `:app:testDebugUnitTest`, `ktlintCheck`, `detekt`, `:app:assembleRelease`, and `cargo build` all pass.
- On a Pixel 4a: verified the `debugSwitch` migration; a debug-capture round-trip forces logging (bundle contains hook_report.txt + logcat_vpnhide.txt) and restores `debug` to `debugSwitch` afterward with `autoHiddenPackages` intact; a stable cold start makes no config write (no churn).