### PR TITLE
Diagnostics & dashboard redesign: honest who-hid-the-VPN attribution

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,6 +25,7 @@ These short files cover everything specific to this repo. Skipping them leads to
 - [docs/storage.md](docs/storage.md) — current storage & activation design: the single JSON canonical, the activator (Rust workspace, four thin bins: kmod/kpm/zygisk/ports) that derives runtime state, LSPosed self-read, the APatch superkey, SELinux layout. Read before touching how config is stored/loaded.
 - [docs/protocol.md](docs/protocol.md) — the frozen v1 control/stats **wire** between the app and the native backends (config/stats/status); the format every backend parser must agree on
 - [docs/detection-vectors.md](docs/detection-vectors.md) — what an app can probe to detect the VPN (or a hidden package), which component (kmod / KPM / zygisk / lsposed / SELinux) covers each vector, how it manifests. Read before adding or changing a hook.
+- [docs/diagnostics.md](docs/diagnostics.md) — how the app self-tests hiding and attributes *who* hid the VPN (root-differential, `CheckOutcome`, `LayerStatus`/verdict, the self-in-tunnel gate). Read before touching the diagnostics/dashboard.
 - [docs/adb-root-debugging.md](docs/adb-root-debugging.md) — how to make `adb shell su` useful on KernelSU/APatch/Magisk test devices; covers UID 0 without capabilities, SELinux denials on `/data/adb` and `/data/system`, and KPM/KPatch diagnostics.
 - [docs/changelog.md](docs/changelog.md) — changelog storage (`changelog.d/` fragments + history JSON), `./scripts/changelog.py` usage
 - [docs/releasing.md](docs/releasing.md) — `./scripts/release.py` usage, version-bump flow

--- a/changelog.d/added-diagnostics-now-checks-that-vpn-hide-6408.md
+++ b/changelog.d/added-diagnostics-now-checks-that-vpn-hide-6408.md
@@ -1,0 +1,9 @@
+_2026-07-03_
+
+## English
+
+Diagnostics now checks that VPN Hide itself is routed through your VPN; if it has been split-tunnelled out, it asks you to add it to the tunnel instead of running meaningless checks.
+
+## Русский
+
+Диагностика теперь проверяет, что сам VPN Hide идёт через ваш VPN; если он выведен из туннеля сплит-туннелем, приложение просит добавить его в туннель вместо бессмысленных проверок.

--- a/changelog.d/added-diagnostics-now-includes-an-rtm-getrule-ecf9.md
+++ b/changelog.d/added-diagnostics-now-includes-an-rtm-getrule-ecf9.md
@@ -1,0 +1,9 @@
+_2026-07-03_
+
+## English
+
+Diagnostics now includes an RTM_GETRULE check that detects a VPN leaking through per-app policy routing rules.
+
+## Русский
+
+В диагностику добавлена проверка RTM_GETRULE: она ловит VPN, который выдают правила policy routing для отдельных приложений.

--- a/changelog.d/changed-diagnostics-now-probes-the-legacy-networkinfo-e96a.md
+++ b/changelog.d/changed-diagnostics-now-probes-the-legacy-networkinfo-e96a.md
@@ -1,0 +1,9 @@
+_2026-07-03_
+
+## English
+
+Diagnostics now probes the legacy NetworkInfo APIs (getActiveNetworkInfo / getNetworkInfo(TYPE_VPN)) and drops the uninformative system-proxy check.
+
+## Русский
+
+Диагностика теперь проверяет легаси-API NetworkInfo (getActiveNetworkInfo / getNetworkInfo(TYPE_VPN)) и больше не показывает неинформативную проверку системного прокси.

--- a/changelog.d/changed-java-level-diagnostics-now-attribute-who-54cf.md
+++ b/changelog.d/changed-java-level-diagnostics-now-attribute-who-54cf.md
@@ -1,0 +1,9 @@
+_2026-07-03_
+
+## English
+
+Java-level diagnostics now attribute who hid the VPN (hidden by the backend, or a leak) like the native checks, instead of a bare clean/fail.
+
+## Русский
+
+Java-проверки в диагностике теперь показывают, кто скрыл VPN (скрыто бэкендом или утечка), как и нативные, — вместо простого «чисто/провал».

--- a/changelog.d/changed-the-detailed-diagnostics-screen-now-shows-2f9d.md
+++ b/changelog.d/changed-the-detailed-diagnostics-screen-now-shows-2f9d.md
@@ -1,0 +1,9 @@
+_2026-07-03_
+
+## English
+
+The detailed diagnostics screen now shows who hid the VPN on each check — the backend, SELinux, or nothing to hide — instead of a bare pass/fail.
+
+## Русский
+
+Экран подробной диагностики теперь показывает, кто скрыл VPN в каждой проверке — бэкенд, SELinux или скрывать нечего — вместо простого «пройдено/провал».

--- a/changelog.d/fixed-dashboard-native-java-level-tiles-no-44ea.md
+++ b/changelog.d/fixed-dashboard-native-java-level-tiles-no-44ea.md
@@ -1,0 +1,9 @@
+_2026-07-03_
+
+## English
+
+Dashboard native/Java level tiles no longer mislabel an unloaded backend as "Partial" or a mostly-working layer as "Not working": each layer now reads OK / Partial / Not active, judged by what actually hid the VPN.
+
+## Русский
+
+Плитки нативного и Java уровня на дашборде больше не показывают незагруженный бэкенд как «Частично», а в основном рабочий слой — как «Не работает»: уровень теперь честно оценивается OK / Частично / Не активен по тому, что реально спрятало VPN.

--- a/docs/diagnostics.md
+++ b/docs/diagnostics.md
@@ -1,0 +1,139 @@
+# Diagnostics — how VPN Hide self-tests hiding and attributes the result
+
+This is the **self-diagnosis** model: how the app checks that hiding actually
+works for its own process and honestly reports *who* hid the VPN on each vector.
+For the hiding side (which backend covers which detection vector) see
+[detection-vectors.md](detection-vectors.md); for the app↔backend wire see
+[protocol.md](protocol.md).
+
+Devices this was validated on: Pixel 4a (sunfish, Magisk, 4.14, kmod/KPM/Zygisk),
+Pixel 8 Pro (husky, KernelSU-Next, GKI 6.1, KPM), and an Android 13 Zygisk device.
+
+## 1. The problem it solves
+
+A check result used to be a single tri-state boolean that conflated three unrelated
+meanings of "pass": (a) the backend hid the VPN, (b) SELinux denied the probe
+(EACCES), (c) there was nothing to leak on that surface. Counting all "passes" as
+backend wins made an *installed-but-inactive* backend read as "Partial" (its
+SELinux-blocked reads counted as passes) and a mostly-working Java layer read as
+"Not working" (any one failing probe painted the whole layer red).
+
+## 2. Root-differential — the reliable classifier
+
+A clean probe result is ambiguous on its own: hook-suppressed and nothing-to-leak
+look identical. Root (uid 0) is **not** a hook target, so a privileged read is the
+ground truth for "what is actually on this surface". The app runs each native probe
+twice — **in-process** (its own uid + SELinux domain + hooks) and **as root** — and
+diffs them:
+
+| root sees | app read | → outcome |
+|---|---|---|
+| nothing | — | **NothingToLeak** (empty ground truth wins, even over EACCES) |
+| VPN | EACCES | **HiddenBySelinux** |
+| VPN | ok, clean | **HiddenByBackend** |
+| — | app saw VPN | **Leak** |
+
+Priority: an empty ground truth is checked **before** EACCES — if root sees nothing,
+the SELinux block is moot, it is simply nothing-to-leak.
+
+**Ground truth is the same Rust probe binary run as root**, not shell `ip`/`cat`.
+`GroundTruthProbe` extracts `vhprobe` from the APK, stages it to `/data/local/tmp`,
+and execs it via `su`; it emits the same JSON as the in-process JNI path
+(`run_all_json`), so the two views are directly comparable per check id. (This
+replaced an earlier gobley/UniFFI binding — the whole native surface is now one
+JSON-returning function built with plain cargo-ndk.)
+
+## 3. Per-check outcome (`CheckOutcome`)
+
+`Leak` · `HiddenByBackend` · `HiddenBySelinux` · `NothingToLeak` ·
+`NotMeasured(reason)`. Wire/log tokens: `leak`, `hidden_backend`, `hidden_selinux`,
+`nothing_to_leak`, `not_measured_no_network`, `not_measured_no_ground_truth`.
+
+The Rust probe reports `Pass` / `Fail` / `SelinuxBlocked` (EACCES/EPERM, no longer
+folded into `Pass`) / `NetworkBlocked` (ECONNREFUSED from `socket()` — no network
+permission). Native checks classify via the root differential above. **Java** checks
+have no root differential (framework IPC), so they are binary — clean ⟹
+`HiddenByBackend`, dirty ⟹ `Leak` — which is honest only because the self-in-tunnel
+gate (§5) guarantees a VPN artifact was present to hide.
+
+## 4. Layer status & verdict (dashboard tiles)
+
+Each dashboard tile is a `LayerStatus`: `Absent` (no module installed) · `Inactive`
+(installed, not loaded this boot) · `Active(hidden, leaks)`. Presence is decided
+**before** the checks, so an unloaded backend can never render a verdict — it just
+reads "not active" (this is the type-level fix for the old "Partial"). An `Active`
+tile's verdict:
+
+- `leaks == 0` → **Ok**
+- `hidden > 0 && leaks > 0` → **Partial** (hides some, an owned vector still leaks)
+- `hidden == 0 && leaks > 0` → **Broken** (loaded but suppressed nothing)
+
+`hidden` must be a *measurement* (the root differential), never inferred from a clean
+probe — otherwise Partial and Broken are indistinguishable. The native tile is judged
+**only on vectors the active backend owns** (has a hook for): a leak on a not-owned
+vector (e.g. `/proc/net/dev` under a kernel backend — no kernel hook exists) does not
+turn the tile red; it surfaces as a hero warning instead. So the **tile** answers "is
+this module doing its job" and the **hero** answers "is the VPN hidden at all". The
+Java tile uses the same rollup; LSPosed owns every Java check, so all its leaks count.
+
+## 5. Self-in-tunnel gate
+
+Diagnostics are meaningless if VPN Hide itself is not routed through the VPN: split-
+tunnelled out, there is no VPN artifact for its own probes to be hidden *from*, so
+every check would read misleadingly clean. Before running any checks the app asks
+`vhprobe --uid <selfUid>` (root, hook-inert) whether its own uid is routed through the
+VPN. Two passes over the policy rules (both address families): learn the VPN egress
+table id(s) from rules that egress via a VPN interface (`oif tun*`), then check whether
+a `uidrange` rule steers this uid into exactly that table. This is stricter than the
+broad `netlink_getrule` diagnostic predicate — every uid sits in *some* per-network
+table (wlan/rmnet, also non-standard), so it must pin the VPN table specifically. If
+not routed, the UI shows an "add VPN Hide to your tunnel" prompt instead of clean
+results. A `null` answer (no root) does not block.
+
+## 6. Empirical facts that shape the checks
+
+- **SELinux carries part of "protection", and it is invisible without the
+  differential.** On both test kernels, 8 of 13 native probes "pass" under enforcing
+  *only* because SELinux denies the read. Three of those — `/proc/net/if_inet6`,
+  `/proc/net/dev`, `/sys/class/net` — have **no backend coverage at all** under a
+  kernel backend (no kernel hook exists for those procfs/sysfs paths, by design); on a
+  permissive device they leak `tun0`. This is why the permissive-SELinux warning
+  exists and why SELinux attribution is dev-facing, not a user alarm.
+- **The VPN lives in protected sockets + per-UID policy tables, not the main route
+  table.** A split-tunnel VPN app marks its sockets and installs `ip rule … uidrange
+  <uid> lookup tun0`; it does *not* put a default route in the main table. So
+  `/proc/net/route` (main table only) shows no VPN for the target and resolves to
+  `NothingToLeak` — while **RTM_GETRULE** (policy rules) is the real routing detection
+  vector, added as a probe mirroring the `fib_nl_fill_rule` kernel filter.
+- **Some checks never fire** on any config: both `/proc/net/route` reads (native +
+  Java) and the removed system-proxy check. They only added false confidence; the
+  route reads are kept because the differential now labels them `NothingToLeak`
+  honestly, the proxy check was dropped.
+- **Suppression counters can distinguish "hook not loaded" from "hook not working"**
+  (a per-hook Δ>0 during a probe is proof the hook did real work). They are **not**
+  used by diagnostics — the root differential already gives the full 4-way + `hidden`
+  without them — and stay only in the Statistics tab.
+
+## 7. Native check → owning hook (KPM/kmod), verified on Pixel 4a
+
+The kernel backend's 10 hooks map to the diagnostic checks below; the "gaps" rows are
+SELinux/zygisk territory by design, not bugs. Full hiding matrix in
+[detection-vectors.md](detection-vectors.md).
+
+| check id | probes | kernel hook | notes |
+|---|---|---|---|
+| `ioctl_flags`, `ioctl_mtu` | `SIOCGIF*` by name | `dev_ioctl` | ENODEV for tun0 |
+| `ioctl_conf` | `SIOCGIFCONF` | `sock_ioctl` | tun0 absent from ifconf |
+| `getifaddrs`, `netlink_getlink` | RTM_GETLINK / getifaddrs | `rtnl_fill_ifinfo`, `inet*_fill_ifaddr` | |
+| `netlink_getroute` | RTM_GETROUTE v4/v6 | `fib_dump_info`, `rt6_fill_node` | |
+| `netlink_getrule` | RTM_GETRULE policy rules | `fib_nl_fill_rule` | v4+v6; kernel-only vector |
+| `proc_route` | `/proc/net/route` | `fib_route_seq_show` | main table — empty for split-tunnel VPN |
+| `proc_ipv6_route` | `/proc/net/ipv6_route` | `ipv6_route_seq_show` | |
+| `proc_if_inet6` | `/proc/net/if_inet6` | **(none)** | no kernel seq_show hook — zygisk `openat` or SELinux only |
+| `proc_dev` | `/proc/net/dev` | **(none)** | zygisk `openat` or SELinux only |
+| `sys_class_net` | `/sys/class/net` | **(none)** | SELinux only |
+
+Java-level checks (LSPosed) cover the framework side — `hasTransport(VPN)`,
+`NET_CAPABILITY_NOT_VPN`, `VpnTransportInfo`, `getAllNetworks`, `LinkProperties`,
+`getNetworkForType(TYPE_VPN)`, the push `NetworkCallback` (issue #70), and the legacy
+`getActiveNetworkInfo` / `getNetworkInfo(TYPE_VPN)` APIs.

--- a/lsposed/app/build.gradle.kts
+++ b/lsposed/app/build.gradle.kts
@@ -73,7 +73,15 @@ val rustSdkDir =
         (fromProps ?: System.getenv("ANDROID_HOME") ?: System.getenv("ANDROID_SDK_ROOT"))?.let(::file)
             ?: error("Android SDK not found: set sdk.dir in local.properties or ANDROID_HOME.")
     }
-val rustNdkDir = rustSdkDir.resolve("ndk/$rustNdkVersion").absolutePath
+// Prefer an explicit NDK env (ANDROID_NDK_HOME/_ROOT) the way the zygisk build
+// does — the CI image installs the NDK standalone at $ANDROID_NDK_HOME, not under
+// $SDK/ndk/<version>. Fall back to the SDK-managed path for local dev.
+val rustNdkDir =
+    (System.getenv("ANDROID_NDK_HOME") ?: System.getenv("ANDROID_NDK_ROOT"))
+        ?.let(::file)
+        ?.takeIf { it.isDirectory }
+        ?.absolutePath
+        ?: rustSdkDir.resolve("ndk/$rustNdkVersion").absolutePath
 val nativeCrateDir = projectDir.parentFile.resolve("native")
 val rustAssetsOut = rustAssetsDir.get().asFile
 

--- a/lsposed/app/build.gradle.kts
+++ b/lsposed/app/build.gradle.kts
@@ -1,12 +1,7 @@
 import java.io.FileInputStream
 import java.util.Properties
-import org.gradle.api.DefaultTask
-import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.tasks.Exec
-import org.gradle.api.tasks.InputFile
-import org.gradle.api.tasks.PathSensitive
 import org.gradle.api.tasks.PathSensitivity
-import org.gradle.api.tasks.TaskAction
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
@@ -15,8 +10,6 @@ plugins {
     alias(libs.plugins.kotlin.atomicfu)
     alias(libs.plugins.kotlin.serialization)
     alias(libs.plugins.compose.compiler)
-    alias(libs.plugins.gobley.cargo)
-    alias(libs.plugins.gobley.uniffi)
     alias(libs.plugins.detekt)
 }
 
@@ -55,61 +48,64 @@ tasks.register<Exec>("ktlintCheck") {
     commandLine("ktlint", "${projectDir}/src/**/*.kt")
 }
 
-cargo {
-    packageDirectory = layout.projectDirectory.dir("../native")
-    // Don't bundle the Rust lib into Android unit-test resources. Unit tests
-    // never load the native lib, and bundling drags in a Linux x64 cargo
-    // build that fails because the source uses Android-shaped ioctl request
-    // types incompatible with glibc.
-    builds.withType(gobley.gradle.cargo.dsl.CargoJvmBuild::class.java).configureEach {
-        androidUnitTest.set(false)
+// The native check probes ship two ways from one Rust crate (../native):
+//   - libvpnhide_checks.so — a cdylib loaded in-process (System.loadLibrary)
+//     for the app-view probe (real uid + SELinux domain + zygisk/kernel hooks);
+//   - vhprobe — a root-exec'able bin for the ground-truth probe. Shipped as an
+//     asset, not a jniLib: AGP 9 defaults to extractNativeLibs=false, so a
+//     jniLib isn't a real on-disk file and can't be exec'd.
+// Built with cargo-ndk (the same toolchain the zygisk module already uses).
+// This replaces the gobley/UniFFI plugin (and its AGP-9 fork): the whole native
+// surface is now one JSON-returning function, so codegen bindings aren't worth
+// the dependency. -P 29 matches minSdk (getifaddrs needs API >= 24).
+val rustJniLibsDir = layout.buildDirectory.dir("rustNative/jniLibs")
+val rustAssetsDir = layout.buildDirectory.dir("rustNative/assets")
+
+// Resolve SDK/NDK to plain values at configuration time so the task action
+// captures no Project references (configuration-cache safe). NDK version mirrors
+// android.ndkVersion below.
+val rustNdkVersion = "28.2.13676358"
+val rustSdkDir =
+    run {
+        val lp = rootProject.file("local.properties")
+        val fromProps =
+            lp.takeIf { it.exists() }?.let { Properties().apply { load(it.inputStream()) }.getProperty("sdk.dir") }
+        (fromProps ?: System.getenv("ANDROID_HOME") ?: System.getenv("ANDROID_SDK_ROOT"))?.let(::file)
+            ?: error("Android SDK not found: set sdk.dir in local.properties or ANDROID_HOME.")
     }
-}
+val rustNdkDir = rustSdkDir.resolve("ndk/$rustNdkVersion").absolutePath
+val nativeCrateDir = projectDir.parentFile.resolve("native")
+val rustAssetsOut = rustAssetsDir.get().asFile
 
-uniffi {
-    generateFromLibrary {
-        packageName = "dev.okhsunrog.vpnhide.checks"
-    }
-}
-
-abstract class SuppressGeneratedUniffiWarningsTask : DefaultTask() {
-    @get:InputFile
-    @get:PathSensitive(PathSensitivity.RELATIVE)
-    abstract val bindingFile: RegularFileProperty
-
-    @TaskAction
-    fun suppress() {
-        // UniFFI emits two intentional object references as bare expressions.
-        // Keep the suppression scoped to the generated binding file so real
-        // UNUSED_EXPRESSION warnings in hand-written Kotlin still surface.
-        val binding = bindingFile.get().asFile
-        if (!binding.isFile) return
-
-        val original = binding.readText()
-        val updated =
-            original.replaceFirst(
-                "@file:Suppress(\"RemoveRedundantBackticks\")",
-                "@file:Suppress(\"RemoveRedundantBackticks\", \"UNUSED_EXPRESSION\")",
-            )
-        if (updated != original) {
-            binding.writeText(updated)
+val buildRustProbe =
+    tasks.register<Exec>("buildRustProbe") {
+        group = "build"
+        description = "Builds the vpnhide_checks cdylib + vhprobe bin via cargo-ndk."
+        workingDir = nativeCrateDir
+        environment("ANDROID_NDK_HOME", rustNdkDir)
+        environment("NDK_HOME", rustNdkDir)
+        inputs.dir(nativeCrateDir.resolve("src")).withPathSensitivity(PathSensitivity.RELATIVE)
+        inputs.file(nativeCrateDir.resolve("Cargo.toml"))
+        outputs.dir(rustJniLibsDir)
+        outputs.dir(rustAssetsDir)
+        commandLine(
+            "cargo", "ndk",
+            "-t", "arm64-v8a",
+            "-P", "29",
+            "-o", rustJniLibsDir.get().asFile.absolutePath,
+            "build", "--release",
+        )
+        // Locals (not top-level script vals) so the doLast action captures only
+        // File values — required for configuration-cache serialization.
+        val probeBin = nativeCrateDir.resolve("target/aarch64-linux-android/release/vhprobe")
+        val probeDest = rustAssetsOut.resolve("bin/arm64-v8a/vhprobe")
+        doLast {
+            probeDest.parentFile.mkdirs()
+            probeBin.copyTo(probeDest, overwrite = true)
         }
     }
-}
 
-val generatedUniffiBinding =
-    layout.buildDirectory.file("generated/uniffi/main/dev/okhsunrog/vpnhide/checks/vpnhide_checks.android.kt")
-
-val suppressGeneratedUniffiWarnings =
-    tasks.register<SuppressGeneratedUniffiWarningsTask>("suppressGeneratedUniffiWarnings") {
-        dependsOn("buildUniffiBindings")
-        bindingFile.set(generatedUniffiBinding)
-        outputs.upToDateWhen { false }
-    }
-
-tasks.matching { it.name.startsWith("compile") && it.name.endsWith("Kotlin") }.configureEach {
-    dependsOn(suppressGeneratedUniffiWarnings)
-}
+tasks.named("preBuild").configure { dependsOn(buildRustProbe) }
 
 android {
     namespace = "dev.okhsunrog.vpnhide"
@@ -212,6 +208,12 @@ android {
     packaging {
         resources.excludes += "META-INF/*.kotlin_module"
     }
+
+    // Pick up the cargo-ndk outputs (buildRustProbe): cdylib as a jniLib, the
+    // ground-truth probe bin as an asset. buildRustProbe runs via preBuild, so
+    // these dirs are populated before the merge/package tasks read them.
+    sourceSets["main"].jniLibs.srcDir(rustJniLibsDir.get().asFile)
+    sourceSets["main"].assets.srcDir(rustAssetsDir.get().asFile)
 
     // Skip Android Lint on test source sets. Our `src/test/` is pure JVM
     // unit-test logic (filter/recommendation builders) — no Android

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/AgentControl.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/AgentControl.kt
@@ -633,25 +633,18 @@ private fun ProtectionCheck.toAgentProtectionSummary(): AgentProtectionSummary =
                 state = "checked",
                 native = native.toAgentStatus(),
                 java = java.toAgentStatus(),
-                nativePassed = (native as? NativeResult.Fail)?.passed,
-                nativeFailed = (native as? NativeResult.Fail)?.failed,
-                javaFailed = (java as? JavaResult.Fail)?.failedChecks,
+                nativePassed = (native as? LayerStatus.Active)?.hidden,
+                nativeFailed = (native as? LayerStatus.Active)?.leaks,
+                javaFailed = (java as? LayerStatus.Active)?.leaks,
             )
         }
     }
 
-private fun NativeResult.toAgentStatus(): String =
+private fun LayerStatus.toAgentStatus(): String =
     when (this) {
-        NativeResult.Ok -> "ok"
-        NativeResult.NoModule -> "no_module"
-        is NativeResult.Fail -> "fail"
-    }
-
-private fun JavaResult.toAgentStatus(): String =
-    when (this) {
-        JavaResult.Ok -> "ok"
-        JavaResult.HooksInactive -> "hooks_inactive"
-        is JavaResult.Fail -> "fail"
+        LayerStatus.Absent -> "absent"
+        LayerStatus.Inactive -> "inactive"
+        is LayerStatus.Active -> verdict.name.lowercase()
     }
 
 private fun CheckResults.toAgentDiagnosticsReport(): AgentDiagnosticsReport {

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/AgentControl.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/AgentControl.kt
@@ -38,8 +38,14 @@ internal object AgentControl {
         withAppContext(context) { context ->
             val results = DiagnosticsCache.awaitFullResults(context)
             if (results == null) {
+                val gatedState =
+                    if (DiagnosticsCache.state.value is DiagnosticsCache.State.SelfNotRouted) {
+                        "self_not_routed"
+                    } else {
+                        "vpn_off"
+                    }
                 AgentDiagnosticsReport(
-                    state = "vpn_off",
+                    state = gatedState,
                     score = AgentCheckScore(0, 0),
                     nativeChecks = emptyList(),
                     javaChecks = emptyList(),
@@ -626,6 +632,10 @@ private fun ProtectionCheck.toAgentProtectionSummary(): AgentProtectionSummary =
 
         ProtectionCheck.NeedsRestart -> {
             AgentProtectionSummary(state = "needs_restart")
+        }
+
+        ProtectionCheck.SelfNotRouted -> {
+            AgentProtectionSummary(state = "self_not_routed")
         }
 
         is ProtectionCheck.Checked -> {

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/AgentControl.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/AgentControl.kt
@@ -659,8 +659,9 @@ private fun LayerStatus.toAgentStatus(): String =
 
 private fun CheckResults.toAgentDiagnosticsReport(): AgentDiagnosticsReport {
     val score = all.score()
-    // The Rust native checks (in NATIVE_CHECKS order) carry the who-hid-it
-    // outcome from the root differential; nativeExtra and Java checks don't yet.
+    // Native checks (in NATIVE_CHECKS order) carry the root-differential outcome;
+    // Java checks carry the gate-derived outcome on the result itself. nativeExtra
+    // (Java-implemented native-level probes) has no outcome.
     val nativeWithOutcomes =
         native.mapIndexed { i, cr ->
             cr.toAgentCheckResult(nativeOutcomes[NATIVE_CHECKS.getOrNull(i)?.id]?.token())
@@ -669,7 +670,7 @@ private fun CheckResults.toAgentDiagnosticsReport(): AgentDiagnosticsReport {
         state = "ready",
         score = AgentCheckScore(score.passed, score.total),
         nativeChecks = nativeWithOutcomes,
-        javaChecks = java.map { it.toAgentCheckResult(null) },
+        javaChecks = java.map { it.toAgentCheckResult(it.outcome?.token()) },
     )
 }
 

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/AgentControl.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/AgentControl.kt
@@ -656,15 +656,21 @@ private fun JavaResult.toAgentStatus(): String =
 
 private fun CheckResults.toAgentDiagnosticsReport(): AgentDiagnosticsReport {
     val score = all.score()
+    // The Rust native checks (in NATIVE_CHECKS order) carry the who-hid-it
+    // outcome from the root differential; nativeExtra and Java checks don't yet.
+    val nativeWithOutcomes =
+        native.mapIndexed { i, cr ->
+            cr.toAgentCheckResult(nativeOutcomes[NATIVE_CHECKS.getOrNull(i)?.id]?.token())
+        } + nativeExtra.map { it.toAgentCheckResult(null) }
     return AgentDiagnosticsReport(
         state = "ready",
         score = AgentCheckScore(score.passed, score.total),
-        nativeChecks = nativeAll.map(CheckResult::toAgentCheckResult),
-        javaChecks = java.map(CheckResult::toAgentCheckResult),
+        nativeChecks = nativeWithOutcomes,
+        javaChecks = java.map { it.toAgentCheckResult(null) },
     )
 }
 
-private fun CheckResult.toAgentCheckResult(): AgentCheckResult =
+private fun CheckResult.toAgentCheckResult(outcome: String? = null): AgentCheckResult =
     AgentCheckResult(
         name = name,
         status =
@@ -674,6 +680,7 @@ private fun CheckResult.toAgentCheckResult(): AgentCheckResult =
                 null -> "info"
             },
         detail = detail,
+        outcome = outcome,
     )
 
 private fun StatisticsState.toAgentStatisticsState(selfPackage: String? = null): AgentStatisticsState {

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/AgentControlModels.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/AgentControlModels.kt
@@ -62,7 +62,7 @@ data class AgentModuleState(
 /** Dashboard protection summary. */
 @Serializable
 data class AgentProtectionSummary(
-    /** none, needs_restart, checked, or vpn_off. */
+    /** none, needs_restart, self_not_routed, checked, or vpn_off. */
     val state: String,
     /** Native-level summary: ok, fail, no_module, or null. */
     val native: String? = null,
@@ -88,7 +88,7 @@ data class AgentDashboardMessage(
 /** Full diagnostics result. */
 @Serializable
 data class AgentDiagnosticsReport(
-    /** ready or vpn_off. */
+    /** ready, vpn_off, or self_not_routed. */
     val state: String,
     /** Combined pass score, excluding informational checks. */
     val score: AgentCheckScore,

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/AgentControlModels.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/AgentControlModels.kt
@@ -127,6 +127,10 @@ data class AgentCheckResult(
     val status: String,
     /** Probe detail text. */
     val detail: String,
+    /** Who-hid-it outcome from the root differential (native checks): leak,
+     * hidden_backend, hidden_selinux, nothing_to_leak, not_measured_*. Null for
+     * checks without a root-differential outcome (Java / nativeExtra). */
+    val outcome: String? = null,
 )
 
 /** Statistics tab state. */

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/CheckOutcome.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/CheckOutcome.kt
@@ -1,0 +1,93 @@
+package dev.okhsunrog.vpnhide
+
+import dev.okhsunrog.vpnhide.checks.CheckOutput
+import dev.okhsunrog.vpnhide.checks.CheckStatus
+
+/**
+ * The honest per-check outcome, decided from the app's in-process probe result
+ * combined with the root ground-truth differential (see [GroundTruthProbe]).
+ *
+ * Unlike the legacy `passed: Boolean?`, a clean app-view result is split by WHO
+ * hid the VPN: the backend (root sees it, the app doesn't), SELinux (the app was
+ * EACCES-blocked), or nothing at all (root also sees nothing). [NotMeasured] is
+ * orthogonal — the probe produced no usable observation, so it votes for neither.
+ */
+sealed interface CheckOutcome {
+    /** App saw VPN-shaped data — a real leak. */
+    data object Leak : CheckOutcome
+
+    /** App saw no VPN and root did: the active backend hid it. (Attribution to a
+     * specific hook is layered on later from the coverage map / counters.) */
+    data object HiddenByBackend : CheckOutcome
+
+    /** The app's read was denied by SELinux — SELinux hid it, not a backend hook. */
+    data object HiddenBySelinux : CheckOutcome
+
+    /** Nothing VPN-shaped on this surface for anyone (root also saw nothing). */
+    data object NothingToLeak : CheckOutcome
+
+    /** No usable observation: the probe couldn't run, or no ground truth. */
+    data class NotMeasured(
+        val reason: NotMeasuredReason,
+    ) : CheckOutcome
+}
+
+enum class NotMeasuredReason(
+    val token: String,
+) {
+    NoNetworkPermission("not_measured_no_network"),
+    NoGroundTruth("not_measured_no_ground_truth"),
+}
+
+/**
+ * Classify one native check from its app-view result and the root ground truth.
+ *
+ * Priority: a leak is a leak; an empty ground truth means nothing-to-leak even
+ * when the app read was SELinux-blocked (the block is moot when there is nothing
+ * on that surface to hide).
+ */
+fun classifyNativeOutcome(
+    appView: CheckOutput,
+    groundTruth: CheckOutput?,
+): CheckOutcome =
+    when (appView.status) {
+        CheckStatus.FAIL -> {
+            CheckOutcome.Leak
+        }
+
+        CheckStatus.NETWORK_BLOCKED -> {
+            CheckOutcome.NotMeasured(NotMeasuredReason.NoNetworkPermission)
+        }
+
+        // App saw no VPN (PASS or SELINUX_BLOCKED): who hid it? Ask the ground truth.
+        CheckStatus.PASS, CheckStatus.SELINUX_BLOCKED -> {
+            when (groundTruth?.status) {
+                CheckStatus.PASS -> {
+                    CheckOutcome.NothingToLeak // root also clean → nothing there
+                }
+
+                CheckStatus.FAIL -> {
+                    if (appView.status == CheckStatus.SELINUX_BLOCKED) {
+                        CheckOutcome.HiddenBySelinux
+                    } else {
+                        CheckOutcome.HiddenByBackend
+                    }
+                }
+
+                // No root result, or root itself blocked/limited → cannot attribute.
+                else -> {
+                    CheckOutcome.NotMeasured(NotMeasuredReason.NoGroundTruth)
+                }
+            }
+        }
+    }
+
+/** Stable wire/log token for an outcome (for the agent bridge + debug export). */
+fun CheckOutcome.token(): String =
+    when (this) {
+        CheckOutcome.Leak -> "leak"
+        CheckOutcome.HiddenByBackend -> "hidden_backend"
+        CheckOutcome.HiddenBySelinux -> "hidden_selinux"
+        CheckOutcome.NothingToLeak -> "nothing_to_leak"
+        is CheckOutcome.NotMeasured -> reason.token
+    }

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/CheckOutcome.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/CheckOutcome.kt
@@ -82,6 +82,26 @@ fun classifyNativeOutcome(
         }
     }
 
+/**
+ * Classify one Java-level check. Java checks are framework IPC with no root
+ * differential — but the diagnostics only run once the self-in-tunnel gate has
+ * confirmed a VPN is up AND this app is routed through it. So a VPN artifact is
+ * always present for a VPN-revealing check to surface; a clean app-view therefore
+ * means the LSPosed hook removed it, and a dirty one is a real leak. There is no
+ * "nothing to leak" case on this layer.
+ *
+ * [NotMeasured] is only a defensive edge for a probe that could not actually run
+ * (passed == null): a hidden framework method that reflection can't reach, or no
+ * active network — states the gate makes near-impossible but that we refuse to
+ * paint as a backend success.
+ */
+fun classifyJavaOutcome(passed: Boolean?): CheckOutcome =
+    when (passed) {
+        false -> CheckOutcome.Leak
+        true -> CheckOutcome.HiddenByBackend
+        null -> CheckOutcome.NotMeasured(NotMeasuredReason.NoGroundTruth)
+    }
+
 /** Stable wire/log token for an outcome (for the agent bridge + debug export). */
 fun CheckOutcome.token(): String =
     when (this) {

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DashboardData.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DashboardData.kt
@@ -78,30 +78,9 @@ sealed interface ProtectionCheck {
     data object NeedsRestart : ProtectionCheck
 
     data class Checked(
-        val native: NativeResult,
-        val java: JavaResult,
+        val native: LayerStatus,
+        val java: LayerStatus,
     ) : ProtectionCheck
-}
-
-sealed interface NativeResult {
-    data object Ok : NativeResult
-
-    data class Fail(
-        val passed: Int,
-        val failed: Int,
-    ) : NativeResult
-
-    data object NoModule : NativeResult
-}
-
-sealed interface JavaResult {
-    data object Ok : JavaResult
-
-    data class Fail(
-        val failedChecks: Int,
-    ) : JavaResult
-
-    data object HooksInactive : JavaResult
 }
 
 internal enum class FlashableModuleKind { Kmod, Kpm, Zygisk, Ports }
@@ -277,8 +256,29 @@ internal enum class HeroStatus { Protected, Attention, Unprotected, VpnOff }
 
 internal fun protectionFullyPassed(protection: ProtectionCheck): Boolean =
     protection is ProtectionCheck.Checked &&
-        protection.native is NativeResult.Ok &&
-        protection.java is JavaResult.Ok
+        (protection.native as? LayerStatus.Active)?.verdict == Verdict.Ok &&
+        (protection.java as? LayerStatus.Active)?.verdict == Verdict.Ok
+
+/** Worst-signal rank a layer contributes to the hero: leaking-and-dead = 2,
+ * partial / inactive / absent = 1, ok = 0. */
+private fun LayerStatus.heroRank(): Int =
+    when (this) {
+        LayerStatus.Absent -> {
+            1
+        }
+
+        LayerStatus.Inactive -> {
+            1
+        }
+
+        is LayerStatus.Active -> {
+            when (verdict) {
+                Verdict.Ok -> 0
+                Verdict.Partial -> 1
+                Verdict.Broken -> 2
+            }
+        }
+    }
 
 /** Overall health, ranked worst-signal-wins from protection state + errors/warnings. */
 internal fun computeHeroStatus(
@@ -296,15 +296,7 @@ internal fun computeHeroStatus(
         }
 
         is ProtectionCheck.Checked -> {
-            val native = p.native
-            val java = p.java
-            val hardFail = (native is NativeResult.Fail && native.passed == 0) || java is JavaResult.Fail
-            val partial =
-                native is NativeResult.Fail || native is NativeResult.NoModule || java is JavaResult.HooksInactive
-            when {
-                hardFail -> rank = maxOf(rank, 2)
-                partial -> rank = maxOf(rank, 1)
-            }
+            rank = maxOf(rank, p.native.heroRank(), p.java.heroRank())
         }
     }
     when {
@@ -1651,6 +1643,9 @@ internal suspend fun loadDashboardState(
     val vpnActive = isVpnActiveFromSnapshot(shellSnapshot["vpn_ifaces"].orEmpty())
     VpnHideLog.i(TAG, "vpnActive=$vpnActive selfNeedsRestart=$selfNeedsRestart")
 
+    // Native leaks on vectors the active backend does not own (SELinux/zygisk
+    // territory) — set during the protection computation, surfaced via the hero.
+    var unownedNativeLeakCount = 0
     val protection: ProtectionCheck =
         when {
             !vpnActive -> {
@@ -1671,15 +1666,12 @@ internal suspend fun loadDashboardState(
                     // summarize; fall back to the same retry path as no-VPN.
                     ProtectionCheck.NoVpn
                 } else {
-                    val native =
-                        if (hasNative) checks.nativeAll.toNativeResult() else NativeResult.NoModule
-                    val java =
-                        if (lsposed is LsposedState.Active) {
-                            checks.java.toJavaResult()
-                        } else {
-                            JavaResult.HooksInactive
-                        }
-                    VpnHideLog.i(TAG, "nativeResult=$native javaResult=$java")
+                    // Tiles judge each backend on the vectors it owns; unowned leaks
+                    // (out of scope for the tile) are surfaced via the hero warning below.
+                    val native = summarizeNativeLayer(nativeBackend, checks.nativeOutcomes)
+                    val java = summarizeJavaLayer(lsposed is LsposedState.Active, checks.java)
+                    unownedNativeLeakCount = unownedNativeLeaks(nativeBackend, checks.nativeOutcomes)
+                    VpnHideLog.i(TAG, "nativeLayer=$native javaLayer=$java unownedLeaks=$unownedNativeLeakCount")
                     ProtectionCheck.Checked(native, java)
                 }
             }
@@ -1697,9 +1689,13 @@ internal suspend fun loadDashboardState(
     // partial/full, or a Java probe fails). Without this the state shows only as
     // an amber hero/tile with no explanation — surface a warning that links to
     // the full diagnostics for the per-check breakdown.
-    if (protection is ProtectionCheck.Checked &&
-        (protection.native is NativeResult.Fail || protection.java is JavaResult.Fail)
-    ) {
+    // A leak is a leak: an active layer's owned vector leaks, or a native surface
+    // the backend doesn't cover leaks (only SELinux would). Either way the VPN is
+    // detectable — link to the per-check breakdown.
+    val checked = protection as? ProtectionCheck.Checked
+    val nativeLeaks = (checked?.native as? LayerStatus.Active)?.leaks ?: 0
+    val javaLeaks = (checked?.java as? LayerStatus.Active)?.leaks ?: 0
+    if (nativeLeaks > 0 || javaLeaks > 0 || unownedNativeLeakCount > 0) {
         messages +=
             DashboardMessage(
                 DashboardMessageSeverity.WARNING,
@@ -1725,31 +1721,4 @@ internal suspend fun loadDashboardState(
         protection = protection,
         messages = messages,
     )
-}
-
-/**
- * Roll up the UniFFI native probe results into the Dashboard "Native level"
- * summary. NETWORK_BLOCKED probes report `passed == null` and don't count
- * either way; if nothing actually ran, that's OK (a dedicated banner covers the
- * no-network-permission case).
- */
-internal fun List<CheckResult>.toNativeResult(): NativeResult {
-    val passed = count { it.passed == true }
-    val failed = count { it.passed == false }
-    return when {
-        passed == 0 && failed == 0 -> NativeResult.Ok
-        failed == 0 -> NativeResult.Ok
-        passed > 0 -> NativeResult.Fail(passed, failed)
-        else -> NativeResult.Fail(0, failed)
-    }
-}
-
-/**
- * Roll up the VPN-presence Java probe results into the Dashboard "Java API
- * level" summary — the count that detected a leak. Probes with no active
- * network report `passed == true` ("nothing to leak"), so they don't trip it.
- */
-internal fun List<CheckResult>.toJavaResult(): JavaResult {
-    val failed = count { it.passed == false }
-    return if (failed == 0) JavaResult.Ok else JavaResult.Fail(failed)
 }

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DashboardData.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DashboardData.kt
@@ -77,6 +77,10 @@ sealed interface ProtectionCheck {
 
     data object NeedsRestart : ProtectionCheck
 
+    // A VPN is up, but this app is not routed through it (split-tunnelled out) —
+    // hiding is moot for us, so we ask the user to add VPN Hide to the tunnel.
+    data object SelfNotRouted : ProtectionCheck
+
     data class Checked(
         val native: LayerStatus,
         val java: LayerStatus,
@@ -291,7 +295,7 @@ internal fun computeHeroStatus(
     // 0 = protected, 1 = attention, 2 = unprotected — keep the worst signal.
     var rank = 0
     when (p) {
-        ProtectionCheck.NeedsRestart -> {
+        ProtectionCheck.NeedsRestart, ProtectionCheck.SelfNotRouted -> {
             rank = maxOf(rank, 1)
         }
 
@@ -1662,9 +1666,15 @@ internal suspend fun loadDashboardState(
                 // result so its "OK" state means every protection probe passed.
                 val checks = DiagnosticsCache.awaitFullResults(context)
                 if (checks == null) {
-                    // No active VPN per the check run (or it failed) — nothing to
-                    // summarize; fall back to the same retry path as no-VPN.
-                    ProtectionCheck.NoVpn
+                    // No results to summarize. Distinguish the self-not-routed gate
+                    // (VPN up but this app split-tunnelled out) from a genuine
+                    // no-VPN / failed run, so the hero can guide "add to tunnel"
+                    // instead of the wrong "turn on VPN".
+                    if (DiagnosticsCache.state.value is DiagnosticsCache.State.SelfNotRouted) {
+                        ProtectionCheck.SelfNotRouted
+                    } else {
+                        ProtectionCheck.NoVpn
+                    }
                 } else {
                     // Tiles judge each backend on the vectors it owns; unowned leaks
                     // (out of scope for the tile) are surfaced via the hero warning below.

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DashboardData.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DashboardData.kt
@@ -1647,8 +1647,11 @@ internal suspend fun loadDashboardState(
     val vpnActive = isVpnActiveFromSnapshot(shellSnapshot["vpn_ifaces"].orEmpty())
     VpnHideLog.i(TAG, "vpnActive=$vpnActive selfNeedsRestart=$selfNeedsRestart")
 
-    // Native leaks on vectors the active backend does not own (SELinux/zygisk
-    // territory) — set during the protection computation, surfaced via the hero.
+    // Native leaks the tile doesn't score: vectors the active backend does not own
+    // (SELinux/zygisk territory), plus the Java-implemented native-level probes
+    // (NetworkInterface enum, /proc/net/route via ART) which carry no root
+    // differential and so aren't in nativeOutcomes. Set during the protection
+    // computation, surfaced via the hero warning so a leak there is never invisible.
     var unownedNativeLeakCount = 0
     val protection: ProtectionCheck =
         when {
@@ -1680,7 +1683,12 @@ internal suspend fun loadDashboardState(
                     // (out of scope for the tile) are surfaced via the hero warning below.
                     val native = summarizeNativeLayer(nativeBackend, checks.nativeOutcomes)
                     val java = summarizeJavaLayer(lsposed is LsposedState.Active, checks.java)
-                    unownedNativeLeakCount = unownedNativeLeaks(nativeBackend, checks.nativeOutcomes)
+                    // Rust-probe leaks the tile doesn't own, plus any Java-native
+                    // probe (nativeExtra) that saw the VPN — the latter has no
+                    // outcome, so fold its raw fails in here so they still warn.
+                    unownedNativeLeakCount =
+                        unownedNativeLeaks(nativeBackend, checks.nativeOutcomes) +
+                        checks.nativeExtra.count { it.passed == false }
                     VpnHideLog.i(TAG, "nativeLayer=$native javaLayer=$java unownedLeaks=$unownedNativeLeakCount")
                     ProtectionCheck.Checked(native, java)
                 }

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DashboardScreen.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DashboardScreen.kt
@@ -630,96 +630,78 @@ private fun moduleSummaryAccent(state: DashboardState): Color {
     }
 }
 
+/** One tile label for any layer, from its [LayerStatus]/[Verdict]. Native and
+ * Java tiles now share this mapping. */
+@Composable
+private fun layerSummaryText(layer: LayerStatus): String =
+    when (layer) {
+        LayerStatus.Absent -> {
+            stringResource(R.string.dashboard_protection_no_module)
+        }
+
+        LayerStatus.Inactive -> {
+            stringResource(R.string.dashboard_protection_not_active)
+        }
+
+        is LayerStatus.Active -> {
+            when (layer.verdict) {
+                Verdict.Ok -> stringResource(R.string.dashboard_protection_ok)
+                Verdict.Partial -> stringResource(R.string.dashboard_protection_partial)
+                Verdict.Broken -> stringResource(R.string.dashboard_protection_fail)
+            }
+        }
+    }
+
+@Composable
+private fun layerSummaryAccent(layer: LayerStatus): Color =
+    when (layer) {
+        LayerStatus.Absent -> {
+            MaterialTheme.colorScheme.onSurfaceVariant
+        }
+
+        LayerStatus.Inactive -> {
+            MaterialTheme.colorScheme.onSurfaceVariant
+        }
+
+        is LayerStatus.Active -> {
+            when (layer.verdict) {
+                Verdict.Ok -> StatusColors.successDot
+                Verdict.Partial -> StatusColors.warningAccent
+                Verdict.Broken -> StatusColors.errorAccent
+            }
+        }
+    }
+
 @Composable
 private fun nativeSummaryText(protection: ProtectionCheck): String =
     when (protection) {
-        ProtectionCheck.NoVpn -> {
-            stringResource(R.string.dashboard_hero_vpnoff_title)
-        }
-
-        ProtectionCheck.NeedsRestart -> {
-            stringResource(R.string.dashboard_protection_unknown)
-        }
-
-        is ProtectionCheck.Checked -> {
-            when (val native = protection.native) {
-                NativeResult.Ok -> {
-                    stringResource(R.string.dashboard_protection_ok)
-                }
-
-                is NativeResult.Fail -> {
-                    if (native.passed > 0) {
-                        stringResource(R.string.dashboard_protection_partial)
-                    } else {
-                        stringResource(R.string.dashboard_protection_fail)
-                    }
-                }
-
-                NativeResult.NoModule -> {
-                    stringResource(R.string.dashboard_protection_no_module)
-                }
-            }
-        }
+        ProtectionCheck.NoVpn -> stringResource(R.string.dashboard_hero_vpnoff_title)
+        ProtectionCheck.NeedsRestart -> stringResource(R.string.dashboard_protection_unknown)
+        is ProtectionCheck.Checked -> layerSummaryText(protection.native)
     }
 
 @Composable
 private fun nativeSummaryAccent(protection: ProtectionCheck): Color =
     when (protection) {
-        ProtectionCheck.NoVpn -> {
-            StatusColors.infoAccent
-        }
-
-        ProtectionCheck.NeedsRestart -> {
-            StatusColors.warningAccent
-        }
-
-        is ProtectionCheck.Checked -> {
-            when (val native = protection.native) {
-                NativeResult.Ok -> StatusColors.successDot
-                is NativeResult.Fail -> if (native.passed > 0) StatusColors.warningAccent else StatusColors.errorAccent
-                NativeResult.NoModule -> MaterialTheme.colorScheme.onSurfaceVariant
-            }
-        }
+        ProtectionCheck.NoVpn -> StatusColors.infoAccent
+        ProtectionCheck.NeedsRestart -> StatusColors.warningAccent
+        is ProtectionCheck.Checked -> layerSummaryAccent(protection.native)
     }
 
 @Composable
 private fun javaSummaryText(protection: ProtectionCheck): String =
     when (protection) {
-        ProtectionCheck.NoVpn -> {
-            stringResource(R.string.dashboard_hero_vpnoff_title)
-        }
-
-        ProtectionCheck.NeedsRestart -> {
-            stringResource(R.string.dashboard_protection_unknown)
-        }
-
-        is ProtectionCheck.Checked -> {
-            when (protection.java) {
-                JavaResult.Ok -> stringResource(R.string.dashboard_protection_ok)
-                is JavaResult.Fail -> stringResource(R.string.dashboard_protection_fail)
-                JavaResult.HooksInactive -> stringResource(R.string.dashboard_protection_hooks_inactive)
-            }
-        }
+        ProtectionCheck.NoVpn -> stringResource(R.string.dashboard_hero_vpnoff_title)
+        ProtectionCheck.NeedsRestart -> stringResource(R.string.dashboard_protection_unknown)
+        is ProtectionCheck.Checked -> layerSummaryText(protection.java)
     }
 
 @Composable
 private fun javaSummaryAccent(protection: ProtectionCheck): Color =
     when (protection) {
-        ProtectionCheck.NoVpn -> {
-            StatusColors.infoAccent
-        }
-
-        ProtectionCheck.NeedsRestart -> {
-            StatusColors.warningAccent
-        }
-
-        is ProtectionCheck.Checked -> {
-            when (protection.java) {
-                JavaResult.Ok -> StatusColors.successDot
-                is JavaResult.Fail -> StatusColors.errorAccent
-                JavaResult.HooksInactive -> MaterialTheme.colorScheme.onSurfaceVariant
-            }
-        }
+        ProtectionCheck.NoVpn -> StatusColors.infoAccent
+        ProtectionCheck.NeedsRestart -> StatusColors.warningAccent
+        is ProtectionCheck.Checked -> layerSummaryAccent(protection.java)
     }
 
 private data class InstalledVisual(

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DashboardScreen.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DashboardScreen.kt
@@ -684,32 +684,40 @@ private fun layerSummaryAccent(layer: LayerStatus): Color =
 @Composable
 private fun nativeSummaryText(protection: ProtectionCheck): String =
     when (protection) {
-        ProtectionCheck.NoVpn -> stringResource(R.string.dashboard_hero_vpnoff_title)
-        ProtectionCheck.NeedsRestart, ProtectionCheck.SelfNotRouted -> stringResource(R.string.dashboard_protection_unknown)
-        is ProtectionCheck.Checked -> layerSummaryText(protection.native)
+        // VPN off / app not in the tunnel / needs restart: the layer wasn't measured, so the
+        // tile just reads "not checked" — the hero and banner carry the actual reason.
+        ProtectionCheck.NoVpn, ProtectionCheck.NeedsRestart, ProtectionCheck.SelfNotRouted -> {
+            stringResource(R.string.dashboard_protection_unknown)
+        }
+
+        is ProtectionCheck.Checked -> {
+            layerSummaryText(protection.native)
+        }
     }
 
 @Composable
 private fun nativeSummaryAccent(protection: ProtectionCheck): Color =
     when (protection) {
-        ProtectionCheck.NoVpn -> StatusColors.infoAccent
-        ProtectionCheck.NeedsRestart, ProtectionCheck.SelfNotRouted -> StatusColors.warningAccent
+        ProtectionCheck.NoVpn, ProtectionCheck.NeedsRestart, ProtectionCheck.SelfNotRouted -> MaterialTheme.colorScheme.onSurfaceVariant
         is ProtectionCheck.Checked -> layerSummaryAccent(protection.native)
     }
 
 @Composable
 private fun javaSummaryText(protection: ProtectionCheck): String =
     when (protection) {
-        ProtectionCheck.NoVpn -> stringResource(R.string.dashboard_hero_vpnoff_title)
-        ProtectionCheck.NeedsRestart, ProtectionCheck.SelfNotRouted -> stringResource(R.string.dashboard_protection_unknown)
-        is ProtectionCheck.Checked -> layerSummaryText(protection.java)
+        ProtectionCheck.NoVpn, ProtectionCheck.NeedsRestart, ProtectionCheck.SelfNotRouted -> {
+            stringResource(R.string.dashboard_protection_unknown)
+        }
+
+        is ProtectionCheck.Checked -> {
+            layerSummaryText(protection.java)
+        }
     }
 
 @Composable
 private fun javaSummaryAccent(protection: ProtectionCheck): Color =
     when (protection) {
-        ProtectionCheck.NoVpn -> StatusColors.infoAccent
-        ProtectionCheck.NeedsRestart, ProtectionCheck.SelfNotRouted -> StatusColors.warningAccent
+        ProtectionCheck.NoVpn, ProtectionCheck.NeedsRestart, ProtectionCheck.SelfNotRouted -> MaterialTheme.colorScheme.onSurfaceVariant
         is ProtectionCheck.Checked -> layerSummaryAccent(protection.java)
     }
 

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DashboardScreen.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DashboardScreen.kt
@@ -198,9 +198,8 @@ fun DashboardScreen(
                 )
             }
 
-            is ProtectionCheck.Checked -> {
-                Unit
-            }
+            // Per-layer verdict renders in the cards below; no hero banner here.
+            is ProtectionCheck.Checked -> {}
         }
         Spacer(Modifier.height(20.dp))
 

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DashboardScreen.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DashboardScreen.kt
@@ -198,6 +198,16 @@ fun DashboardScreen(
                 )
             }
 
+            is ProtectionCheck.SelfNotRouted -> {
+                Spacer(Modifier.height(12.dp))
+                SelfNotRoutedPrompt(
+                    onRetry = {
+                        DashboardCache.refresh(scope, context, selfNeedsRestart)
+                        DiagnosticsCache.retry(scope, context)
+                    },
+                )
+            }
+
             // Per-layer verdict renders in the cards below; no hero banner here.
             is ProtectionCheck.Checked -> {}
         }
@@ -675,7 +685,7 @@ private fun layerSummaryAccent(layer: LayerStatus): Color =
 private fun nativeSummaryText(protection: ProtectionCheck): String =
     when (protection) {
         ProtectionCheck.NoVpn -> stringResource(R.string.dashboard_hero_vpnoff_title)
-        ProtectionCheck.NeedsRestart -> stringResource(R.string.dashboard_protection_unknown)
+        ProtectionCheck.NeedsRestart, ProtectionCheck.SelfNotRouted -> stringResource(R.string.dashboard_protection_unknown)
         is ProtectionCheck.Checked -> layerSummaryText(protection.native)
     }
 
@@ -683,7 +693,7 @@ private fun nativeSummaryText(protection: ProtectionCheck): String =
 private fun nativeSummaryAccent(protection: ProtectionCheck): Color =
     when (protection) {
         ProtectionCheck.NoVpn -> StatusColors.infoAccent
-        ProtectionCheck.NeedsRestart -> StatusColors.warningAccent
+        ProtectionCheck.NeedsRestart, ProtectionCheck.SelfNotRouted -> StatusColors.warningAccent
         is ProtectionCheck.Checked -> layerSummaryAccent(protection.native)
     }
 
@@ -691,7 +701,7 @@ private fun nativeSummaryAccent(protection: ProtectionCheck): Color =
 private fun javaSummaryText(protection: ProtectionCheck): String =
     when (protection) {
         ProtectionCheck.NoVpn -> stringResource(R.string.dashboard_hero_vpnoff_title)
-        ProtectionCheck.NeedsRestart -> stringResource(R.string.dashboard_protection_unknown)
+        ProtectionCheck.NeedsRestart, ProtectionCheck.SelfNotRouted -> stringResource(R.string.dashboard_protection_unknown)
         is ProtectionCheck.Checked -> layerSummaryText(protection.java)
     }
 
@@ -699,7 +709,7 @@ private fun javaSummaryText(protection: ProtectionCheck): String =
 private fun javaSummaryAccent(protection: ProtectionCheck): Color =
     when (protection) {
         ProtectionCheck.NoVpn -> StatusColors.infoAccent
-        ProtectionCheck.NeedsRestart -> StatusColors.warningAccent
+        ProtectionCheck.NeedsRestart, ProtectionCheck.SelfNotRouted -> StatusColors.warningAccent
         is ProtectionCheck.Checked -> layerSummaryAccent(protection.java)
     }
 

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DiagnosticsCache.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DiagnosticsCache.kt
@@ -50,6 +50,12 @@ internal object DiagnosticsCache {
 
         data object VpnOff : State
 
+        // A VPN is up on the device, but this app's own uid is not routed through
+        // it (excluded by split tunnelling). The checks would be meaningless —
+        // nothing to hide from us — so we ask the user to add VPN Hide to the
+        // tunnel instead of showing misleadingly-clean results.
+        data object SelfNotRouted : State
+
         data object Failed : State
 
         data class Ready(
@@ -93,7 +99,7 @@ internal object DiagnosticsCache {
                 if (inflight?.isActive == true) return
             }
 
-            State.NotRun, State.VpnOff, State.Failed -> { /* proceed */ }
+            State.NotRun, State.VpnOff, State.SelfNotRouted, State.Failed -> { /* proceed */ }
         }
         if (inflight?.isActive == true) return
         inflight = scope.launch { doRun(context.applicationContext) }
@@ -117,7 +123,10 @@ internal object DiagnosticsCache {
     suspend fun awaitFullResults(context: Context): CheckResults? {
         run(cacheScope, context)
         val terminal =
-            state.first { it is State.VpnOff || it is State.Failed || (it is State.Ready && it.complete) }
+            state.first {
+                it is State.VpnOff || it is State.SelfNotRouted || it is State.Failed ||
+                    (it is State.Ready && it.complete)
+            }
         return (terminal as? State.Ready)?.results
     }
 
@@ -129,6 +138,17 @@ internal object DiagnosticsCache {
             if (!vpnActive) {
                 _state.value = State.VpnOff
                 StartupTrace.mark("diagnostics_cache_vpn_off")
+                return
+            }
+            // Self-in-tunnel gate: a VPN is up, but is *this* app routed through
+            // it? If it is provably not (excluded by split tunnelling), the checks
+            // have nothing to hide from us — block with a "add to tunnel" prompt.
+            // A null answer (no root to tell) does not block — a no-root device is
+            // already handled as VPN-off above.
+            val selfRouted = withContext(Dispatchers.IO) { GroundTruthProbe.selfRoutedThroughVpn(appContext) }
+            if (selfRouted == false) {
+                _state.value = State.SelfNotRouted
+                StartupTrace.mark("diagnostics_cache_self_not_routed")
                 return
             }
             val cm = appContext.getSystemService(ConnectivityManager::class.java)

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DiagnosticsCache.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DiagnosticsCache.kt
@@ -112,7 +112,7 @@ internal object DiagnosticsCache {
      * Suspend until the full Diagnostics result is available. Dashboard uses
      * this path so the top-level "OK" state is backed by every protection
      * probe shown in Settings → Detailed diagnostics, including the slow push-callback
-     * and route/proxy Java checks.
+     * and route/NetworkInfo Java checks.
      */
     suspend fun awaitFullResults(context: Context): CheckResults? {
         run(cacheScope, context)

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DiagnosticsScreen.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DiagnosticsScreen.kt
@@ -112,6 +112,15 @@ fun DiagnosticsScreen(
                 )
             }
 
+            diagState is DiagnosticsCache.State.SelfNotRouted -> {
+                SelfNotRoutedPrompt(
+                    onRetry = {
+                        DiagnosticsCache.retry(scope, context)
+                        DashboardCache.refresh(scope, context, selfNeedsRestart)
+                    },
+                )
+            }
+
             diagState is DiagnosticsCache.State.Failed -> {
                 DiagnosticsFailedPrompt(
                     onRetry = {

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DiagnosticsScreen.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DiagnosticsScreen.kt
@@ -9,13 +9,16 @@ import android.os.Build
 import android.util.Log
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
 import androidx.compose.material.icons.filled.FiberManualRecord
 import androidx.compose.material.icons.filled.FileDownload
 import androidx.compose.material.icons.filled.Stop
@@ -24,6 +27,7 @@ import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.rotate
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
@@ -512,72 +516,56 @@ private fun formatSize(bytes: Long): String {
     return "%.1f MB".format(mb)
 }
 
-/** Card container + pill (text and accent) for one check. Native checks colour
- * by the root-differential [CheckOutcome] — green when hidden (by backend or
- * SELinux) or nothing-to-leak, red on a real leak, grey when not measured.
- * Java checks have no ground truth, so they fall back to the [passed] tri-state. */
-private class CheckBadge(
-    val text: String,
+/**
+ * One check's status: a coloured **dot + short word** (the "3-B" treatment — the
+ * app's own status-dot idiom from the module rows). The card colour tracks current
+ * reality only — green when hidden (by backend OR SELinux) or nothing-to-leak, red
+ * on a real leak, neutral when not measured — so a normal enforcing device is all
+ * green. The backend-vs-SELinux attribution rides on the dot colour + word, never
+ * on the card colour (no alarm on SELinux-protected items). Detail is collapsed by
+ * default and revealed on tap; a leak is the only thing expanded up front.
+ */
+private data class DiagStatus(
+    val label: String,
     val accent: Color,
     val container: Color,
+    val expandedByDefault: Boolean,
 )
 
 @Composable
-private fun checkBadge(r: CheckResult): CheckBadge {
-    val success = StatusColors.successContainer()
-    val error = StatusColors.errorContainer()
-    val neutral = StatusColors.neutralContainer()
+private fun diagStatus(r: CheckResult): DiagStatus {
+    val ok = DiagStatus(stringResource(R.string.diag_status_ok), StatusColors.successDot, StatusColors.successContainer(), false)
+    val leak = DiagStatus(stringResource(R.string.diag_status_leak), StatusColors.errorDot, StatusColors.errorContainer(), true)
+    val notMeasured =
+        DiagStatus(stringResource(R.string.diag_status_nomeasure), StatusColors.neutralAccent, StatusColors.neutralContainer(), false)
     return when (r.outcome) {
         CheckOutcome.Leak -> {
-            CheckBadge(stringResource(R.string.diag_pill_leak), StatusColors.errorAccent, error)
+            leak
         }
 
-        CheckOutcome.HiddenByBackend -> {
-            CheckBadge(stringResource(R.string.diag_pill_backend), StatusColors.successBadge, success)
+        // Hidden by the backend, or simply nothing to leak: both read as plain OK.
+        CheckOutcome.HiddenByBackend, CheckOutcome.NothingToLeak -> {
+            ok
         }
 
-        // Hidden, but by SELinux rather than a backend hook: green card (no leak),
-        // blue pill to flag the distinction the redesign is about.
+        // Hidden by SELinux, not a backend hook: still a green card (no alarm), but a
+        // blue dot + "SELinux" word flags the distinction the redesign is about.
         CheckOutcome.HiddenBySelinux -> {
-            CheckBadge(stringResource(R.string.diag_pill_selinux), StatusColors.infoAccent, success)
-        }
-
-        CheckOutcome.NothingToLeak -> {
-            CheckBadge(stringResource(R.string.diag_pill_nothing), StatusColors.neutralAccent, success)
+            DiagStatus(stringResource(R.string.diag_status_selinux), StatusColors.infoAccent, StatusColors.successContainer(), false)
         }
 
         is CheckOutcome.NotMeasured -> {
-            CheckBadge(stringResource(R.string.diag_pill_not_measured), StatusColors.neutralAccent, neutral)
+            notMeasured
         }
 
+        // Java-implemented native-level probes carry no outcome — fall back to passed.
         null -> {
             when (r.passed) {
-                true -> CheckBadge(stringResource(R.string.diag_pill_clean), StatusColors.successBadge, success)
-                false -> CheckBadge(stringResource(R.string.diag_pill_leak), StatusColors.errorAccent, error)
-                null -> CheckBadge(stringResource(R.string.diag_pill_not_measured), StatusColors.neutralAccent, neutral)
+                true -> ok
+                false -> leak
+                null -> notMeasured
             }
         }
-    }
-}
-
-@Composable
-private fun OutcomePill(
-    text: String,
-    accent: Color,
-) {
-    Box(
-        modifier =
-            Modifier
-                .clip(RoundedCornerShape(50))
-                .background(accent.copy(alpha = 0.16f))
-                .padding(horizontal = 10.dp, vertical = 3.dp),
-    ) {
-        Text(
-            text = text,
-            color = accent,
-            fontWeight = FontWeight.SemiBold,
-            fontSize = 12.sp,
-        )
     }
 }
 
@@ -587,12 +575,14 @@ private fun CheckCard(
     index: Int = -1,
     count: Int = 1,
 ) {
-    val badge = checkBadge(r)
+    val status = diagStatus(r)
+    var expanded by remember(r.name) { mutableStateOf(status.expandedByDefault) }
+    val caretRotation by animateFloatAsState(if (expanded) 90f else 0f, label = "caret")
     GroupedCard(
         index = index,
         count = count,
-        modifier = Modifier.fillMaxWidth(),
-        color = badge.container,
+        modifier = Modifier.fillMaxWidth().clickable { expanded = !expanded },
+        color = status.container,
     ) {
         Column(modifier = Modifier.padding(12.dp)) {
             Row(
@@ -606,15 +596,34 @@ private fun CheckCard(
                     fontWeight = FontWeight.Bold,
                     modifier = Modifier.weight(1f).padding(end = 8.dp),
                 )
-                OutcomePill(badge.text, badge.accent)
+                Row(
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.spacedBy(8.dp),
+                ) {
+                    Box(modifier = Modifier.size(9.dp).clip(CircleShape).background(status.accent))
+                    Text(
+                        text = status.label,
+                        color = status.accent,
+                        fontWeight = FontWeight.SemiBold,
+                        fontSize = 12.sp,
+                    )
+                    Icon(
+                        imageVector = Icons.AutoMirrored.Filled.KeyboardArrowRight,
+                        contentDescription = null,
+                        tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                        modifier = Modifier.size(18.dp).rotate(caretRotation),
+                    )
+                }
             }
-            Spacer(Modifier.height(4.dp))
-            Text(
-                text = r.detail,
-                style = MaterialTheme.typography.bodySmall,
-                fontFamily = FontFamily.Monospace,
-                color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.8f),
-            )
+            if (expanded) {
+                Spacer(Modifier.height(6.dp))
+                Text(
+                    text = r.detail,
+                    style = MaterialTheme.typography.bodySmall,
+                    fontFamily = FontFamily.Monospace,
+                    color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.8f),
+                )
+            }
         }
     }
 }

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DiagnosticsScreen.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DiagnosticsScreen.kt
@@ -9,6 +9,7 @@ import android.os.Build
 import android.util.Log
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.foundation.background
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.rememberScrollState
@@ -22,6 +23,8 @@ import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontFamily
@@ -500,40 +503,87 @@ private fun formatSize(bytes: Long): String {
     return "%.1f MB".format(mb)
 }
 
+/** Card container + pill (text and accent) for one check. Native checks colour
+ * by the root-differential [CheckOutcome] — green when hidden (by backend or
+ * SELinux) or nothing-to-leak, red on a real leak, grey when not measured.
+ * Java checks have no ground truth, so they fall back to the [passed] tri-state. */
+private class CheckBadge(
+    val text: String,
+    val accent: Color,
+    val container: Color,
+)
+
+@Composable
+private fun checkBadge(r: CheckResult): CheckBadge {
+    val success = StatusColors.successContainer()
+    val error = StatusColors.errorContainer()
+    val neutral = StatusColors.neutralContainer()
+    return when (r.outcome) {
+        CheckOutcome.Leak -> {
+            CheckBadge(stringResource(R.string.diag_pill_leak), StatusColors.errorAccent, error)
+        }
+
+        CheckOutcome.HiddenByBackend -> {
+            CheckBadge(stringResource(R.string.diag_pill_backend), StatusColors.successBadge, success)
+        }
+
+        // Hidden, but by SELinux rather than a backend hook: green card (no leak),
+        // blue pill to flag the distinction the redesign is about.
+        CheckOutcome.HiddenBySelinux -> {
+            CheckBadge(stringResource(R.string.diag_pill_selinux), StatusColors.infoAccent, success)
+        }
+
+        CheckOutcome.NothingToLeak -> {
+            CheckBadge(stringResource(R.string.diag_pill_nothing), StatusColors.neutralAccent, success)
+        }
+
+        is CheckOutcome.NotMeasured -> {
+            CheckBadge(stringResource(R.string.diag_pill_not_measured), StatusColors.neutralAccent, neutral)
+        }
+
+        null -> {
+            when (r.passed) {
+                true -> CheckBadge(stringResource(R.string.diag_pill_clean), StatusColors.successBadge, success)
+                false -> CheckBadge(stringResource(R.string.diag_pill_leak), StatusColors.errorAccent, error)
+                null -> CheckBadge(stringResource(R.string.diag_pill_not_measured), StatusColors.neutralAccent, neutral)
+            }
+        }
+    }
+}
+
+@Composable
+private fun OutcomePill(
+    text: String,
+    accent: Color,
+) {
+    Box(
+        modifier =
+            Modifier
+                .clip(RoundedCornerShape(50))
+                .background(accent.copy(alpha = 0.16f))
+                .padding(horizontal = 10.dp, vertical = 3.dp),
+    ) {
+        Text(
+            text = text,
+            color = accent,
+            fontWeight = FontWeight.SemiBold,
+            fontSize = 12.sp,
+        )
+    }
+}
+
 @Composable
 private fun CheckCard(
     r: CheckResult,
     index: Int = -1,
     count: Int = 1,
 ) {
-    val actualColor =
-        when (r.passed) {
-            true -> StatusColors.successContainer()
-            false -> StatusColors.errorContainer()
-            null -> MaterialTheme.colorScheme.surfaceVariant
-        }
-
-    val badgeText =
-        stringResource(
-            when (r.passed) {
-                true -> R.string.badge_pass
-                false -> R.string.badge_fail
-                null -> R.string.badge_info
-            },
-        )
-
-    val badgeColor =
-        when (r.passed) {
-            true -> StatusColors.successBadge
-            false -> StatusColors.errorAccent
-            null -> MaterialTheme.colorScheme.onSurfaceVariant
-        }
-
+    val badge = checkBadge(r)
     GroupedCard(
         index = index,
         count = count,
         modifier = Modifier.fillMaxWidth(),
-        color = actualColor,
+        color = badge.container,
     ) {
         Column(modifier = Modifier.padding(12.dp)) {
             Row(
@@ -545,14 +595,9 @@ private fun CheckCard(
                     text = r.name,
                     style = MaterialTheme.typography.bodyLarge,
                     fontWeight = FontWeight.Bold,
-                    modifier = Modifier.weight(1f),
+                    modifier = Modifier.weight(1f).padding(end = 8.dp),
                 )
-                Text(
-                    text = badgeText,
-                    fontWeight = FontWeight.Bold,
-                    fontSize = 13.sp,
-                    color = badgeColor,
-                )
+                OutcomePill(badge.text, badge.accent)
             }
             Spacer(Modifier.height(4.dp))
             Text(

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DiagnosticsScreen.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DiagnosticsScreen.kt
@@ -28,7 +28,6 @@ import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import dev.okhsunrog.vpnhide.checks.CheckOutput
 import dev.okhsunrog.vpnhide.generated.IfaceLists
 import dev.okhsunrog.vpnhide.ui.components.EnhancedButton
 import dev.okhsunrog.vpnhide.ui.components.EnhancedCard

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/GroundTruthProbe.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/GroundTruthProbe.kt
@@ -1,0 +1,45 @@
+package dev.okhsunrog.vpnhide
+
+import android.content.Context
+import dev.okhsunrog.vpnhide.checks.CheckOutput
+import dev.okhsunrog.vpnhide.checks.NativeProbe
+import java.io.File
+
+/**
+ * Runs the same native probes as **root** — uid 0 is not a hook target, so its
+ * view is the unfiltered truth to diff against the app's in-process view.
+ *
+ * The probe binary ships as an APK asset (AGP 9 keeps native libs compressed in
+ * the APK, so a jniLib isn't an on-disk executable). We extract it into the app
+ * sandbox, then stage it to `/data/local/tmp` (correctly labelled for exec under
+ * root) and run it via `su`.
+ */
+object GroundTruthProbe {
+    private const val ASSET = "bin/arm64-v8a/vhprobe"
+    private const val STAGED = "/data/local/tmp/vpnhide_vhprobe"
+    private const val TAG = LogTags.DIAG
+
+    /** id -> ground-truth outcome, or empty when root/exec is unavailable (the
+     * caller then classifies those checks as NotMeasured(NoGroundTruth)). */
+    fun run(context: Context): Map<String, CheckOutput> {
+        val local = extractBinary(context) ?: return emptyMap()
+        val (exit, out) =
+            suExec(
+                "cp '${local.absolutePath}' $STAGED && chmod 700 $STAGED && $STAGED; rm -f $STAGED",
+            )
+        val json = out.trim()
+        if (exit != 0 || !json.startsWith("[")) {
+            VpnHideLog.w(TAG, "ground-truth probe unavailable (exit=$exit, no root?)")
+            return emptyMap()
+        }
+        return NativeProbe.parse(json)
+    }
+
+    private fun extractBinary(context: Context): File? =
+        runCatching {
+            val dest = File(context.filesDir, "vhprobe")
+            context.assets.open(ASSET).use { input -> dest.outputStream().use { input.copyTo(it) } }
+            dest
+        }.onFailure { VpnHideLog.w(TAG, "failed to extract vhprobe asset: ${it.message}") }
+            .getOrNull()
+}

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/GroundTruthProbe.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/GroundTruthProbe.kt
@@ -35,6 +35,27 @@ object GroundTruthProbe {
         return NativeProbe.parse(json)
     }
 
+    /**
+     * The self-in-tunnel gate: is this app's own uid routed through the VPN?
+     * Runs the probe as root with `--uid` (a hook-inert, unfiltered read of the
+     * policy rules). Returns null when root/exec is unavailable — the caller then
+     * does not block, since a no-root device is already handled as "VPN off".
+     */
+    fun selfRoutedThroughVpn(context: Context): Boolean? {
+        val local = extractBinary(context) ?: return null
+        val uid = android.os.Process.myUid()
+        val (exit, out) =
+            suExec(
+                "cp '${local.absolutePath}' $STAGED && chmod 700 $STAGED && $STAGED --uid $uid; rm -f $STAGED",
+            )
+        val json = out.trim()
+        if (exit != 0 || !json.startsWith("{")) {
+            VpnHideLog.w(TAG, "self-routed probe unavailable (exit=$exit, no root?)")
+            return null
+        }
+        return runCatching { org.json.JSONObject(json).getBoolean("routed") }.getOrNull()
+    }
+
     private fun extractBinary(context: Context): File? =
         runCatching {
             val dest = File(context.filesDir, "vhprobe")

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/JavaChecks.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/JavaChecks.kt
@@ -4,6 +4,7 @@ import android.net.ConnectivityManager
 import android.net.LinkProperties
 import android.net.Network
 import android.net.NetworkCapabilities
+import android.net.NetworkInfo
 import android.net.Uri
 import android.os.Build
 import androidx.activity.compose.rememberLauncherForActivityResult
@@ -177,7 +178,8 @@ internal fun runExtraJavaChecks(
         checkActiveNetworkVpn(cm, res.getString(R.string.check_active_network_vpn)),
         checkNetworkCallbackVpn(cm, res.getString(R.string.check_network_callback)),
         checkLinkPropertiesRoutes(cm, res.getString(R.string.check_link_properties_routes)),
-        checkProxyHost(res.getString(R.string.check_proxy_host)),
+        checkActiveNetworkInfo(cm, res.getString(R.string.check_active_network_info)),
+        checkNetworkInfoVpn(cm, res.getString(R.string.check_network_info_vpn)),
     ).logged()
 }
 
@@ -513,19 +515,45 @@ private fun checkLinkPropertiesRoutes(
         CheckResult(name, vpnRoutes.isEmpty(), detail)
     }
 
-private fun checkProxyHost(name: String): CheckResult {
-    val httpHost = System.getProperty("http.proxyHost")
-    val socksHost = System.getProperty("socksProxyHost")
-    val hasProxy = !httpHost.isNullOrEmpty() || !socksHost.isNullOrEmpty()
+// Legacy NetworkInfo leaks (exercise the LSPOSED_NETWORK_INFO parcel hook +
+// the ConnectivityService result sanitizer — surfaces with no other check).
+// getActiveNetworkInfo() marshals a NetworkInfo across Binder; without the
+// hook an on-VPN caller sees type=VPN. The hook disguises it as WIFI.
+@Suppress("DEPRECATION")
+private fun checkActiveNetworkInfo(
+    cm: ConnectivityManager,
+    name: String,
+): CheckResult {
+    val info = cm.activeNetworkInfo ?: return CheckResult(name, true, "no active network info")
+    val isVpn = info.type == ConnectivityManager.TYPE_VPN || info.typeName.equals("VPN", ignoreCase = true)
     val detail =
-        if (!hasProxy) {
-            "no proxy (http=$httpHost, socks=$socksHost)"
+        if (!isVpn) {
+            "type=${info.type} (${info.typeName})"
         } else {
-            val httpPort = System.getProperty("http.proxyPort")
-            val socksPort = System.getProperty("socksProxyPort")
-            "proxy found — http=$httpHost:$httpPort, socks=$socksHost:$socksPort"
+            "activeNetworkInfo type=VPN (${info.typeName})"
         }
-    return CheckResult(name, !hasProxy, detail)
+    return CheckResult(name, !isVpn, detail)
+}
+
+// getNetworkInfo(TYPE_VPN) probes the legacy VPN type directly (issue #85). The
+// hook nulls it for a target; a non-null result that reports connected/connecting
+// still answers "a VPN-type network exists", which is the leak.
+@Suppress("DEPRECATION")
+private fun checkNetworkInfoVpn(
+    cm: ConnectivityManager,
+    name: String,
+): CheckResult {
+    val info =
+        cm.getNetworkInfo(ConnectivityManager.TYPE_VPN)
+            ?: return CheckResult(name, true, "getNetworkInfo(TYPE_VPN) returned null")
+    val leaks = info.isConnectedOrConnecting
+    val detail =
+        if (!leaks) {
+            "TYPE_VPN state=${info.state}"
+        } else {
+            "getNetworkInfo(TYPE_VPN) connected: ${info.typeName} ${info.state}"
+        }
+    return CheckResult(name, !leaks, detail)
 }
 
 private fun checkProcNetRouteJava(name: String): CheckResult =

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/JavaChecks.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/JavaChecks.kt
@@ -225,26 +225,31 @@ private fun nativeCheckResult(
 // ==========================================================================
 
 /** Shared preamble for the capability-based checks: resolve the active
- * network's [NetworkCapabilities], reporting "no active network" / "no
- * capabilities" (both PASS — nothing for an app to leak) when absent. */
+ * network's [NetworkCapabilities]. A missing active network / capabilities is
+ * reported as `passed == null` (not measured) rather than a green pass: the
+ * self-in-tunnel gate guarantees an active network is present, so an absent one
+ * means the probe couldn't observe — not that a backend hid the VPN. Classifying
+ * it PASS would paint a false "hidden by backend" ([classifyJavaOutcome]). */
 private inline fun withActiveCaps(
     cm: ConnectivityManager,
     name: String,
     body: (NetworkCapabilities) -> CheckResult,
 ): CheckResult {
-    val net = cm.activeNetwork ?: return CheckResult(name, true, "no active network")
-    val caps = cm.getNetworkCapabilities(net) ?: return CheckResult(name, true, "no capabilities")
+    val net = cm.activeNetwork ?: return CheckResult(name, null, "no active network")
+    val caps = cm.getNetworkCapabilities(net) ?: return CheckResult(name, null, "no capabilities")
     return body(caps)
 }
 
-/** Shared preamble for the LinkProperties-based checks. */
+/** Shared preamble for the LinkProperties-based checks. A missing active network
+ * / link properties is `passed == null` (not measured) for the same reason as
+ * [withActiveCaps] — the gate makes it an unobservable edge, not a clean pass. */
 private inline fun withActiveLinkProperties(
     cm: ConnectivityManager,
     name: String,
     body: (LinkProperties) -> CheckResult,
 ): CheckResult {
-    val net = cm.activeNetwork ?: return CheckResult(name, true, "no active network")
-    val lp = cm.getLinkProperties(net) ?: return CheckResult(name, true, "no link properties")
+    val net = cm.activeNetwork ?: return CheckResult(name, null, "no active network")
+    val lp = cm.getLinkProperties(net) ?: return CheckResult(name, null, "no link properties")
     return body(lp)
 }
 
@@ -381,7 +386,9 @@ private fun checkNetworkForTypeVpn(
 ): CheckResult {
     val result = queryNetworkForType(cm, ConnectivityManager.TYPE_VPN)
     result.error?.let { return CheckResult(name, false, it) }
-    if (result.unavailable) return CheckResult(name, true, "getNetworkForType unavailable")
+    // Reflection couldn't reach getNetworkForType — probe didn't run (not measured),
+    // not a clean pass. A non-null TYPE_VPN network below is still a legitimate hidden.
+    if (result.unavailable) return CheckResult(name, null, "getNetworkForType unavailable")
     val vpnNetwork = result.network ?: return CheckResult(name, true, "TYPE_VPN returned null")
 
     val caps = cm.getNetworkCapabilities(vpnNetwork)
@@ -400,10 +407,10 @@ private fun checkActiveNetworkHandle(
     cm: ConnectivityManager,
     name: String,
 ): CheckResult {
-    val active = cm.activeNetwork ?: return CheckResult(name, true, "no active network")
+    val active = cm.activeNetwork ?: return CheckResult(name, null, "no active network")
     val vpnResult = queryNetworkForType(cm, ConnectivityManager.TYPE_VPN)
     vpnResult.error?.let { return CheckResult(name, false, it) }
-    if (vpnResult.unavailable) return CheckResult(name, true, "active=$active, getNetworkForType unavailable")
+    if (vpnResult.unavailable) return CheckResult(name, null, "active=$active, getNetworkForType unavailable")
     val vpnNetwork = vpnResult.network ?: return CheckResult(name, true, "active=$active, TYPE_VPN not exposed")
 
     val leaksVpnHandle = active == vpnNetwork
@@ -424,7 +431,7 @@ private fun checkAllNetworksHandles(
     val networks = cm.allNetworks
     val vpnResult = queryNetworkForType(cm, ConnectivityManager.TYPE_VPN)
     vpnResult.error?.let { return CheckResult(name, false, it) }
-    if (vpnResult.unavailable) return CheckResult(name, true, "${networks.size} networks, getNetworkForType unavailable")
+    if (vpnResult.unavailable) return CheckResult(name, null, "${networks.size} networks, getNetworkForType unavailable")
     val vpnNetwork = vpnResult.network ?: return CheckResult(name, true, "${networks.size} networks, TYPE_VPN not exposed")
 
     val containsVpnHandle = networks.any { it == vpnNetwork }

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/JavaChecks.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/JavaChecks.kt
@@ -156,7 +156,7 @@ internal fun runCoreChecks(
             checkTransportInfo(cm, res.getString(R.string.check_transport_info)),
             checkAllNetworksVpn(cm, res.getString(R.string.check_all_networks_vpn)),
             checkLinkPropertiesIfname(cm, res.getString(R.string.check_link_properties)),
-        ).logged()
+        ).logged().withJavaOutcomes()
 
     return CheckResults(
         native = native,
@@ -180,8 +180,16 @@ internal fun runExtraJavaChecks(
         checkLinkPropertiesRoutes(cm, res.getString(R.string.check_link_properties_routes)),
         checkActiveNetworkInfo(cm, res.getString(R.string.check_active_network_info)),
         checkNetworkInfoVpn(cm, res.getString(R.string.check_network_info_vpn)),
-    ).logged()
+    ).logged().withJavaOutcomes()
 }
+
+/**
+ * Attach the who-hid-it [CheckOutcome] to Java-level checks. The gate guarantees
+ * a VPN is up and this app is routed through it, so clean ⟹ hidden by LSPosed,
+ * dirty ⟹ leak (see [classifyJavaOutcome]). Applied only to the pure Java-API
+ * checks — the Java-implemented native-level probes stay on the passed tri-state.
+ */
+private fun List<CheckResult>.withJavaOutcomes(): List<CheckResult> = map { it.copy(outcome = classifyJavaOutcome(it.passed)) }
 
 /** Log each Java check result; native probes already log via [nativeCheck]. */
 private fun List<CheckResult>.logged(): List<CheckResult> =

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/JavaChecks.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/JavaChecks.kt
@@ -27,6 +27,8 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import dev.okhsunrog.vpnhide.checks.CheckOutput
+import dev.okhsunrog.vpnhide.checks.CheckStatus
+import dev.okhsunrog.vpnhide.checks.NativeProbe
 import dev.okhsunrog.vpnhide.generated.IfaceLists
 import dev.okhsunrog.vpnhide.ui.components.EnhancedButton
 import dev.okhsunrog.vpnhide.ui.components.EnhancedCard
@@ -111,7 +113,16 @@ internal fun runCoreChecks(
 
     val res = context.resources
 
-    val native = NATIVE_CHECKS.map { spec -> nativeCheck(res.getString(spec.labelRes), spec.run) }
+    // One JNI call runs every native probe in-process (app view); join the
+    // results back to the specs by stable id.
+    val nativeOutcomes = NativeProbe.runAll()
+    val native =
+        NATIVE_CHECKS.map { spec ->
+            val out =
+                nativeOutcomes[spec.id]
+                    ?: CheckOutput(CheckStatus.NETWORK_BLOCKED, "no native result for ${spec.id}")
+            nativeCheckResult(res.getString(spec.labelRes), out)
+        }
 
     val nativeExtra =
         listOf(
@@ -167,19 +178,13 @@ internal fun runAllChecks(
     context: android.content.Context,
 ): CheckResults = runCoreChecks(cm, context).copy(extraJava = runExtraJavaChecks(cm, context))
 
-private fun nativeCheck(
+private fun nativeCheckResult(
     name: String,
-    block: () -> CheckOutput,
-): CheckResult =
-    try {
-        val out = block()
-        VpnHideLog.i(TAG, "[$name] ${out.status}: ${out.detail}")
-        CheckResult(name, out.status.toPassed(), out.detail)
-    } catch (e: Exception) {
-        val detail = e.message ?: e.javaClass.simpleName
-        VpnHideLog.e(TAG, "[$name] $detail", e)
-        CheckResult(name, false, detail)
-    }
+    out: CheckOutput,
+): CheckResult {
+    VpnHideLog.i(TAG, "[$name] ${out.status}: ${out.detail}")
+    return CheckResult(name, out.status.toPassed(), out.detail)
+}
 
 // ==========================================================================
 //  Java API checks

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/JavaChecks.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/JavaChecks.kt
@@ -58,7 +58,7 @@ data class CheckResult(
 )
 
 internal data class CheckResults(
-    // UniFFI native probes from the fast phase.
+    // Rust native probes (in-process app view) from the fast phase.
     val native: List<CheckResult>,
     // Java-implemented native-level probes (NetworkInterface enum, /proc/net/route)
     // — shown under "Native level" and included in Dashboard once the full
@@ -69,6 +69,10 @@ internal data class CheckResults(
     // Remaining Java probes (active-network, push callback, routes, proxy) —
     // the slow push-callback check lives here, so it runs in a second phase.
     val extraJava: List<CheckResult> = emptyList(),
+    // Honest per-check outcome for the Rust native checks, keyed by spec id —
+    // the who-hid-it differential (app view vs root ground truth). Empty when the
+    // ground-truth probe couldn't run.
+    val nativeOutcomes: Map<String, CheckOutcome> = emptyMap(),
 ) {
     val nativeAll get() = native + nativeExtra
     val java get() = coreJava + extraJava
@@ -113,15 +117,26 @@ internal fun runCoreChecks(
 
     val res = context.resources
 
-    // One JNI call runs every native probe in-process (app view); join the
-    // results back to the specs by stable id.
-    val nativeOutcomes = NativeProbe.runAll()
+    // One JNI call runs every native probe in-process (app view); a root-exec of
+    // the same probes gives the unfiltered ground truth for the who-hid-it
+    // differential. Join both back to the specs by stable id.
+    val nativeAppView = NativeProbe.runAll()
+    val nativeGroundTruth = GroundTruthProbe.run(context)
     val native =
         NATIVE_CHECKS.map { spec ->
             val out =
-                nativeOutcomes[spec.id]
+                nativeAppView[spec.id]
                     ?: CheckOutput(CheckStatus.NETWORK_BLOCKED, "no native result for ${spec.id}")
             nativeCheckResult(res.getString(spec.labelRes), out)
+        }
+    val nativeOutcomes =
+        NATIVE_CHECKS.associate { spec ->
+            val app =
+                nativeAppView[spec.id]
+                    ?: CheckOutput(CheckStatus.NETWORK_BLOCKED, "no result")
+            val outcome = classifyNativeOutcome(app, nativeGroundTruth[spec.id])
+            VpnHideLog.i(TAG, "[outcome] ${spec.id}: ${outcome.token()}")
+            spec.id to outcome
         }
 
     val nativeExtra =
@@ -139,7 +154,12 @@ internal fun runCoreChecks(
             checkLinkPropertiesIfname(cm, res.getString(R.string.check_link_properties)),
         ).logged()
 
-    return CheckResults(native = native, nativeExtra = nativeExtra, coreJava = coreJava)
+    return CheckResults(
+        native = native,
+        nativeExtra = nativeExtra,
+        coreJava = coreJava,
+        nativeOutcomes = nativeOutcomes,
+    )
 }
 
 internal fun runExtraJavaChecks(

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/JavaChecks.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/JavaChecks.kt
@@ -55,6 +55,10 @@ data class CheckResult(
     val name: String,
     val passed: Boolean?,
     val detail: String,
+    // The who-hid-it attribution for native probes (root differential). Null for
+    // Java-level checks, which have no root ground truth — those fall back to the
+    // legacy [passed] tri-state in the UI.
+    val outcome: CheckOutcome? = null,
 )
 
 internal data class CheckResults(
@@ -122,21 +126,20 @@ internal fun runCoreChecks(
     // differential. Join both back to the specs by stable id.
     val nativeAppView = NativeProbe.runAll()
     val nativeGroundTruth = GroundTruthProbe.run(context)
+    // One pass builds both the per-check UI results and the outcome map (keyed by
+    // spec id for the agent bridge / dashboard). The outcome — the root-differential
+    // attribution — rides along on each CheckResult so the UI is a pure function of
+    // the list.
+    val nativeOutcomes = LinkedHashMap<String, CheckOutcome>()
     val native =
         NATIVE_CHECKS.map { spec ->
             val out =
                 nativeAppView[spec.id]
                     ?: CheckOutput(CheckStatus.NETWORK_BLOCKED, "no native result for ${spec.id}")
-            nativeCheckResult(res.getString(spec.labelRes), out)
-        }
-    val nativeOutcomes =
-        NATIVE_CHECKS.associate { spec ->
-            val app =
-                nativeAppView[spec.id]
-                    ?: CheckOutput(CheckStatus.NETWORK_BLOCKED, "no result")
-            val outcome = classifyNativeOutcome(app, nativeGroundTruth[spec.id])
+            val outcome = classifyNativeOutcome(out, nativeGroundTruth[spec.id])
             VpnHideLog.i(TAG, "[outcome] ${spec.id}: ${outcome.token()}")
-            spec.id to outcome
+            nativeOutcomes[spec.id] = outcome
+            nativeCheckResult(res.getString(spec.labelRes), out, outcome)
         }
 
     val nativeExtra =
@@ -201,9 +204,10 @@ internal fun runAllChecks(
 private fun nativeCheckResult(
     name: String,
     out: CheckOutput,
+    outcome: CheckOutcome? = null,
 ): CheckResult {
     VpnHideLog.i(TAG, "[$name] ${out.status}: ${out.detail}")
-    return CheckResult(name, out.status.toPassed(), out.detail)
+    return CheckResult(name, out.status.toPassed(), out.detail, outcome = outcome)
 }
 
 // ==========================================================================

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/LayerStatus.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/LayerStatus.kt
@@ -77,10 +77,11 @@ internal fun summarizeJavaLayer(
     javaChecks: List<CheckResult>,
 ): LayerStatus {
     if (!lsposedActive) return LayerStatus.Inactive
-    val scored = javaChecks.filter { it.passed != null }
+    // Same shape as the native tile: hidden/leaks read off the who-hid-it outcome
+    // (attached by withJavaOutcomes), so Partial vs Broken is a measurement.
     return LayerStatus.Active(
-        hidden = scored.count { it.passed == true },
-        leaks = scored.count { it.passed == false },
+        hidden = javaChecks.count { it.outcome is CheckOutcome.HiddenByBackend },
+        leaks = javaChecks.count { it.outcome is CheckOutcome.Leak },
     )
 }
 

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/LayerStatus.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/LayerStatus.kt
@@ -61,7 +61,10 @@ internal fun summarizeNativeLayer(
             null -> HookIds.KERNEL_HOOK_MASK
         }
     val ownedIds = NATIVE_CHECKS.filter { it.hasHookIn(ownMask) }.map { it.id }.toSet()
-    val hidden = outcomes.values.count { it is CheckOutcome.HiddenByBackend }
+    // Both counts are scoped to vectors this backend owns, so hidden and leaks
+    // describe the same vector set — a cross-backend hidden (only possible if the
+    // one-active-backend invariant ever breaks) can't mask an owned Broken verdict.
+    val hidden = outcomes.count { (id, outcome) -> outcome is CheckOutcome.HiddenByBackend && id in ownedIds }
     val leaks = outcomes.count { (id, outcome) -> outcome is CheckOutcome.Leak && id in ownedIds }
     return LayerStatus.Active(hidden = hidden, leaks = leaks)
 }

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/LayerStatus.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/LayerStatus.kt
@@ -1,0 +1,102 @@
+package dev.okhsunrog.vpnhide
+
+import dev.okhsunrog.vpnhide.generated.HookIds
+
+/**
+ * Per-layer backend health for a dashboard tile. Presence (Absent / Inactive)
+ * is decided *before* the checks, so an unloaded backend can never render as a
+ * leak or a verdict — it just reads "not active". This is the fix for the old
+ * "Partial" that a not-loaded backend used to show from SELinux-only passes.
+ */
+sealed interface LayerStatus {
+    /** No backend module installed for this layer. */
+    data object Absent : LayerStatus
+
+    /** Installed but not loaded this boot (needs a reboot / manager toggle). */
+    data object Inactive : LayerStatus
+
+    /** Active and measured. [hidden] = vectors the backend provably hid;
+     * [leaks] = vectors it owns that still leak. */
+    data class Active(
+        val hidden: Int,
+        val leaks: Int,
+    ) : LayerStatus
+}
+
+enum class Verdict { Ok, Partial, Broken }
+
+/**
+ * Ok = nothing owned leaks. Partial = the backend hides some but an owned vector
+ * still leaks (works, has a gap). Broken = active but hid nothing while leaking
+ * (loaded yet dead). [hidden] must be a *measurement* (root differential), never
+ * inferred from a clean probe — else Partial and Broken are indistinguishable.
+ */
+val LayerStatus.Active.verdict: Verdict
+    get() =
+        when {
+            leaks == 0 -> Verdict.Ok
+            hidden > 0 -> Verdict.Partial
+            else -> Verdict.Broken
+        }
+
+private fun NativeCheckSpec.hasHookIn(mask: Int): Boolean = expectedHooks.any { (1 shl it.id) and mask != 0 }
+
+/**
+ * Native tile = health of the active backend, judged **only on vectors it owns**
+ * (has a hook for). A leak on a not-owned vector (e.g. /proc/net/dev under a
+ * kernel backend — no kernel hook exists) is out of scope for the tile; it
+ * surfaces via the hero instead. Kernel backends (kmod/KPM) own kernel-hook
+ * vectors; Zygisk owns zygisk-hook vectors.
+ */
+internal fun summarizeNativeLayer(
+    backend: DisplayNativeBackend,
+    outcomes: Map<String, CheckOutcome>,
+): LayerStatus {
+    if (backend.state is ModuleState.NotInstalled) return LayerStatus.Absent
+    if (!moduleActive(backend.state)) return LayerStatus.Inactive
+    val ownMask =
+        when (backend.id) {
+            NativeBackendId.Kmod, NativeBackendId.Kpm -> HookIds.KERNEL_HOOK_MASK
+            NativeBackendId.Zygisk -> HookIds.ZYGISK_HOOK_MASK
+            null -> HookIds.KERNEL_HOOK_MASK
+        }
+    val ownedIds = NATIVE_CHECKS.filter { it.hasHookIn(ownMask) }.map { it.id }.toSet()
+    val hidden = outcomes.values.count { it is CheckOutcome.HiddenByBackend }
+    val leaks = outcomes.count { (id, outcome) -> outcome is CheckOutcome.Leak && id in ownedIds }
+    return LayerStatus.Active(hidden = hidden, leaks = leaks)
+}
+
+/**
+ * Java tile from the LSPosed hook state + the Java check results. Java probes are
+ * framework IPC with no root differential, so a clean result is taken as
+ * hidden-by-LSPosed; a couple of failing probes read as Partial ("leaking n"),
+ * not a blanket "not working".
+ */
+internal fun summarizeJavaLayer(
+    lsposedActive: Boolean,
+    javaChecks: List<CheckResult>,
+): LayerStatus {
+    if (!lsposedActive) return LayerStatus.Inactive
+    val scored = javaChecks.filter { it.passed != null }
+    return LayerStatus.Active(
+        hidden = scored.count { it.passed == true },
+        leaks = scored.count { it.passed == false },
+    )
+}
+
+/** Native leaks on vectors the active backend does NOT own — surfaced via the
+ * hero (a warning), not the tile. Zero when the backend covers everything that
+ * leaks, or when SELinux is masking (those are hidden_selinux, not leaks). */
+internal fun unownedNativeLeaks(
+    backend: DisplayNativeBackend,
+    outcomes: Map<String, CheckOutcome>,
+): Int {
+    if (backend.state !is ModuleState.Installed || !moduleActive(backend.state)) return 0
+    val ownMask =
+        when (backend.id) {
+            NativeBackendId.Zygisk -> HookIds.ZYGISK_HOOK_MASK
+            else -> HookIds.KERNEL_HOOK_MASK
+        }
+    val ownedIds = NATIVE_CHECKS.filter { it.hasHookIn(ownMask) }.map { it.id }.toSet()
+    return outcomes.count { (id, outcome) -> outcome is CheckOutcome.Leak && id !in ownedIds }
+}

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/NativeChecks.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/NativeChecks.kt
@@ -26,7 +26,13 @@ internal data class NativeCheckSpec(
 internal fun CheckStatus.toPassed(): Boolean? =
     when (this) {
         CheckStatus.PASS -> true
+
+        // Legacy tri-state: a SELinux-blocked read is "no VPN visible" (green) for
+        // the current UI. The honest split (SELinux vs backend) lives in CheckOutcome.
+        CheckStatus.SELINUX_BLOCKED -> true
+
         CheckStatus.FAIL -> false
+
         CheckStatus.NETWORK_BLOCKED -> null
     }
 

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/NativeChecks.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/NativeChecks.kt
@@ -98,6 +98,13 @@ internal val NATIVE_CHECKS: List<NativeCheckSpec> =
                 ),
         ),
         NativeCheckSpec(
+            // Kernel-only vector: no zygisk hook parses RTM_NEWRULE. The
+            // fib_nl_fill_rule kernel hook trims the per-UID tun policy rules.
+            id = "netlink_getrule",
+            labelRes = R.string.check_netlink_getrule,
+            expectedHooks = setOf(HookIds.Hook.FIB_NL_FILL_RULE),
+        ),
+        NativeCheckSpec(
             id = "proc_route",
             labelRes = R.string.check_proc_route,
             expectedHooks = setOf(HookIds.Hook.FIB_ROUTE_SEQ_SHOW, HookIds.Hook.ZYGISK_OPENAT),
@@ -108,9 +115,12 @@ internal val NATIVE_CHECKS: List<NativeCheckSpec> =
             expectedHooks = setOf(HookIds.Hook.IPV6_ROUTE_SEQ_SHOW, HookIds.Hook.ZYGISK_OPENAT),
         ),
         NativeCheckSpec(
+            // No kernel seq_show hook exists for /proc/net/if_inet6 — INET6_FILL_IFADDR
+            // covers the netlink RTM_GETADDR path, not this procfs read. So a kernel
+            // backend does not own this vector; only the zygisk openat filter (or SELinux).
             id = "proc_if_inet6",
             labelRes = R.string.check_proc_if_inet6,
-            expectedHooks = setOf(HookIds.Hook.INET6_FILL_IFADDR, HookIds.Hook.ZYGISK_OPENAT),
+            expectedHooks = setOf(HookIds.Hook.ZYGISK_OPENAT),
         ),
         NativeCheckSpec(
             id = "proc_dev",

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/NativeChecks.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/NativeChecks.kt
@@ -1,31 +1,19 @@
 package dev.okhsunrog.vpnhide
 
-import dev.okhsunrog.vpnhide.checks.CheckOutput
 import dev.okhsunrog.vpnhide.checks.CheckStatus
-import dev.okhsunrog.vpnhide.checks.checkGetifaddrs
-import dev.okhsunrog.vpnhide.checks.checkIoctlSiocgifconf
-import dev.okhsunrog.vpnhide.checks.checkIoctlSiocgifflags
-import dev.okhsunrog.vpnhide.checks.checkIoctlSiocgifmtu
-import dev.okhsunrog.vpnhide.checks.checkNetlinkGetlink
-import dev.okhsunrog.vpnhide.checks.checkNetlinkGetroute
-import dev.okhsunrog.vpnhide.checks.checkProcNetDev
-import dev.okhsunrog.vpnhide.checks.checkProcNetIfInet6
-import dev.okhsunrog.vpnhide.checks.checkProcNetIpv6Route
-import dev.okhsunrog.vpnhide.checks.checkProcNetRoute
-import dev.okhsunrog.vpnhide.checks.checkSysClassNet
 import dev.okhsunrog.vpnhide.generated.HookIds
 
 /**
- * One native (UniFFI / kmod-or-zygisk-covered) detection probe. [id] is a
- * stable, non-localized key used for logging on the Dashboard protection
- * path; [labelRes] is the user-facing localized name shown on the
- * Diagnostics screen; [run] executes the probe.
+ * One native (kmod / KPM / zygisk-covered) detection probe. [id] is the stable,
+ * non-localized key that matches the Rust probe registry (`run_all` in
+ * lsposed/native) — the app joins probe results to these specs by id. [labelRes]
+ * is the user-facing localized name shown on the Diagnostics screen;
+ * [expectedHooks] are the hooks that should cover this vector.
  */
 internal data class NativeCheckSpec(
     val id: String,
     val labelRes: Int,
     val expectedHooks: Set<HookIds.Hook> = emptySet(),
-    val run: () -> CheckOutput,
 )
 
 /**
@@ -43,9 +31,10 @@ internal fun CheckStatus.toPassed(): Boolean? =
     }
 
 /**
- * The native probe suite, in display order. Run once by [runCoreChecks]; the
- * Diagnostics screen lists the results and the Dashboard summary rolls them up
- * via [toNativeResult] — no second copy of this list or second execution.
+ * The native probe suite, in display order. The probes themselves run in Rust
+ * (one JSON call via [dev.okhsunrog.vpnhide.checks.NativeProbe]); these specs
+ * carry the display label and the expected-hook coverage, joined to the probe
+ * results by [NativeCheckSpec.id].
  */
 internal val NATIVE_CHECKS: List<NativeCheckSpec> =
     listOf(
@@ -53,17 +42,17 @@ internal val NATIVE_CHECKS: List<NativeCheckSpec> =
             id = "ioctl_flags",
             labelRes = R.string.check_ioctl_flags,
             expectedHooks = setOf(HookIds.Hook.DEV_IOCTL, HookIds.Hook.ZYGISK_IOCTL),
-        ) { checkIoctlSiocgifflags() },
+        ),
         NativeCheckSpec(
             id = "ioctl_mtu",
             labelRes = R.string.check_ioctl_mtu,
             expectedHooks = setOf(HookIds.Hook.DEV_IOCTL, HookIds.Hook.ZYGISK_IOCTL),
-        ) { checkIoctlSiocgifmtu() },
+        ),
         NativeCheckSpec(
             id = "ioctl_conf",
             labelRes = R.string.check_ioctl_conf,
             expectedHooks = setOf(HookIds.Hook.SOCK_IOCTL, HookIds.Hook.ZYGISK_IOCTL),
-        ) { checkIoctlSiocgifconf() },
+        ),
         NativeCheckSpec(
             id = "getifaddrs",
             labelRes = R.string.check_getifaddrs,
@@ -74,7 +63,7 @@ internal val NATIVE_CHECKS: List<NativeCheckSpec> =
                     HookIds.Hook.INET6_FILL_IFADDR,
                     HookIds.Hook.ZYGISK_GETIFADDRS,
                 ),
-        ) { checkGetifaddrs() },
+        ),
         NativeCheckSpec(
             id = "netlink_getlink",
             labelRes = R.string.check_netlink_getlink,
@@ -88,7 +77,7 @@ internal val NATIVE_CHECKS: List<NativeCheckSpec> =
                     HookIds.Hook.ZYGISK_RECVFROM,
                     HookIds.Hook.ZYGISK_RECVFROM_CHK,
                 ),
-        ) { checkNetlinkGetlink() },
+        ),
         NativeCheckSpec(
             id = "netlink_getroute",
             labelRes = R.string.check_netlink_getroute,
@@ -101,26 +90,26 @@ internal val NATIVE_CHECKS: List<NativeCheckSpec> =
                     HookIds.Hook.ZYGISK_RECVFROM,
                     HookIds.Hook.ZYGISK_RECVFROM_CHK,
                 ),
-        ) { checkNetlinkGetroute() },
+        ),
         NativeCheckSpec(
             id = "proc_route",
             labelRes = R.string.check_proc_route,
             expectedHooks = setOf(HookIds.Hook.FIB_ROUTE_SEQ_SHOW, HookIds.Hook.ZYGISK_OPENAT),
-        ) { checkProcNetRoute() },
+        ),
         NativeCheckSpec(
             id = "proc_ipv6_route",
             labelRes = R.string.check_proc_ipv6_route,
             expectedHooks = setOf(HookIds.Hook.IPV6_ROUTE_SEQ_SHOW, HookIds.Hook.ZYGISK_OPENAT),
-        ) { checkProcNetIpv6Route() },
+        ),
         NativeCheckSpec(
             id = "proc_if_inet6",
             labelRes = R.string.check_proc_if_inet6,
             expectedHooks = setOf(HookIds.Hook.INET6_FILL_IFADDR, HookIds.Hook.ZYGISK_OPENAT),
-        ) { checkProcNetIfInet6() },
+        ),
         NativeCheckSpec(
             id = "proc_dev",
             labelRes = R.string.check_proc_dev,
             expectedHooks = setOf(HookIds.Hook.ZYGISK_OPENAT),
-        ) { checkProcNetDev() },
-        NativeCheckSpec("sys_class_net", R.string.check_sys_class_net) { checkSysClassNet() },
+        ),
+        NativeCheckSpec("sys_class_net", R.string.check_sys_class_net),
     )

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/VpnOffPrompt.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/VpnOffPrompt.kt
@@ -27,6 +27,18 @@ internal fun VpnOffPrompt(
 ) = RetryPromptCard(R.string.vpn_off_prompt, onRetry, modifier)
 
 /**
+ * Banner + retry button for the "a VPN is up, but VPN Hide itself is not routed
+ * through it (split-tunnelled out)" state — the checks would be meaningless, so
+ * we ask the user to add VPN Hide to the tunnel. Distinct from [VpnOffPrompt]
+ * (no VPN at all) so the guidance is actionable.
+ */
+@Composable
+internal fun SelfNotRoutedPrompt(
+    onRetry: () -> Unit,
+    modifier: Modifier = Modifier,
+) = RetryPromptCard(R.string.self_not_routed_prompt, onRetry, modifier)
+
+/**
  * Banner + retry button for a diagnostics run that *failed* (root dropped, shell
  * exec error) rather than finding the VPN off — kept separate from
  * [VpnOffPrompt] so an active-VPN user isn't wrongly told their VPN is off.

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/checks/NativeProbe.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/checks/NativeProbe.kt
@@ -12,7 +12,7 @@ import kotlinx.serialization.json.Json
  * produced in-process (app view) and by the root-exec'd `vhprobe` bin (ground
  * truth), so this parser serves both.
  */
-enum class CheckStatus { PASS, FAIL, NETWORK_BLOCKED }
+enum class CheckStatus { PASS, FAIL, SELINUX_BLOCKED, NETWORK_BLOCKED }
 
 data class CheckOutput(
     val status: CheckStatus,
@@ -47,6 +47,7 @@ object NativeProbe {
         when (raw) {
             "pass" -> CheckStatus.PASS
             "fail" -> CheckStatus.FAIL
+            "selinux_blocked" -> CheckStatus.SELINUX_BLOCKED
             else -> CheckStatus.NETWORK_BLOCKED
         }
 

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/checks/NativeProbe.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/checks/NativeProbe.kt
@@ -1,0 +1,59 @@
+package dev.okhsunrog.vpnhide.checks
+
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+
+/**
+ * Native detection-probe outcome, shared by both transports.
+ *
+ * Replaces the UniFFI-generated types: the whole native surface is now one
+ * JSON-returning function ([NativeProbe.runAllChecksJson]), so the Rust crate
+ * builds with plain cargo-ndk (no gobley plugin / AGP-9 fork). The same JSON is
+ * produced in-process (app view) and by the root-exec'd `vhprobe` bin (ground
+ * truth), so this parser serves both.
+ */
+enum class CheckStatus { PASS, FAIL, NETWORK_BLOCKED }
+
+data class CheckOutput(
+    val status: CheckStatus,
+    val detail: String,
+)
+
+/** JNI entry to the in-process (app-view) probe run. */
+object NativeProbe {
+    init {
+        System.loadLibrary("vpnhide_checks")
+    }
+
+    /** Runs every native probe in this process and returns a JSON array of
+     * `{id, status, detail}`. Backed by the Rust `run_all_json`. */
+    external fun runAllChecksJson(): String
+
+    /** In-process (app-view) run: probes execute as this app (real uid +
+     * SELinux domain + zygisk/kernel hooks), keyed by stable check id. */
+    fun runAll(): Map<String, CheckOutput> = parse(runAllChecksJson())
+
+    /** Parse a probe JSON blob (from either transport) into id -> outcome. */
+    fun parse(json: String): Map<String, CheckOutput> =
+        runCatching {
+            probeJson.decodeFromString<List<CheckJson>>(json).associate { c ->
+                c.id to CheckOutput(statusOf(c.status), c.detail)
+            }
+        }.getOrDefault(emptyMap())
+
+    private val probeJson = Json { ignoreUnknownKeys = true }
+
+    private fun statusOf(raw: String): CheckStatus =
+        when (raw) {
+            "pass" -> CheckStatus.PASS
+            "fail" -> CheckStatus.FAIL
+            else -> CheckStatus.NETWORK_BLOCKED
+        }
+
+    @Serializable
+    private data class CheckJson(
+        val id: String,
+        val status: String,
+        val detail: String,
+    )
+}

--- a/lsposed/app/src/main/res/values-ru/strings.xml
+++ b/lsposed/app/src/main/res/values-ru/strings.xml
@@ -111,6 +111,7 @@
     <string name="dashboard_protection_unknown">Не проверено</string>
     <string name="dashboard_protection_no_module">Нет модуля</string>
     <string name="dashboard_protection_hooks_inactive">Хуки неактивны</string>
+    <string name="dashboard_protection_not_active">Не активен</string>
     <string name="dashboard_needs_restart">VPN Hide только что включил скрытие для самого себя. Принудительно остановите VPN Hide и откройте снова, чтобы проверить скрытие — перезагрузка устройства не нужна.</string>
     <string name="vpn_off_prompt">VPN не активен. Включите его и нажмите «Повторить», чтобы проверить скрытие.</string>
     <string name="vpn_off_retry">Повторить</string>

--- a/lsposed/app/src/main/res/values-ru/strings.xml
+++ b/lsposed/app/src/main/res/values-ru/strings.xml
@@ -352,6 +352,13 @@
     <string name="badge_pass">ОК</string>
     <string name="badge_fail">ПРОВАЛ</string>
     <string name="badge_info">ИНФО</string>
+    <!-- Плашки исхода проверки в диагностике — кто скрыл VPN на этом векторе. -->
+    <string name="diag_pill_leak">Утечка</string>
+    <string name="diag_pill_backend">Скрыто бэкендом</string>
+    <string name="diag_pill_selinux">Скрыто SELinux</string>
+    <string name="diag_pill_nothing">Нечего скрывать</string>
+    <string name="diag_pill_clean">Чисто</string>
+    <string name="diag_pill_not_measured">Не измерено</string>
     <string name="banner_ready">VPN активен. Для этого приложения включено скрытие. Результаты проверок ниже.</string>
     <string name="banner_added_self">Для VPN Hide включено скрытие. Принудительно остановите VPN Hide и откройте снова, чтобы нативные проверки начали работать — перезагрузка устройства не нужна.</string>
     <string name="banner_network_blocked">Доступ к сети отключён для этого приложения. Проверки ioctl (SIOCGIFFLAGS, SIOCGIFMTU, SIOCGIFCONF) не могут быть выполнены. Включите в Настройки → Приложения → VPN Hide → Мобильный интернет и Wi-Fi.</string>

--- a/lsposed/app/src/main/res/values-ru/strings.xml
+++ b/lsposed/app/src/main/res/values-ru/strings.xml
@@ -353,13 +353,10 @@
     <string name="badge_pass">ОК</string>
     <string name="badge_fail">ПРОВАЛ</string>
     <string name="badge_info">ИНФО</string>
-    <!-- Плашки исхода проверки в диагностике — кто скрыл VPN на этом векторе. -->
-    <string name="diag_pill_leak">Утечка</string>
-    <string name="diag_pill_backend">Скрыто бэкендом</string>
-    <string name="diag_pill_selinux">Скрыто SELinux</string>
-    <string name="diag_pill_nothing">Нечего скрывать</string>
-    <string name="diag_pill_clean">Чисто</string>
-    <string name="diag_pill_not_measured">Не измерено</string>
+    <!-- Статус проверки в диагностике: цветная точка + короткое слово (кто скрыл VPN на этом векторе). -->
+    <string name="diag_status_ok">ОК</string>
+    <string name="diag_status_leak">Утечка</string>
+    <string name="diag_status_nomeasure">Нет данных</string>
     <string name="banner_ready">VPN активен. Для этого приложения включено скрытие. Результаты проверок ниже.</string>
     <string name="banner_added_self">Для VPN Hide включено скрытие. Принудительно остановите VPN Hide и откройте снова, чтобы нативные проверки начали работать — перезагрузка устройства не нужна.</string>
     <string name="banner_network_blocked">Доступ к сети отключён для этого приложения. Проверки ioctl (SIOCGIFFLAGS, SIOCGIFMTU, SIOCGIFCONF) не могут быть выполнены. Включите в Настройки → Приложения → VPN Hide → Мобильный интернет и Wi-Fi.</string>

--- a/lsposed/app/src/main/res/values-ru/strings.xml
+++ b/lsposed/app/src/main/res/values-ru/strings.xml
@@ -114,6 +114,7 @@
     <string name="dashboard_protection_not_active">Не активен</string>
     <string name="dashboard_needs_restart">VPN Hide только что включил скрытие для самого себя. Принудительно остановите VPN Hide и откройте снова, чтобы проверить скрытие — перезагрузка устройства не нужна.</string>
     <string name="vpn_off_prompt">VPN не активен. Включите его и нажмите «Повторить», чтобы проверить скрытие.</string>
+    <string name="self_not_routed_prompt">VPN активен, но VPN Hide через него не идёт. Добавьте VPN Hide в туннель вашего VPN (не исключайте его сплит-туннелем) и нажмите «Повторить» — иначе этим проверкам нечего скрывать.</string>
     <string name="vpn_off_retry">Повторить</string>
     <string name="diag_failed_prompt">Не удалось выполнить проверку скрытия — возможно, отклонён root-доступ или команда завершилась с ошибкой. Нажмите «Повторить». Обычно это временно.</string>
 

--- a/lsposed/app/src/main/res/values-ru/strings.xml
+++ b/lsposed/app/src/main/res/values-ru/strings.xml
@@ -110,7 +110,6 @@
     <string name="dashboard_protection_fail">Не работает</string>
     <string name="dashboard_protection_unknown">Не проверено</string>
     <string name="dashboard_protection_no_module">Нет модуля</string>
-    <string name="dashboard_protection_hooks_inactive">Хуки неактивны</string>
     <string name="dashboard_protection_not_active">Не активен</string>
     <string name="dashboard_needs_restart">VPN Hide только что включил скрытие для самого себя. Принудительно остановите VPN Hide и откройте снова, чтобы проверить скрытие — перезагрузка устройства не нужна.</string>
     <string name="vpn_off_prompt">VPN не активен. Включите его и нажмите «Повторить», чтобы проверить скрытие.</string>
@@ -350,9 +349,6 @@
     <string name="logcat_recording_status">● Запись · %1$s · %2$s</string>
     <string name="logcat_last_recording">Последняя запись · %1$s · %2$s</string>
     <string name="summary_format">%1$d/%2$d пройдено</string>
-    <string name="badge_pass">ОК</string>
-    <string name="badge_fail">ПРОВАЛ</string>
-    <string name="badge_info">ИНФО</string>
     <!-- Статус проверки в диагностике: цветная точка + короткое слово (кто скрыл VPN на этом векторе). -->
     <string name="diag_status_ok">ОК</string>
     <string name="diag_status_leak">Утечка</string>

--- a/lsposed/app/src/main/res/values/strings.xml
+++ b/lsposed/app/src/main/res/values/strings.xml
@@ -157,6 +157,7 @@
     <string name="dashboard_protection_not_active">Not active</string>
     <string name="dashboard_needs_restart">VPN Hide just enabled hiding for itself. Restart VPN Hide (force-stop and reopen) to check hiding — no device reboot needed.</string>
     <string name="vpn_off_prompt">No active VPN. Turn it on, then tap Retry to run the hiding checks.</string>
+    <string name="self_not_routed_prompt">A VPN is active, but VPN Hide isn\'t routed through it. Add VPN Hide to your VPN\'s tunnel (don\'t exclude it with split tunneling), then tap Retry — otherwise there is nothing to hide from these checks.</string>
     <string name="vpn_off_retry">Retry</string>
     <string name="diag_failed_prompt">The hiding checks couldn\'t run — root access may have been denied or a command failed. Tap Retry. This is usually transient.</string>
 

--- a/lsposed/app/src/main/res/values/strings.xml
+++ b/lsposed/app/src/main/res/values/strings.xml
@@ -147,6 +147,7 @@
     <string name="dashboard_protection_unknown">Not checked</string>
     <string name="dashboard_protection_no_module">No module</string>
     <string name="dashboard_protection_hooks_inactive">Hooks inactive</string>
+    <string name="dashboard_protection_not_active">Not active</string>
     <string name="dashboard_needs_restart">VPN Hide just enabled hiding for itself. Restart VPN Hide (force-stop and reopen) to check hiding — no device reboot needed.</string>
     <string name="vpn_off_prompt">No active VPN. Turn it on, then tap Retry to run the hiding checks.</string>
     <string name="vpn_off_retry">Retry</string>

--- a/lsposed/app/src/main/res/values/strings.xml
+++ b/lsposed/app/src/main/res/values/strings.xml
@@ -364,6 +364,7 @@
     <string name="check_getifaddrs" translatable="false">getifaddrs() enum</string>
     <string name="check_netlink_getlink" translatable="false">netlink RTM_GETLINK</string>
     <string name="check_netlink_getroute" translatable="false">netlink RTM_GETROUTE</string>
+    <string name="check_netlink_getrule" translatable="false">netlink RTM_GETRULE</string>
     <string name="check_proc_route" translatable="false">/proc/net/route</string>
     <string name="check_proc_ipv6_route" translatable="false">/proc/net/ipv6_route</string>
     <string name="check_proc_if_inet6" translatable="false">/proc/net/if_inet6</string>

--- a/lsposed/app/src/main/res/values/strings.xml
+++ b/lsposed/app/src/main/res/values/strings.xml
@@ -91,6 +91,13 @@
     <string name="badge_pass">PASS</string>
     <string name="badge_fail">FAIL</string>
     <string name="badge_info">INFO</string>
+    <!-- Diagnostics check outcome pills — who hid the VPN on this vector. -->
+    <string name="diag_pill_leak">Leak</string>
+    <string name="diag_pill_backend">Hidden by backend</string>
+    <string name="diag_pill_selinux">Hidden by SELinux</string>
+    <string name="diag_pill_nothing">Nothing to hide</string>
+    <string name="diag_pill_clean">Clean</string>
+    <string name="diag_pill_not_measured">Not measured</string>
     <string name="banner_ready">VPN is active. Hiding is enabled for this app. Results below.</string>
     <string name="banner_added_self">Enabled hiding for VPN Hide. Restart VPN Hide (force-stop and reopen) for native-level checks to take effect — no device reboot needed.</string>
     <string name="banner_network_blocked">Network access is disabled for this app. ioctl checks (SIOCGIFFLAGS, SIOCGIFMTU, SIOCGIFCONF) cannot run without it. Enable in Settings → Apps → VPN Hide → Mobile data &amp; Wi-Fi.</string>

--- a/lsposed/app/src/main/res/values/strings.xml
+++ b/lsposed/app/src/main/res/values/strings.xml
@@ -392,7 +392,8 @@
     <string name="check_network_callback" translatable="false">NetworkCallback (push)</string>
     <string name="check_link_properties" translatable="false">LinkProperties ifname</string>
     <string name="check_link_properties_routes" translatable="false">LinkProperties routes</string>
-    <string name="check_proxy_host" translatable="false">System proxy properties</string>
+    <string name="check_active_network_info" translatable="false">getActiveNetworkInfo()</string>
+    <string name="check_network_info_vpn" translatable="false">getNetworkInfo(TYPE_VPN)</string>
 
     <!-- Settings screen -->
     <string name="settings_title">Settings</string>

--- a/lsposed/app/src/main/res/values/strings.xml
+++ b/lsposed/app/src/main/res/values/strings.xml
@@ -88,9 +88,6 @@
     <string name="logcat_btn_stop">Stop and save</string>
     <string name="logcat_recording_status">● Recording · %1$s · %2$s</string>
     <string name="logcat_last_recording">Last recording · %1$s · %2$s</string>
-    <string name="badge_pass">PASS</string>
-    <string name="badge_fail">FAIL</string>
-    <string name="badge_info">INFO</string>
     <!-- Diagnostics per-check status: coloured dot + short word (who hid the VPN on this vector). -->
     <string name="diag_status_ok">OK</string>
     <string name="diag_status_selinux" translatable="false">SELinux</string>
@@ -151,7 +148,6 @@
     <string name="dashboard_protection_fail">Not working</string>
     <string name="dashboard_protection_unknown">Not checked</string>
     <string name="dashboard_protection_no_module">No module</string>
-    <string name="dashboard_protection_hooks_inactive">Hooks inactive</string>
     <string name="dashboard_protection_not_active">Not active</string>
     <string name="dashboard_needs_restart">VPN Hide just enabled hiding for itself. Restart VPN Hide (force-stop and reopen) to check hiding — no device reboot needed.</string>
     <string name="vpn_off_prompt">No active VPN. Turn it on, then tap Retry to run the hiding checks.</string>

--- a/lsposed/app/src/main/res/values/strings.xml
+++ b/lsposed/app/src/main/res/values/strings.xml
@@ -91,13 +91,11 @@
     <string name="badge_pass">PASS</string>
     <string name="badge_fail">FAIL</string>
     <string name="badge_info">INFO</string>
-    <!-- Diagnostics check outcome pills — who hid the VPN on this vector. -->
-    <string name="diag_pill_leak">Leak</string>
-    <string name="diag_pill_backend">Hidden by backend</string>
-    <string name="diag_pill_selinux">Hidden by SELinux</string>
-    <string name="diag_pill_nothing">Nothing to hide</string>
-    <string name="diag_pill_clean">Clean</string>
-    <string name="diag_pill_not_measured">Not measured</string>
+    <!-- Diagnostics per-check status: coloured dot + short word (who hid the VPN on this vector). -->
+    <string name="diag_status_ok">OK</string>
+    <string name="diag_status_selinux" translatable="false">SELinux</string>
+    <string name="diag_status_leak">Leak</string>
+    <string name="diag_status_nomeasure">No data</string>
     <string name="banner_ready">VPN is active. Hiding is enabled for this app. Results below.</string>
     <string name="banner_added_self">Enabled hiding for VPN Hide. Restart VPN Hide (force-stop and reopen) for native-level checks to take effect — no device reboot needed.</string>
     <string name="banner_network_blocked">Network access is disabled for this app. ioctl checks (SIOCGIFFLAGS, SIOCGIFMTU, SIOCGIFCONF) cannot run without it. Enable in Settings → Apps → VPN Hide → Mobile data &amp; Wi-Fi.</string>

--- a/lsposed/app/src/test/kotlin/dev/okhsunrog/vpnhide/CheckStatusToPassedTest.kt
+++ b/lsposed/app/src/test/kotlin/dev/okhsunrog/vpnhide/CheckStatusToPassedTest.kt
@@ -12,4 +12,11 @@ class CheckStatusToPassedTest {
         assertEquals(false, CheckStatus.FAIL.toPassed())
         assertNull(CheckStatus.NETWORK_BLOCKED.toPassed())
     }
+
+    @Test
+    fun `selinux-blocked maps to true for the legacy tri-state`() {
+        // A SELinux-blocked read is "no VPN visible" (green) for the passed-based
+        // UI; the honest SELinux-vs-backend split lives in CheckOutcome instead.
+        assertEquals(true, CheckStatus.SELINUX_BLOCKED.toPassed())
+    }
 }

--- a/lsposed/app/src/test/kotlin/dev/okhsunrog/vpnhide/ClassifyJavaOutcomeTest.kt
+++ b/lsposed/app/src/test/kotlin/dev/okhsunrog/vpnhide/ClassifyJavaOutcomeTest.kt
@@ -1,0 +1,30 @@
+package dev.okhsunrog.vpnhide
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * The Java layer has no root differential; the self-in-tunnel gate guarantees a
+ * VPN artifact is present, so the outcome is binary — clean is hidden-by-LSPosed,
+ * dirty is a leak — with NotMeasured only as a defensive edge for a probe that
+ * could not run (passed == null). There is no nothing-to-leak on this layer.
+ */
+class ClassifyJavaOutcomeTest {
+    @Test
+    fun `app saw the VPN is a leak`() {
+        assertEquals(CheckOutcome.Leak, classifyJavaOutcome(false))
+    }
+
+    @Test
+    fun `clean app view is hidden by the backend`() {
+        assertEquals(CheckOutcome.HiddenByBackend, classifyJavaOutcome(true))
+    }
+
+    @Test
+    fun `a probe that could not run is not measured`() {
+        assertEquals(
+            CheckOutcome.NotMeasured(NotMeasuredReason.NoGroundTruth),
+            classifyJavaOutcome(null),
+        )
+    }
+}

--- a/lsposed/app/src/test/kotlin/dev/okhsunrog/vpnhide/ClassifyNativeOutcomeTest.kt
+++ b/lsposed/app/src/test/kotlin/dev/okhsunrog/vpnhide/ClassifyNativeOutcomeTest.kt
@@ -1,0 +1,118 @@
+package dev.okhsunrog.vpnhide
+
+import dev.okhsunrog.vpnhide.checks.CheckOutput
+import dev.okhsunrog.vpnhide.checks.CheckStatus
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * The root-differential is the core of the diagnostics redesign: it splits a
+ * clean app-view into hidden-by-backend / hidden-by-SELinux / nothing-to-leak by
+ * comparing against an unfiltered root ground truth. These cases pin the exact
+ * truth table verified on-device (Pixel 4a / 8 Pro, enforcing & permissive).
+ */
+class ClassifyNativeOutcomeTest {
+    private fun out(
+        status: CheckStatus,
+        detail: String = "",
+    ) = CheckOutput(status, detail)
+
+    // ── A leak is a leak, whatever the ground truth says ──────────────────
+
+    @Test
+    fun `app sees VPN is always a leak`() {
+        for (gt in listOf(null, out(CheckStatus.PASS), out(CheckStatus.FAIL))) {
+            assertEquals(CheckOutcome.Leak, classifyNativeOutcome(out(CheckStatus.FAIL), gt))
+        }
+    }
+
+    // ── Probe could not run ───────────────────────────────────────────────
+
+    @Test
+    fun `network-blocked app view is not measured, regardless of ground truth`() {
+        assertEquals(
+            CheckOutcome.NotMeasured(NotMeasuredReason.NoNetworkPermission),
+            classifyNativeOutcome(out(CheckStatus.NETWORK_BLOCKED), out(CheckStatus.FAIL)),
+        )
+    }
+
+    // ── Clean app view (PASS): who hid it? ────────────────────────────────
+
+    @Test
+    fun `pass with root also clean is nothing to leak`() {
+        assertEquals(
+            CheckOutcome.NothingToLeak,
+            classifyNativeOutcome(out(CheckStatus.PASS), out(CheckStatus.PASS)),
+        )
+    }
+
+    @Test
+    fun `pass while root sees the VPN is hidden by the backend`() {
+        assertEquals(
+            CheckOutcome.HiddenByBackend,
+            classifyNativeOutcome(out(CheckStatus.PASS), out(CheckStatus.FAIL)),
+        )
+    }
+
+    @Test
+    fun `pass without a usable ground truth is not measured`() {
+        assertEquals(
+            CheckOutcome.NotMeasured(NotMeasuredReason.NoGroundTruth),
+            classifyNativeOutcome(out(CheckStatus.PASS), null),
+        )
+        // Root itself blocked/limited → still cannot attribute.
+        assertEquals(
+            CheckOutcome.NotMeasured(NotMeasuredReason.NoGroundTruth),
+            classifyNativeOutcome(out(CheckStatus.PASS), out(CheckStatus.SELINUX_BLOCKED)),
+        )
+        assertEquals(
+            CheckOutcome.NotMeasured(NotMeasuredReason.NoGroundTruth),
+            classifyNativeOutcome(out(CheckStatus.PASS), out(CheckStatus.NETWORK_BLOCKED)),
+        )
+    }
+
+    // ── SELinux-blocked app view: the honest split from the redesign ──────
+
+    @Test
+    fun `selinux-blocked while root sees the VPN is hidden by SELinux, not the backend`() {
+        assertEquals(
+            CheckOutcome.HiddenBySelinux,
+            classifyNativeOutcome(out(CheckStatus.SELINUX_BLOCKED), out(CheckStatus.FAIL)),
+        )
+    }
+
+    @Test
+    fun `selinux-blocked but root is clean is nothing to leak (empty ground truth wins)`() {
+        // The block is moot when there is nothing on that surface to hide.
+        assertEquals(
+            CheckOutcome.NothingToLeak,
+            classifyNativeOutcome(out(CheckStatus.SELINUX_BLOCKED), out(CheckStatus.PASS)),
+        )
+    }
+
+    @Test
+    fun `selinux-blocked without a usable ground truth is not measured`() {
+        assertEquals(
+            CheckOutcome.NotMeasured(NotMeasuredReason.NoGroundTruth),
+            classifyNativeOutcome(out(CheckStatus.SELINUX_BLOCKED), null),
+        )
+    }
+
+    // ── Stable tokens (agent bridge / debug export wire) ──────────────────
+
+    @Test
+    fun `tokens are stable`() {
+        assertEquals("leak", CheckOutcome.Leak.token())
+        assertEquals("hidden_backend", CheckOutcome.HiddenByBackend.token())
+        assertEquals("hidden_selinux", CheckOutcome.HiddenBySelinux.token())
+        assertEquals("nothing_to_leak", CheckOutcome.NothingToLeak.token())
+        assertEquals(
+            "not_measured_no_network",
+            CheckOutcome.NotMeasured(NotMeasuredReason.NoNetworkPermission).token(),
+        )
+        assertEquals(
+            "not_measured_no_ground_truth",
+            CheckOutcome.NotMeasured(NotMeasuredReason.NoGroundTruth).token(),
+        )
+    }
+}

--- a/lsposed/app/src/test/kotlin/dev/okhsunrog/vpnhide/DashboardUiStateTest.kt
+++ b/lsposed/app/src/test/kotlin/dev/okhsunrog/vpnhide/DashboardUiStateTest.kt
@@ -6,6 +6,10 @@ import org.junit.Assert.assertTrue
 import org.junit.Test
 
 class DashboardUiStateTest {
+    private val ok = LayerStatus.Active(hidden = 5, leaks = 0)
+    private val partial = LayerStatus.Active(hidden = 5, leaks = 1)
+    private val broken = LayerStatus.Active(hidden = 0, leaks = 3)
+
     @Test
     fun `computeHeroStatus returns protected when checks pass and there are no issues`() {
         assertEquals(
@@ -13,7 +17,7 @@ class DashboardUiStateTest {
             computeHeroStatus(
                 state =
                     dashboardState(
-                        protection = ProtectionCheck.Checked(NativeResult.Ok, JavaResult.Ok),
+                        protection = ProtectionCheck.Checked(ok, ok),
                     ),
                 errorCount = 0,
                 warningCount = 0,
@@ -25,7 +29,7 @@ class DashboardUiStateTest {
     fun `computeHeroStatus ignores info messages`() {
         val state =
             dashboardState(
-                protection = ProtectionCheck.Checked(NativeResult.Ok, JavaResult.Ok),
+                protection = ProtectionCheck.Checked(ok, ok),
                 messages = listOf(DashboardMessage(DashboardMessageSeverity.INFO, "note")),
             )
 
@@ -40,14 +44,14 @@ class DashboardUiStateTest {
     }
 
     @Test
-    fun `protectionFullyPassed is true only when native and java checks pass`() {
-        assertTrue(protectionFullyPassed(ProtectionCheck.Checked(NativeResult.Ok, JavaResult.Ok)))
+    fun `protectionFullyPassed is true only when native and java layers are ok`() {
+        assertTrue(protectionFullyPassed(ProtectionCheck.Checked(ok, ok)))
         assertFalse(protectionFullyPassed(ProtectionCheck.NoVpn))
         assertFalse(protectionFullyPassed(ProtectionCheck.NeedsRestart))
-        assertFalse(protectionFullyPassed(ProtectionCheck.Checked(NativeResult.NoModule, JavaResult.Ok)))
-        assertFalse(protectionFullyPassed(ProtectionCheck.Checked(NativeResult.Fail(passed = 2, failed = 1), JavaResult.Ok)))
-        assertFalse(protectionFullyPassed(ProtectionCheck.Checked(NativeResult.Ok, JavaResult.Fail(failedChecks = 1))))
-        assertFalse(protectionFullyPassed(ProtectionCheck.Checked(NativeResult.Ok, JavaResult.HooksInactive)))
+        assertFalse(protectionFullyPassed(ProtectionCheck.Checked(LayerStatus.Absent, ok)))
+        assertFalse(protectionFullyPassed(ProtectionCheck.Checked(partial, ok)))
+        assertFalse(protectionFullyPassed(ProtectionCheck.Checked(ok, partial)))
+        assertFalse(protectionFullyPassed(ProtectionCheck.Checked(ok, LayerStatus.Inactive)))
     }
 
     @Test
@@ -63,7 +67,7 @@ class DashboardUiStateTest {
     }
 
     @Test
-    fun `computeHeroStatus returns attention for restart partial native or warning`() {
+    fun `computeHeroStatus returns attention for restart partial layer or warning`() {
         assertEquals(
             HeroStatus.Attention,
             computeHeroStatus(
@@ -77,7 +81,20 @@ class DashboardUiStateTest {
             computeHeroStatus(
                 state =
                     dashboardState(
-                        protection = ProtectionCheck.Checked(NativeResult.Fail(passed = 2, failed = 1), JavaResult.Ok),
+                        protection = ProtectionCheck.Checked(partial, ok),
+                    ),
+                errorCount = 0,
+                warningCount = 0,
+            ),
+        )
+        // A couple of failing Java probes is Partial (works, has a gap) → Attention,
+        // no longer a hard "not working".
+        assertEquals(
+            HeroStatus.Attention,
+            computeHeroStatus(
+                state =
+                    dashboardState(
+                        protection = ProtectionCheck.Checked(ok, partial),
                     ),
                 errorCount = 0,
                 warningCount = 0,
@@ -88,7 +105,7 @@ class DashboardUiStateTest {
             computeHeroStatus(
                 state =
                     dashboardState(
-                        protection = ProtectionCheck.Checked(NativeResult.Ok, JavaResult.Ok),
+                        protection = ProtectionCheck.Checked(ok, ok),
                     ),
                 errorCount = 0,
                 warningCount = 1,
@@ -97,13 +114,13 @@ class DashboardUiStateTest {
     }
 
     @Test
-    fun `computeHeroStatus returns unprotected for hard failures or errors`() {
+    fun `computeHeroStatus returns unprotected for broken layer or errors`() {
         assertEquals(
             HeroStatus.Unprotected,
             computeHeroStatus(
                 state =
                     dashboardState(
-                        protection = ProtectionCheck.Checked(NativeResult.Fail(passed = 0, failed = 3), JavaResult.Ok),
+                        protection = ProtectionCheck.Checked(broken, ok),
                     ),
                 errorCount = 0,
                 warningCount = 0,
@@ -114,7 +131,7 @@ class DashboardUiStateTest {
             computeHeroStatus(
                 state =
                     dashboardState(
-                        protection = ProtectionCheck.Checked(NativeResult.Ok, JavaResult.Fail(failedChecks = 1)),
+                        protection = ProtectionCheck.Checked(ok, broken),
                     ),
                 errorCount = 0,
                 warningCount = 0,
@@ -125,7 +142,7 @@ class DashboardUiStateTest {
             computeHeroStatus(
                 state =
                     dashboardState(
-                        protection = ProtectionCheck.Checked(NativeResult.Ok, JavaResult.Ok),
+                        protection = ProtectionCheck.Checked(ok, ok),
                     ),
                 errorCount = 1,
                 warningCount = 0,
@@ -161,7 +178,7 @@ class DashboardUiStateTest {
         zygisk: ModuleState = ModuleState.NotInstalled,
         lsposed: LsposedState = LsposedState.NotInstalled,
         ports: ModuleState = ModuleState.NotInstalled,
-        protection: ProtectionCheck = ProtectionCheck.Checked(NativeResult.Ok, JavaResult.Ok),
+        protection: ProtectionCheck = ProtectionCheck.Checked(ok, ok),
         messages: List<DashboardMessage> = emptyList(),
     ): DashboardState =
         DashboardState(

--- a/lsposed/app/src/test/kotlin/dev/okhsunrog/vpnhide/DashboardUiStateTest.kt
+++ b/lsposed/app/src/test/kotlin/dev/okhsunrog/vpnhide/DashboardUiStateTest.kt
@@ -48,6 +48,7 @@ class DashboardUiStateTest {
         assertTrue(protectionFullyPassed(ProtectionCheck.Checked(ok, ok)))
         assertFalse(protectionFullyPassed(ProtectionCheck.NoVpn))
         assertFalse(protectionFullyPassed(ProtectionCheck.NeedsRestart))
+        assertFalse(protectionFullyPassed(ProtectionCheck.SelfNotRouted))
         assertFalse(protectionFullyPassed(ProtectionCheck.Checked(LayerStatus.Absent, ok)))
         assertFalse(protectionFullyPassed(ProtectionCheck.Checked(partial, ok)))
         assertFalse(protectionFullyPassed(ProtectionCheck.Checked(ok, partial)))
@@ -72,6 +73,16 @@ class DashboardUiStateTest {
             HeroStatus.Attention,
             computeHeroStatus(
                 state = dashboardState(protection = ProtectionCheck.NeedsRestart),
+                errorCount = 0,
+                warningCount = 0,
+            ),
+        )
+        // A VPN is up but this app is split-tunnelled out — action needed, not a
+        // hard failure and not "VPN off".
+        assertEquals(
+            HeroStatus.Attention,
+            computeHeroStatus(
+                state = dashboardState(protection = ProtectionCheck.SelfNotRouted),
                 errorCount = 0,
                 warningCount = 0,
             ),

--- a/lsposed/app/src/test/kotlin/dev/okhsunrog/vpnhide/LayerStatusTest.kt
+++ b/lsposed/app/src/test/kotlin/dev/okhsunrog/vpnhide/LayerStatusTest.kt
@@ -105,13 +105,18 @@ class LayerStatusTest {
     }
 
     @Test
-    fun `java layer counts passed as hidden and failed as leaks, ignoring not-run`() {
+    fun `java layer counts hidden-by-backend and leaks off the outcome, ignoring not-measured`() {
         val checks =
             listOf(
-                CheckResult("a", passed = true, detail = ""),
-                CheckResult("b", passed = true, detail = ""),
-                CheckResult("c", passed = false, detail = ""),
-                CheckResult("d", passed = null, detail = ""),
+                CheckResult("a", passed = true, detail = "", outcome = CheckOutcome.HiddenByBackend),
+                CheckResult("b", passed = true, detail = "", outcome = CheckOutcome.HiddenByBackend),
+                CheckResult("c", passed = false, detail = "", outcome = CheckOutcome.Leak),
+                CheckResult(
+                    "d",
+                    passed = null,
+                    detail = "",
+                    outcome = CheckOutcome.NotMeasured(NotMeasuredReason.NoGroundTruth),
+                ),
             )
         assertEquals(
             LayerStatus.Active(hidden = 2, leaks = 1),

--- a/lsposed/app/src/test/kotlin/dev/okhsunrog/vpnhide/LayerStatusTest.kt
+++ b/lsposed/app/src/test/kotlin/dev/okhsunrog/vpnhide/LayerStatusTest.kt
@@ -1,0 +1,121 @@
+package dev.okhsunrog.vpnhide
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * Layer rollup: presence gates before the checks (an inactive backend can never
+ * render a verdict), and the tile is judged only on vectors the backend owns —
+ * the fix for the old "inactive backend shows Partial" from SELinux-only passes.
+ */
+class LayerStatusTest {
+    private fun installed(active: Boolean) = ModuleState.Installed(version = "1.0", active = active, targetCount = 1)
+
+    private fun kmod(state: ModuleState) =
+        displayNativeBackend(
+            NativeBackendStates(kmod = state, kpm = ModuleState.NotInstalled, zygisk = ModuleState.NotInstalled),
+        )
+
+    private fun zygisk(state: ModuleState) =
+        displayNativeBackend(
+            NativeBackendStates(kmod = ModuleState.NotInstalled, kpm = ModuleState.NotInstalled, zygisk = state),
+        )
+
+    // ── verdict ───────────────────────────────────────────────────────────
+
+    @Test
+    fun `verdict is Ok when nothing owned leaks`() {
+        assertEquals(Verdict.Ok, LayerStatus.Active(hidden = 5, leaks = 0).verdict)
+    }
+
+    @Test
+    fun `verdict is Partial when it hides some but an owned vector still leaks`() {
+        assertEquals(Verdict.Partial, LayerStatus.Active(hidden = 5, leaks = 1).verdict)
+    }
+
+    @Test
+    fun `verdict is Broken when active but hid nothing while leaking`() {
+        assertEquals(Verdict.Broken, LayerStatus.Active(hidden = 0, leaks = 3).verdict)
+    }
+
+    // ── presence gates before checks ───────────────────────────────────────
+
+    @Test
+    fun `native layer is Absent when the module is not installed`() {
+        assertEquals(LayerStatus.Absent, summarizeNativeLayer(kmod(ModuleState.NotInstalled), emptyMap()))
+    }
+
+    @Test
+    fun `native layer is Inactive when installed but not loaded`() {
+        // Even with SELinux-only passes in the map, an inactive backend is never Active.
+        val outcomes = mapOf("ioctl_flags" to CheckOutcome.HiddenBySelinux)
+        assertEquals(LayerStatus.Inactive, summarizeNativeLayer(kmod(installed(active = false)), outcomes))
+    }
+
+    // ── the tile is judged only on OWNED vectors ───────────────────────────
+
+    @Test
+    fun `a leak on a vector the kernel backend does not own is out of scope for the tile`() {
+        // ioctl_flags: kernel-owned (dev_ioctl). proc_dev: zygisk-only (no kernel
+        // hook) → a leak there must NOT drag the kmod tile toward Broken.
+        val outcomes =
+            mapOf(
+                "ioctl_flags" to CheckOutcome.HiddenByBackend,
+                "ioctl_mtu" to CheckOutcome.HiddenByBackend,
+                "proc_dev" to CheckOutcome.Leak,
+            )
+        val layer = summarizeNativeLayer(kmod(installed(active = true)), outcomes)
+        assertEquals(LayerStatus.Active(hidden = 2, leaks = 0), layer)
+        // …but it is still surfaced, via the unowned-leak count (the hero warning).
+        assertEquals(1, unownedNativeLeaks(kmod(installed(active = true)), outcomes))
+    }
+
+    @Test
+    fun `a leak on an owned vector counts against the tile`() {
+        val outcomes = mapOf("ioctl_flags" to CheckOutcome.Leak)
+        val layer = summarizeNativeLayer(kmod(installed(active = true)), outcomes)
+        assertEquals(LayerStatus.Active(hidden = 0, leaks = 1), layer)
+        assertEquals(Verdict.Broken, (layer as LayerStatus.Active).verdict)
+    }
+
+    @Test
+    fun `ownership is per backend family - zygisk owns what the kernel does not`() {
+        // Mirror image of the kmod case: proc_dev (zygisk openat) is zygisk-owned;
+        // netlink_getrule (fib_nl_fill_rule, kernel-only — no zygisk parses rule
+        // dumps) is not. That kernel-only leak is out of scope for the zygisk tile
+        // and shows up as an unowned leak instead. (Note: ioctl_flags would NOT
+        // work here — it is zygisk-owned too, via zygisk_ioctl.)
+        val outcomes =
+            mapOf(
+                "proc_dev" to CheckOutcome.Leak,
+                "netlink_getrule" to CheckOutcome.Leak,
+            )
+        assertEquals(
+            LayerStatus.Active(hidden = 0, leaks = 1),
+            summarizeNativeLayer(zygisk(installed(active = true)), outcomes),
+        )
+        assertEquals(1, unownedNativeLeaks(zygisk(installed(active = true)), outcomes))
+    }
+
+    // ── java layer ─────────────────────────────────────────────────────────
+
+    @Test
+    fun `java layer is Inactive when LSPosed is not active`() {
+        assertEquals(LayerStatus.Inactive, summarizeJavaLayer(lsposedActive = false, javaChecks = emptyList()))
+    }
+
+    @Test
+    fun `java layer counts passed as hidden and failed as leaks, ignoring not-run`() {
+        val checks =
+            listOf(
+                CheckResult("a", passed = true, detail = ""),
+                CheckResult("b", passed = true, detail = ""),
+                CheckResult("c", passed = false, detail = ""),
+                CheckResult("d", passed = null, detail = ""),
+            )
+        assertEquals(
+            LayerStatus.Active(hidden = 2, leaks = 1),
+            summarizeJavaLayer(lsposedActive = true, javaChecks = checks),
+        )
+    }
+}

--- a/lsposed/gradle/libs.versions.toml
+++ b/lsposed/gradle/libs.versions.toml
@@ -11,7 +11,6 @@ core-ktx = "1.19.0"
 datastore = "1.2.1"
 material-kolor = "4.1.1"
 squircle-shape = "5.3.0"
-gobley = "0.3.8-agp9.1.okhsunrog1"
 detekt = "1.23.8"
 cpd = "3.5"
 kotlinx-serialization-json = "1.9.0"
@@ -37,7 +36,5 @@ kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 kotlin-atomicfu = { id = "org.jetbrains.kotlin.plugin.atomicfu", version.ref = "kotlin" }
 kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
 compose-compiler = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
-gobley-cargo = { id = "dev.gobley.cargo", version.ref = "gobley" }
-gobley-uniffi = { id = "dev.gobley.uniffi", version.ref = "gobley" }
 detekt = { id = "io.gitlab.arturbosch.detekt", version.ref = "detekt" }
 cpd = { id = "de.aaschmid.cpd", version.ref = "cpd" }

--- a/lsposed/native/Cargo.lock
+++ b/lsposed/native/Cargo.lock
@@ -3,111 +3,10 @@
 version = 4
 
 [[package]]
-name = "anyhow"
-version = "1.0.102"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
-
-[[package]]
-name = "askama"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d4744ed2eef2645831b441d8f5459689ade2ab27c854488fbab1fbe94fce1a7"
-dependencies = [
- "askama_derive",
- "itoa",
- "percent-encoding",
- "serde",
- "serde_json",
-]
-
-[[package]]
-name = "askama_derive"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d661e0f57be36a5c14c48f78d09011e67e0cb618f269cca9f2fd8d15b68c46ac"
-dependencies = [
- "askama_parser",
- "basic-toml",
- "memchr",
- "proc-macro2",
- "quote",
- "rustc-hash",
- "serde",
- "serde_derive",
- "syn",
-]
-
-[[package]]
-name = "askama_parser"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf315ce6524c857bb129ff794935cf6d42c82a6cff60526fe2a63593de4d0d4f"
-dependencies = [
- "memchr",
- "serde",
- "serde_derive",
- "winnow",
-]
-
-[[package]]
-name = "autocfg"
-version = "1.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
-
-[[package]]
-name = "basic-toml"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba62675e8242a4c4e806d12f11d136e626e6c8361d6b829310732241652a178a"
-dependencies = [
- "serde",
-]
-
-[[package]]
-name = "bitflags"
-version = "2.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
-
-[[package]]
 name = "bytes"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ae3f5d315924270530207e2a68396c3cc547f6dca3fbdca317cfb1a51edb593"
-
-[[package]]
-name = "camino"
-version = "1.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4ce8d3bd5823c7504d3f579f13e7b2f3da252fcb938c594d5680ee508bf846f"
-dependencies = [
- "serde_core",
-]
-
-[[package]]
-name = "cargo-platform"
-version = "0.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e35af189006b9c0f00a064685c727031e3ed2d8020f7ba284d78cc2671bd36ea"
-dependencies = [
- "serde",
-]
-
-[[package]]
-name = "cargo_metadata"
-version = "0.19.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd5eb614ed4c27c5d706420e4320fbe3216ab31fa1c33cd8246ac36dae4479ba"
-dependencies = [
- "camino",
- "cargo-platform",
- "semver",
- "serde",
- "serde_json",
- "thiserror",
-]
 
 [[package]]
 name = "cfg-if"
@@ -116,84 +15,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
-name = "equivalent"
-version = "1.0.2"
+name = "combine"
+version = "4.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
-
-[[package]]
-name = "errno"
-version = "0.3.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
+checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
 dependencies = [
- "libc",
- "windows-sys",
-]
-
-[[package]]
-name = "fastrand"
-version = "2.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
-
-[[package]]
-name = "fs-err"
-version = "2.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88a41f105fe1d5b6b34b2055e3dc59bb79b46b48b2040b9e6c7b4b5de097aa41"
-dependencies = [
- "autocfg",
-]
-
-[[package]]
-name = "getrandom"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
-dependencies = [
- "cfg-if",
- "libc",
- "r-efi",
-]
-
-[[package]]
-name = "glob"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
-
-[[package]]
-name = "goblin"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b363a30c165f666402fe6a3024d3bec7ebc898f96a4a23bd1c99f8dbf3f4f47"
-dependencies = [
- "log",
- "plain",
- "scroll",
-]
-
-[[package]]
-name = "hashbrown"
-version = "0.17.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
-
-[[package]]
-name = "heck"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
-
-[[package]]
-name = "indexmap"
-version = "2.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
-dependencies = [
- "equivalent",
- "hashbrown",
+ "bytes",
+ "memchr",
 ]
 
 [[package]]
@@ -203,16 +31,59 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
+name = "jni"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
+dependencies = [
+ "cfg-if",
+ "combine",
+ "jni-macros",
+ "jni-sys",
+ "log",
+ "simd_cesu8",
+ "thiserror",
+ "walkdir",
+ "windows-link",
+]
+
+[[package]]
+name = "jni-macros"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "simd_cesu8",
+ "syn",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6377a88cb3910bee9b0fa88d4f42e1d2da8e79915598f65fb0c7ee14c878af2"
+dependencies = [
+ "jni-sys-macros",
+]
+
+[[package]]
+name = "jni-sys-macros"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
+dependencies = [
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "libc"
 version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
-
-[[package]]
-name = "linux-raw-sys"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "log"
@@ -225,40 +96,6 @@ name = "memchr"
 version = "2.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
-
-[[package]]
-name = "minimal-lexical"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
-
-[[package]]
-name = "nom"
-version = "7.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
-dependencies = [
- "memchr",
- "minimal-lexical",
-]
-
-[[package]]
-name = "once_cell"
-version = "1.21.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
-
-[[package]]
-name = "percent-encoding"
-version = "2.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
-
-[[package]]
-name = "plain"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "proc-macro2"
@@ -279,48 +116,21 @@ dependencies = [
 ]
 
 [[package]]
-name = "r-efi"
-version = "6.0.0"
+name = "rustc_version"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
-
-[[package]]
-name = "rustc-hash"
-version = "2.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
-
-[[package]]
-name = "rustix"
-version = "1.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
 dependencies = [
- "bitflags",
- "errno",
- "libc",
- "linux-raw-sys",
- "windows-sys",
+ "semver",
 ]
 
 [[package]]
-name = "scroll"
-version = "0.12.0"
+name = "same-file"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ab8598aa408498679922eff7fa985c25d58a90771bd6be794434c5277eab1a6"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
- "scroll_derive",
-]
-
-[[package]]
-name = "scroll_derive"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1783eabc414609e28a5ba76aee5ddd52199f7107a0b24c2e9746a1ecc34a683d"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
+ "winapi-util",
 ]
 
 [[package]]
@@ -328,10 +138,6 @@ name = "semver"
 version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
-dependencies = [
- "serde",
- "serde_core",
-]
 
 [[package]]
 name = "serde"
@@ -377,22 +183,20 @@ dependencies = [
 ]
 
 [[package]]
-name = "siphasher"
-version = "0.3.11"
+name = "simd_cesu8"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38b58827f4464d87d377d175e90bf58eb00fd8716ff0a62f80356b5e61555d0d"
+checksum = "94f90157bb87cddf702797c5dadfa0be7d266cdf49e22da2fcaa32eff75b2c33"
+dependencies = [
+ "rustc_version",
+ "simdutf8",
+]
 
 [[package]]
-name = "smawk"
-version = "0.3.3"
+name = "simdutf8"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8e2fb0f499abb4d162f2bedad68f5ef91a1682b5a03596ddb67efd37768d100"
-
-[[package]]
-name = "static_assertions"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
 name = "syn"
@@ -403,28 +207,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
-]
-
-[[package]]
-name = "tempfile"
-version = "3.27.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
-dependencies = [
- "fastrand",
- "getrandom",
- "once_cell",
- "rustix",
- "windows-sys",
-]
-
-[[package]]
-name = "textwrap"
-version = "0.16.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c13547615a44dc9c452a8a534638acdf07120d4b6847c8178705da06306a3057"
-dependencies = [
- "smawk",
 ]
 
 [[package]]
@@ -448,154 +230,38 @@ dependencies = [
 ]
 
 [[package]]
-name = "toml"
-version = "0.5.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4f7f0dd8d50a853a531c426359045b1998f04219d88799810762cd4ad314234"
-dependencies = [
- "serde",
-]
-
-[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
-name = "uniffi"
-version = "0.29.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3291800a6b06569f7d3e15bdb6dc235e0f0c8bd3eb07177f430057feb076415f"
-dependencies = [
- "anyhow",
- "cargo_metadata",
- "uniffi_bindgen",
- "uniffi_core",
- "uniffi_macros",
- "uniffi_pipeline",
-]
-
-[[package]]
-name = "uniffi_bindgen"
-version = "0.29.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a04b99fa7796eaaa7b87976a0dbdd1178dc1ee702ea00aca2642003aef9b669e"
-dependencies = [
- "anyhow",
- "askama",
- "camino",
- "cargo_metadata",
- "fs-err",
- "glob",
- "goblin",
- "heck",
- "indexmap",
- "once_cell",
- "serde",
- "tempfile",
- "textwrap",
- "toml",
- "uniffi_internal_macros",
- "uniffi_meta",
- "uniffi_pipeline",
- "uniffi_udl",
-]
-
-[[package]]
-name = "uniffi_core"
-version = "0.29.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f38a9a27529ccff732f8efddb831b65b1e07f7dea3fd4cacd4a35a8c4b253b98"
-dependencies = [
- "anyhow",
- "bytes",
- "once_cell",
- "static_assertions",
-]
-
-[[package]]
-name = "uniffi_internal_macros"
-version = "0.29.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09acd2ce09c777dd65ee97c251d33c8a972afc04873f1e3b21eb3492ade16933"
-dependencies = [
- "anyhow",
- "indexmap",
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "uniffi_macros"
-version = "0.29.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5596f178c4f7aafa1a501c4e0b96236a96bc2ef92bdb453d83e609dad0040152"
-dependencies = [
- "camino",
- "fs-err",
- "once_cell",
- "proc-macro2",
- "quote",
- "serde",
- "syn",
- "toml",
- "uniffi_meta",
-]
-
-[[package]]
-name = "uniffi_meta"
-version = "0.29.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "beadc1f460eb2e209263c49c4f5b19e9a02e00a3b2b393f78ad10d766346ecff"
-dependencies = [
- "anyhow",
- "siphasher",
- "uniffi_internal_macros",
- "uniffi_pipeline",
-]
-
-[[package]]
-name = "uniffi_pipeline"
-version = "0.29.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd76b3ac8a2d964ca9fce7df21c755afb4c77b054a85ad7a029ad179cc5abb8a"
-dependencies = [
- "anyhow",
- "heck",
- "indexmap",
- "tempfile",
- "uniffi_internal_macros",
-]
-
-[[package]]
-name = "uniffi_udl"
-version = "0.29.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4319cf905911d70d5b97ce0f46f101619a22e9a189c8c46d797a9955e9233716"
-dependencies = [
- "anyhow",
- "textwrap",
- "uniffi_meta",
- "weedle2",
-]
-
-[[package]]
 name = "vpnhide_checks"
 version = "1.0.0"
 dependencies = [
+ "jni",
  "libc",
- "uniffi",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
-name = "weedle2"
-version = "5.0.0"
+name = "walkdir"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "998d2c24ec099a87daf9467808859f9d82b61f1d9c9701251aea037f514eae0e"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
 dependencies = [
- "nom",
+ "same-file",
+ "winapi-util",
+]
+
+[[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys",
 ]
 
 [[package]]
@@ -611,15 +277,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
-]
-
-[[package]]
-name = "winnow"
-version = "0.7.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
-dependencies = [
- "memchr",
 ]
 
 [[package]]

--- a/lsposed/native/Cargo.toml
+++ b/lsposed/native/Cargo.toml
@@ -7,11 +7,20 @@ license = "MIT"
 
 [lib]
 name = "vpnhide_checks"
-crate-type = ["cdylib"]
+# cdylib: loaded in-process via System.loadLibrary for the app-view JNI probe.
+# rlib:   linked by the `vhprobe` bin (root-exec ground-truth probe).
+crate-type = ["cdylib", "rlib"]
+
+[[bin]]
+name = "vhprobe"
+path = "src/bin/vhprobe.rs"
 
 [dependencies]
-uniffi = "0.29"
 libc = "0.2"
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+# Minimal JNI surface: one exported function returning the checks as JSON.
+jni = { version = "0.22.4", default-features = false }
 
 [profile.release]
 opt-level = "z"

--- a/lsposed/native/src/bin/vhprobe.rs
+++ b/lsposed/native/src/bin/vhprobe.rs
@@ -1,6 +1,21 @@
 // Ground-truth probe: runs the exact same native checks as the in-process JNI
 // path, but exec'd as root (uid 0 is not a hook target) so its view is the
 // unfiltered truth. The app diffs this against its own in-process run.
+//
+// `--uid <n>`: the self-in-tunnel gate — report whether uid <n> is routed
+// through the VPN (a policy rule steers it into a tun table). Emits
+// `{uid, routed, detail}` instead of the full checks array.
 fn main() {
+    let args: Vec<String> = std::env::args().collect();
+    if let Some(i) = args.iter().position(|a| a == "--uid") {
+        match args.get(i + 1).and_then(|s| s.parse::<u32>().ok()) {
+            Some(uid) => println!("{}", vpnhide_checks::self_routed_json(uid)),
+            None => {
+                eprintln!("usage: vhprobe --uid <uid>");
+                std::process::exit(2);
+            }
+        }
+        return;
+    }
     println!("{}", vpnhide_checks::run_all_json());
 }

--- a/lsposed/native/src/bin/vhprobe.rs
+++ b/lsposed/native/src/bin/vhprobe.rs
@@ -1,0 +1,6 @@
+// Ground-truth probe: runs the exact same native checks as the in-process JNI
+// path, but exec'd as root (uid 0 is not a hook target) so its view is the
+// unfiltered truth. The app diffs this against its own in-process run.
+fn main() {
+    println!("{}", vpnhide_checks::run_all_json());
+}

--- a/lsposed/native/src/lib.rs
+++ b/lsposed/native/src/lib.rs
@@ -12,15 +12,19 @@ use crate::generated::iface_lists::matches_vpn;
 #[derive(serde::Serialize, Debug, Clone, Copy, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub enum CheckStatus {
-    /// Probe ran and saw nothing VPN-shaped, or was legitimately blocked
-    /// (SELinux denial, ENODEV, etc.) — both outcomes confirm the VPN is
-    /// hidden from this surface.
+    /// Probe ran and saw nothing VPN-shaped — the VPN is hidden from this
+    /// surface (by a backend hook, or simply nothing to leak here). The caller
+    /// distinguishes those two via the root ground-truth differential.
     Pass,
     /// Probe surfaced VPN-shaped data the kmod / zygisk should have hidden.
     Fail,
+    /// The probe was denied by SELinux (EACCES/EPERM) before it could read.
+    /// Distinct from Pass: the app saw no VPN, but SELinux blocked the read —
+    /// not a backend hook — so it is not evidence the backend works.
+    SelinuxBlocked,
     /// App has no network permission, so the probe couldn't run at all.
-    /// Reported separately from Pass/Fail so the UI can tell the user to
-    /// enable network access before trusting the results.
+    /// Reported separately so the UI can tell the user to enable network
+    /// access before trusting the results.
     NetworkBlocked,
 }
 
@@ -41,6 +45,13 @@ impl CheckOutput {
     fn fail(detail: impl Into<String>) -> Self {
         Self {
             status: CheckStatus::Fail,
+            detail: detail.into(),
+        }
+    }
+
+    fn selinux_blocked(detail: impl Into<String>) -> Self {
+        Self {
+            status: CheckStatus::SelinuxBlocked,
             detail: detail.into(),
         }
     }
@@ -292,7 +303,7 @@ fn check_proc_file(path: &str) -> CheckOutput {
     match std::fs::read_to_string(path) {
         Err(e) => {
             if is_selinux_denial(&e) {
-                return CheckOutput::pass(format!(
+                return CheckOutput::selinux_blocked(format!(
                     "access denied by SELinux ({e}) — app cannot read {path}"
                 ));
             }
@@ -354,7 +365,7 @@ fn open_netlink() -> Result<i32, CheckOutput> {
         if fd < 0 {
             let e = std::io::Error::last_os_error();
             return Err(if is_selinux_denial(&e) {
-                CheckOutput::pass(format!("netlink socket denied by SELinux ({e})"))
+                CheckOutput::selinux_blocked(format!("netlink socket denied by SELinux ({e})"))
             } else {
                 CheckOutput::fail(format!("cannot create netlink socket: {e}"))
             });
@@ -367,7 +378,7 @@ fn open_netlink() -> Result<i32, CheckOutput> {
             let e = std::io::Error::last_os_error();
             libc::close(fd);
             return Err(if is_selinux_denial(&e) {
-                CheckOutput::pass(format!(
+                CheckOutput::selinux_blocked(format!(
                     "netlink bind denied by SELinux ({e}) — app cannot enumerate interfaces"
                 ))
             } else {
@@ -613,7 +624,7 @@ fn check_sys_class_net() -> CheckOutput {
     match std::fs::read_dir("/sys/class/net") {
         Err(e) => {
             if is_selinux_denial(&e) {
-                CheckOutput::pass(format!("access denied by SELinux ({e})"))
+                CheckOutput::selinux_blocked(format!("access denied by SELinux ({e})"))
             } else {
                 CheckOutput::fail(format!("cannot open /sys/class/net: {e}"))
             }

--- a/lsposed/native/src/lib.rs
+++ b/lsposed/native/src/lib.rs
@@ -629,6 +629,13 @@ fn check_netlink_getroute() -> CheckOutput {
 /// mirrors that predicate so a working backend reads as "hidden" and root
 /// ground-truth (not a target → hook inert) reads as "leak".
 fn check_netlink_getrule() -> CheckOutput {
+    check_netlink_getrule_uid(unsafe { libc::getuid() })
+}
+
+/// RTM_GETRULE for a specific uid. The `vhprobe --uid` self-routing gate reuses
+/// this to answer "is <uid> routed through the VPN?" — a matching policy rule
+/// (or a VPN-named iif/oif) means yes.
+fn check_netlink_getrule_uid(myuid: u32) -> CheckOutput {
     // rtattr types and standard table ids (linux/fib_rules.h, linux/rtnetlink.h).
     const FRA_IIFNAME: u16 = 3;
     const FRA_TABLE: u16 = 15;
@@ -642,8 +649,6 @@ fn check_netlink_getrule() -> CheckOutput {
         Ok(fd) => fd,
         Err(out) => return out,
     };
-
-    let myuid = unsafe { libc::getuid() };
 
     unsafe {
         // fib_rule_hdr shares Rtmsg's 12-byte layout (family + 7 u8 + u32 flags).
@@ -844,6 +849,158 @@ fn run_all() -> Vec<CheckJson> {
 /// call the exact same code.
 pub fn run_all_json() -> String {
     serde_json::to_string(&run_all()).unwrap_or_else(|_| "[]".to_string())
+}
+
+#[derive(serde::Serialize)]
+struct SelfRouted {
+    uid: u32,
+    routed: bool,
+    detail: String,
+}
+
+/// The self-in-tunnel gate: is `uid` routed through the VPN? Run as root (not a
+/// hook target) so the answer is the unfiltered ground truth. Serialized as
+/// `{uid, routed, detail}`.
+///
+/// This is NOT the diagnostic predicate (`check_netlink_getrule`, which mirrors
+/// the kernel hook's broad "any non-standard table > 100" rule). Policy routing
+/// steers every UID into *some* per-network table (wlan0, rmnet, tun0 — all
+/// non-standard), so the broad predicate would call any online UID "routed".
+/// The gate must pin the VPN table specifically: first learn which table id a
+/// rule egresses to the VPN interface (`oif tun0`), then ask whether a uidrange
+/// rule steers this UID into exactly that table.
+pub fn self_routed_json(uid: u32) -> String {
+    let (routed, detail) = uid_routed_through_vpn(uid);
+    let sr = SelfRouted {
+        uid,
+        routed,
+        detail,
+    };
+    serde_json::to_string(&sr).unwrap_or_else(|_| "{}".to_string())
+}
+
+struct GateRule {
+    table: u32,
+    uid_lo: u32,
+    uid_hi: u32,
+    has_uidrange: bool,
+    oif_vpn: bool,
+}
+
+fn uid_routed_through_vpn(myuid: u32) -> (bool, String) {
+    const FRA_TABLE: u16 = 15;
+    const FRA_OIFNAME: u16 = 17;
+    const FRA_UID_RANGE: u16 = 20;
+
+    let fd = match open_netlink() {
+        Ok(fd) => fd,
+        Err(out) => return (false, out.detail),
+    };
+
+    let mut rules: Vec<GateRule> = Vec::new();
+
+    unsafe {
+        #[repr(C)]
+        struct Req {
+            nlh: libc::nlmsghdr,
+            frh: Rtmsg,
+        }
+        let mut req: Req = std::mem::zeroed();
+        req.nlh.nlmsg_len = std::mem::size_of::<Req>() as u32;
+        req.nlh.nlmsg_type = libc::RTM_GETRULE;
+        req.nlh.nlmsg_flags = (libc::NLM_F_REQUEST | libc::NLM_F_DUMP) as u16;
+        req.nlh.nlmsg_seq = 1;
+        req.frh.rtm_family = libc::AF_INET as u8;
+
+        if libc::send(
+            fd,
+            std::ptr::from_ref(&req).cast(),
+            req.nlh.nlmsg_len as usize,
+            0,
+        ) < 0
+        {
+            let e = last_os_error();
+            libc::close(fd);
+            return (false, format!("send error: {e}"));
+        }
+
+        let mut buf = AlignedBytes::<32768>::zeroed();
+        let hdr_plus_rtmsg = std::mem::size_of::<libc::nlmsghdr>() + std::mem::size_of::<Rtmsg>();
+
+        for _ in 0..MAX_NETLINK_RECV_ITERS {
+            let len = netlink_recv(fd, &mut buf.0);
+            if len <= 0 {
+                break;
+            }
+            let cont = parse_netlink_msgs(
+                &buf.0,
+                len as usize,
+                libc::RTM_NEWRULE,
+                |b, offset, msg_len| {
+                    let frh =
+                        &*(b.as_ptr().add(offset + std::mem::size_of::<libc::nlmsghdr>())
+                            as *const Rtmsg);
+                    let mut r = GateRule {
+                        table: frh.rtm_table as u32,
+                        uid_lo: 0,
+                        uid_hi: 0,
+                        has_uidrange: false,
+                        oif_vpn: false,
+                    };
+                    for_each_rtattr(b, offset + hdr_plus_rtmsg, offset + msg_len, |rta, payload| {
+                        match rta.rta_type {
+                            FRA_OIFNAME if !payload.is_empty() => {
+                                let name = cstr_to_str(payload.as_ptr() as *const libc::c_char);
+                                if is_vpn_iface(&name) {
+                                    r.oif_vpn = true;
+                                }
+                            }
+                            FRA_TABLE if payload.len() >= 4 => {
+                                r.table = u32::from_ne_bytes(payload[..4].try_into().unwrap());
+                            }
+                            FRA_UID_RANGE if payload.len() >= 8 => {
+                                r.uid_lo = u32::from_ne_bytes(payload[..4].try_into().unwrap());
+                                r.uid_hi = u32::from_ne_bytes(payload[4..8].try_into().unwrap());
+                                r.has_uidrange = true;
+                            }
+                            _ => {}
+                        }
+                    });
+                    rules.push(r);
+                },
+            );
+            if !cont {
+                break;
+            }
+        }
+        libc::close(fd);
+    }
+
+    // Pass 1: the VPN egress table id(s) — tables a rule routes out via `oif tun0`.
+    let vpn_tables: Vec<u32> = rules
+        .iter()
+        .filter(|r| r.oif_vpn)
+        .map(|r| r.table)
+        .collect();
+
+    // Pass 2: is this UID steered into exactly a VPN table by a uidrange rule?
+    // Exclude the universal 0..u32::MAX catch-all (not a per-app membership rule).
+    let routed = rules.iter().any(|r| {
+        r.has_uidrange
+            && r.uid_lo <= myuid
+            && myuid <= r.uid_hi
+            && !(r.uid_lo == 0 && r.uid_hi == u32::MAX)
+            && vpn_tables.contains(&r.table)
+    });
+
+    let detail = if vpn_tables.is_empty() {
+        format!("no VPN egress rule found for uid {myuid}")
+    } else if routed {
+        format!("uid {myuid} routed into VPN table(s) {vpn_tables:?}")
+    } else {
+        format!("uid {myuid} not in any VPN table(s) {vpn_tables:?}")
+    };
+    (routed, detail)
 }
 
 /// In-process (app-view) entry. Class/package must match the Kotlin

--- a/lsposed/native/src/lib.rs
+++ b/lsposed/native/src/lib.rs
@@ -5,11 +5,12 @@ use std::io::ErrorKind;
 
 use crate::generated::iface_lists::matches_vpn;
 
-uniffi::setup_scaffolding!();
+// ── Probe outcome types — serialized to JSON on both transports ───────
+// In-process (app view) via the JNI export below; root ground-truth via the
+// `vhprobe` bin. Same code, same JSON schema on both sides.
 
-// ── Probe outcome types — crossing the FFI ───────────────────────────
-
-#[derive(uniffi::Enum, Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(serde::Serialize, Debug, Clone, Copy, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
 pub enum CheckStatus {
     /// Probe ran and saw nothing VPN-shaped, or was legitimately blocked
     /// (SELinux denial, ENODEV, etc.) — both outcomes confirm the VPN is
@@ -23,7 +24,7 @@ pub enum CheckStatus {
     NetworkBlocked,
 }
 
-#[derive(uniffi::Record, Debug, Clone)]
+#[derive(serde::Serialize, Debug, Clone)]
 pub struct CheckOutput {
     pub status: CheckStatus,
     pub detail: String,
@@ -167,7 +168,6 @@ unsafe fn with_inet_dgram_socket(f: impl FnOnce(libc::c_int) -> CheckOutput) -> 
     out
 }
 
-#[uniffi::export]
 fn check_ioctl_siocgifflags() -> CheckOutput {
     unsafe {
         with_inet_dgram_socket(|fd| {
@@ -202,7 +202,6 @@ fn check_ioctl_siocgifflags() -> CheckOutput {
     }
 }
 
-#[uniffi::export]
 fn check_ioctl_siocgifmtu() -> CheckOutput {
     unsafe {
         with_inet_dgram_socket(|fd| {
@@ -229,7 +228,6 @@ fn check_ioctl_siocgifmtu() -> CheckOutput {
     }
 }
 
-#[uniffi::export]
 fn check_ioctl_siocgifconf() -> CheckOutput {
     unsafe {
         with_inet_dgram_socket(|fd| {
@@ -261,7 +259,6 @@ fn check_ioctl_siocgifconf() -> CheckOutput {
     }
 }
 
-#[uniffi::export]
 fn check_getifaddrs() -> CheckOutput {
     unsafe {
         let mut addrs: *mut libc::ifaddrs = std::ptr::null_mut();
@@ -457,7 +454,6 @@ unsafe fn for_each_rtattr(
     }
 }
 
-#[uniffi::export]
 fn check_netlink_getlink() -> CheckOutput {
     let fd = match open_netlink() {
         Ok(fd) => fd,
@@ -533,7 +529,6 @@ fn check_netlink_getlink() -> CheckOutput {
     }
 }
 
-#[uniffi::export]
 fn check_netlink_getroute() -> CheckOutput {
     let fd = match open_netlink() {
         Ok(fd) => fd,
@@ -614,7 +609,6 @@ fn check_netlink_getroute() -> CheckOutput {
     }
 }
 
-#[uniffi::export]
 fn check_sys_class_net() -> CheckOutput {
     match std::fs::read_dir("/sys/class/net") {
         Err(e) => {
@@ -643,17 +637,14 @@ fn check_sys_class_net() -> CheckOutput {
 //    keeps a thin `checkProcNetFoo(): CheckOutput` surface instead of
 //    pushing path strings across the FFI. ──────────────────────────────
 
-#[uniffi::export]
 fn check_proc_net_route() -> CheckOutput {
     check_proc_file("/proc/net/route")
 }
 
-#[uniffi::export]
 fn check_proc_net_if_inet6() -> CheckOutput {
     check_proc_file("/proc/net/if_inet6")
 }
 
-#[uniffi::export]
 fn check_proc_net_ipv6_route() -> CheckOutput {
     check_proc_file("/proc/net/ipv6_route")
 }
@@ -666,7 +657,64 @@ fn check_proc_net_ipv6_route() -> CheckOutput {
 // no honest check to run; the address-leak vector on these files is covered by
 // zygisk's tcp/tcp6/udp socket-table filters, not by a self-diagnostic.
 
-#[uniffi::export]
 fn check_proc_net_dev() -> CheckOutput {
     check_proc_file("/proc/net/dev")
+}
+
+// ── Registry + JSON transport ─────────────────────────────────────────────
+// One code path, two transports: the JNI export runs this in the app's own
+// process (app view — real uid + SELinux domain + zygisk/kernel hooks); the
+// `vhprobe` bin runs it as root (ground truth — uid 0 is not a hook target).
+// Both emit the same JSON; the app classifies by comparing per-`id`.
+
+#[derive(serde::Serialize)]
+struct CheckJson {
+    /// Stable id — matches NativeChecks.kt `NativeCheckSpec.id`.
+    id: &'static str,
+    status: CheckStatus,
+    detail: String,
+}
+
+fn run_all() -> Vec<CheckJson> {
+    fn j(id: &'static str, out: CheckOutput) -> CheckJson {
+        CheckJson {
+            id,
+            status: out.status,
+            detail: out.detail,
+        }
+    }
+    vec![
+        j("ioctl_flags", check_ioctl_siocgifflags()),
+        j("ioctl_mtu", check_ioctl_siocgifmtu()),
+        j("ioctl_conf", check_ioctl_siocgifconf()),
+        j("getifaddrs", check_getifaddrs()),
+        j("netlink_getlink", check_netlink_getlink()),
+        j("netlink_getroute", check_netlink_getroute()),
+        j("proc_route", check_proc_net_route()),
+        j("proc_ipv6_route", check_proc_net_ipv6_route()),
+        j("proc_if_inet6", check_proc_net_if_inet6()),
+        j("proc_dev", check_proc_net_dev()),
+        j("sys_class_net", check_sys_class_net()),
+    ]
+}
+
+/// Run every native probe in display order and serialize to a JSON array of
+/// `{id, status, detail}`. Public so both the JNI export and the `vhprobe` bin
+/// call the exact same code.
+pub fn run_all_json() -> String {
+    serde_json::to_string(&run_all()).unwrap_or_else(|_| "[]".to_string())
+}
+
+/// In-process (app-view) entry. Class/package must match the Kotlin
+/// `object dev.okhsunrog.vpnhide.checks.NativeProbe`.
+#[cfg(target_os = "android")]
+#[unsafe(no_mangle)]
+pub extern "system" fn Java_dev_okhsunrog_vpnhide_checks_NativeProbe_runAllChecksJson<'local>(
+    mut env: jni::EnvUnowned<'local>,
+    _class: jni::objects::JClass<'local>,
+) -> jni::objects::JString<'local> {
+    env.with_env(|env| -> jni::errors::Result<jni::objects::JString<'local>> {
+        env.new_string(run_all_json())
+    })
+    .resolve::<jni::errors::ThrowRuntimeExAndDefault>()
 }

--- a/lsposed/native/src/lib.rs
+++ b/lsposed/native/src/lib.rs
@@ -620,6 +620,64 @@ fn check_netlink_getroute() -> CheckOutput {
     }
 }
 
+/// Send an RTM_GETRULE dump for `family` on an already-bound `fd` and invoke
+/// `on_rule(buf, offset, msg_len)` for each RTM_NEWRULE message. The kernel's
+/// rule dump is per-family, and Android installs the per-app VPN policy rules for
+/// BOTH IPv4 and IPv6 — so callers dump `AF_INET` and `AF_INET6` on the same
+/// socket (distinct seq) and merge, else an IPv6 rule set is invisible. Returns
+/// the OS error string on a send failure; a short read / NLMSG_DONE ends the dump.
+///
+/// # Safety
+/// `fd` must be a bound NETLINK_ROUTE socket; `buf` must be 8-aligned and large
+/// enough for a dump chunk (the callers pass a 32 KiB `AlignedBytes`).
+unsafe fn dump_fib_rules(
+    fd: i32,
+    family: u8,
+    seq: u32,
+    buf: &mut [u8],
+    mut on_rule: impl FnMut(&[u8], usize, usize),
+) -> Result<(), String> {
+    unsafe {
+        #[repr(C)]
+        struct Req {
+            nlh: libc::nlmsghdr,
+            frh: Rtmsg,
+        }
+        let mut req: Req = std::mem::zeroed();
+        req.nlh.nlmsg_len = std::mem::size_of::<Req>() as u32;
+        req.nlh.nlmsg_type = libc::RTM_GETRULE;
+        req.nlh.nlmsg_flags = (libc::NLM_F_REQUEST | libc::NLM_F_DUMP) as u16;
+        req.nlh.nlmsg_seq = seq;
+        req.frh.rtm_family = family;
+
+        if libc::send(
+            fd,
+            std::ptr::from_ref(&req).cast(),
+            req.nlh.nlmsg_len as usize,
+            0,
+        ) < 0
+        {
+            return Err(last_os_error());
+        }
+
+        for _ in 0..MAX_NETLINK_RECV_ITERS {
+            let len = netlink_recv(fd, buf);
+            if len <= 0 {
+                break;
+            }
+            let cont = parse_netlink_msgs(buf, len as usize, libc::RTM_NEWRULE, &mut on_rule);
+            if !cont {
+                break;
+            }
+        }
+        Ok(())
+    }
+}
+
+/// The address families whose policy-rule dumps together cover an Android VPN's
+/// per-app routing (v4 + v6). Iterated by both the diagnostic and the gate.
+const RULE_FAMILIES: [u8; 2] = [libc::AF_INET as u8, libc::AF_INET6 as u8];
+
 /// RTM_GETRULE — policy routing rules. On Android the VPN's per-app policy is
 /// expressed as `ip rule` entries steering a UID range into the interface's own
 /// routing table (`... uidrange 10236-10236 lookup tun0`), plus rules that name
@@ -650,107 +708,77 @@ fn check_netlink_getrule_uid(myuid: u32) -> CheckOutput {
         Err(out) => return out,
     };
 
+    let mut leaks: Vec<String> = Vec::new();
+    let mut total = 0u32;
+
     unsafe {
-        // fib_rule_hdr shares Rtmsg's 12-byte layout (family + 7 u8 + u32 flags).
-        #[repr(C)]
-        struct Req {
-            nlh: libc::nlmsghdr,
-            frh: Rtmsg,
-        }
-        let mut req: Req = std::mem::zeroed();
-        req.nlh.nlmsg_len = std::mem::size_of::<Req>() as u32;
-        req.nlh.nlmsg_type = libc::RTM_GETRULE;
-        req.nlh.nlmsg_flags = (libc::NLM_F_REQUEST | libc::NLM_F_DUMP) as u16;
-        req.nlh.nlmsg_seq = 1;
-        req.frh.rtm_family = libc::AF_INET as u8;
-
-        if libc::send(
-            fd,
-            std::ptr::from_ref(&req).cast(),
-            req.nlh.nlmsg_len as usize,
-            0,
-        ) < 0
-        {
-            let e = last_os_error();
-            libc::close(fd);
-            return CheckOutput::fail(format!("send error: {e}"));
-        }
-
         let mut buf = AlignedBytes::<32768>::zeroed();
-        let mut leaks: Vec<String> = Vec::new();
-        let mut total = 0u32;
         let hdr_plus_rtmsg = std::mem::size_of::<libc::nlmsghdr>() + std::mem::size_of::<Rtmsg>();
 
-        for _ in 0..MAX_NETLINK_RECV_ITERS {
-            let len = netlink_recv(fd, &mut buf.0);
-            if len <= 0 {
-                break;
-            }
-            let cont = parse_netlink_msgs(
-                &buf.0,
-                len as usize,
-                libc::RTM_NEWRULE,
-                |b, offset, msg_len| {
-                    total += 1;
-                    let frh =
-                        &*(b.as_ptr().add(offset + std::mem::size_of::<libc::nlmsghdr>())
-                            as *const Rtmsg);
-                    // The low byte of the table id lives in the header; the full
-                    // u32 arrives in FRA_TABLE (Android tun tables are > 255).
-                    let mut table = frh.rtm_table as u32;
-                    let mut uid_lo = 0u32;
-                    let mut uid_hi = 0u32;
-                    let mut has_uidrange = false;
-                    let mut iface_hit: Option<String> = None;
-                    for_each_rtattr(b, offset + hdr_plus_rtmsg, offset + msg_len, |rta, payload| {
-                        match rta.rta_type {
-                            FRA_IIFNAME | FRA_OIFNAME if !payload.is_empty() => {
-                                let name = cstr_to_str(payload.as_ptr() as *const libc::c_char);
-                                if is_vpn_iface(&name) {
-                                    iface_hit = Some(name);
-                                }
-                            }
-                            FRA_TABLE if payload.len() >= 4 => {
-                                table = u32::from_ne_bytes(payload[..4].try_into().unwrap());
-                            }
-                            FRA_UID_RANGE if payload.len() >= 8 => {
-                                uid_lo = u32::from_ne_bytes(payload[..4].try_into().unwrap());
-                                uid_hi = u32::from_ne_bytes(payload[4..8].try_into().unwrap());
-                                has_uidrange = true;
-                            }
-                            _ => {}
+        // fib_rule_hdr shares Rtmsg's 12-byte layout (family + 7 u8 + u32 flags).
+        let mut on_rule = |b: &[u8], offset: usize, msg_len: usize| {
+            total += 1;
+            let frh =
+                &*(b.as_ptr().add(offset + std::mem::size_of::<libc::nlmsghdr>()) as *const Rtmsg);
+            // The low byte of the table id lives in the header; the full u32
+            // arrives in FRA_TABLE (Android tun tables are > 255).
+            let mut table = frh.rtm_table as u32;
+            let mut uid_lo = 0u32;
+            let mut uid_hi = 0u32;
+            let mut has_uidrange = false;
+            let mut iface_hit: Option<String> = None;
+            for_each_rtattr(b, offset + hdr_plus_rtmsg, offset + msg_len, |rta, payload| {
+                match rta.rta_type {
+                    FRA_IIFNAME | FRA_OIFNAME if !payload.is_empty() => {
+                        let name = cstr_to_str(payload.as_ptr() as *const libc::c_char);
+                        if is_vpn_iface(&name) {
+                            iface_hit = Some(name);
                         }
-                    });
-                    // Mirror fib_nl_fill_rule: a rule leaks the VPN if it names a
-                    // VPN interface, or steers this very UID into a non-standard
-                    // table (the per-app tun policy rule). The 0..u32::MAX range
-                    // is the catch-all default rule, not a VPN rule.
-                    if let Some(name) = iface_hit {
-                        leaks.push(format!("iface {name}"));
-                    } else if has_uidrange
-                        && uid_lo <= myuid
-                        && myuid <= uid_hi
-                        && !(uid_lo == 0 && uid_hi == u32::MAX)
-                        && table != RT_TABLE_MAIN
-                        && table != RT_TABLE_LOCAL
-                        && table != RT_TABLE_DEFAULT
-                        && table > 100
-                    {
-                        leaks.push(format!("uid {myuid} → table {table}"));
                     }
-                },
-            );
-            if !cont {
-                break;
+                    FRA_TABLE if payload.len() >= 4 => {
+                        table = u32::from_ne_bytes(payload[..4].try_into().unwrap());
+                    }
+                    FRA_UID_RANGE if payload.len() >= 8 => {
+                        uid_lo = u32::from_ne_bytes(payload[..4].try_into().unwrap());
+                        uid_hi = u32::from_ne_bytes(payload[4..8].try_into().unwrap());
+                        has_uidrange = true;
+                    }
+                    _ => {}
+                }
+            });
+            // Mirror fib_nl_fill_rule: a rule leaks the VPN if it names a VPN
+            // interface, or steers this very UID into a non-standard table (the
+            // per-app tun policy rule). The 0..u32::MAX range is the catch-all
+            // default rule, not a VPN rule.
+            if let Some(name) = iface_hit {
+                leaks.push(format!("iface {name}"));
+            } else if has_uidrange
+                && uid_lo <= myuid
+                && myuid <= uid_hi
+                && !(uid_lo == 0 && uid_hi == u32::MAX)
+                && table != RT_TABLE_MAIN
+                && table != RT_TABLE_LOCAL
+                && table != RT_TABLE_DEFAULT
+                && table > 100
+            {
+                leaks.push(format!("uid {myuid} → table {table}"));
+            }
+        };
+
+        // Dump v4 and v6 rules on the same socket (distinct seq) and merge.
+        for (i, family) in RULE_FAMILIES.into_iter().enumerate() {
+            if let Err(e) = dump_fib_rules(fd, family, (i + 1) as u32, &mut buf.0, &mut on_rule) {
+                libc::close(fd);
+                return CheckOutput::fail(format!("send error: {e}"));
             }
         }
         libc::close(fd);
+    }
 
-        if leaks.is_empty() {
-            CheckOutput::pass(format!("{total} policy rules, none reveal VPN"))
-        } else {
-            CheckOutput::fail(format!("VPN policy rule(s): {}", join_list(&leaks)))
-        }
+    if leaks.is_empty() {
+        CheckOutput::pass(format!("{total} policy rules, none reveal VPN"))
+    } else {
+        CheckOutput::fail(format!("VPN policy rule(s): {}", join_list(&leaks)))
     }
 }
 
@@ -900,77 +928,47 @@ fn uid_routed_through_vpn(myuid: u32) -> (bool, String) {
     let mut rules: Vec<GateRule> = Vec::new();
 
     unsafe {
-        #[repr(C)]
-        struct Req {
-            nlh: libc::nlmsghdr,
-            frh: Rtmsg,
-        }
-        let mut req: Req = std::mem::zeroed();
-        req.nlh.nlmsg_len = std::mem::size_of::<Req>() as u32;
-        req.nlh.nlmsg_type = libc::RTM_GETRULE;
-        req.nlh.nlmsg_flags = (libc::NLM_F_REQUEST | libc::NLM_F_DUMP) as u16;
-        req.nlh.nlmsg_seq = 1;
-        req.frh.rtm_family = libc::AF_INET as u8;
-
-        if libc::send(
-            fd,
-            std::ptr::from_ref(&req).cast(),
-            req.nlh.nlmsg_len as usize,
-            0,
-        ) < 0
-        {
-            let e = last_os_error();
-            libc::close(fd);
-            return (false, format!("send error: {e}"));
-        }
-
         let mut buf = AlignedBytes::<32768>::zeroed();
         let hdr_plus_rtmsg = std::mem::size_of::<libc::nlmsghdr>() + std::mem::size_of::<Rtmsg>();
 
-        for _ in 0..MAX_NETLINK_RECV_ITERS {
-            let len = netlink_recv(fd, &mut buf.0);
-            if len <= 0 {
-                break;
-            }
-            let cont = parse_netlink_msgs(
-                &buf.0,
-                len as usize,
-                libc::RTM_NEWRULE,
-                |b, offset, msg_len| {
-                    let frh =
-                        &*(b.as_ptr().add(offset + std::mem::size_of::<libc::nlmsghdr>())
-                            as *const Rtmsg);
-                    let mut r = GateRule {
-                        table: frh.rtm_table as u32,
-                        uid_lo: 0,
-                        uid_hi: 0,
-                        has_uidrange: false,
-                        oif_vpn: false,
-                    };
-                    for_each_rtattr(b, offset + hdr_plus_rtmsg, offset + msg_len, |rta, payload| {
-                        match rta.rta_type {
-                            FRA_OIFNAME if !payload.is_empty() => {
-                                let name = cstr_to_str(payload.as_ptr() as *const libc::c_char);
-                                if is_vpn_iface(&name) {
-                                    r.oif_vpn = true;
-                                }
-                            }
-                            FRA_TABLE if payload.len() >= 4 => {
-                                r.table = u32::from_ne_bytes(payload[..4].try_into().unwrap());
-                            }
-                            FRA_UID_RANGE if payload.len() >= 8 => {
-                                r.uid_lo = u32::from_ne_bytes(payload[..4].try_into().unwrap());
-                                r.uid_hi = u32::from_ne_bytes(payload[4..8].try_into().unwrap());
-                                r.has_uidrange = true;
-                            }
-                            _ => {}
+        let mut on_rule = |b: &[u8], offset: usize, msg_len: usize| {
+            let frh =
+                &*(b.as_ptr().add(offset + std::mem::size_of::<libc::nlmsghdr>()) as *const Rtmsg);
+            let mut r = GateRule {
+                table: frh.rtm_table as u32,
+                uid_lo: 0,
+                uid_hi: 0,
+                has_uidrange: false,
+                oif_vpn: false,
+            };
+            for_each_rtattr(b, offset + hdr_plus_rtmsg, offset + msg_len, |rta, payload| {
+                match rta.rta_type {
+                    FRA_OIFNAME if !payload.is_empty() => {
+                        let name = cstr_to_str(payload.as_ptr() as *const libc::c_char);
+                        if is_vpn_iface(&name) {
+                            r.oif_vpn = true;
                         }
-                    });
-                    rules.push(r);
-                },
-            );
-            if !cont {
-                break;
+                    }
+                    FRA_TABLE if payload.len() >= 4 => {
+                        r.table = u32::from_ne_bytes(payload[..4].try_into().unwrap());
+                    }
+                    FRA_UID_RANGE if payload.len() >= 8 => {
+                        r.uid_lo = u32::from_ne_bytes(payload[..4].try_into().unwrap());
+                        r.uid_hi = u32::from_ne_bytes(payload[4..8].try_into().unwrap());
+                        r.has_uidrange = true;
+                    }
+                    _ => {}
+                }
+            });
+            rules.push(r);
+        };
+
+        // v4 + v6: a VPN steers the uid into a tun table for both families; either
+        // membership means routed, so merge both dumps before deciding.
+        for (i, family) in RULE_FAMILIES.into_iter().enumerate() {
+            if let Err(e) = dump_fib_rules(fd, family, (i + 1) as u32, &mut buf.0, &mut on_rule) {
+                libc::close(fd);
+                return (false, format!("send error: {e}"));
             }
         }
         libc::close(fd);

--- a/lsposed/native/src/lib.rs
+++ b/lsposed/native/src/lib.rs
@@ -620,6 +620,135 @@ fn check_netlink_getroute() -> CheckOutput {
     }
 }
 
+/// RTM_GETRULE — policy routing rules. On Android the VPN's per-app policy is
+/// expressed as `ip rule` entries steering a UID range into the interface's own
+/// routing table (`... uidrange 10236-10236 lookup tun0`), plus rules that name
+/// the VPN interface directly (`iif/oif tun0`). Reading those rules reveals the
+/// VPN even when /proc/net/route (main table only) shows nothing. The kernel
+/// `fib_nl_fill_rule` hook trims exactly these from a target's dump; this probe
+/// mirrors that predicate so a working backend reads as "hidden" and root
+/// ground-truth (not a target → hook inert) reads as "leak".
+fn check_netlink_getrule() -> CheckOutput {
+    // rtattr types and standard table ids (linux/fib_rules.h, linux/rtnetlink.h).
+    const FRA_IIFNAME: u16 = 3;
+    const FRA_TABLE: u16 = 15;
+    const FRA_OIFNAME: u16 = 17;
+    const FRA_UID_RANGE: u16 = 20;
+    const RT_TABLE_DEFAULT: u32 = 253;
+    const RT_TABLE_MAIN: u32 = 254;
+    const RT_TABLE_LOCAL: u32 = 255;
+
+    let fd = match open_netlink() {
+        Ok(fd) => fd,
+        Err(out) => return out,
+    };
+
+    let myuid = unsafe { libc::getuid() };
+
+    unsafe {
+        // fib_rule_hdr shares Rtmsg's 12-byte layout (family + 7 u8 + u32 flags).
+        #[repr(C)]
+        struct Req {
+            nlh: libc::nlmsghdr,
+            frh: Rtmsg,
+        }
+        let mut req: Req = std::mem::zeroed();
+        req.nlh.nlmsg_len = std::mem::size_of::<Req>() as u32;
+        req.nlh.nlmsg_type = libc::RTM_GETRULE;
+        req.nlh.nlmsg_flags = (libc::NLM_F_REQUEST | libc::NLM_F_DUMP) as u16;
+        req.nlh.nlmsg_seq = 1;
+        req.frh.rtm_family = libc::AF_INET as u8;
+
+        if libc::send(
+            fd,
+            std::ptr::from_ref(&req).cast(),
+            req.nlh.nlmsg_len as usize,
+            0,
+        ) < 0
+        {
+            let e = last_os_error();
+            libc::close(fd);
+            return CheckOutput::fail(format!("send error: {e}"));
+        }
+
+        let mut buf = AlignedBytes::<32768>::zeroed();
+        let mut leaks: Vec<String> = Vec::new();
+        let mut total = 0u32;
+        let hdr_plus_rtmsg = std::mem::size_of::<libc::nlmsghdr>() + std::mem::size_of::<Rtmsg>();
+
+        for _ in 0..MAX_NETLINK_RECV_ITERS {
+            let len = netlink_recv(fd, &mut buf.0);
+            if len <= 0 {
+                break;
+            }
+            let cont = parse_netlink_msgs(
+                &buf.0,
+                len as usize,
+                libc::RTM_NEWRULE,
+                |b, offset, msg_len| {
+                    total += 1;
+                    let frh =
+                        &*(b.as_ptr().add(offset + std::mem::size_of::<libc::nlmsghdr>())
+                            as *const Rtmsg);
+                    // The low byte of the table id lives in the header; the full
+                    // u32 arrives in FRA_TABLE (Android tun tables are > 255).
+                    let mut table = frh.rtm_table as u32;
+                    let mut uid_lo = 0u32;
+                    let mut uid_hi = 0u32;
+                    let mut has_uidrange = false;
+                    let mut iface_hit: Option<String> = None;
+                    for_each_rtattr(b, offset + hdr_plus_rtmsg, offset + msg_len, |rta, payload| {
+                        match rta.rta_type {
+                            FRA_IIFNAME | FRA_OIFNAME if !payload.is_empty() => {
+                                let name = cstr_to_str(payload.as_ptr() as *const libc::c_char);
+                                if is_vpn_iface(&name) {
+                                    iface_hit = Some(name);
+                                }
+                            }
+                            FRA_TABLE if payload.len() >= 4 => {
+                                table = u32::from_ne_bytes(payload[..4].try_into().unwrap());
+                            }
+                            FRA_UID_RANGE if payload.len() >= 8 => {
+                                uid_lo = u32::from_ne_bytes(payload[..4].try_into().unwrap());
+                                uid_hi = u32::from_ne_bytes(payload[4..8].try_into().unwrap());
+                                has_uidrange = true;
+                            }
+                            _ => {}
+                        }
+                    });
+                    // Mirror fib_nl_fill_rule: a rule leaks the VPN if it names a
+                    // VPN interface, or steers this very UID into a non-standard
+                    // table (the per-app tun policy rule). The 0..u32::MAX range
+                    // is the catch-all default rule, not a VPN rule.
+                    if let Some(name) = iface_hit {
+                        leaks.push(format!("iface {name}"));
+                    } else if has_uidrange
+                        && uid_lo <= myuid
+                        && myuid <= uid_hi
+                        && !(uid_lo == 0 && uid_hi == u32::MAX)
+                        && table != RT_TABLE_MAIN
+                        && table != RT_TABLE_LOCAL
+                        && table != RT_TABLE_DEFAULT
+                        && table > 100
+                    {
+                        leaks.push(format!("uid {myuid} → table {table}"));
+                    }
+                },
+            );
+            if !cont {
+                break;
+            }
+        }
+        libc::close(fd);
+
+        if leaks.is_empty() {
+            CheckOutput::pass(format!("{total} policy rules, none reveal VPN"))
+        } else {
+            CheckOutput::fail(format!("VPN policy rule(s): {}", join_list(&leaks)))
+        }
+    }
+}
+
 fn check_sys_class_net() -> CheckOutput {
     match std::fs::read_dir("/sys/class/net") {
         Err(e) => {
@@ -701,6 +830,7 @@ fn run_all() -> Vec<CheckJson> {
         j("getifaddrs", check_getifaddrs()),
         j("netlink_getlink", check_netlink_getlink()),
         j("netlink_getroute", check_netlink_getroute()),
+        j("netlink_getrule", check_netlink_getrule()),
         j("proc_route", check_proc_net_route()),
         j("proc_ipv6_route", check_proc_net_ipv6_route()),
         j("proc_if_inet6", check_proc_net_if_inet6()),

--- a/lsposed/native/src/lib.rs
+++ b/lsposed/native/src/lib.rs
@@ -718,8 +718,10 @@ fn check_netlink_getrule_uid(myuid: u32) -> CheckOutput {
         // fib_rule_hdr shares Rtmsg's 12-byte layout (family + 7 u8 + u32 flags).
         let mut on_rule = |b: &[u8], offset: usize, msg_len: usize| {
             total += 1;
-            let frh =
-                &*(b.as_ptr().add(offset + std::mem::size_of::<libc::nlmsghdr>()) as *const Rtmsg);
+            let frh = &*(b
+                .as_ptr()
+                .add(offset + std::mem::size_of::<libc::nlmsghdr>())
+                as *const Rtmsg);
             // The low byte of the table id lives in the header; the full u32
             // arrives in FRA_TABLE (Android tun tables are > 255).
             let mut table = frh.rtm_table as u32;
@@ -727,8 +729,11 @@ fn check_netlink_getrule_uid(myuid: u32) -> CheckOutput {
             let mut uid_hi = 0u32;
             let mut has_uidrange = false;
             let mut iface_hit: Option<String> = None;
-            for_each_rtattr(b, offset + hdr_plus_rtmsg, offset + msg_len, |rta, payload| {
-                match rta.rta_type {
+            for_each_rtattr(
+                b,
+                offset + hdr_plus_rtmsg,
+                offset + msg_len,
+                |rta, payload| match rta.rta_type {
                     FRA_IIFNAME | FRA_OIFNAME if !payload.is_empty() => {
                         let name = cstr_to_str(payload.as_ptr() as *const libc::c_char);
                         if is_vpn_iface(&name) {
@@ -744,8 +749,8 @@ fn check_netlink_getrule_uid(myuid: u32) -> CheckOutput {
                         has_uidrange = true;
                     }
                     _ => {}
-                }
-            });
+                },
+            );
             // Mirror fib_nl_fill_rule: a rule leaks the VPN if it names a VPN
             // interface, or steers this very UID into a non-standard table (the
             // per-app tun policy rule). The 0..u32::MAX range is the catch-all
@@ -932,8 +937,10 @@ fn uid_routed_through_vpn(myuid: u32) -> (bool, String) {
         let hdr_plus_rtmsg = std::mem::size_of::<libc::nlmsghdr>() + std::mem::size_of::<Rtmsg>();
 
         let mut on_rule = |b: &[u8], offset: usize, msg_len: usize| {
-            let frh =
-                &*(b.as_ptr().add(offset + std::mem::size_of::<libc::nlmsghdr>()) as *const Rtmsg);
+            let frh = &*(b
+                .as_ptr()
+                .add(offset + std::mem::size_of::<libc::nlmsghdr>())
+                as *const Rtmsg);
             let mut r = GateRule {
                 table: frh.rtm_table as u32,
                 uid_lo: 0,
@@ -941,8 +948,11 @@ fn uid_routed_through_vpn(myuid: u32) -> (bool, String) {
                 has_uidrange: false,
                 oif_vpn: false,
             };
-            for_each_rtattr(b, offset + hdr_plus_rtmsg, offset + msg_len, |rta, payload| {
-                match rta.rta_type {
+            for_each_rtattr(
+                b,
+                offset + hdr_plus_rtmsg,
+                offset + msg_len,
+                |rta, payload| match rta.rta_type {
                     FRA_OIFNAME if !payload.is_empty() => {
                         let name = cstr_to_str(payload.as_ptr() as *const libc::c_char);
                         if is_vpn_iface(&name) {
@@ -958,8 +968,8 @@ fn uid_routed_through_vpn(myuid: u32) -> (bool, String) {
                         r.has_uidrange = true;
                     }
                     _ => {}
-                }
-            });
+                },
+            );
             rules.push(r);
         };
 
@@ -1009,8 +1019,10 @@ pub extern "system" fn Java_dev_okhsunrog_vpnhide_checks_NativeProbe_runAllCheck
     mut env: jni::EnvUnowned<'local>,
     _class: jni::objects::JClass<'local>,
 ) -> jni::objects::JString<'local> {
-    env.with_env(|env| -> jni::errors::Result<jni::objects::JString<'local>> {
-        env.new_string(run_all_json())
-    })
+    env.with_env(
+        |env| -> jni::errors::Result<jni::objects::JString<'local>> {
+            env.new_string(run_all_json())
+        },
+    )
     .resolve::<jni::errors::ThrowRuntimeExAndDefault>()
 }

--- a/lsposed/settings.gradle.kts
+++ b/lsposed/settings.gradle.kts
@@ -3,12 +3,6 @@ pluginManagement {
         google()
         mavenCentral()
         gradlePluginPortal()
-        // Gobley fork with AGP 9 support (not yet released upstream — see PR
-        // gobley/gobley#282 plus our onVariants-timing fix). Published here as
-        // dev.gobley.* 0.3.8-agp9.1.okhsunrog1. Source (public):
-        //   https://github.com/okhsunrog/gobley/tree/agp9-pr282
-        // Drop this repo + revert the gobley version once upstream ships 0.3.8.
-        maven { url = uri("https://maven.okhsunrog.dev") }
     }
 }
 
@@ -20,8 +14,6 @@ dependencyResolutionManagement {
         // Xposed API (public mirror — api.xposed.info is sometimes flaky)
         maven { url = uri("https://api.xposed.info/") }
         maven { url = uri("https://jitpack.io") }
-        // Gobley fork plugin runtime artifacts (see pluginManagement above).
-        maven { url = uri("https://maven.okhsunrog.dev") }
     }
 }
 


### PR DESCRIPTION
Reworks the diagnostics and dashboard semantics so protection is reported honestly. A check result used to be one tri-state boolean that conflated three unrelated things — the backend hid the VPN, SELinux blocked the read, or there was nothing to leak — so an installed-but-inactive backend read as "Partial" and a mostly-working Java layer as "Not working". Every check now attributes *who* hid the VPN via a root-differential: the in-process app view of each native probe compared against an unfiltered root run of the same probe (uid 0 is not a hook target). Along the way it drops the gobley/UniFFI native bridge (an AGP-9 fork) for a plain cargo-ndk + JNI/JSON transport.

- Replace gobley/UniFFI with a cargo-ndk `Exec` task + hand-written JNI returning JSON; the probe ships both as `libvpnhide_checks.so` (in-process app view) and an extracted `vhprobe` asset (root ground truth).
- Add `CheckStatus::SelinuxBlocked`/`NetworkBlocked` (stop folding EACCES into `Pass`) and the root-differential `CheckOutcome`: Leak / HiddenByBackend / HiddenBySelinux / NothingToLeak / NotMeasured.
- Rewire the dashboard tiles onto a unified `LayerStatus` (Absent / Inactive / Active(hidden, leaks)) with an Ok / Partial / Broken verdict, judged only on the vectors a backend actually owns — fixing the "inactive backend shows Partial" bug. The native and Java tiles share the same rollup; unowned leaks surface on the hero, not the tile.
- Gate diagnostics on VPN Hide itself being routed through the VPN: if it has been split-tunnelled out there is nothing to hide from its own probes, so it asks the user to add it to the tunnel instead of showing misleadingly-clean results.
- Redesign the detailed Diagnostics screen: each check is a compact row — name + a coloured status dot and a short word (OK / SELinux / Leak / No data) — with the raw detail collapsed and revealed on tap; a leak is the only thing expanded up front. The card stays green whether the backend or SELinux hid it (no false alarm); the backend-vs-SELinux nuance rides on the dot colour.
- Add an RTM_GETRULE native probe (IPv4 + IPv6) mirroring the `fib_nl_fill_rule` kernel filter — catches a VPN leaking through per-app policy routing rules that `/proc/net/route` (main table only) never shows.
- Probe the legacy NetworkInfo APIs (getActiveNetworkInfo / getNetworkInfo(TYPE_VPN)), drop the never-firing system-proxy check, and fix the `proc_if_inet6` hook attribution (no kernel seq_show hook exists for that path — only the zygisk `openat` filter or SELinux owns it).

Testing: validated on a Pixel 4a (kmod + KPM, 4.14), a Pixel 8 Pro (KernelSU-Next, GKI 6.1), and an Android 13 Zygisk device across backend enabled/disabled and SELinux enforcing/permissive. The root-differential attribution matrix, the self-in-tunnel gate (both directions), the RTM_GETRULE v4+v6 dump, and the compact Diagnostics screen were all verified on-device.
