### PR TITLE
Fix Hiding tab search and unsaved row movement

### DIFF
--- a/changelog.d/fixed-protection-search-now-closes-on-back-e72d.md
+++ b/changelog.d/fixed-protection-search-now-closes-on-back-e72d.md
@@ -1,0 +1,9 @@
+_2026-07-04_
+
+## English
+
+Protection search now closes on back, and unsaved app role toggles no longer move rows between groups before Save.
+
+## Русский
+
+Поиск на вкладке защиты теперь закрывается по кнопке назад, а несохранённые переключения ролей больше не перемещают приложения между группами до нажатия Save.

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/AppPickerScreen.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/AppPickerScreen.kt
@@ -79,6 +79,7 @@ internal data class AppEntry(
     val portPolicy: PortPolicy? = null,
     val declaresVpnService: Boolean = false,
     val nameContainsVpn: Boolean = false,
+    override val groupSelected: Boolean = java || native || appHiding || ports,
 ) : TargetEntry {
     override val anySelected get() = java || native || appHiding || ports
 }

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/MainActivity.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/MainActivity.kt
@@ -371,6 +371,10 @@ private fun MainScreen() {
             searchQuery = ""
         }
     }
+    BackHandler(enabled = searchActive && currentTab == Tab.Protection) {
+        searchActive = false
+        searchQuery = ""
+    }
 
     var showSettings by remember { mutableStateOf(false) }
     if (showSettings) {

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/TargetPickerData.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/TargetPickerData.kt
@@ -50,11 +50,11 @@ internal fun <T : TargetEntry> targetListSections(
     return listOf(
         TargetListSection(
             group = TargetListGroup.Configured,
-            entries = entries.filter { it.anySelected },
+            entries = entries.filter { it.groupSelected },
         ),
         TargetListSection(
             group = TargetListGroup.OtherApps,
-            entries = entries.filterNot { it.anySelected },
+            entries = entries.filterNot { it.groupSelected },
         ),
     ).filter { it.entries.isNotEmpty() }
 }
@@ -90,7 +90,7 @@ internal fun firstVisibleTargetLabel(
 private fun <T : TargetEntry> targetEntryComparator(sortMode: TargetListSortMode): Comparator<T> =
     when (sortMode) {
         TargetListSortMode.ConfiguredFirst -> {
-            compareBy<T> { if (it.anySelected) 0 else 1 }
+            compareBy<T> { if (it.groupSelected) 0 else 1 }
                 .then(labelComparator())
         }
 

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/TargetPickerScaffold.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/TargetPickerScaffold.kt
@@ -83,6 +83,10 @@ internal interface TargetEntry {
      * "keep selected system apps visible even when system apps are hidden"
      * filter rule and the system-app filter exemption. */
     val anySelected: Boolean
+
+    /** Selection state from the last loaded/saved config. Unsaved edits should
+     * not move rows between Configured and Other apps before the user saves. */
+    val groupSelected: Boolean get() = anySelected
 }
 
 /** Result of merging the cached app list with a screen's target snapshot.

--- a/lsposed/app/src/test/kotlin/dev/okhsunrog/vpnhide/TargetPickerDataTest.kt
+++ b/lsposed/app/src/test/kotlin/dev/okhsunrog/vpnhide/TargetPickerDataTest.kt
@@ -31,6 +31,27 @@ class TargetPickerDataTest {
     }
 
     @Test
+    fun `configured first groups by saved state while rows have unsaved edits`() {
+        val visible =
+            visibleTargetEntries(
+                entries =
+                    listOf(
+                        target("com.configured", "Configured", selected = false, groupSelected = true),
+                        target("com.other", "Other", selected = true, groupSelected = false),
+                    ),
+                searchQuery = "",
+                showSystem = false,
+                showRussianOnly = false,
+                sortMode = TargetListSortMode.ConfiguredFirst,
+            )
+
+        val sections = targetListSections(visible, TargetListSortMode.ConfiguredFirst)
+        assertEquals(listOf(TargetListGroup.Configured, TargetListGroup.OtherApps), sections.map { it.group })
+        assertEquals(listOf("Configured"), sections[0].entries.map { it.label })
+        assertEquals(listOf("Other"), sections[1].entries.map { it.label })
+    }
+
+    @Test
     fun `alphabetical sort ignores configured state`() {
         val visible =
             visibleTargetEntries(
@@ -111,12 +132,14 @@ class TargetPickerDataTest {
         label: String,
         selected: Boolean = false,
         isSystem: Boolean = false,
+        groupSelected: Boolean = selected,
     ): TestTarget =
         TestTarget(
             packageName = packageName,
             label = label,
             isSystem = isSystem,
             selected = selected,
+            groupSelected = groupSelected,
         )
 
     private data class TestTarget(
@@ -124,6 +147,7 @@ class TargetPickerDataTest {
         override val label: String,
         override val isSystem: Boolean,
         val selected: Boolean,
+        override val groupSelected: Boolean,
     ) : TargetEntry {
         override val icon: Drawable? = null
         override val userIds: List<Int> = emptyList()


### PR DESCRIPTION
## Summary

Fixes two Hiding tab UX regressions from #232 in one change:

- closes the active Protection/Hiding search field on back instead of letting the app exit
- keeps rows in their saved Configured/Other apps group while role toggles are still unsaved, so apps do not jump away before Save

## Root cause

The search UI had no active `BackHandler`, so system back navigation handled the gesture. The configured-first list also grouped and sorted rows from the current draft role state, causing an app from Other apps to move into Configured immediately after any role toggle.

## Testing

- `cd lsposed && ./gradlew :app:testDebugUnitTest --tests dev.okhsunrog.vpnhide.TargetPickerDataTest`
- `cd lsposed && ./gradlew :app:detekt`
- `ktlint "lsposed/app/src/**/*.kt"`
- `cd lsposed && ./gradlew :app:lintDebug :app:testDebugUnitTest`
- `cd lsposed && ./gradlew cpdCheck`

Closes #232