### PR TITLE
Module download buttons and clearer kmod-load wording

### DIFF
--- a/changelog.d/added-the-install-recommendation-card-now-has-68d3.md
+++ b/changelog.d/added-the-install-recommendation-card-now-has-68d3.md
@@ -1,0 +1,9 @@
+_2026-07-04_
+
+## English
+
+The dashboard now offers one-tap module downloads: a button to grab the exact recommended zip from the latest release (plus a link to all releases), and a download button on outdated-version and wrong-variant module warnings.
+
+## Русский
+
+На дашборде появилось скачивание модулей в один тап: кнопка для загрузки точного рекомендованного zip из последнего релиза (плюс ссылка на все релизы) и кнопка скачивания в предупреждениях об устаревшей версии и неверном варианте модуля.

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DashboardData.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DashboardData.kt
@@ -53,6 +53,10 @@ enum class ModuleBrokenReason {
 internal data class ModuleProblem(
     val reason: ModuleBrokenReason?,
     val text: String,
+    // The zip to offer for one-tap download when the fix is re-flashing a specific
+    // artifact (wrong/unknown/unsupported variant, ambiguous load). Null for
+    // problems no download fixes (kprobes missing, signature enforcement).
+    val downloadArtifact: String? = null,
 )
 
 sealed interface LsposedState {
@@ -240,6 +244,9 @@ internal data class DashboardMessage(
     val severity: DashboardMessageSeverity,
     val text: String,
     val action: DashboardMessageAction? = null,
+    // When set, the banner renders a "download this zip" button that grabs this
+    // named artifact from the latest release (wrong variant, outdated module, …).
+    val downloadArtifact: String? = null,
 )
 
 internal data class DashboardState(
@@ -767,6 +774,14 @@ private fun renderKmodProblem(
 ): ModuleProblem =
     ModuleProblem(
         reason = kind.reason,
+        downloadArtifact =
+            when (kind) {
+                is KmodProblemKind.UnsupportedKernel -> kind.recommendedArtifact
+                is KmodProblemKind.WrongVariant -> kind.recommendedArtifact
+                is KmodProblemKind.UnknownVariant -> kind.recommendedArtifact
+                is KmodProblemKind.AmbiguousLoadFailed -> kind.tryArtifact.takeIf { it.endsWith(".zip") }
+                else -> null
+            },
         text =
             when (kind) {
                 KmodProblemKind.KprobesMissing -> {
@@ -1217,12 +1232,18 @@ internal suspend fun loadDashboardState(
     val res = context.resources
     val selfPkg = context.packageName
 
-    fun err(text: String) {
-        messages += DashboardMessage(DashboardMessageSeverity.ERROR, text)
+    fun err(
+        text: String,
+        downloadArtifact: String? = null,
+    ) {
+        messages += DashboardMessage(DashboardMessageSeverity.ERROR, text, downloadArtifact = downloadArtifact)
     }
 
-    fun warn(text: String) {
-        messages += DashboardMessage(DashboardMessageSeverity.WARNING, text)
+    fun warn(
+        text: String,
+        downloadArtifact: String? = null,
+    ) {
+        messages += DashboardMessage(DashboardMessageSeverity.WARNING, text, downloadArtifact = downloadArtifact)
     }
 
     fun info(
@@ -1457,7 +1478,26 @@ internal suspend fun loadDashboardState(
             } else {
                 null
             }
-        warn(buildModuleVersionIssue(res, mismatch.kind, mismatch.moduleVersion, mismatch.appVersion, recommendedArtifact))
+        // Offer the newer module for one-tap download only when the installed
+        // module is OLDER than the app (module newer means the app is behind — the
+        // fix there is updating the app, not re-flashing the module).
+        val moduleOlder =
+            (compareSemver(baseVersion(mismatch.moduleVersion), baseVersion(mismatch.appVersion)) ?: 0) < 0
+        val downloadArtifact =
+            if (moduleOlder) {
+                when (mismatch.kind) {
+                    FlashableModuleKind.Kmod -> recommendedArtifact
+                    FlashableModuleKind.Kpm -> "vpnhide-kpm.zip"
+                    FlashableModuleKind.Zygisk -> "vpnhide-zygisk.zip"
+                    FlashableModuleKind.Ports -> "vpnhide-ports.zip"
+                }
+            } else {
+                null
+            }
+        warn(
+            buildModuleVersionIssue(res, mismatch.kind, mismatch.moduleVersion, mismatch.appVersion, recommendedArtifact),
+            downloadArtifact = downloadArtifact,
+        )
     }
     val totalTargets = lsposedTargetCount + kmodTargetCount + kpmTargetCount + zygiskTargetCount
     if (totalTargets == 0) {
@@ -1639,7 +1679,7 @@ internal suspend fun loadDashboardState(
     // because both come from the same value. classifyKpmProblem only matches
     // runtime=activator, so this can never double up with the
     // conflict/awaiting-superkey warnings below.
-    kmodProblem?.let { err(it.text) }
+    kmodProblem?.let { err(it.text, it.downloadArtifact) }
     kpmProblem?.let { err(it.text) }
 
     // ── Protection checks ──

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DashboardScreen.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DashboardScreen.kt
@@ -1,5 +1,6 @@
 package dev.okhsunrog.vpnhide
 
+import android.content.Context
 import android.content.Intent
 import android.net.Uri
 import androidx.compose.animation.core.RepeatMode
@@ -242,7 +243,7 @@ fun DashboardScreen(
                     text = issue.text,
                     containerColor = errorBg,
                     contentColor = onBannerColor,
-                    action = messageActionSlot(issue.action, onOpenDiagnostics) { showContact = true },
+                    action = messageActionSlot(issue, onOpenDiagnostics) { showContact = true },
                 )
                 Spacer(Modifier.height(6.dp))
             }
@@ -257,7 +258,7 @@ fun DashboardScreen(
                     text = issue.text,
                     containerColor = warningBg,
                     contentColor = onBannerColor,
-                    action = messageActionSlot(issue.action, onOpenDiagnostics) { showContact = true },
+                    action = messageActionSlot(issue, onOpenDiagnostics) { showContact = true },
                 )
                 Spacer(Modifier.height(6.dp))
             }
@@ -272,7 +273,7 @@ fun DashboardScreen(
                     text = message.text,
                     containerColor = infoBg,
                     contentColor = onBannerColor,
-                    action = messageActionSlot(message.action, onOpenDiagnostics) { showContact = true },
+                    action = messageActionSlot(message, onOpenDiagnostics) { showContact = true },
                 )
                 Spacer(Modifier.height(6.dp))
             }
@@ -288,15 +289,21 @@ fun DashboardScreen(
 // place, so a new action is an enum case + one branch here — not an edit in
 // every message loop. The data layer stays UI-free (it only emits the tag).
 private fun messageActionSlot(
-    action: DashboardMessageAction?,
+    message: DashboardMessage,
     onOpenDiagnostics: () -> Unit,
     onContactAuthor: () -> Unit,
-): (@Composable () -> Unit)? =
-    when (action) {
+): (@Composable () -> Unit)? {
+    // A message that names a downloadable module zip (wrong variant, outdated
+    // version, …) gets a download button; otherwise fall back to its action tag.
+    message.downloadArtifact?.let { artifact ->
+        return { ModuleDownloadButton(artifact) }
+    }
+    return when (message.action) {
         DashboardMessageAction.ContactAuthor -> ({ ContactAuthorButton(onClick = onContactAuthor) })
         DashboardMessageAction.OpenDiagnostics -> ({ DetailsButton(onClick = onOpenDiagnostics) })
         null -> null
     }
+}
 
 @Composable
 private fun DetailsButton(onClick: () -> Unit) {
@@ -1014,6 +1021,28 @@ private fun ModuleBadge(
     }
 }
 
+private const val GITHUB_RELEASES_PAGE = "https://github.com/okhsunrog/vpnhide/releases"
+
+/** Direct download of an asset from the latest release. GitHub redirects
+ * `/releases/latest/download/<asset>` to the current release's asset, so the URL
+ * stays correct without hard-coding a tag or version — we always point at the
+ * latest published release (§ releasing.md). */
+private fun releaseAssetUrl(artifact: String): String = "$GITHUB_RELEASES_PAGE/latest/download/$artifact"
+
+private fun Context.openUrl(url: String) {
+    runCatching { startActivity(Intent(Intent.ACTION_VIEW, Uri.parse(url))) }
+}
+
+/** Compact "download this zip" button for a module-problem banner (wrong variant,
+ * outdated version, …) — grabs the exact named artifact from the latest release. */
+@Composable
+private fun ModuleDownloadButton(artifact: String) {
+    val context = LocalContext.current
+    EnhancedOutlinedButton(onClick = { context.openUrl(releaseAssetUrl(artifact)) }) {
+        Text(stringResource(R.string.dashboard_install_recommendation_download, artifact))
+    }
+}
+
 @Composable
 private fun NativeInstallRecommendationCard(recommendation: NativeInstallRecommendation) {
     val containerColor =
@@ -1122,6 +1151,24 @@ private fun NativeInstallRecommendationCard(recommendation: NativeInstallRecomme
                 style = MaterialTheme.typography.bodySmall,
                 color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.8f),
             )
+            // Bright primary: one-tap download of the exact recommended zip.
+            // Plain secondary: the full releases page, for the ambiguous-variant
+            // case (grab the alternative) or picking anything else.
+            Spacer(Modifier.height(12.dp))
+            val context = LocalContext.current
+            EnhancedButton(
+                onClick = { context.openUrl(releaseAssetUrl(recommendation.recommendedArtifact)) },
+                modifier = Modifier.fillMaxWidth(),
+            ) {
+                Text(stringResource(R.string.dashboard_install_recommendation_download, recommendation.recommendedArtifact))
+            }
+            Spacer(Modifier.height(6.dp))
+            EnhancedOutlinedButton(
+                onClick = { context.openUrl(GITHUB_RELEASES_PAGE) },
+                modifier = Modifier.fillMaxWidth(),
+            ) {
+                Text(stringResource(R.string.dashboard_install_recommendation_all_releases))
+            }
         }
     }
 }

--- a/lsposed/app/src/main/res/values-ru/strings.xml
+++ b/lsposed/app/src/main/res/values-ru/strings.xml
@@ -208,13 +208,15 @@
     <string name="dashboard_install_recommendation_device">Ваше устройство: %1$s, ядро %2$s</string>
     <string name="dashboard_install_recommendation_kmi_note">«%1$s» в версии ядра — это GKI Kernel Module Interface, обозначающий бинарный интерфейс ядра для модулей, а не версию Android на устройстве.</string>
     <string name="dashboard_install_recommendation_kmod">Рекомендуется модуль ядра. Скачайте %1$s.</string>
-    <string name="dashboard_install_recommendation_kmod_ambiguous">Рекомендуется модуль ядра. GKI-ветку вашего ядра не удаётся определить из uname -r, поэтому сначала попробуйте %1$s; если после перезагрузки он не загрузится — установите %2$s.</string>
+    <string name="dashboard_install_recommendation_kmod_ambiguous">Рекомендуется модуль ядра. GKI-ветку вашего ядра не удаётся определить из uname -r, поэтому сначала попробуйте %1$s; если после перезагрузки он не загрузится в ядро — установите %2$s.</string>
     <string name="dashboard_install_recommendation_zygisk">Для вашего устройства модуль ядра не поддерживается. Установите %1$s.</string>
     <string name="dashboard_install_recommendation_zygisk_warning">Банковские и платёжные приложения могут обнаруживать Zygisk-хуки, если для них включён Native. Для таких приложений оставьте Native выключенным и полагайтесь на LSPosed (Java-уровень).</string>
     <string name="dashboard_install_recommendation_kpm">Для вашего ядра рекомендуется KPM (бета) — единый универсальный модуль, скрывающий VPN на уровне ядра, невидимый для анти-тампер проверок. Скачайте %1$s.</string>
     <string name="dashboard_install_recommendation_kpm_needs_runtime">Для вашего ядра рекомендуется KPM (бета) — скрытие на уровне ядра, невидимое для анти-тампер проверок. Сначала нужно установить KPatch-Next-Module. Если не хотите его ставить — используйте vpnhide-zygisk.zip. Файл KPM: %1$s.</string>
     <string name="dashboard_install_recommendation_kpm_beta_note">KPM экспериментальный (бета). Если что-то не работает — можно вернуться на Zygisk и связаться с автором.</string>
-    <string name="dashboard_install_recommendation_kmod_kpm_alt">Модуль ядра — стабильное и наиболее протестированное решение. KPM (бета) — альтернатива: один универсальный модуль без привязки к GKI-варианту, полезен, если zip с kmod не загружается.</string>
+    <string name="dashboard_install_recommendation_kmod_kpm_alt">Модуль ядра — стабильное и наиболее протестированное решение. KPM (бета) — альтернатива: один универсальный модуль без привязки к GKI-варианту; полезен, если модуль ядра не загружается в ваше ядро (неподходящий вариант или ядро требует подписанные модули).</string>
+    <string name="dashboard_install_recommendation_download">Скачать %1$s</string>
+    <string name="dashboard_install_recommendation_all_releases">Все релизы</string>
     <string name="dashboard_issue_kpm_capable_but_zygisk">Ваше ядро поддерживает более скрытный KPM (бета), но установлен только Zygisk. Банковские и платёжные приложения могут обнаруживать Zygisk; KPM скрывает VPN на уровне ядра. Стоит установить %1$s.</string>
     <string name="dashboard_issue_kpm_experimental_kmod">KPM пока экспериментальный (бета) и сейчас активен. При проблемах попробуйте модуль ядра (kmod) и, пожалуйста, свяжитесь с автором.</string>
     <string name="dashboard_issue_kpm_experimental_zygisk">KPM пока экспериментальный (бета) и сейчас активен. При проблемах попробуйте Zygisk и, пожалуйста, свяжитесь с автором.</string>

--- a/lsposed/app/src/main/res/values/strings.xml
+++ b/lsposed/app/src/main/res/values/strings.xml
@@ -237,13 +237,15 @@
     <string name="dashboard_install_recommendation_device">Your device: %1$s, kernel %2$s</string>
     <string name="dashboard_install_recommendation_kmi_note">\"%1$s\" in the kernel version is the GKI Kernel Module Interface tag — it identifies the kernel\'s binary interface to modules, not your Android OS release.</string>
     <string name="dashboard_install_recommendation_kmod">Kernel module is recommended. Download %1$s.</string>
-    <string name="dashboard_install_recommendation_kmod_ambiguous">Kernel module is recommended. Your kernel\'s GKI branch isn\'t identifiable from uname -r, so try %1$s first; if it doesn\'t load after reboot, install %2$s instead.</string>
+    <string name="dashboard_install_recommendation_kmod_ambiguous">Kernel module is recommended. Your kernel\'s GKI branch isn\'t identifiable from uname -r, so try %1$s first; if it doesn\'t load into the kernel after reboot, install %2$s instead.</string>
     <string name="dashboard_install_recommendation_zygisk">Kernel module is not supported for your device. Install %1$s.</string>
     <string name="dashboard_install_recommendation_zygisk_warning">Banking and payment apps may detect Zygisk hooks when Native is enabled for them. Leave Native off for those apps and rely on LSPosed (Java-level) hiding.</string>
     <string name="dashboard_install_recommendation_kpm">KPM (beta) is recommended for your kernel — a single universal module that hides at the kernel level, invisible to anti-tamper. Download %1$s.</string>
     <string name="dashboard_install_recommendation_kpm_needs_runtime">KPM (beta) is recommended for your kernel — kernel-level hiding, invisible to anti-tamper. It needs the KPatch-Next-Module installed first. If you\'d rather not install that, use vpnhide-zygisk.zip instead. KPM artifact: %1$s.</string>
     <string name="dashboard_install_recommendation_kpm_beta_note">KPM is experimental (beta). If something doesn\'t work, you can fall back to Zygisk and contact the author.</string>
-    <string name="dashboard_install_recommendation_kmod_kpm_alt">The kernel module is the stable, most-tested choice. KPM (beta) is an alternative — one universal module, no GKI variant to match — useful if the kmod zip won\'t load.</string>
+    <string name="dashboard_install_recommendation_kmod_kpm_alt">The kernel module is the stable, most-tested choice. KPM (beta) is an alternative — one universal module, no GKI variant to match — useful if the kernel module won\'t load into your kernel (wrong variant, or the kernel enforces module signatures).</string>
+    <string name="dashboard_install_recommendation_download">Download %1$s</string>
+    <string name="dashboard_install_recommendation_all_releases">All releases</string>
     <string name="dashboard_issue_kpm_capable_but_zygisk">Your kernel supports the stealthier KPM (beta), but only Zygisk is installed. Zygisk is detectable by banking/payment apps; KPM hides at the kernel level. Consider installing %1$s.</string>
     <string name="dashboard_issue_kpm_experimental_kmod">The KPM backend is experimental (beta) and currently active. If you hit problems, try the kernel module (kmod) instead, and please contact the author.</string>
     <string name="dashboard_issue_kpm_experimental_zygisk">The KPM backend is experimental (beta) and currently active. If you hit problems, try Zygisk instead, and please contact the author.</string>


### PR DESCRIPTION
The install-recommendation card told the user to download a specific module zip but gave no way to get it, and the KPM-alternative note said the kmod zip "won't load" — which in Russian reads as "won't download". This adds one-tap downloads where the app already knows the exact artifact, and clarifies the wording. Downloads always target the latest release via GitHub's `/releases/latest/download/<asset>` redirect, independent of the app's (possibly dev-build) version.

- The recommendation card gains two buttons: a bright one that downloads the exact recommended zip, and a plain "All releases" link for the ambiguous-variant case or picking something else.
- Module-problem and version-mismatch banners that name a zip (wrong / unknown / unsupported variant, ambiguous load, outdated module) get a download button too, via a new `DashboardMessage.downloadArtifact`. The outdated-version download is offered only when the installed module is older than the app (a newer module means the app is behind — the fix there is updating the app).
- Reword the kmod-load strings: "won't load" → "won't load into your kernel (wrong variant, or the kernel enforces module signatures)", so it no longer reads as a download failure.

Testing: built and checked on a Pixel 8 Pro — the recommendation card's two buttons render and open the right URLs; the banner download path was verified by build/logic (that device has no native backend installed, so the wrong-variant/outdated banners don't appear).
