### PR TITLE
Distinguish nothing-to-leak, show root ground truth, drop two dead checks

### DIFF
--- a/changelog.d/changed-diagnostics-now-probes-the-legacy-networkinfo-e96a.md
+++ b/changelog.d/changed-diagnostics-now-probes-the-legacy-networkinfo-e96a.md
@@ -2,8 +2,8 @@ _2026-07-03_
 
 ## English
 
-Diagnostics now probes the legacy NetworkInfo APIs (getActiveNetworkInfo / getNetworkInfo(TYPE_VPN)) and drops the uninformative system-proxy check.
+Diagnostics now probes the legacy getNetworkInfo(TYPE_VPN) API and drops the uninformative system-proxy check.
 
 ## Русский
 
-Диагностика теперь проверяет легаси-API NetworkInfo (getActiveNetworkInfo / getNetworkInfo(TYPE_VPN)) и больше не показывает неинформативную проверку системного прокси.
+Диагностика теперь проверяет легаси-API getNetworkInfo(TYPE_VPN) и больше не показывает неинформативную проверку системного прокси.

--- a/changelog.d/changed-the-detailed-diagnostics-screen-now-shows-a64b.md
+++ b/changelog.d/changed-the-detailed-diagnostics-screen-now-shows-a64b.md
@@ -1,0 +1,9 @@
+_2026-07-04_
+
+## English
+
+The detailed diagnostics screen now shows what root saw on each native check next to the app's own read, and marks 'nothing to hide' distinctly from a backend win — so a SELinux-blocked check that has nothing to leak explains itself instead of looking protected.
+
+## Русский
+
+Экран подробной диагностики теперь показывает, что видит root по каждой нативной проверке, рядом с чтением самого приложения, и отличает «нечего скрывать» от заслуги бэкенда — так SELinux-заблокированная проверка, где скрывать нечего, объясняет себя, а не выглядит «защищённой».

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/AgentControl.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/AgentControl.kt
@@ -685,6 +685,7 @@ private fun CheckResult.toAgentCheckResult(outcome: String? = null): AgentCheckR
             },
         detail = detail,
         outcome = outcome,
+        groundTruthDetail = groundTruthDetail,
     )
 
 private fun StatisticsState.toAgentStatisticsState(selfPackage: String? = null): AgentStatisticsState {

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/AgentControlModels.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/AgentControlModels.kt
@@ -131,6 +131,9 @@ data class AgentCheckResult(
      * hidden_backend, hidden_selinux, nothing_to_leak, not_measured_*. Null for
      * checks without a root-differential outcome (Java / nativeExtra). */
     val outcome: String? = null,
+    /** The root ground-truth probe's own detail (native checks) — what root saw on
+     * this surface, the basis for the outcome. Null for checks without a root diff. */
+    val groundTruthDetail: String? = null,
 )
 
 /** Statistics tab state. */

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DiagnosticsScreen.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DiagnosticsScreen.kt
@@ -538,14 +538,25 @@ private fun diagStatus(r: CheckResult): DiagStatus {
     val leak = DiagStatus(stringResource(R.string.diag_status_leak), StatusColors.errorDot, StatusColors.errorContainer(), true)
     val notMeasured =
         DiagStatus(stringResource(R.string.diag_status_nomeasure), StatusColors.neutralAccent, StatusColors.neutralContainer(), false)
+    // Nothing to leak on this surface for anyone (root also saw nothing). A grey
+    // "nothing to hide" dot on a green (not-leaking) card — distinct from the green
+    // "OK" the backend earns, so it never reads as active protection where there
+    // is none (e.g. /proc/net/route: the split-tunnel VPN isn't in the main table).
+    val nothingToLeak =
+        DiagStatus(stringResource(R.string.diag_status_nothing), StatusColors.neutralAccent, StatusColors.successContainer(), false)
     return when (r.outcome) {
         CheckOutcome.Leak -> {
             leak
         }
 
-        // Hidden by the backend, or simply nothing to leak: both read as plain OK.
-        CheckOutcome.HiddenByBackend, CheckOutcome.NothingToLeak -> {
+        // The backend provably hid the VPN here.
+        CheckOutcome.HiddenByBackend -> {
             ok
+        }
+
+        // Not hidden by us — there was simply nothing on this surface to leak.
+        CheckOutcome.NothingToLeak -> {
+            nothingToLeak
         }
 
         // Hidden by SELinux, not a backend hook: still a green card (no alarm), but a
@@ -617,8 +628,14 @@ private fun CheckCard(
             }
             if (expanded) {
                 Spacer(Modifier.height(6.dp))
+                // For native checks the root ground-truth detail is shown next to the
+                // app-view read — it is what the verdict is derived from (e.g. a
+                // SELinux-blocked read reads as "nothing to leak" precisely because
+                // "root: N routes, no VPN"). Java checks have no root diff → plain detail.
+                val detailText =
+                    r.groundTruthDetail?.let { gt -> "app:  ${r.detail}\nroot: $gt" } ?: r.detail
                 Text(
-                    text = r.detail,
+                    text = detailText,
                     style = MaterialTheme.typography.bodySmall,
                     fontFamily = FontFamily.Monospace,
                     color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.8f),

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/JavaChecks.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/JavaChecks.kt
@@ -37,9 +37,7 @@ import dev.okhsunrog.vpnhide.ui.components.GroupedCard
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
-import java.io.BufferedReader
 import java.io.File
-import java.io.InputStreamReader
 import java.net.NetworkInterface
 import java.text.SimpleDateFormat
 import java.util.Date
@@ -60,6 +58,11 @@ data class CheckResult(
     // Java-level checks, which have no root ground truth — those fall back to the
     // legacy [passed] tri-state in the UI.
     val outcome: CheckOutcome? = null,
+    // The root ground-truth probe's own detail for native checks — what root saw on
+    // this surface. Shown next to the app-view detail so the verdict is explained
+    // (e.g. "root: 42 routes, no VPN" is WHY a SELinux-blocked read reads as nothing
+    // to leak). Null for Java checks and any probe without a root differential.
+    val groundTruthDetail: String? = null,
 )
 
 internal data class CheckResults(
@@ -137,16 +140,21 @@ internal fun runCoreChecks(
             val out =
                 nativeAppView[spec.id]
                     ?: CheckOutput(CheckStatus.NETWORK_BLOCKED, "no native result for ${spec.id}")
-            val outcome = classifyNativeOutcome(out, nativeGroundTruth[spec.id])
+            val groundTruth = nativeGroundTruth[spec.id]
+            val outcome = classifyNativeOutcome(out, groundTruth)
             VpnHideLog.i(TAG, "[outcome] ${spec.id}: ${outcome.token()}")
             nativeOutcomes[spec.id] = outcome
-            nativeCheckResult(res.getString(spec.labelRes), out, outcome)
+            nativeCheckResult(res.getString(spec.labelRes), out, outcome, groundTruth?.detail)
         }
 
+    // NetworkInterface.getNetworkInterfaces() is the canonical Java iface-enum a
+    // detector uses; kept even though the Rust getifaddrs probe covers the same
+    // syscall. (The /proc/net/route Java duplicate was dropped — the Rust probe
+    // covers that vector with proper attribution, and the Java one could only
+    // report a misleading "OK" on the SELinux denial for want of a root diff.)
     val nativeExtra =
         listOf(
             checkNetworkInterfaceEnum(res.getString(R.string.check_net_iface_enum)),
-            checkProcNetRouteJava(res.getString(R.string.check_proc_route_java)),
         ).logged()
 
     val coreJava =
@@ -178,7 +186,6 @@ internal fun runExtraJavaChecks(
         checkActiveNetworkVpn(cm, res.getString(R.string.check_active_network_vpn)),
         checkNetworkCallbackVpn(cm, res.getString(R.string.check_network_callback)),
         checkLinkPropertiesRoutes(cm, res.getString(R.string.check_link_properties_routes)),
-        checkActiveNetworkInfo(cm, res.getString(R.string.check_active_network_info)),
         checkNetworkInfoVpn(cm, res.getString(R.string.check_network_info_vpn)),
     ).logged().withJavaOutcomes()
 }
@@ -215,9 +222,10 @@ private fun nativeCheckResult(
     name: String,
     out: CheckOutput,
     outcome: CheckOutcome? = null,
+    groundTruthDetail: String? = null,
 ): CheckResult {
     VpnHideLog.i(TAG, "[$name] ${out.status}: ${out.detail}")
-    return CheckResult(name, out.status.toPassed(), out.detail, outcome = outcome)
+    return CheckResult(name, out.status.toPassed(), out.detail, outcome = outcome, groundTruthDetail = groundTruthDetail)
 }
 
 // ==========================================================================
@@ -530,29 +538,12 @@ private fun checkLinkPropertiesRoutes(
         CheckResult(name, vpnRoutes.isEmpty(), detail)
     }
 
-// Legacy NetworkInfo leaks (exercise the LSPOSED_NETWORK_INFO parcel hook +
-// the ConnectivityService result sanitizer — surfaces with no other check).
-// getActiveNetworkInfo() marshals a NetworkInfo across Binder; without the
-// hook an on-VPN caller sees type=VPN. The hook disguises it as WIFI.
-@Suppress("DEPRECATION")
-private fun checkActiveNetworkInfo(
-    cm: ConnectivityManager,
-    name: String,
-): CheckResult {
-    val info = cm.activeNetworkInfo ?: return CheckResult(name, true, "no active network info")
-    val isVpn = info.type == ConnectivityManager.TYPE_VPN || info.typeName.equals("VPN", ignoreCase = true)
-    val detail =
-        if (!isVpn) {
-            "type=${info.type} (${info.typeName})"
-        } else {
-            "activeNetworkInfo type=VPN (${info.typeName})"
-        }
-    return CheckResult(name, !isVpn, detail)
-}
-
 // getNetworkInfo(TYPE_VPN) probes the legacy VPN type directly (issue #85). The
-// hook nulls it for a target; a non-null result that reports connected/connecting
-// still answers "a VPN-type network exists", which is the leak.
+// LSPOSED_NETWORK_INFO parcel hook nulls it for a target; a non-null result that
+// reports connected/connecting still answers "a VPN-type network exists" — the
+// leak. (Its companion getActiveNetworkInfo() was dropped: .type reports the
+// underlying transport (WIFI/mobile) for an active VPN, not TYPE_VPN, so it never
+// surfaced the leak.)
 @Suppress("DEPRECATION")
 private fun checkNetworkInfoVpn(
     cm: ConnectivityManager,
@@ -570,35 +561,3 @@ private fun checkNetworkInfoVpn(
         }
     return CheckResult(name, !leaks, detail)
 }
-
-private fun checkProcNetRouteJava(name: String): CheckResult =
-    try {
-        val allLines = mutableListOf<String>()
-        val vpnLines = mutableListOf<String>()
-        BufferedReader(InputStreamReader(java.io.FileInputStream("/proc/net/route"))).use { br ->
-            while (true) {
-                val line = br.readLine() ?: break
-                allLines.add(line)
-                // /proc/net/route is whitespace-separated; check
-                // each token instead of just startsWith on the raw
-                // line so we don't match e.g. an IP-as-hex by chance.
-                if (line.split(Regex("\\s+")).any(IfaceLists::isVpnIface)) {
-                    vpnLines.add(line.take(60))
-                }
-            }
-        }
-        val detail =
-            if (vpnLines.isEmpty()) {
-                "${allLines.size} lines, no VPN entries"
-            } else {
-                "${vpnLines.size} VPN lines:\n${vpnLines.joinToString("\n") { "  $it" }}"
-            }
-        CheckResult(name, vpnLines.isEmpty(), detail)
-    } catch (e: Exception) {
-        val msg = e.message ?: ""
-        if (msg.contains("EACCES") || msg.contains("Permission denied")) {
-            CheckResult(name, true, "access denied by SELinux")
-        } else {
-            CheckResult(name, false, "${e.message}")
-        }
-    }

--- a/lsposed/app/src/main/res/values-ru/strings.xml
+++ b/lsposed/app/src/main/res/values-ru/strings.xml
@@ -355,6 +355,7 @@
     <string name="diag_status_ok">ОК</string>
     <string name="diag_status_leak">Утечка</string>
     <string name="diag_status_nomeasure">Нет данных</string>
+    <string name="diag_status_nothing">Нечего скрывать</string>
     <string name="banner_ready">VPN активен. Для этого приложения включено скрытие. Результаты проверок ниже.</string>
     <string name="banner_added_self">Для VPN Hide включено скрытие. Принудительно остановите VPN Hide и откройте снова, чтобы нативные проверки начали работать — перезагрузка устройства не нужна.</string>
     <string name="banner_network_blocked">Доступ к сети отключён для этого приложения. Проверки ioctl (SIOCGIFFLAGS, SIOCGIFMTU, SIOCGIFCONF) не могут быть выполнены. Включите в Настройки → Приложения → VPN Hide → Мобильный интернет и Wi-Fi.</string>

--- a/lsposed/app/src/main/res/values/strings.xml
+++ b/lsposed/app/src/main/res/values/strings.xml
@@ -93,6 +93,7 @@
     <string name="diag_status_selinux" translatable="false">SELinux</string>
     <string name="diag_status_leak">Leak</string>
     <string name="diag_status_nomeasure">No data</string>
+    <string name="diag_status_nothing">Nothing to hide</string>
     <string name="banner_ready">VPN is active. Hiding is enabled for this app. Results below.</string>
     <string name="banner_added_self">Enabled hiding for VPN Hide. Restart VPN Hide (force-stop and reopen) for native-level checks to take effect — no device reboot needed.</string>
     <string name="banner_network_blocked">Network access is disabled for this app. ioctl checks (SIOCGIFFLAGS, SIOCGIFMTU, SIOCGIFCONF) cannot run without it. Enable in Settings → Apps → VPN Hide → Mobile data &amp; Wi-Fi.</string>
@@ -375,7 +376,6 @@
     <string name="check_proc_dev" translatable="false">/proc/net/dev</string>
     <string name="check_sys_class_net" translatable="false">/sys/class/net</string>
     <string name="check_net_iface_enum" translatable="false">NetworkInterface enum</string>
-    <string name="check_proc_route_java" translatable="false">/proc/net/route (Java)</string>
 
     <!-- Java/LSPosed check names (technical, not translatable) -->
     <string name="check_has_transport_vpn" translatable="false">hasTransport(VPN)</string>
@@ -389,7 +389,6 @@
     <string name="check_network_callback" translatable="false">NetworkCallback (push)</string>
     <string name="check_link_properties" translatable="false">LinkProperties ifname</string>
     <string name="check_link_properties_routes" translatable="false">LinkProperties routes</string>
-    <string name="check_active_network_info" translatable="false">getActiveNetworkInfo()</string>
     <string name="check_network_info_vpn" translatable="false">getNetworkInfo(TYPE_VPN)</string>
 
     <!-- Settings screen -->


### PR DESCRIPTION
Fixes a confusing "OK" in the diagnostics and removes two checks that don't pull their weight.

On a device with no native backend, the `/proc/net/route` check showed a green "OK" even though its detail said "access denied by SELinux". It classifies as `NothingToLeak` — root also sees nothing there, because a split-tunnel VPN's route lives in a per-UID policy table, not the main routing table — but `NothingToLeak` was collapsed into the same green "OK" a backend earns, so an empty surface read as active protection.

- `NothingToLeak` now has its own neutral "nothing to hide" pill, distinct from the backend "OK".
- Native check detail now shows the root ground-truth read (`root: …`) next to the app's own read (`app: …`) — the basis for the verdict. Adjacent cards with the same "access denied by SELinux" app read now explain themselves: one is "nothing to hide" (`root: no VPN`), the next is "SELinux" (`root: VPN present`). Plumbed through `CheckResult.groundTruthDetail` and exposed on the agent bridge.
- Drop the `/proc/net/route (Java)` probe — a duplicate of the native Rust probe with no root differential, so it could only report a misleading "OK" on the SELinux denial. The Rust probe already covers that vector correctly.
- Drop `getActiveNetworkInfo()` — its `.type` reports the underlying transport (WIFI/mobile) for an active VPN, not `TYPE_VPN`, so it never surfaced the leak. `getNetworkInfo(TYPE_VPN)` covers the same LSPOSED_NETWORK_INFO hook and works. `NetworkInterface enum` is kept (the canonical Java iface-enum a detector uses).

Testing: verified on a Pixel 8 Pro with all modules off via the agent bridge (runFullDiagnostics) — `/proc/net/route` reads `nothing_to_leak` with `root: 2 lines, no VPN entries`, `/proc/net/ipv6_route` reads `hidden_selinux` with `root: 4 VPN lines`, and the dropped checks no longer appear.
