### PR TITLE
Fix FolkPatch KPM activation

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -77,7 +77,7 @@ Open the VPN Hide app. The **Dashboard** tab will detect your device and kernel,
 
 Install the recommended module:
 - **kmod:** via KernelSU-Next / KernelSU / Magisk manager → Modules → Install from storage.
-- **KPM:** install `vpnhide-kpm.zip`; under APatch the app may ask you to save the SuperKey in **Settings → Security** for boot-time activation. Under Magisk, KernelSU, and KernelSU-Next, install KPatch-Next-Module first if it is not already installed.
+- **KPM:** install `vpnhide-kpm.zip`; under APatch/FolkPatch the app may ask you to save the SuperKey in **Settings → Security** for boot-time activation if the runtime does not expose a trusted KernelPatch `su` token. Under Magisk, KernelSU, and KernelSU-Next, install KPatch-Next-Module first if it is not already installed.
 - **Zygisk:** via KernelSU-Next, KernelSU, or Magisk manager → Modules.
 
 Reboot the device after installing the native module.

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ vpnhide скрывает от выбранных приложений три в�
 
 Установите рекомендованный модуль:
 - **kmod:** через KernelSU-Next / KernelSU / Magisk → Модули → Установить из хранилища.
-- **KPM:** установите `vpnhide-kpm.zip`; под APatch приложение может попросить сохранить SuperKey в **Настройки → Безопасность** для активации при загрузке. Под Magisk, KernelSU и KernelSU-Next сначала установите KPatch-Next-Module, если он ещё не установлен.
+- **KPM:** установите `vpnhide-kpm.zip`; под APatch/FolkPatch приложение может попросить сохранить SuperKey в **Настройки → Безопасность** для активации при загрузке, если runtime не выдаёт доверенный `su`-токен KernelPatch. Под Magisk, KernelSU и KernelSU-Next сначала установите KPatch-Next-Module, если он ещё не установлен.
 - **Zygisk:** через KernelSU-Next, KernelSU или Magisk → Модули.
 
 Перезагрузите устройство после установки нативного модуля.

--- a/changelog.d/fixed-kpm-activation-now-works-on-folkpatch-98ce.md
+++ b/changelog.d/fixed-kpm-activation-now-works-on-folkpatch-98ce.md
@@ -1,0 +1,9 @@
+_2026-07-04_
+
+## English
+
+KPM activation now works on FolkPatch/APatch setups that expose the trusted su KernelPatch control token, without requiring users to save a SuperKey when the runtime already grants it.
+
+## Русский
+
+Активация KPM теперь работает на FolkPatch/APatch-системах с доверенным su-токеном управления KernelPatch: сохранять SuperKey больше не требуется, если runtime уже выдаёт такой доступ.

--- a/crates/activator/src/lib.rs
+++ b/crates/activator/src/lib.rs
@@ -44,7 +44,7 @@ const PORTS_LOAD_LOG: &str = "/data/adb/vpnhide_ports/load_log";
 const MAX_NATIVE_TARGETS: usize = MAX_TARGET_UIDS;
 const PM_READY_ATTEMPTS: u32 = 60;
 const APATCH_SUPERCALL_NR: c_long = 45;
-const APATCH_SUPERCALL_DEFAULT_VERSION_CODE: c_long = 0x000d02;
+const APATCH_SUPERCALL_DEFAULT_VERSION_CODE: c_long = 0x000d00;
 const APATCH_SUPERCALL_MAGIC: c_long = 0x1158;
 const APATCH_TRUSTED_SU_KEY: &str = "su";
 const SUPERCALL_HELLO: c_long = 0x1000;
@@ -53,7 +53,7 @@ const SUPERCALL_KPM_LOAD: c_long = 0x1020;
 const SUPERCALL_KPM_CONTROL: c_long = 0x1022;
 const SUPERCALL_KPM_LIST: c_long = 0x1031;
 const APATCH_SUPERCALL_VERSION_FALLBACKS: &[c_long] = &[
-    0x000d01, 0x000d00, 0x000c02, 0x000c01, 0x000c00, 0x000b01, 0x000b00, 0x000a05,
+    0x000d02, 0x000d01, 0x000c02, 0x000c01, 0x000c00, 0x000b01, 0x000b00, 0x000a05,
 ];
 
 unsafe extern "C" {
@@ -1809,6 +1809,10 @@ mod tests {
     #[test]
     fn apatch_command_candidates_include_current_and_folkpatch_versions() {
         let candidates = apatch_command_candidates();
+        assert_eq!(
+            candidates.first(),
+            Some(&ApatchCommandStyle::Versioned(0x000d00))
+        );
         assert!(candidates.contains(&ApatchCommandStyle::Versioned(0x000d02)));
         assert!(candidates.contains(&ApatchCommandStyle::Versioned(0x000d01)));
         assert!(candidates.contains(&ApatchCommandStyle::Versioned(0x000d00)));

--- a/crates/activator/src/lib.rs
+++ b/crates/activator/src/lib.rs
@@ -44,15 +44,17 @@ const PORTS_LOAD_LOG: &str = "/data/adb/vpnhide_ports/load_log";
 const MAX_NATIVE_TARGETS: usize = MAX_TARGET_UIDS;
 const PM_READY_ATTEMPTS: u32 = 60;
 const APATCH_SUPERCALL_NR: c_long = 45;
-const APATCH_SUPERCALL_DEFAULT_VERSION_CODE: c_long = 0x000d00;
+const APATCH_SUPERCALL_DEFAULT_VERSION_CODE: c_long = 0x000d02;
 const APATCH_SUPERCALL_MAGIC: c_long = 0x1158;
+const APATCH_TRUSTED_SU_KEY: &str = "su";
 const SUPERCALL_HELLO: c_long = 0x1000;
 const SUPERCALL_HELLO_MAGIC: c_long = 0x11581158;
 const SUPERCALL_KPM_LOAD: c_long = 0x1020;
 const SUPERCALL_KPM_CONTROL: c_long = 0x1022;
 const SUPERCALL_KPM_LIST: c_long = 0x1031;
-const APATCH_SUPERCALL_VERSION_FALLBACKS: &[c_long] =
-    &[0x000c02, 0x000c01, 0x000c00, 0x000b01, 0x000b00, 0x000a05];
+const APATCH_SUPERCALL_VERSION_FALLBACKS: &[c_long] = &[
+    0x000d01, 0x000d00, 0x000c02, 0x000c01, 0x000c00, 0x000b01, 0x000b00, 0x000a05,
+];
 
 unsafe extern "C" {
     fn syscall(num: c_long, ...) -> c_long;
@@ -777,6 +779,17 @@ fn read_superkey() -> Result<String> {
     }
 }
 
+fn apatch_auth_candidates() -> Vec<String> {
+    let mut keys = Vec::new();
+    if let Ok(key) = read_superkey() {
+        keys.push(key);
+    }
+    if !keys.iter().any(|key| key == APATCH_TRUSTED_SU_KEY) {
+        keys.push(APATCH_TRUSTED_SU_KEY.to_owned());
+    }
+    keys
+}
+
 enum KpmClient {
     KpatchCli {
         path: PathBuf,
@@ -790,11 +803,26 @@ enum KpmClient {
 impl KpmClient {
     fn detect() -> Result<Self> {
         if Path::new(APATCH_DIR).is_dir() {
-            let key = read_superkey()
-                .map_err(|e| format!("APatch KPM requires saved superkey at {SUPERKEY_FILE}: {e}"));
-            let key = key?;
-            let style = apatch_probe(&key)?;
-            return Ok(Self::ApatchSupercall { key, style });
+            let mut failures = Vec::new();
+            for key in apatch_auth_candidates() {
+                match apatch_probe(&key) {
+                    Ok(style) => return Ok(Self::ApatchSupercall { key, style }),
+                    Err(e) => {
+                        let label = if key == APATCH_TRUSTED_SU_KEY {
+                            "trusted su"
+                        } else {
+                            "saved key"
+                        };
+                        failures.push(format!("{label}: {e}"));
+                    }
+                }
+            }
+            return Err(format!(
+                "APatch/FolkPatch KPM requires a valid saved superkey at {SUPERKEY_FILE} \
+                 or a trusted '{APATCH_TRUSTED_SU_KEY}' supercall grant (attempts: {})",
+                failures.join("; ")
+            )
+            .into());
         }
         let path = find_kpatch().ok_or("kpatch CLI not found")?;
         kpatch_hello(&path)?;
@@ -1776,6 +1804,21 @@ mod tests {
             0x1000,
         );
         assert_eq!(SUPERCALL_HELLO_MAGIC, 0x11581158);
+    }
+
+    #[test]
+    fn apatch_command_candidates_include_current_and_folkpatch_versions() {
+        let candidates = apatch_command_candidates();
+        assert!(candidates.contains(&ApatchCommandStyle::Versioned(0x000d02)));
+        assert!(candidates.contains(&ApatchCommandStyle::Versioned(0x000d01)));
+        assert!(candidates.contains(&ApatchCommandStyle::Versioned(0x000d00)));
+        assert_eq!(
+            candidates
+                .iter()
+                .filter(|style| **style == ApatchCommandStyle::Versioned(0x000d01))
+                .count(),
+            1,
+        );
     }
 
     #[test]

--- a/docs/state.md
+++ b/docs/state.md
@@ -78,15 +78,15 @@ module reinstall. They hold binaries and boot scripts, not user-managed config.
 ### `/data/adb/modules/vpnhide_kpm/`
 
 - `module.prop`: module metadata.
-- `post-fs-data.sh`: loads KPM automatically on keyless KPatch-Next; on APatch
-  records `awaiting_superkey` and leaves saved-key load/config to service.
+- `post-fs-data.sh`: loads KPM automatically on keyless KPatch-Next; on
+  APatch/FolkPatch records a deferred status and leaves load/config to service.
 - `service.sh`: starts `activator --boot-wait` in the background.
 - `uninstall.sh`: removes KPM-specific persistent status and legacy targets
   under `/data/adb/vpnhide_kpm/`.
 - `activator`: Rust bin that refuses to run when the `.ko` backend is present,
   reads optional `/data/adb/vpnhide/superkey`, loads/configures KPM through
-  APatch direct supercalls or KPatch-Next `kpatch kpm load` + `kpatch kpm ctl0`
-  (including the standalone KPatch-Next-Module CLI path).
+  APatch/FolkPatch direct supercalls or KPatch-Next `kpatch kpm load` +
+  `kpatch kpm ctl0` (including the standalone KPatch-Next-Module CLI path).
 - `vpnhide.kpm`: KernelPatch module binary.
 
 ### `/data/adb/modules/vpnhide_zygisk/`
@@ -188,10 +188,11 @@ so activator delivers one bounded snapshot.
 ### KPM Supercall Channel
 
 No file or proc node. The KPM activator sends the same `vpnhide 1 config` text
-wire through the KernelPatch KPM ctl0 supercall. On APatch it invokes the
-supercall directly with the saved SuperKey; on KPatch-Next it uses
-`kpatch kpm ctl0` from the runtime's own CLI. Status/stats use the same ctl0
-request/response channel.
+wire through the KernelPatch KPM ctl0 supercall. On APatch/FolkPatch it invokes
+the supercall directly with the saved SuperKey when present, otherwise with the
+runtime's trusted `su` token when that grant is available. On KPatch-Next it
+uses `kpatch kpm ctl0` from the runtime's own CLI. Status/stats use the same
+ctl0 request/response channel.
 
 ### Zygisk Module-Dir `targets.txt`
 
@@ -299,14 +300,15 @@ post-fs-data:
   KPM post-fs-data
     -> refuse if .ko module is installed+enabled
     -> keyless KPatch-Next: load vpnhide.kpm
-    -> APatch: defer to service activator; without saved key, write awaiting_superkey
+    -> APatch/FolkPatch: defer to service activator; service tries saved key,
+       then trusted su token, else writes awaiting_superkey
 
 service:
   kmod / KPM / Zygisk service.sh
     -> start that module's activator with --boot-wait in the background
     -> activator waits for PackageManager to expose dev.okhsunrog.vpnhide
     -> kmod activator also waits for /proc/vpnhide_ctl
-    -> KPM activator uses saved APatch SuperKey when present
+    -> KPM activator uses saved APatch SuperKey or trusted su token when present
     -> activator reads canonical JSON and writes exactly one native channel
   ports service.sh
     -> start background waiter

--- a/docs/storage.md
+++ b/docs/storage.md
@@ -211,7 +211,7 @@ crates/
     src/lib.rs              # shared core: JSON schema (serde), pkg→uid resolution
                             #   (`pm`), project_native(json) -> String
     src/bin/kmod.rs         #   project_native(json) → write("/proc/vpnhide_ctl")
-    src/bin/kpm.rs          #   project_native(json) → APatch supercall / KPatch-Next `kpatch`
+    src/bin/kpm.rs          #   project_native(json) → APatch/FolkPatch supercall / KPatch-Next `kpatch`
     src/bin/zygisk.rs       #   project_native(json) → write_atomic(module_dir file)
     src/bin/ports.rs        #   project_ports(json) → iptables-restore/ip6tables-restore
 zygisk/                     # cdylib — the injected .so. deps: protocol (+ shadowhook).
@@ -241,7 +241,7 @@ zygisk/                     # cdylib — the injected .so. deps: protocol (+ sha
 | Backend | Channel | Kind | Note |
 |---|---|---|---|
 | kmod | `/proc/vpnhide_ctl` | proc node | write = config (kernel parses to memory); read = status+stats |
-| KPM | KPM ctl0 supercall | supercall | APatch direct supercall or KPatch-Next runtime `kpatch kpm ctl0`; no file |
+| KPM | KPM ctl0 supercall | supercall | APatch/FolkPatch direct supercall or KPatch-Next runtime `kpatch kpm ctl0`; no file |
 | Zygisk | file in its module dir | file | the `.so` reads it via the `get_module_dir()` fd |
 
 Why Zygisk needs a file in its module dir even though there is one canonical: the
@@ -320,7 +320,7 @@ UID-gated — *any* process could invoke it. The **superkey** is the capability 
 that authenticates "may control the kernel patch". So it defends against the same
 **unprivileged** adversary this project already cares about: without it, a non-root
 app could `ctl0` our config or grant itself root. (KPatch-Next `d05` under
-Magisk/KSU is **keyless**; this whole section is **APatch-only**.)
+Magisk/KSU is **keyless**; this whole section is **APatch/FolkPatch-only**.)
 
 - **Default:** session-only, re-prompt each session (APatch's own model).
 - **Optional flag `rememberSuperkey`** (in the canonical `settings`): persist it so
@@ -340,15 +340,18 @@ Magisk/KSU is **keyless**; this whole section is **APatch-only**.)
 - **What it unlocks: APatch boot activation.** With the key on disk, the `kpm`
   activator reads it at boot and uses APatch's KernelPatch supercall ABI directly
   to load/configure the KPM — so APatch reaches **parity with keyless KPatch-Next**
-  (protection active after a reboot, no app open needed). Without the flag, APatch
-  cannot be configured at boot because the KPM supercalls require the real key.
+  (protection active after a reboot, no app open needed). Some FolkPatch/APatch
+  builds expose a trusted `su` token to already-authorized root callers; on those
+  builds the activator can use that token and no saved SuperKey is needed.
+  Without either token, boot records `awaiting_superkey`.
 - **Plain file, not Keystore.** The boot activator is a Rust binary, not an Android
   app, so it cannot call Android Keystore (a framework/binder API). Keystore-wrapping
   could protect the *app-time* use only, not the boot path. So the boot-usable copy
   is a plain file; FBE DE-encryption protects it at rest on a powered-off device.
 - **Threat-model fit:** readable by **root only** (trusted in this project's model),
-  never by unprivileged apps or non-root `adb` (§7). The APatch activator calls the
-  supercall directly, so the key is not passed through an external `kpatch` argv.
+  never by unprivileged apps or non-root `adb` (§7). The APatch/FolkPatch activator
+  calls the supercall directly, so the key is not passed through an external
+  `kpatch` argv.
 
 ---
 
@@ -436,9 +439,9 @@ IPC for the native backends. This document supersedes its statements about the
 - **LSPosed does not consume the wire** — it reads the canonical JSON directly
   (§3). protocol.md's "LSPosed parses its config profile from its file" / the
   LSPosed rows in its channel + profile tables are superseded here.
-- **APatch boot is configurable** when the superkey is persisted (§6); without
-  it, boot records `awaiting_superkey` and activation resumes after the app
-  supplies the key.
+- **APatch/FolkPatch boot is configurable** when the superkey is persisted (§6)
+  or the runtime grants the trusted `su` token; without either, boot records
+  `awaiting_superkey` and activation resumes after the app supplies the key.
 - **The app does not hand-build per-channel configs** — the activator does
   (§4). The serialiser is the Rust `protocol` crate, shared with the Zygisk `.so`.
 

--- a/kmod/kpm/README.md
+++ b/kmod/kpm/README.md
@@ -105,9 +105,10 @@ everywhere (target the upstream `kpm.h` ABI).
 
 Supported runtimes — pick whichever matches the device's root:
 
-- **APatch** — KernelPatch is built in; the flashable zip installs as an
-  APatch/APM module, and the vpnhide activator loads/configures `vpnhide.kpm`
-  through direct KernelPatch supercalls with the saved APatch SuperKey.
+- **APatch / FolkPatch** — KernelPatch is built in; the flashable zip installs
+  as an APatch/APM module, and the vpnhide activator loads/configures
+  `vpnhide.kpm` through direct KernelPatch supercalls with the saved APatch
+  SuperKey or the runtime's trusted `su` token when available.
 - **KernelSU-Next** — flash **KPatch-Next** (one module, no switch to APatch).
 - **Magisk or stock KernelSU** — flash the standalone
   [KPatch-Next-Module](https://github.com/KernelSU-Next/KPatch-Next-Module).
@@ -120,16 +121,16 @@ Supported runtimes — pick whichever matches the device's root:
 
 Persistence: a one-shot runtime `sc_kpm_load` is **lost on reboot**. The
 vpnhide KPM module therefore ships `vpnhide.kpm` plus boot scripts: KPatch-Next
-loads via its runtime `kpatch` CLI, while APatch defers to the activator and
-uses the saved SuperKey when present.
+loads via its runtime `kpatch` CLI, while APatch/FolkPatch defers to the
+activator and uses the saved SuperKey or trusted `su` token when present.
 
 Targeting / control plane: our target-UID set is delivered via the module's
 own `KPM_CTL0` supercall + load-args (the shape the QEMU harness exercises) —
 this is independent of KPatch-Next's generic `package_config` →
 `kpatch exclude_set <uid>` mechanism. The app stores package roles in
 `/data/system/vpnhide_config.json`; the KPM activator resolves that canonical
-config and pushes the same text wire through APatch direct supercalls or
-KPatch-Next `kpatch kpm ctl0`.
+config and pushes the same text wire through APatch/FolkPatch direct supercalls
+or KPatch-Next `kpatch kpm ctl0`.
 
 ## Safety — read before testing on a device
 

--- a/kmod/kpm/module/post-fs-data.sh
+++ b/kmod/kpm/module/post-fs-data.sh
@@ -7,10 +7,10 @@
 #
 # Runtime split (protocol §7.4):
 #   - KPatch-Next (Magisk / KSU), keyless (d05): load here, fully automatic.
-#   - APatch, superkey-required (c02): post-fs-data has no superkey, so it
-#     records `awaiting_superkey`; service.sh can load/configure later through
-#     the activator's direct supercall path if the app saved
-#     /data/adb/vpnhide/superkey.
+#   - APatch/FolkPatch: post-fs-data records a deferred status; service.sh
+#     can load/configure later through the activator's direct supercall path
+#     with a saved /data/adb/vpnhide/superkey or the runtime's trusted `su`
+#     supercall grant.
 #
 # Single-active guard (protocol §1.5): if the .ko backend is installed, do NOT
 # load the KPM. They wrap the same kernel functions and co-residence freezes
@@ -80,9 +80,9 @@ if [ ! -f "$KPM" ]; then
     exit 1
 fi
 
-# --- APatch (c02): superkey-required, service activator owns load/config ------
+# --- APatch/FolkPatch: service activator owns load/config -------------------
 if [ -d /data/adb/ap ]; then
-    log -t vpnhide "kpm: APatch runtime — deferring load to service activator (superkey)"
+    log -t vpnhide "kpm: APatch/FolkPatch runtime — deferring load to service activator"
     write_status apatch 0 awaiting_superkey
     exit 0
 fi

--- a/kmod/kpm/module/service.sh
+++ b/kmod/kpm/module/service.sh
@@ -4,6 +4,7 @@
 
 MODDIR="${0%/*}"
 ACTIVATOR="$MODDIR/activator"
+KPM="$MODDIR/vpnhide.kpm"
 STATUS_DIR="/data/adb/vpnhide_kpm"
 STATUS_FILE="$STATUS_DIR/load_status"
 SUPERKEY_FILE="/data/adb/vpnhide/superkey"
@@ -41,10 +42,10 @@ apply_at_boot() {
         write_status activator 0 "activator missing at $ACTIVATOR"
         return 1
     fi
-    if [ -d /data/adb/ap ] && [ ! -s "$SUPERKEY_FILE" ]; then
-        log -t vpnhide "kpm: APatch runtime — awaiting saved superkey"
-        write_status apatch 0 awaiting_superkey
-        return 0
+    if [ ! -f "$KPM" ]; then
+        log -t vpnhide "kpm: KPM missing at $KPM"
+        write_status activator 0 "vpnhide.kpm missing at $KPM"
+        return 1
     fi
 
     out="$("$ACTIVATOR" --boot-wait 2>&1)"
@@ -63,6 +64,11 @@ apply_at_boot() {
             ;;
         *)
             log -t vpnhide "kpm: activator failed rc=$rc"
+            if [ -d /data/adb/ap ] && [ ! -s "$SUPERKEY_FILE" ] && \
+               printf '%s' "$out" | grep -q "APatch/FolkPatch KPM requires"; then
+                write_status apatch 0 awaiting_superkey
+                return 0
+            fi
             write_status activator 0 "rc=$rc $out"
             return "$rc"
             ;;

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DashboardData.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DashboardData.kt
@@ -137,14 +137,15 @@ internal fun kpmDeferredForConflict(
 }
 
 /**
- * True when the KPM boot script stood down this boot because it runs under APatch
- * and no superkey is saved yet (`runtime=apatch, loaded=0, detail=awaiting_superkey`
- * for the current boot_id — see kmod/kpm/module/post-fs-data.sh and protocol §1.5).
+ * True when the KPM boot script stood down this boot because it runs under
+ * APatch/FolkPatch and has no usable saved SuperKey or trusted `su` token
+ * (`runtime=apatch, loaded=0, detail=awaiting_superkey` for the current
+ * boot_id — see kmod/kpm/module/service.sh and protocol §1.5).
  *
  * Distinct from [kpmDeferredForConflict] (that writes `runtime=conflict`): here the
- * module is installed and healthy but dormant, waiting for the user to save the
- * APatch superkey in Settings so the service activator can load it. Without this,
- * the dashboard would just show KPM as inactive with no explanation.
+ * module is installed and healthy but dormant, waiting for an APatch SuperKey
+ * in Settings so the service activator can load it. Without this, the dashboard
+ * would just show KPM as inactive with no explanation.
  */
 internal fun kpmAwaitingSuperkey(
     loadStatusSection: String,
@@ -157,6 +158,12 @@ internal fun kpmAwaitingSuperkey(
         load["detail"]?.trim() == "awaiting_superkey" &&
         !bootId.isNullOrEmpty() &&
         bootId == currentBootId.trim()
+}
+
+internal fun kpatchRuntimeAvailable(kpatchRuntimeSection: String): Boolean {
+    val props = parseKeyValueLines(kpatchRuntimeSection)
+    if (props["apatch_dir"]?.trim() == "1") return true
+    return props["hello_exit"]?.trim() == "0"
 }
 
 internal data class PortsApplyProblem(
@@ -1284,9 +1291,9 @@ internal suspend fun loadDashboardState(
     // the "kmod-capable kernel, only zygisk installed" warning (W1), and the
     // wrong-variant detection below.
     val kernelRaw = shellSnapshot["kernel_release"].orEmpty()
-    val kpatchRuntimeAvailable = shellSnapshot["kpatch_runtime"].orEmpty().trim() == "1"
+    val hasKpatchRuntime = kpatchRuntimeAvailable(shellSnapshot["kpatch_runtime"].orEmpty())
     val kernelRecommendation =
-        buildNativeInstallRecommendation(kernelRaw, androidMajorVersionLabel(), kpatchRuntimeAvailable)
+        buildNativeInstallRecommendation(kernelRaw, androidMajorVersionLabel(), hasKpatchRuntime)
     val kmodLoadStatus =
         readKmodLoadStatus(
             currentBootId.trim(),
@@ -1627,9 +1634,9 @@ internal suspend fun loadDashboardState(
         }
     }
 
-    // KPM is installed under APatch but dormant because no superkey is saved yet.
-    // Without this the module just reads as inactive with no reason; tell the user
-    // to save the superkey so the service activator can load it.
+    // KPM is installed under APatch/FolkPatch but dormant because neither a
+    // trusted `su` token nor a saved SuperKey was usable. Without this the module
+    // just reads as inactive with no reason.
     if (kpm is ModuleState.Installed &&
         kpmAwaitingSuperkey(shellSnapshot["kpm_load_status"].orEmpty(), currentBootId)
     ) {

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DebugShellSnapshot.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DebugShellSnapshot.kt
@@ -188,6 +188,7 @@ internal fun buildDebugShellSnapshotCommand(): String =
       echo "ksu_version=${'$'}(cat /data/adb/ksu/version 2>/dev/null || true)"
       echo "ksud_version=${'$'}(ksud --version 2>/dev/null || true)"
       [ -d /data/adb/ap ] && echo "apatch_dir=1" || echo "apatch_dir=0"
+      [ -x /data/adb/apd ] && echo "apd=1" || echo "apd=0"
       [ -d /data/adb/magisk ] && echo "magisk_dir=1" || echo "magisk_dir=0"
       [ -d /data/adb/ksu ] && echo "ksu_dir=1" || echo "ksu_dir=0"
       ls -ldZ /data/adb /data/adb/modules /data/adb/modules_update 2>&1 ||
@@ -257,7 +258,14 @@ internal fun buildDebugShellSnapshotCommand(): String =
     '
     emit_eval kpatch_runtime '
       [ -d /data/adb/ap ] && echo "apatch_dir=1" || echo "apatch_dir=0"
+      [ -x /data/adb/apd ] && echo "apd=1" || echo "apd=0"
       [ -s $SUPERKEY_FILE ] && echo "superkey_saved=1" || echo "superkey_saved=0"
+      if [ -f /data/adb/fp/kpms/kpm_autoload_config.json ]; then
+        echo "folkpatch_kpm_autoload=1"
+        sed -n "1,80p" /data/adb/fp/kpms/kpm_autoload_config.json 2>&1 || true
+      else
+        echo "folkpatch_kpm_autoload=0"
+      fi
       BIN="${'$'}(kpatch_bin 2>/dev/null || true)"
       if [ -n "${'$'}BIN" ]; then
         echo "kpatch_bin=${'$'}BIN"

--- a/lsposed/app/src/main/res/values-ru/strings.xml
+++ b/lsposed/app/src/main/res/values-ru/strings.xml
@@ -263,7 +263,7 @@
     <string name="dashboard_issue_kmod_capable_but_zygisk">Ваше ядро поддерживает модуль ядра — он работает в пространстве ядра и невидим для анти-тампер проверок. Zygisk тоже работает, но банковские и платёжные приложения могут обнаружить его хуки, если для них включён Native. Установите %1$s и удалите Zygisk-модуль.</string>
     <string name="dashboard_issue_native_conflict_kernel">Модуль ядра (.ko) и KPM установлены одновременно. Они перехватывают одни и те же функции ядра, и при одновременной работе устройство может полностью зависнуть. Оставьте только один — удалите либо модуль ядра, либо KPM.</string>
     <string name="dashboard_issue_native_conflict_deferred">Модуль ядра (.ko) и KPM установлены одновременно. KPM отключился при загрузке, чтобы не подвесить устройство, и сейчас бездействует. Оставьте только один — удалите KPM (или модуль ядра).</string>
-    <string name="dashboard_issue_kpm_awaiting_superkey">KPM установлен, но не активен: APatch нужен суперключ, чтобы его загрузить. Сохраните его в Настройки → Безопасность и перезагрузитесь для активации нативного скрытия.</string>
+    <string name="dashboard_issue_kpm_awaiting_superkey">KPM установлен, но не активен: APatch/FolkPatch не смог загрузить его через доверенный su-токен. Сохраните SuperKey в Настройки → Безопасность и перезагрузитесь для активации нативного скрытия.</string>
     <string name="dashboard_issue_kpm_activator_missing">Модуль KPM повреждён: отсутствует бинарник активатора (%1$s). Переустановите vpnhide-kpm.zip из последнего релиза.</string>
     <string name="dashboard_issue_kpm_load_failed">KPM установлен, но не загрузился: %1$s. Чтобы приложить полный лог загрузки к отчёту об ошибке, нажмите Настройки → Отладка → Собрать отладочный лог, либо переустановите vpnhide-kpm.zip из последнего релиза.</string>
     <string name="dashboard_issue_multiple_native">Установлено больше одного Native-бэкенда. Активным может быть только один (приоритет: модуль ядра, затем KPM, затем Zygisk), остальные простаивают. Удалите неиспользуемые, чтобы не засорять систему.</string>
@@ -457,9 +457,9 @@
     <string name="settings_auto_hide_saved">Настройки скрытия приложений сохранены.</string>
     <string name="settings_auto_hide_failed">Не удалось обновить настройки скрытия приложений.</string>
     <string name="settings_security">Безопасность</string>
-    <string name="settings_superkey_title">APatch SuperKey</string>
+    <string name="settings_superkey_title">APatch/FolkPatch SuperKey</string>
     <string name="settings_superkey_saved">Сохранён для активации KPM при загрузке.</string>
-    <string name="settings_superkey_not_saved">Не сохранён; APatch KPM нужно активировать из приложения после загрузки.</string>
+    <string name="settings_superkey_not_saved">Не сохранён; APatch/FolkPatch KPM может потребовать активацию из приложения после загрузки, если доверенный su недоступен.</string>
     <string name="settings_superkey_placeholder">SuperKey</string>
     <string name="settings_superkey_store">Сохранить SuperKey</string>
     <string name="settings_superkey_clear">Очистить</string>

--- a/lsposed/app/src/main/res/values/strings.xml
+++ b/lsposed/app/src/main/res/values/strings.xml
@@ -292,7 +292,7 @@
     <string name="dashboard_issue_kmod_capable_but_zygisk">Your kernel supports the kernel module — it hooks in kernel space and is invisible to anti-tamper checks. Zygisk works too, but banking and payment apps may detect its hooks when Native is enabled for them. Install %1$s and uninstall the Zygisk module for cleaner coverage.</string>
     <string name="dashboard_issue_native_conflict_kernel">The kernel module (.ko) and the KPM are both installed. They hook the same kernel functions, and having both active can hard-freeze the device. Keep only one — uninstall either the kernel module or the KPM.</string>
     <string name="dashboard_issue_native_conflict_deferred">The kernel module (.ko) and the KPM are both installed. The KPM stood down at boot to avoid a freeze, so it isn\'t doing anything. Keep only one — uninstall the KPM (or the kernel module).</string>
-    <string name="dashboard_issue_kpm_awaiting_superkey">The KPM is installed but inactive: APatch needs your superkey to load it. Save it in Settings → Security, then reboot to activate native hiding.</string>
+    <string name="dashboard_issue_kpm_awaiting_superkey">The KPM is installed but inactive: APatch/FolkPatch could not load it with the trusted su token. Save your SuperKey in Settings → Security, then reboot to activate native hiding.</string>
     <string name="dashboard_issue_kpm_activator_missing">KPM module is corrupted: the activator binary is missing (%1$s). Reinstall vpnhide-kpm.zip from the latest release.</string>
     <string name="dashboard_issue_kpm_load_failed">KPM installed but failed to load: %1$s. Use Settings → Debugging → Collect debug log to attach the full boot-time output to a bug report, or reinstall vpnhide-kpm.zip from the latest release.</string>
     <string name="dashboard_issue_multiple_native">More than one native backend is installed. Only one can be active at a time (priority: kernel module, then KPM, then Zygisk); the others sit idle. Uninstall the ones you don\'t use to keep things clean.</string>
@@ -488,9 +488,9 @@
     <string name="settings_auto_hide_saved">App hiding settings saved.</string>
     <string name="settings_auto_hide_failed">Failed to update app hiding settings.</string>
     <string name="settings_security">Security</string>
-    <string name="settings_superkey_title">APatch SuperKey</string>
+    <string name="settings_superkey_title">APatch/FolkPatch SuperKey</string>
     <string name="settings_superkey_saved">Saved for boot-time KPM activation.</string>
-    <string name="settings_superkey_not_saved">Not saved; APatch KPM needs in-app activation after boot.</string>
+    <string name="settings_superkey_not_saved">Not saved; APatch/FolkPatch KPM may need in-app activation after boot if trusted su is unavailable.</string>
     <string name="settings_superkey_placeholder">SuperKey</string>
     <string name="settings_superkey_store">Store SuperKey</string>
     <string name="settings_superkey_clear">Clear</string>

--- a/lsposed/app/src/test/kotlin/dev/okhsunrog/vpnhide/NativeBackendTest.kt
+++ b/lsposed/app/src/test/kotlin/dev/okhsunrog/vpnhide/NativeBackendTest.kt
@@ -199,6 +199,43 @@ class NativeBackendTest {
         assertEquals(false, kpmAwaitingSuperkey("", "boot-1"))
     }
 
+    // ── kpatchRuntimeAvailable ───────────────────────────────────────────
+
+    @Test
+    fun `kpatch runtime available when APatch or FolkPatch directory is present`() {
+        val runtime =
+            """
+            apatch_dir=1
+            superkey_saved=0
+            kpatch_bin=(not found)
+            """.trimIndent()
+        assertEquals(true, kpatchRuntimeAvailable(runtime))
+    }
+
+    @Test
+    fun `kpatch runtime available when KPatch-Next hello succeeds`() {
+        val runtime =
+            """
+            apatch_dir=0
+            superkey_saved=0
+            kpatch_bin=/data/adb/modules/KPatch-Next/bin/kpatch
+            hello_exit=0
+            list_exit=0
+            """.trimIndent()
+        assertEquals(true, kpatchRuntimeAvailable(runtime))
+    }
+
+    @Test
+    fun `kpatch runtime unavailable when neither APatch nor KPatch-Next responds`() {
+        val runtime =
+            """
+            apatch_dir=0
+            superkey_saved=0
+            kpatch_bin=(not found)
+            """.trimIndent()
+        assertEquals(false, kpatchRuntimeAvailable(runtime))
+    }
+
     // ── detectKpmModule ──────────────────────────────────────────────────
 
     @Test


### PR DESCRIPTION
## Summary
- add APatch/FolkPatch KPM auth fallbacks, including current KernelPatch protocol versions and trusted su token attempts
- let the KPM service activator try runtime auth before reporting that a SuperKey is needed
- update dashboard detection, diagnostics, docs, and strings for APatch/FolkPatch behavior

## Validation
- cargo fmt --manifest-path crates/activator/Cargo.toml
- cargo test --manifest-path crates/activator/Cargo.toml
- cd lsposed && ./gradlew :app:testDebugUnitTest --tests dev.okhsunrog.vpnhide.NativeBackendTest --tests dev.okhsunrog.vpnhide.BuildNativeInstallRecommendationTest
- cd lsposed && ./gradlew app:ktlintCheck
- cd lsposed && ./gradlew :app:detekt
- sh -n kmod/kpm/module/post-fs-data.sh && sh -n kmod/kpm/module/service.sh
- git diff --check
- python3 kmod/kpm/build.py
- Pixel 4a on FolkPatch 4.3: installed rebuilt KPM, verified activator status reports loaded=1/configured and VPN diagnostics pass with WGTunnel active (native hidden=4 leaks=0, java hidden=12 leaks=0)

## Notes
On the tested FolkPatch build, KPM supercalls still required the real saved SuperKey; trusted su was attempted but not accepted by that runtime. The service now attempts activation first and reports the APatch/FolkPatch SuperKey requirement instead of stopping early.