### PR TITLE
Single-row adaptive app bar; filters as list chips; airy Dashboard header

### DIFF
--- a/changelog.d/changed-compact-single-row-app-bar-logo-ea17.md
+++ b/changelog.d/changed-compact-single-row-app-bar-logo-ea17.md
@@ -1,0 +1,9 @@
+_2026-07-04_
+
+## English
+
+Compact single-row app bar (logo, title and actions on one line) that scales the brand down on very narrow screens; Apps-list filters moved out of the top-bar menu into chips above the list.
+
+## Русский
+
+Компактная однострочная шапка (логотип, заголовок и кнопки в одну строку), бренд ужимается на очень узких экранах; фильтры списка приложений вынесены из меню шапки в чипы над списком.

--- a/changelog.d/changed-on-large-screens-the-dashboard-expands-3406.md
+++ b/changelog.d/changed-on-large-screens-the-dashboard-expands-3406.md
@@ -1,0 +1,9 @@
+_2026-07-04_
+
+## English
+
+On large screens the Dashboard expands its header into a larger brand and animates back to the compact bar when you switch tabs.
+
+## Русский
+
+На больших экранах шапка Dashboard раскрывается в крупный бренд и плавно возвращается к компактной строке при переключении вкладок.

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/AppPickerScreen.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/AppPickerScreen.kt
@@ -92,6 +92,9 @@ internal fun AppPickerScreen(
     showSystem: Boolean,
     showRussianOnly: Boolean,
     sortMode: TargetListSortMode,
+    onToggleSystem: () -> Unit,
+    onToggleRussianOnly: () -> Unit,
+    onSortModeChange: (TargetListSortMode) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     TargetPickerScreen(
@@ -99,6 +102,9 @@ internal fun AppPickerScreen(
         showSystem = showSystem,
         showRussianOnly = showRussianOnly,
         sortMode = sortMode,
+        onToggleSystem = onToggleSystem,
+        onToggleRussianOnly = onToggleRussianOnly,
+        onSortModeChange = onSortModeChange,
         modifier = modifier,
         helpPrefKey = "apps_unified",
         helpTitle = stringResource(R.string.apps_help_title),

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/MainActivity.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/MainActivity.kt
@@ -11,6 +11,7 @@ import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.animation.AnimatedContent
 import androidx.compose.animation.EnterTransition
 import androidx.compose.animation.ExitTransition
+import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.core.tween
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
@@ -33,6 +34,7 @@ import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
@@ -40,6 +42,7 @@ import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.lerp
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
 import androidx.lifecycle.compose.LocalLifecycleOwner
@@ -260,6 +263,59 @@ private fun AppTopBarTitle(currentTab: Tab) {
     }
 }
 
+/**
+ * Brand block (logo + wordmark + tab label) for the main header, able to grow.
+ * [progress] 0 = compact (single-line bar, same as everywhere), 1 = airy (big
+ * logo dropped below the pinned action buttons — used only on the Dashboard on
+ * tall screens). It also keeps the narrow-screen down-scaling of the compact
+ * state so nothing wraps on small widths.
+ */
+@Composable
+private fun AppHeaderBrand(
+    currentTab: Tab,
+    progress: Float,
+    modifier: Modifier = Modifier,
+) {
+    val tabLabel =
+        when (currentTab) {
+            Tab.Dashboard -> stringResource(R.string.tab_dashboard)
+            Tab.Statistics -> stringResource(R.string.tab_statistics)
+            Tab.Protection -> stringResource(R.string.tab_protection)
+        }
+    BoxWithConstraints(modifier) {
+        val narrowScale = (maxWidth.value / 200f).coerceIn(0.6f, 1f)
+        val logoSize = lerp(38.dp * narrowScale, 58.dp, progress)
+        val titleSize = MaterialTheme.typography.headlineSmall.fontSize * narrowScale * (1f + 0.28f * progress)
+        val subSize = MaterialTheme.typography.labelLarge.fontSize * narrowScale * (1f + 0.12f * progress)
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            Icon(
+                painter = painterResource(R.drawable.topbar_mark),
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.primary,
+                modifier = Modifier.size(logoSize),
+            )
+            Spacer(Modifier.width(lerp(12.dp, 16.dp, progress)))
+            Column {
+                Text(
+                    text = stringResource(R.string.app_name),
+                    style = MaterialTheme.typography.headlineSmall,
+                    fontSize = titleSize,
+                    fontWeight = FontWeight.Bold,
+                    color = MaterialTheme.colorScheme.onSurface,
+                    maxLines = 1,
+                )
+                Text(
+                    text = tabLabel,
+                    style = MaterialTheme.typography.labelLarge,
+                    fontSize = subSize,
+                    color = MaterialTheme.colorScheme.primary,
+                    maxLines = 1,
+                )
+            }
+        }
+    }
+}
+
 @Composable
 private fun TopBarActionButton(
     onClick: () -> Unit,
@@ -442,18 +498,46 @@ private fun MainScreen() {
                     modifier = Modifier.fillMaxWidth(),
                 ) {}
             } else {
-                TopAppBar(
-                    title = { AppTopBarTitle(currentTab) },
-                    colors =
-                        TopAppBarDefaults.topAppBarColors(
-                            containerColor = AppColors.topBarContainer,
-                            scrolledContainerColor = AppColors.topBarScrolledContainer,
-                            titleContentColor = MaterialTheme.colorScheme.onSurface,
-                            actionIconContentColor = MaterialTheme.colorScheme.onSurfaceVariant,
-                        ),
-                    actions = {
+                // Dashboard on a tall screen gets an "airy" header: the brand
+                // grows and drops below the (fixed) action buttons. Everywhere
+                // else — and on short screens — it stays the compact single row.
+                // The whole thing morphs via `headerProgress` on tab switch.
+                val airy =
+                    currentTab == Tab.Dashboard &&
+                        LocalConfiguration.current.screenHeightDp >= 760
+                val headerProgress by animateFloatAsState(
+                    targetValue = if (airy) 1f else 0f,
+                    animationSpec = tween(durationMillis = 300),
+                    label = "headerAiry",
+                )
+                // Room the brand must leave for the pinned buttons in the compact
+                // state (2 actions normally, 3 on Protection with Search).
+                val actionReserve = ((if (currentTab == Tab.Protection) 3 else 2) * 52 + 24).dp
+                Surface(color = AppColors.topBarContainer) {
+                    Box(
+                        modifier =
+                            Modifier
+                                .fillMaxWidth()
+                                .statusBarsPadding(),
+                    ) {
+                        AppHeaderBrand(
+                            currentTab = currentTab,
+                            progress = headerProgress,
+                            modifier =
+                                Modifier
+                                    .align(Alignment.TopStart)
+                                    .padding(
+                                        start = 16.dp,
+                                        top = lerp(13.dp, 32.dp, headerProgress),
+                                        bottom = lerp(13.dp, 22.dp, headerProgress),
+                                        end = lerp(actionReserve, 12.dp, headerProgress),
+                                    ),
+                        )
                         Row(
-                            modifier = Modifier.padding(end = 16.dp),
+                            modifier =
+                                Modifier
+                                    .align(Alignment.TopEnd)
+                                    .padding(top = 10.dp, end = 16.dp),
                             horizontalArrangement = Arrangement.spacedBy(8.dp),
                             verticalAlignment = Alignment.CenterVertically,
                         ) {
@@ -536,8 +620,8 @@ private fun MainScreen() {
                                 )
                             }
                         }
-                    },
-                )
+                    }
+                }
             }
         },
         bottomBar = {

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/MainActivity.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/MainActivity.kt
@@ -24,7 +24,6 @@ import androidx.compose.material.icons.automirrored.filled.List
 import androidx.compose.material.icons.filled.BarChart
 import androidx.compose.material.icons.filled.Clear
 import androidx.compose.material.icons.filled.ErrorOutline
-import androidx.compose.material.icons.filled.FilterList
 import androidx.compose.material.icons.filled.Home
 import androidx.compose.material.icons.filled.Lock
 import androidx.compose.material.icons.filled.Refresh
@@ -226,25 +225,37 @@ private fun AppTopBarTitle(currentTab: Tab) {
             Tab.Statistics -> stringResource(R.string.tab_statistics)
             Tab.Protection -> stringResource(R.string.tab_protection)
         }
-    Row(verticalAlignment = Alignment.CenterVertically) {
-        Icon(
-            painter = painterResource(R.drawable.topbar_mark),
-            contentDescription = null,
-            tint = MaterialTheme.colorScheme.primary,
-            modifier = Modifier.size(46.dp),
-        )
-        Spacer(Modifier.width(12.dp))
-        Column {
-            Text(
-                text = stringResource(R.string.app_name),
-                style = MaterialTheme.typography.headlineSmall,
-                fontWeight = FontWeight.Bold,
+    // The full-size brand block (logo + wordmark) wants ~190dp. Material3's
+    // TopAppBar hands the title only the width left over after the action
+    // buttons, so on very narrow / high-density screens that slot shrinks.
+    // Scale the logo and the two text lines down together (never below 70%) so
+    // the brand stays on a single line instead of wrapping.
+    BoxWithConstraints {
+        val scale = (maxWidth.value / 200f).coerceIn(0.6f, 1f)
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            Icon(
+                painter = painterResource(R.drawable.topbar_mark),
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.primary,
+                modifier = Modifier.size(46.dp * scale),
             )
-            Text(
-                text = tabLabel,
-                style = MaterialTheme.typography.labelLarge,
-                color = MaterialTheme.colorScheme.primary,
-            )
+            Spacer(Modifier.width(12.dp * scale))
+            Column {
+                Text(
+                    text = stringResource(R.string.app_name),
+                    style = MaterialTheme.typography.headlineSmall,
+                    fontSize = MaterialTheme.typography.headlineSmall.fontSize * scale,
+                    fontWeight = FontWeight.Bold,
+                    maxLines = 1,
+                )
+                Text(
+                    text = tabLabel,
+                    style = MaterialTheme.typography.labelLarge,
+                    fontSize = MaterialTheme.typography.labelLarge.fontSize * scale,
+                    color = MaterialTheme.colorScheme.primary,
+                    maxLines = 1,
+                )
+            }
         }
     }
 }
@@ -299,7 +310,6 @@ private fun MainScreen() {
     var showSystem by remember { mutableStateOf(false) }
     var showRussianOnly by remember { mutableStateOf(false) }
     var targetSortMode by remember { mutableStateOf(TargetListSortMode.ConfiguredFirst) }
-    var showFilterMenu by remember { mutableStateOf(false) }
     val appListLoading by AppListCache.loading.collectAsState()
     val targetsLoading by TargetsCache.loading.collectAsState()
     val dashboardLoading by DashboardCache.loading.collectAsState()
@@ -432,7 +442,7 @@ private fun MainScreen() {
                     modifier = Modifier.fillMaxWidth(),
                 ) {}
             } else {
-                LargeTopAppBar(
+                TopAppBar(
                     title = { AppTopBarTitle(currentTab) },
                     colors =
                         TopAppBarDefaults.topAppBarColors(
@@ -480,72 +490,15 @@ private fun MainScreen() {
                                     }
                                 }
                             if (currentTab == Tab.Protection) {
+                                // Filters (system / RU / sort) now live as chips in
+                                // the Apps list itself — see TargetFilterChips. Only
+                                // Search stays in the bar, so the 4-button crowding
+                                // on narrow/high-density screens is gone.
                                 TopBarActionButton(onClick = { searchActive = true }) {
                                     Icon(
                                         Icons.Default.Search,
                                         contentDescription = null,
                                     )
-                                }
-                                Box {
-                                    val anyFilterActive =
-                                        showSystem ||
-                                            showRussianOnly ||
-                                            targetSortMode != TargetListSortMode.ConfiguredFirst
-                                    TopBarActionButton(
-                                        onClick = { showFilterMenu = true },
-                                        active = anyFilterActive,
-                                    ) {
-                                        Icon(
-                                            Icons.Default.FilterList,
-                                            contentDescription = null,
-                                        )
-                                    }
-                                    DropdownMenu(
-                                        expanded = showFilterMenu,
-                                        onDismissRequest = { showFilterMenu = false },
-                                    ) {
-                                        DropdownMenuItem(
-                                            text = { Text(stringResource(R.string.filter_show_system)) },
-                                            onClick = { showSystem = !showSystem },
-                                            leadingIcon = {
-                                                Checkbox(
-                                                    checked = showSystem,
-                                                    onCheckedChange = null,
-                                                )
-                                            },
-                                        )
-                                        DropdownMenuItem(
-                                            text = { Text(stringResource(R.string.filter_russian_only)) },
-                                            onClick = { showRussianOnly = !showRussianOnly },
-                                            leadingIcon = {
-                                                Checkbox(
-                                                    checked = showRussianOnly,
-                                                    onCheckedChange = null,
-                                                )
-                                            },
-                                        )
-                                        HorizontalDivider()
-                                        DropdownMenuItem(
-                                            text = { Text(stringResource(R.string.sort_configured_first)) },
-                                            onClick = { targetSortMode = TargetListSortMode.ConfiguredFirst },
-                                            leadingIcon = {
-                                                RadioButton(
-                                                    selected = targetSortMode == TargetListSortMode.ConfiguredFirst,
-                                                    onClick = null,
-                                                )
-                                            },
-                                        )
-                                        DropdownMenuItem(
-                                            text = { Text(stringResource(R.string.sort_alphabetical)) },
-                                            onClick = { targetSortMode = TargetListSortMode.Alphabetical },
-                                            leadingIcon = {
-                                                RadioButton(
-                                                    selected = targetSortMode == TargetListSortMode.Alphabetical,
-                                                    onClick = null,
-                                                )
-                                            },
-                                        )
-                                    }
                                 }
                             }
                             TopBarActionButton(
@@ -678,6 +631,9 @@ private fun MainScreen() {
                             showSystem = showSystem,
                             showRussianOnly = showRussianOnly,
                             sortMode = targetSortMode,
+                            onToggleSystem = { showSystem = !showSystem },
+                            onToggleRussianOnly = { showRussianOnly = !showRussianOnly },
+                            onSortModeChange = { targetSortMode = it },
                             modifier = Modifier.padding(innerPadding),
                         )
                     }
@@ -693,7 +649,7 @@ private fun StartupLoadingScreen() {
     Scaffold(
         containerColor = AppColors.screenBackground,
         topBar = {
-            LargeTopAppBar(
+            TopAppBar(
                 title = { AppTopBarTitle(Tab.Dashboard) },
                 colors =
                     TopAppBarDefaults.topAppBarColors(

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/ProtectionScreen.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/ProtectionScreen.kt
@@ -14,6 +14,9 @@ internal fun ProtectionScreen(
     showSystem: Boolean,
     showRussianOnly: Boolean,
     sortMode: TargetListSortMode,
+    onToggleSystem: () -> Unit,
+    onToggleRussianOnly: () -> Unit,
+    onSortModeChange: (TargetListSortMode) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     AppPickerScreen(
@@ -21,6 +24,9 @@ internal fun ProtectionScreen(
         showSystem = showSystem,
         showRussianOnly = showRussianOnly,
         sortMode = sortMode,
+        onToggleSystem = onToggleSystem,
+        onToggleRussianOnly = onToggleRussianOnly,
+        onSortModeChange = onSortModeChange,
         modifier = modifier,
     )
 }

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/TargetPickerScaffold.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/TargetPickerScaffold.kt
@@ -5,6 +5,7 @@ import android.graphics.drawable.Drawable
 import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.interaction.collectIsDraggedAsState
 import androidx.compose.foundation.layout.Arrangement
@@ -28,9 +29,11 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Button
 import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.FilterChip
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.SnackbarDuration
 import androidx.compose.material3.SnackbarHost
@@ -131,6 +134,9 @@ internal fun <T : TargetEntry> TargetPickerScreen(
     showSystem: Boolean,
     showRussianOnly: Boolean,
     sortMode: TargetListSortMode,
+    onToggleSystem: () -> Unit,
+    onToggleRussianOnly: () -> Unit,
+    onSortModeChange: (TargetListSortMode) -> Unit,
     modifier: Modifier,
     helpPrefKey: String,
     helpTitle: String,
@@ -259,6 +265,17 @@ internal fun <T : TargetEntry> TargetPickerScreen(
                             }
                         }
                     }
+                    item(key = "filters") {
+                        TargetFilterChips(
+                            showSystem = showSystem,
+                            showRussianOnly = showRussianOnly,
+                            sortMode = sortMode,
+                            onToggleSystem = onToggleSystem,
+                            onToggleRussianOnly = onToggleRussianOnly,
+                            onSortModeChange = onSortModeChange,
+                            modifier = Modifier.padding(start = 12.dp, end = 12.dp, top = 2.dp, bottom = 4.dp),
+                        )
+                    }
                     visibleSections.forEach { section ->
                         section.group?.let { group ->
                             item(key = "group_${group.name}") {
@@ -375,6 +392,59 @@ private fun TargetGroupHeader(
                 .fillMaxWidth()
                 .padding(start = 16.dp, top = 14.dp, end = 16.dp, bottom = 6.dp),
     )
+}
+
+/**
+ * Filter chips shown inline above the Apps list: sort order, show-system, and
+ * RU-only. These used to be a top-bar filter dropdown; moving them into the
+ * list frees the app bar so its remaining actions (Search, Refresh, Settings)
+ * fit on narrow / high-density screens without crowding. The row scrolls
+ * horizontally so the chips always stay on a single line (never wrap).
+ */
+@Composable
+internal fun TargetFilterChips(
+    showSystem: Boolean,
+    showRussianOnly: Boolean,
+    sortMode: TargetListSortMode,
+    onToggleSystem: () -> Unit,
+    onToggleRussianOnly: () -> Unit,
+    onSortModeChange: (TargetListSortMode) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val configuredFirst = sortMode == TargetListSortMode.ConfiguredFirst
+    Row(
+        modifier =
+            modifier
+                .fillMaxWidth()
+                .horizontalScroll(rememberScrollState()),
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
+    ) {
+        // "Configured first" sort is the default, so its chip is selected out of
+        // the box; tapping it off falls back to alphabetical order.
+        FilterChip(
+            selected = configuredFirst,
+            onClick = {
+                onSortModeChange(
+                    if (configuredFirst) {
+                        TargetListSortMode.Alphabetical
+                    } else {
+                        TargetListSortMode.ConfiguredFirst
+                    },
+                )
+            },
+            label = { Text(stringResource(R.string.sort_configured_first)) },
+        )
+        FilterChip(
+            selected = showSystem,
+            onClick = onToggleSystem,
+            label = { Text(stringResource(R.string.filter_show_system)) },
+        )
+        FilterChip(
+            selected = showRussianOnly,
+            onClick = onToggleRussianOnly,
+            label = { Text(stringResource(R.string.filter_russian_only)) },
+        )
+    }
 }
 
 /**

--- a/lsposed/app/src/main/res/values-ru/strings.xml
+++ b/lsposed/app/src/main/res/values-ru/strings.xml
@@ -13,10 +13,9 @@
     <string name="btn_cancel">Отмена</string>
     <string name="action_refresh">Обновить</string>
     <string name="search_placeholder">Поиск приложений&#8230;</string>
-    <string name="filter_show_system">Показать системные приложения</string>
-    <string name="filter_russian_only">Только российские</string>
+    <string name="filter_show_system">Системные</string>
+    <string name="filter_russian_only">Российские</string>
     <string name="sort_configured_first">Сначала настроенные</string>
-    <string name="sort_alphabetical">По алфавиту</string>
     <string name="target_group_configured">Настроенные</string>
     <string name="target_group_other_apps">Остальные приложения</string>
     <string name="target_group_header">%1$s · %2$d</string>

--- a/lsposed/app/src/main/res/values/strings.xml
+++ b/lsposed/app/src/main/res/values/strings.xml
@@ -13,10 +13,9 @@
     <string name="btn_cancel">Cancel</string>
     <string name="action_refresh">Refresh</string>
     <string name="search_placeholder">Search apps&#8230;</string>
-    <string name="filter_show_system">Show system apps</string>
-    <string name="filter_russian_only">Russian apps only</string>
+    <string name="filter_show_system">System</string>
+    <string name="filter_russian_only">Russian</string>
     <string name="sort_configured_first">Configured first</string>
-    <string name="sort_alphabetical">Alphabetical</string>
     <string name="target_group_configured">Configured</string>
     <string name="target_group_other_apps">Other apps</string>
     <string name="target_group_header">%1$s · %2$d</string>


### PR DESCRIPTION
Reworks the top app bar into a single compact row so the logo, tab title and actions sit on one line, reclaiming the vertical space the old two-tier LargeTopAppBar wasted on short and high-density screens (where it pushed the list off-screen). The Apps-list filters move out of the top-bar dropdown into chips above the list — which is what frees the room for the brand plus three actions on one row. On tall screens the Dashboard additionally expands its header into a larger brand and animates back to the compact bar when you switch tabs.

- Replace `LargeTopAppBar` with a compact single-line bar (logo + tab title + actions on one row); the brand scales down proportionally on narrow widths so "VPN Hide" never wraps or clips.
- Move the Apps-list filters (show-system, RU-only, sort) from the top-bar dropdown into a horizontally scrollable chip row above the list; "Configured first" is selected by default. Only Search stays as a bar action.
- Dashboard on tall screens (`screenHeightDp >= 760`) gets an "airy" header: the logo grows and drops below the fixed action buttons. It is one adaptive header, not a per-tab swap — an animated `headerProgress` morphs it to the compact bar on tab switch, and the content below follows. A `Surface` + `Box` replaces the fixed-height bar so the header can take the extra height.

Testing: verified on Pixel 4a (851 dp) and Pixel 8 Pro (892 dp), and at simulated 320 / 288 dp via `wm density` — brand stays on one line, filters stay on one row, header morph is smooth.