### PR TITLE
Keep Cargo.lock in sync on release bump; build --locked (fix -dirty artifacts)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -290,7 +290,7 @@ checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
 name = "vpnhide_activator"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -299,11 +299,11 @@ dependencies = [
 
 [[package]]
 name = "vpnhide_protocol"
-version = "1.0.0"
+version = "1.1.0"
 
 [[package]]
 name = "vpnhide_zygisk"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "android_logger",
  "cmake",

--- a/lsposed/app/build.gradle.kts
+++ b/lsposed/app/build.gradle.kts
@@ -101,7 +101,9 @@ val buildRustProbe =
             "-t", "arm64-v8a",
             "-P", "29",
             "-o", rustJniLibsDir.get().asFile.absolutePath,
-            "build", "--release",
+            // --locked: fail if Cargo.lock drifted rather than rewriting it (a
+            // dirtied tree stamps the build "-dirty" via git describe --dirty).
+            "build", "--release", "--locked",
         )
         // Locals (not top-level script vals) so the doLast action captures only
         // File values — required for configuration-cache serialization.

--- a/lsposed/native/Cargo.lock
+++ b/lsposed/native/Cargo.lock
@@ -237,7 +237,7 @@ checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
 name = "vpnhide_checks"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "jni",
  "libc",

--- a/scripts/build_lib.py
+++ b/scripts/build_lib.py
@@ -126,6 +126,10 @@ def build_activator_bin(
             "arm64-v8a",
             "build",
             "--release",
+            # Fail loudly if Cargo.lock is out of sync instead of silently
+            # rewriting it — a rewritten lock dirties the tree and stamps every
+            # artifact "X.Y.Z-dirty" via git describe --dirty.
+            "--locked",
             "-p",
             "vpnhide_activator",
             "--bin",

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -36,6 +36,7 @@ After this script succeeds:
 from __future__ import annotations
 
 import re
+import subprocess
 import sys
 from pathlib import Path
 
@@ -139,6 +140,25 @@ def patch_all_sources(version: str, version_code: int, *, dry_run: bool) -> None
     update_gradle_kts(REPO_ROOT / "lsposed/app/build.gradle.kts", vc, dry_run=dry_run)
 
 
+def sync_cargo_locks() -> None:
+    """Refresh the workspace members' versions in the committed Cargo.lock files.
+
+    We just rewrote the crates' `version = "..."` in Cargo.toml. Without also
+    updating Cargo.lock, the first `cargo build` in CI rewrites the lock, which
+    dirties the working tree — so `git describe --dirty` stamps every artifact
+    "X.Y.Z-dirty". `cargo update --offline --workspace` only bumps the workspace
+    members' own versions (no registry access, no dependency churn).
+    """
+    for lock_dir in (REPO_ROOT, REPO_ROOT / "lsposed" / "native"):
+        subprocess.run(
+            ["cargo", "update", "--offline", "--workspace"],
+            cwd=lock_dir,
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+
+
 def write_version_file(version: str) -> None:
     (REPO_ROOT / "VERSION").write_text(f"{version}\n", encoding="utf-8")
 
@@ -216,6 +236,11 @@ def main() -> int:
     console.print("  [green]✓[/green] zygisk/Cargo.toml")
     console.print("  [green]✓[/green] lsposed/native/Cargo.toml")
     console.print("  [green]✓[/green] lsposed/app/build.gradle.kts")
+
+    # Keep Cargo.lock in step with the bumped Cargo.toml versions so the release
+    # build starts from a clean tree (otherwise every artifact gets "-dirty").
+    sync_cargo_locks()
+    console.print("  [green]✓[/green] Cargo.lock (+ lsposed/native)")
 
     console.print()
     console.print("[bold]Next steps:[/bold]")

--- a/zygisk/build.py
+++ b/zygisk/build.py
@@ -45,9 +45,10 @@ def main() -> int:
     env["ANDROID_NDK_HOME"] = android_ndk_home
     env["CARGO_TARGET_DIR"] = str(target_dir)
 
-    # Build the cdylib for arm64-v8a
+    # Build the cdylib for arm64-v8a. --locked: fail if Cargo.lock drifted
+    # rather than rewriting it (a dirtied tree stamps artifacts "-dirty").
     subprocess.run(
-        ["cargo", "ndk", "-t", "arm64-v8a", "build", "--release"],
+        ["cargo", "ndk", "-t", "arm64-v8a", "build", "--release", "--locked"],
         env=env,
         check=True,
     )


### PR DESCRIPTION
The v1.1.0 KPM/Ports (and other Rust) artifacts report their version as `1.1.0-dirty`. Root cause: `release.py` rewrites each crate's `version = "..."` in `Cargo.toml` but never updated `Cargo.lock`, so the lock kept the old version. The first `cargo build` in CI then rewrote the lock to match, which dirtied the working tree — and `get_build_version()`'s `git describe --dirty` appended `-dirty` to every artifact. The binaries are otherwise correct (versionCode is right, the in-app updater works); only the version string is affected.

Two layers so it cannot recur:

- `release.py` now runs `cargo update --offline --workspace` for both lockfiles (root + `lsposed/native`) right after the `Cargo.toml` bump, so the release commit carries a matching lock.
- The Rust build steps (activator, zygisk cdylib, lsposed probe) now pass `--locked`, so a drifted lock fails the build loudly instead of silently rewriting it and dirtying the tree.

Also commits the now-synced 1.1.0 lockfiles so `main` builds clean immediately. The already-published v1.1.0 release is left as-is (per decision); the next release will be clean.

Testing: verified `cargo metadata --locked` passes with the synced lock and fails when the lock is reverted to the stale state, confirming the guard catches the drift.