### PR TITLE
fix(lsposed): attach ConnectivityService hooks on OEM ROMs via deferred getService

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,6 +26,7 @@ These short files cover everything specific to this repo. Skipping them leads to
 - [docs/protocol.md](docs/protocol.md) — the frozen v1 control/stats **wire** between the app and the native backends (config/stats/status); the format every backend parser must agree on
 - [docs/detection-vectors.md](docs/detection-vectors.md) — what an app can probe to detect the VPN (or a hidden package), which component (kmod / KPM / zygisk / lsposed / SELinux) covers each vector, how it manifests. Read before adding or changing a hook.
 - [docs/diagnostics.md](docs/diagnostics.md) — how the app self-tests hiding and attributes *who* hid the VPN (root-differential, `CheckOutcome`, `LayerStatus`/verdict, the self-in-tunnel gate). Read before touching the diagnostics/dashboard.
+- [docs/lsposed-hook-debugging.md](docs/lsposed-hook-debugging.md) — debugging the Java-layer LSPosed hooks: the `cs_*` attach telemetry, reading `hook_report.txt`, and diagnosing why a `ConnectivityService` hook didn't attach on a given ROM. Read before touching `HookEntry.kt`.
 - [docs/adb-root-debugging.md](docs/adb-root-debugging.md) — how to make `adb shell su` useful on KernelSU/APatch/Magisk test devices; covers UID 0 without capabilities, SELinux denials on `/data/adb` and `/data/system`, and KPM/KPatch diagnostics.
 - [docs/changelog.md](docs/changelog.md) — changelog storage (`changelog.d/` fragments + history JSON), `./scripts/changelog.py` usage
 - [docs/releasing.md](docs/releasing.md) — `./scripts/release.py` usage, version-bump flow

--- a/changelog.d/fixed-fixed-incomplete-vpn-hiding-on-some-27e8.md
+++ b/changelog.d/fixed-fixed-incomplete-vpn-hiding-on-some-27e8.md
@@ -1,0 +1,9 @@
+_2026-07-05_
+
+## English
+
+Fixed incomplete VPN hiding on some devices and firmwares (notably many MediaTek-based and custom OEM ROMs), where several app-side checks could still detect the tunnel through legacy connectivity APIs.
+
+## Русский
+
+Исправлено неполное скрытие VPN на части устройств и прошивок (в частности, многие на MediaTek и кастомные OEM-прошивки): отдельные проверки со стороны приложений всё ещё видели туннель через устаревшие сетевые API.

--- a/docs/lsposed-hook-debugging.md
+++ b/docs/lsposed-hook-debugging.md
@@ -155,7 +155,7 @@ Read `cs_attempts` top to bottom and match the divergence from §4:
 | `cs_path` absent; trail ends `… \| B:getService=null` with **no `C`/`D` attach** | Hooks never attached — the service was never resolved. |
 | Trail has **no `C:addService(connectivity) seen`** | The ROM doesn't publish `connectivity` through the hooked `ServiceManager.addService` (seen on MediaTek/OEM). Path D (deferred `getService`) is the fallback that covers this. |
 | `cs_network` has `getNetworkForType=0` (etc.) | That method name/signature differs on the ROM; `hookAllMethods` matched nothing. |
-| `cs_path` set, `cs_network` all `=1`, mask full, **but the connectivity `stats` counters never move** and checks leak | Hooks bound but never fire — an early/pre-construction attach that ART discarded. This is why the install-time classloader path was removed (§8); a late binder attach fixes it. If you still see it, the hooked class isn't the live instance — compare `cs_loader`. |
+| `cs_path` set, `cs_network` all `=1`, mask full, **but the connectivity `stats` counters never move** and checks leak | Hooks bound but never fire. Two known causes, both fixed (§8): an early pre-construction attach ART discarded (the install-time classloader path, removed), or a name-resolved class that isn't the live instance — look for `nameResolvesSame=false` in `cs_attempts` (now we hook `binder.javaClass` directly). |
 
 ## 6. Why logcat is not the tool here
 
@@ -207,10 +207,19 @@ the mask read full yet no connectivity counter ever moved. It tries, in order:
 All three attach *late*, to an already-constructed instance — which is why the
 hooks stick (an install-time classloader attach does not).
 
-Key fact that makes B/C/D work: inside `system_server`, `getService`/the
-`addService` argument return the **local `ConnectivityService` instance**, not a
-`BinderProxy`, so `binder.javaClass.classLoader` is the APEX loader that resolves
-the class.
+Two facts make B/C/D work:
+
+1. Inside `system_server`, `getService`/the `addService` argument return the
+   **local `ConnectivityService` instance**, not a `BinderProxy`, so
+   `binder.javaClass` is the live class.
+2. We hook **`binder.javaClass` directly**, never a name-resolved class. Resolving
+   `com.android.server.ConnectivityService` by name through the binder's
+   classloader can, on a child-loader ROM (MediaTek A11), follow delegation to a
+   *parent* copy of the class — a different `Class` object with the same name.
+   Hooking that copy attaches cleanly (all methods match, mask full) but never
+   fires, because the live binder dispatches to the child copy. The
+   `nameResolvesSame` flag in `cs_attempts` records whether name-resolution would
+   have returned that same live class (`true` on Pixels; `false` is the trap).
 
 The bits and `cs_*` are reported from `reportConnectivityAttach` →
 `LsposedStats.setConnectivityDiagnostics`, which folds the bits into the mask and

--- a/docs/lsposed-hook-debugging.md
+++ b/docs/lsposed-hook-debugging.md
@@ -1,0 +1,221 @@
+# Debugging the LSPosed (Java-layer) hooks
+
+How to tell whether the LSPosed module's `system_server` hooks actually
+attached, how to read the install telemetry, and how to diagnose "some apps
+still detect my VPN" reports that come down to a hook not attaching.
+
+This is the **Java-layer** counterpart to [diagnostics.md](diagnostics.md) (the
+self-test model), [detection-vectors.md](detection-vectors.md) (which backend
+covers which vector), and [lsposed/AGENTS.md](../lsposed/AGENTS.md) (the Kotlin
+module architecture). The wire the state file speaks is in
+[protocol.md](protocol.md).
+
+The hooks live in `lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/HookEntry.kt`;
+the state file they publish is written by `LsposedState.kt` and rendered by
+`HookDiagnostics.kt`.
+
+## 1. Two hook families (why some checks pass while others leak)
+
+The module installs two very different kinds of hook inside `system_server`, and
+they fail independently — so a half-broken Java layer is normal to see:
+
+- **`writeToParcel` sanitizers** on `NetworkCapabilities`, `LinkProperties`,
+  `NetworkInfo`. These are **framework classes on the boot classpath**, always
+  resolvable, so they attach trivially and rarely break. They strip VPN data as
+  the object is serialized to a target UID.
+- **`ConnectivityService` method hooks** — hooks on the actual service methods
+  (`getActiveNetwork`, `getAllNetworks`, `getNetworkForType`, `getNetworkInfo`,
+  the callback dispatchers). These replace/blank the **network handle identity**
+  and legacy-type answers. On Android 13+ the class lives in the Connectivity
+  **APEX**, so these can only be hooked via the service binder's classloader —
+  this is the fragile family (see §8).
+
+Which diagnostics check leans on which family:
+
+| Check | Family | Notes |
+|---|---|---|
+| hasTransport(VPN), hasCapability(NOT_VPN), getTransportInfo | 1 | capabilities |
+| getAllNetworks() VPN scan | 1 | capabilities of each net |
+| LinkProperties ifname / routes | 1 | link properties |
+| ActiveNetwork **transports** | 1 | capabilities of the active net |
+| getNetworkForType(TYPE_VPN) | 2 | legacy type → handle |
+| ActiveNetwork **handle** | 2 | netId identity |
+| getAllNetworks() **handles** | 2 | netId identity |
+| NetworkCallback (push) | 2 | callback dispatch |
+| getNetworkInfo(TYPE_VPN) | 2 | legacy type query |
+
+The tell-tale signature of "family 2 didn't attach" is that **ActiveNetwork
+transports passes but ActiveNetwork handle fails on the same active network**:
+the returned handle is still the VPN's netId, yet its capabilities come back
+clean. Family 1 sanitized the capabilities; family 2 never swapped the handle.
+
+## 2. Where the truth lives: `/data/system/vpnhide_lsposed_state`
+
+The module publishes a small text "control channel" from `system_server`; the
+app reads it. It survives reboots and is **independent of logcat and the
+debug-logging toggle**. Three sections:
+
+```
+vpnhide 1 status        # backend id, kernel ver, hooks bitmask, error code
+backend 0x3
+kver 0x0
+hooks 0x3fc00
+error 0x0
+meta <key> <value>      # one line per metadata key
+...
+vpnhide 1 stats         # per-uid per-hook fire counters
+0x27fe 0xa:0x1 0xb:0x1 0xd:0x1 0xe:0x1 0x10:0xc
+```
+
+It reaches a debug bundle **two ways**, both via a root read (`emit_file` in
+`DebugShellSnapshot.kt`):
+
+- **`hook_report.txt`** — parsed and rendered (status mask, `metadata:` block,
+  installed/missing hooks, counter deltas). This is what you normally read.
+- **`debug_capture.txt`** — the raw file verbatim, under "LSPosed hook state".
+
+Because the read is root-backed and the file is always written, `cs_*` telemetry
+lands in the bundle **even with debug logging off**. Debug logging only enriches
+the *logcat* portions of the bundle.
+
+## 3. Reading `hook_report.txt` (the LSPOSED section)
+
+```
+LSPOSED:
+  status.hooks=0x3fc00
+  status.error=OK(0)
+  installed hooks (8/8):
+    [10] lsposed_link_properties ...
+  metadata:
+    cs_path=C
+    cs_network=getActiveNetwork=1,getAllNetworks=1,getNetworkForType=1
+    ...
+```
+
+The mask is **honest**: the three connectivity bits are set only once those
+hooks actually attach (see §8). A device where they don't shows
+`status.error=PARTIAL_HOOKS`, `installed hooks (5/8)`, and lists them under
+**missing owned hooks** — not a false "8/8 installed".
+
+Hook IDs (bit = id):
+
+| id | hex | name | family | covers |
+|---|---|---|---|---|
+| 10 | 0x400 | lsposed_link_properties | 1 | ifname / routes / DNS |
+| 11 | 0x800 | lsposed_network_capabilities | 1 | transports / NOT_VPN |
+| 12 | 0x1000 | lsposed_network_info | 1 | legacy NetworkInfo type |
+| 13 | 0x2000 | lsposed_network | 2* | Network parcel replacement |
+| 14 | 0x4000 | lsposed_connectivity_result | 2 | getNetworkInfo/LP/NC results |
+| 15 | 0x8000 | lsposed_connectivity_callback | 2 | push callbacks |
+| 16 | 0x10000 | lsposed_connectivity_network | 2 | getActiveNetwork/AllNetworks/ForType |
+| 17 | 0x20000 | lsposed_package_visibility | — | app-hiding from PackageManager |
+
+`0x3fc00` = all of 10–17. The connectivity family is 14|15|16 = `0x1c000`.
+(*13 depends on the CS instance being captured, so it dies with family 2.)
+
+The `stats` counters show which hooks actually **fired** for the target app's
+uid. On a healthy device you see `0xe` (result), `0x10` (network), `0xd`
+(Network parcel) among them; their absence is the first hint family 2 is down.
+
+## 4. The `cs_*` attach telemetry
+
+`ConnectivityService` attaches **asynchronously and by several paths**, so the
+outcome is recorded into `cs_*` meta keys as it happens:
+
+| key | meaning |
+|---|---|
+| `cs_attempts` | full trail: `install … \| A:… \| B:… \| C:… \| D:…` — every path's outcome |
+| `cs_path` | which path finally attached (`A`/`B`/`C`/`D`); **absent if none did** |
+| `cs_class` | resolved class (`com.android.server.ConnectivityService`) |
+| `cs_loader` | classloader chain, e.g. `PathClassLoader<PathClassLoader<BootClassLoader` (double = APEX) vs single `PathClassLoader<BootClassLoader` (system_server) |
+| `cs_ctor` | constructors hooked |
+| `cs_result` | per-method match counts for synchronous results (`getNetworkCapabilities`, `getNetworkInfo`, …) |
+| `cs_network` | `getActiveNetwork` / `getAllNetworks` / `getNetworkForType` counts |
+| `cs_callback` | `callCallbackForRequest` / `sendPendingIntentForRequest` counts |
+
+**Known-good fingerprint (Android 13+, attach via the binder classloader):**
+
+```
+cs_path      C            (or D)
+cs_loader    PathClassLoader<PathClassLoader<BootClassLoader
+cs_network   getActiveNetwork=1,getAllNetworks=1,getNetworkForType=1
+cs_callback  callCallbackForRequest=1,sendPendingIntentForRequest=1
+```
+
+`A:notReady(ClassNotFound com.android.server.ConnectivityService)` in the trail
+is **normal** on A13+ — path A can't see the APEX class, so it hands off to the
+binder-classloader paths.
+
+## 5. Interpreting a failing report
+
+Read `cs_attempts` top to bottom and match the divergence from §4:
+
+| Symptom in `cs_*` | Meaning |
+|---|---|
+| `cs_path` absent; trail ends `… \| B:getService=null` with **no `C`/`D` attach** | Hooks never attached — the service was never resolved. |
+| Trail has **no `C:addService(connectivity) seen`** | The ROM doesn't publish `connectivity` through the hooked `ServiceManager.addService` (seen on MediaTek/OEM). Path D (deferred `getService`) is the fallback that covers this. |
+| `cs_path=A` with a **single** `PathClassLoader<BootClassLoader` | Attached to a class on the system_server loader that may not be the live (APEX) instance — suspect a wrong-classloader match. |
+| `cs_network` has `getNetworkForType=0` (etc.) | That method name/signature differs on the ROM; `hookAllMethods` matched nothing. |
+| `cs_path` set, `cs_network` all `=1`, but checks still leak | Attached, but possibly to the wrong instance — compare `cs_loader` to the known-good chain. |
+
+## 6. Why logcat is not the tool here
+
+The install runs at early boot with debug logging **off** (the flag is read that
+early and defaults false), so the `HookLog.i` install lines are never emitted;
+and even when emitted they are gone by report time (ring-buffer rotation). This
+was confirmed on a *working* device: debug on, zero install lines in logcat, yet
+hooks attached. Always use the state file / `hook_report.txt`, not logcat, to
+answer "did the hooks attach".
+
+## 7. Collecting a report (users / testers)
+
+Prerequisites:
+
+- Root granted to the app (the state file is read via root).
+- The VpnHide module **enabled with "System Framework" scope** in your Xposed
+  manager (it hooks `system_server`, nothing else).
+- An **active VPN** — the leak checks only run against a live tunnel.
+
+Steps:
+
+1. Reboot (so a fresh attach writes current `cs_*` into the state file).
+2. Open VPN Hide once with the VPN connected (its checks run at cold start).
+3. Diagnostics → **Collect debug logs** → send the zip.
+
+Debug logging does **not** need to be on for `cs_*` — it only adds the logcat
+sections. Open `hook_report.txt` and read §3–§5.
+
+## 8. The attach mechanism (developers)
+
+`HookEntry.installConnectivityServiceHook` tries, in order:
+
+- **A** — resolve `com.android.server.ConnectivityService` on the `system_server`
+  classloader now. Works on ≤ A12 (class on `SYSTEMSERVERCLASSPATH`); throws on
+  A13+ (APEX), which releases the once-only latch for the other paths.
+- **B** — `getService("connectivity")` now, hook from its binder's classloader.
+  Usually `null` at install time (service not registered yet).
+- **C** — hook `ServiceManager.addService` to catch the registration and take the
+  binder's classloader. Fast when it fires — but only fires if the ROM actually
+  publishes through that Java method.
+- **D** — deferred fallback: poll `getService("connectivity")` on a short-lived
+  `HandlerThread` (500 ms, ~90 s budget) until the live binder appears, then
+  attach. Independent of *how* the service was registered; this is what covers
+  ROMs where C never fires. The thread is torn down (`quitSafely`) the moment any
+  path attaches or the budget runs out.
+
+Key fact that makes B/C/D work: inside `system_server`, `getService`/the
+`addService` argument return the **local `ConnectivityService` instance**, not a
+`BinderProxy`, so `binder.javaClass.classLoader` is the APEX loader that resolves
+the class.
+
+The bits and `cs_*` are reported from `reportConnectivityAttach` →
+`LsposedStats.setConnectivityDiagnostics`, which folds the bits into the mask and
+the meta into the state file. To add a new signal, record it there — every
+`meta` key is rendered by `HookDiagnostics.kt` automatically, no reader change
+needed.
+
+> Note on module state after updating the APK: normally an Xposed manager keeps a
+> module enabled (with its scope) across an in-place update. If after installing a
+> new build the module shows disabled or unscoped, that is a manager/device
+> quirk — just re-enable it with **System Framework** scope; it is not expected
+> behavior and nothing in VpnHide changes it.

--- a/docs/lsposed-hook-debugging.md
+++ b/docs/lsposed-hook-debugging.md
@@ -154,9 +154,8 @@ Read `cs_attempts` top to bottom and match the divergence from §4:
 |---|---|
 | `cs_path` absent; trail ends `… \| B:getService=null` with **no `C`/`D` attach** | Hooks never attached — the service was never resolved. |
 | Trail has **no `C:addService(connectivity) seen`** | The ROM doesn't publish `connectivity` through the hooked `ServiceManager.addService` (seen on MediaTek/OEM). Path D (deferred `getService`) is the fallback that covers this. |
-| `cs_path=A` with a **single** `PathClassLoader<BootClassLoader` | Attached to a class on the system_server loader that may not be the live (APEX) instance — suspect a wrong-classloader match. |
 | `cs_network` has `getNetworkForType=0` (etc.) | That method name/signature differs on the ROM; `hookAllMethods` matched nothing. |
-| `cs_path` set, `cs_network` all `=1`, but checks still leak | Attached, but possibly to the wrong instance — compare `cs_loader` to the known-good chain. |
+| `cs_path` set, `cs_network` all `=1`, mask full, **but the connectivity `stats` counters never move** and checks leak | Hooks bound but never fire — an early/pre-construction attach that ART discarded. This is why the install-time classloader path was removed (§8); a late binder attach fixes it. If you still see it, the hooked class isn't the live instance — compare `cs_loader`. |
 
 ## 6. Why logcat is not the tool here
 
@@ -187,11 +186,13 @@ sections. Open `hook_report.txt` and read §3–§5.
 
 ## 8. The attach mechanism (developers)
 
-`HookEntry.installConnectivityServiceHook` tries, in order:
+`HookEntry.installConnectivityServiceHook` only ever attaches from the **live
+service binder**, never via the raw `system_server` classloader. A classloader
+attach at install time runs *before* `ConnectivityService` is constructed; ART
+then replaces the method entries during class init/compile and the hooks
+silently never fire — observed on MediaTek A11, where every method matched and
+the mask read full yet no connectivity counter ever moved. It tries, in order:
 
-- **A** — resolve `com.android.server.ConnectivityService` on the `system_server`
-  classloader now. Works on ≤ A12 (class on `SYSTEMSERVERCLASSPATH`); throws on
-  A13+ (APEX), which releases the once-only latch for the other paths.
 - **B** — `getService("connectivity")` now, hook from its binder's classloader.
   Usually `null` at install time (service not registered yet).
 - **C** — hook `ServiceManager.addService` to catch the registration and take the
@@ -202,6 +203,9 @@ sections. Open `hook_report.txt` and read §3–§5.
   attach. Independent of *how* the service was registered; this is what covers
   ROMs where C never fires. The thread is torn down (`quitSafely`) the moment any
   path attaches or the budget runs out.
+
+All three attach *late*, to an already-constructed instance — which is why the
+hooks stick (an install-time classloader attach does not).
 
 Key fact that makes B/C/D work: inside `system_server`, `getService`/the
 `addService` argument return the **local `ConnectivityService` instance**, not a

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/HookEntry.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/HookEntry.kt
@@ -121,7 +121,7 @@ class HookEntry : IXposedHookLoadPackage {
     private fun reportConnectivityAttach(
         path: String,
         csClass: Class<*>,
-        classLoader: ClassLoader,
+        classLoader: ClassLoader?,
         ctorCount: Int,
         resultCounts: Map<String, Int>,
         networkCounts: Map<String, Int>,
@@ -1033,17 +1033,26 @@ class HookEntry : IXposedHookLoadPackage {
         binder: android.os.IBinder,
         path: String,
     ) {
-        val classLoader =
-            binder.javaClass.classLoader ?: run {
-                recordCsAttempt("$path:binderNoClassLoader(${binder.javaClass.name})")
-                HookLog.i("VpnHide: connectivity binder has no classloader; waiting for direct classloader")
-                return
-            }
-        hookConnectivityServiceIfPossible(classLoader, path)
+        // Hook the binder's OWN runtime class, never a name-resolved one. On some
+        // ROMs (MediaTek A11) the live ConnectivityService is defined by a child
+        // classloader, and findClass(name, thatLoader) follows delegation to a
+        // *parent* copy of the class — a different Class object with the same name.
+        // Hooking that copy attaches cleanly (every method matches) yet never
+        // fires, because the live binder dispatches to the child copy (attached,
+        // all counts=1, but no connectivity counter ever moves). binder.javaClass
+        // IS the live class, so hooking it always intercepts the real calls.
+        val csClass = binder.javaClass
+        val loader = csClass.classLoader
+        // Diagnostic: does the old name-resolution yield a *different* object?
+        // nameResolvesSame=false is the delegation trap above. Drop once confirmed.
+        val nameResolvesSame =
+            loader?.let { runCatching { findConnectivityServiceClass(it) === csClass }.getOrNull() }
+        recordCsAttempt("$path:binderClass=${csClass.name} loader=${describeLoader(loader)} nameResolvesSame=$nameResolvesSame")
+        hookConnectivityServiceIfPossible(csClass, path)
     }
 
     private fun hookConnectivityServiceIfPossible(
-        classLoader: ClassLoader,
+        csClass: Class<*>,
         path: String,
     ) {
         if (!connectivityHooked.compareAndSet(false, true)) {
@@ -1051,18 +1060,19 @@ class HookEntry : IXposedHookLoadPackage {
             return
         }
         try {
-            hookConnectivityService(classLoader, path)
+            hookConnectivityService(csClass, path)
         } catch (t: Throwable) {
             connectivityHooked.set(false)
-            recordCsAttempt("$path:notReady(${t.javaClass.simpleName}:${t.message}) loader=${describeLoader(classLoader)}")
-            HookLog.i("VpnHide: ConnectivityService class not ready on ${classLoader.javaClass.name}: ${t.message}")
+            recordCsAttempt("$path:failed(${t.javaClass.simpleName}:${t.message}) class=${csClass.name}")
+            HookLog.i("VpnHide: ConnectivityService hook failed on ${csClass.name}: ${t.message}")
         }
     }
 
+    // Kept only for the hookConnectivityFromBinder diagnostic that proves the
+    // name-resolution-vs-live-class mismatch; the attach itself uses the binder's
+    // own class and never this.
     private fun findConnectivityServiceClass(classLoader: ClassLoader): Class<*> =
         try {
-            // Android 14+ ships ConnectivityService in the repackaged
-            // Connectivity APEX namespace; older releases use the original.
             XposedHelpers.findClass(
                 "android.net.connectivity.com.android.server.ConnectivityService",
                 classLoader,
@@ -1083,10 +1093,9 @@ class HookEntry : IXposedHookLoadPackage {
      * detect VPN only via callbacks.
      */
     private fun hookConnectivityService(
-        classLoader: ClassLoader,
+        csClass: Class<*>,
         path: String,
     ) {
-        val csClass = findConnectivityServiceClass(classLoader)
         val ctorCount =
             try {
                 XposedBridge
@@ -1148,7 +1157,7 @@ class HookEntry : IXposedHookLoadPackage {
             }
         }
 
-        reportConnectivityAttach(path, csClass, classLoader, ctorCount, resultCounts, networkCounts, callbackCounts)
+        reportConnectivityAttach(path, csClass, csClass.classLoader, ctorCount, resultCounts, networkCounts, callbackCounts)
     }
 
     private fun installConnectivityServiceResultHooks(csClass: Class<*>): Map<String, Int> {

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/HookEntry.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/HookEntry.kt
@@ -1043,8 +1043,9 @@ class HookEntry : IXposedHookLoadPackage {
         // IS the live class, so hooking it always intercepts the real calls.
         val csClass = binder.javaClass
         val loader = csClass.classLoader
-        // Diagnostic: does the old name-resolution yield a *different* object?
-        // nameResolvesSame=false is the delegation trap above. Drop once confirmed.
+        // Permanent guard: does name-resolution return this same live class?
+        // nameResolvesSame=false is the delegation trap above — a one-line tell in
+        // the report if another ROM ever loads ConnectivityService oddly.
         val nameResolvesSame =
             loader?.let { runCatching { findConnectivityServiceClass(it) === csClass }.getOrNull() }
         recordCsAttempt("$path:binderClass=${csClass.name} loader=${describeLoader(loader)} nameResolvesSame=$nameResolvesSame")

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/HookEntry.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/HookEntry.kt
@@ -937,14 +937,19 @@ class HookEntry : IXposedHookLoadPackage {
      */
     private fun installConnectivityServiceHook(bootClassLoader: ClassLoader) {
         recordCsAttempt("install sdk=${Build.VERSION.SDK_INT} bootLoader=${describeLoader(bootClassLoader)}")
-        // Path A — try the system_server classloader immediately. Works when CS
-        // is on SYSTEMSERVERCLASSPATH (≤ A12); on A13+ it lives in the
-        // Connectivity APEX and this throws, releasing the latch for B/C.
-        hookConnectivityServiceIfPossible(bootClassLoader, "A")
-
+        // We deliberately do NOT attach via the system_server classloader at
+        // install time (the old "path A"). Even where the class resolves (≤ A12),
+        // hooking it here — before ConnectivityService is constructed — binds
+        // method entries that ART then replaces when the class is initialised and
+        // compiled, so the hooks silently never fire (seen on Redmi Note 8 Pro /
+        // MediaTek A11: every method matched, mask full, yet all checks leaked and
+        // none of the connectivity counters moved). Worse, that early attach grabbed
+        // the once-only latch and blocked the late paths that DO stick. So we only
+        // ever attach from the live service binder, once it exists: B (already up),
+        // C (addService registration), D (deferred poll).
         val serviceManager = XposedHelpers.findClass("android.os.ServiceManager", bootClassLoader)
         // Path B — the service may already be registered; its binder carries the
-        // real (APEX) classloader.
+        // real classloader (the Connectivity APEX loader on A13+).
         val existing = XposedHelpers.callStaticMethod(serviceManager, "getService", "connectivity") as? android.os.IBinder
         recordCsAttempt("B:getService=${existing?.javaClass?.simpleName ?: "null"}")
         existing?.let { hookConnectivityFromBinder(it, "B") }

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/HookEntry.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/HookEntry.kt
@@ -9,6 +9,8 @@ import android.net.RouteInfo
 import android.os.Binder
 import android.os.Build
 import android.os.Bundle
+import android.os.Handler
+import android.os.HandlerThread
 import de.robv.android.xposed.IXposedHookLoadPackage
 import de.robv.android.xposed.XC_MethodHook
 import de.robv.android.xposed.XposedBridge
@@ -64,6 +66,87 @@ class HookEntry : IXposedHookLoadPackage {
 
     @Volatile private var connectivityServiceInstance: Any? = null
 
+    // ── ConnectivityService attach telemetry ──────────────────────────────
+    // The CS hooks are the ones that leak on some devices while the framework
+    // writeToParcel hooks work. Because attachment is deferred and multi-path
+    // (A: system_server classloader now, B: live binder now, C: addService
+    // later), logcat can't reliably show whether/how they attached — proven on
+    // a working device where debug is on yet no install lines appear. So we
+    // accumulate the outcome (resolved class, classloader chain, path, per-
+    // method match counts, every attempt) and publish it to the LSPosed state
+    // file, where it lands in hook_report.txt of any debug bundle regardless of
+    // logcat or the debug-logging toggle.
+    private val csAttempts = java.util.concurrent.CopyOnWriteArrayList<String>()
+
+    @Volatile private var csAttachedMeta: Map<String, String> = emptyMap()
+
+    @Volatile private var csAttachedBits: Int = 0
+
+    // Background poller for path D (deferred getService retry). Created only if D
+    // is actually needed (A/B didn't already attach) and torn down the moment the
+    // hooks land or we give up — no idle thread lingering in system_server.
+    @Volatile private var connectivityRetryThread: HandlerThread? = null
+
+    @Volatile private var connectivityRetryHandler: Handler? = null
+
+    /** Compact classloader-chain fingerprint, e.g. "PathClassLoader<BootClassLoader".
+     *  Distinguishes the system_server loader from a Connectivity-APEX loader —
+     *  a mismatch there is the prime suspect for the hooks not intercepting. */
+    private fun describeLoader(cl: ClassLoader?): String {
+        if (cl == null) return "null"
+        val sb = StringBuilder()
+        var c: ClassLoader? = cl
+        var depth = 0
+        while (c != null && depth < 5) {
+            if (depth > 0) sb.append('<')
+            sb.append(c.javaClass.simpleName.ifBlank { c.javaClass.name })
+            c = c.parent
+            depth++
+        }
+        return sb.toString()
+    }
+
+    private fun publishCsDiag() {
+        val meta = LinkedHashMap<String, String>()
+        meta["cs_attempts"] = csAttempts.joinToString(" | ").ifBlank { "(none)" }
+        meta.putAll(csAttachedMeta)
+        LsposedStats.setConnectivityDiagnostics(csAttachedBits, meta)
+    }
+
+    private fun recordCsAttempt(entry: String) {
+        csAttempts.add(entry)
+        publishCsDiag()
+    }
+
+    private fun reportConnectivityAttach(
+        path: String,
+        csClass: Class<*>,
+        classLoader: ClassLoader,
+        ctorCount: Int,
+        resultCounts: Map<String, Int>,
+        networkCounts: Map<String, Int>,
+        callbackCounts: Map<String, Int>,
+    ) {
+        var bits = 0
+        if (resultCounts.values.any { it > 0 }) bits = bits or hookBit(HookIds.Hook.LSPOSED_CONNECTIVITY_RESULT)
+        if (networkCounts.values.any { it > 0 }) bits = bits or hookBit(HookIds.Hook.LSPOSED_CONNECTIVITY_NETWORK)
+        if (callbackCounts.values.any { it > 0 }) bits = bits or hookBit(HookIds.Hook.LSPOSED_CONNECTIVITY_CALLBACK)
+        csAttachedBits = bits
+
+        fun fmt(m: Map<String, Int>) = m.entries.joinToString(",") { "${it.key}=${it.value}" }
+        csAttachedMeta =
+            linkedMapOf(
+                "cs_path" to path,
+                "cs_class" to csClass.name,
+                "cs_loader" to describeLoader(classLoader),
+                "cs_ctor" to ctorCount.toString(),
+                "cs_result" to fmt(resultCounts),
+                "cs_network" to fmt(networkCounts),
+                "cs_callback" to fmt(callbackCounts),
+            )
+        recordCsAttempt("$path:attached class=${csClass.simpleName} net=[${fmt(networkCounts)}] cb=[${fmt(callbackCounts)}]")
+    }
+
     private fun effectiveCallerUid(): Int {
         val uid = Binder.getCallingUid()
         return if (uid == SYSTEM_UID) currentCallbackUid.get() ?: uid else uid
@@ -100,13 +183,13 @@ class HookEntry : IXposedHookLoadPackage {
             if (tryHook("PackageVisibility", installFailures) { PackageVisibilityHooks.install(lpparam.classLoader) }) {
                 installedMask = installedMask or hookBit(HookIds.Hook.LSPOSED_PACKAGE_VISIBILITY)
             }
-            if (tryHook("ConnectivityService", installFailures) { installConnectivityServiceHook(lpparam.classLoader) }) {
-                installedMask =
-                    installedMask or
-                    hookBit(HookIds.Hook.LSPOSED_CONNECTIVITY_RESULT) or
-                    hookBit(HookIds.Hook.LSPOSED_CONNECTIVITY_CALLBACK) or
-                    hookBit(HookIds.Hook.LSPOSED_CONNECTIVITY_NETWORK)
-            }
+            // ConnectivityService hooks attach asynchronously (the reliable path
+            // only fires when "connectivity" registers, after this returns), so
+            // their bits are NOT set here. reportConnectivityAttach() sets them
+            // via LsposedStats once methods actually match — so the published mask
+            // reflects real attachment and a device where they never attach shows
+            // them under "missing owned hooks" instead of a false "8/8 installed".
+            tryHook("ConnectivityService", installFailures) { installConnectivityServiceHook(lpparam.classLoader) }
             LsposedStats.setStatus(installedMask, hookInstall.brokenFields, installFailures)
         }
     }
@@ -853,38 +936,120 @@ class HookEntry : IXposedHookLoadPackage {
      * APEX (A13+) and in-boot-classpath (A12-) layouts.
      */
     private fun installConnectivityServiceHook(bootClassLoader: ClassLoader) {
-        hookConnectivityServiceIfPossible(bootClassLoader)
+        recordCsAttempt("install sdk=${Build.VERSION.SDK_INT} bootLoader=${describeLoader(bootClassLoader)}")
+        // Path A — try the system_server classloader immediately. Works when CS
+        // is on SYSTEMSERVERCLASSPATH (≤ A12); on A13+ it lives in the
+        // Connectivity APEX and this throws, releasing the latch for B/C.
+        hookConnectivityServiceIfPossible(bootClassLoader, "A")
 
         val serviceManager = XposedHelpers.findClass("android.os.ServiceManager", bootClassLoader)
-        (XposedHelpers.callStaticMethod(serviceManager, "getService", "connectivity") as? android.os.IBinder)
-            ?.let { hookConnectivityFromBinder(it) }
+        // Path B — the service may already be registered; its binder carries the
+        // real (APEX) classloader.
+        val existing = XposedHelpers.callStaticMethod(serviceManager, "getService", "connectivity") as? android.os.IBinder
+        recordCsAttempt("B:getService=${existing?.javaClass?.simpleName ?: "null"}")
+        existing?.let { hookConnectivityFromBinder(it, "B") }
+        // Path C — catch the registration so we get the binder's classloader even
+        // when it isn't up yet at install time.
         XposedBridge.hookAllMethods(
             serviceManager,
             "addService",
             object : XC_MethodHook() {
                 override fun beforeHookedMethod(param: MethodHookParam) {
                     if (param.args.getOrNull(0) != "connectivity") return
-                    (param.args.getOrNull(1) as? android.os.IBinder)?.let { hookConnectivityFromBinder(it) }
+                    recordCsAttempt("C:addService(connectivity) seen")
+                    (param.args.getOrNull(1) as? android.os.IBinder)?.let { hookConnectivityFromBinder(it, "C") }
                 }
             },
         )
+        // Path D — deferred retrying getService(): the robust fallback. On A13+
+        // OEM ROMs (MediaTek/MIUI) the service isn't published through the hooked
+        // ServiceManager.addService, so path C never fires (proven on POCO A13);
+        // but connectivity is always resolvable by name once it's up, so we
+        // re-query on a short timer until the live binder appears and attach from
+        // its (APEX) classloader — independent of the registration mechanism.
+        startConnectivityRetry(serviceManager)
     }
 
-    private fun hookConnectivityFromBinder(binder: android.os.IBinder) {
+    private fun startConnectivityRetry(serviceManager: Class<*>) {
+        if (connectivityHooked.get()) return // A/B already got it — no poller needed
+        val thread = HandlerThread("vpnhide-cs-attach").apply { start() }
+        connectivityRetryThread = thread
+        connectivityRetryHandler = Handler(thread.looper)
+        scheduleConnectivityRetry(serviceManager, 1)
+    }
+
+    private fun stopConnectivityRetry() {
+        connectivityRetryThread?.quitSafely()
+        connectivityRetryThread = null
+        connectivityRetryHandler = null
+    }
+
+    private fun scheduleConnectivityRetry(
+        serviceManager: Class<*>,
+        attempt: Int,
+    ) {
+        val handler = connectivityRetryHandler ?: return
+        if (connectivityHooked.get()) {
+            stopConnectivityRetry()
+            return
+        }
+        if (attempt > CS_RETRY_MAX_ATTEMPTS) {
+            recordCsAttempt("D:gaveUp after ${attempt - 1} tries")
+            stopConnectivityRetry()
+            return
+        }
+        handler.postDelayed({
+            // Path C (or A/B) may have attached while we waited — done, tear down.
+            if (connectivityHooked.get()) {
+                stopConnectivityRetry()
+                return@postDelayed
+            }
+            val binder =
+                try {
+                    XposedHelpers.callStaticMethod(serviceManager, "getService", "connectivity") as? android.os.IBinder
+                } catch (_: Throwable) {
+                    null
+                }
+            if (binder == null) {
+                // Not registered yet — keep waiting.
+                scheduleConnectivityRetry(serviceManager, attempt + 1)
+                return@postDelayed
+            }
+            recordCsAttempt("D:getService(try=$attempt)=${binder.javaClass.simpleName}")
+            hookConnectivityFromBinder(binder, "D")
+            // The name now resolves; retrying the same binder won't change the
+            // outcome, so stop here whether or not the attach stuck.
+            if (!connectivityHooked.get()) recordCsAttempt("D:attachFailed on resolved binder")
+            stopConnectivityRetry()
+        }, CS_RETRY_DELAY_MS)
+    }
+
+    private fun hookConnectivityFromBinder(
+        binder: android.os.IBinder,
+        path: String,
+    ) {
         val classLoader =
             binder.javaClass.classLoader ?: run {
+                recordCsAttempt("$path:binderNoClassLoader(${binder.javaClass.name})")
                 HookLog.i("VpnHide: connectivity binder has no classloader; waiting for direct classloader")
                 return
             }
-        hookConnectivityServiceIfPossible(classLoader)
+        hookConnectivityServiceIfPossible(classLoader, path)
     }
 
-    private fun hookConnectivityServiceIfPossible(classLoader: ClassLoader) {
-        if (!connectivityHooked.compareAndSet(false, true)) return
+    private fun hookConnectivityServiceIfPossible(
+        classLoader: ClassLoader,
+        path: String,
+    ) {
+        if (!connectivityHooked.compareAndSet(false, true)) {
+            recordCsAttempt("$path:skipped(already-hooked)")
+            return
+        }
         try {
-            hookConnectivityService(classLoader)
+            hookConnectivityService(classLoader, path)
         } catch (t: Throwable) {
             connectivityHooked.set(false)
+            recordCsAttempt("$path:notReady(${t.javaClass.simpleName}:${t.message}) loader=${describeLoader(classLoader)}")
             HookLog.i("VpnHide: ConnectivityService class not ready on ${classLoader.javaClass.name}: ${t.message}")
         }
     }
@@ -912,20 +1077,28 @@ class HookEntry : IXposedHookLoadPackage {
      * entirely — don't reveal a VPN exists. Fixes apps (e.g. VTB, issue #70) that
      * detect VPN only via callbacks.
      */
-    private fun hookConnectivityService(classLoader: ClassLoader) {
+    private fun hookConnectivityService(
+        classLoader: ClassLoader,
+        path: String,
+    ) {
         val csClass = findConnectivityServiceClass(classLoader)
-        tryHook("ConnectivityService constructors") {
-            XposedBridge.hookAllConstructors(
-                csClass,
-                object : XC_MethodHook() {
-                    override fun afterHookedMethod(param: MethodHookParam) {
-                        rememberConnectivityService(param.thisObject)
-                    }
-                },
-            )
-        }
-        installConnectivityServiceResultHooks(csClass)
-        installConnectivityServiceNetworkHooks(csClass)
+        val ctorCount =
+            try {
+                XposedBridge
+                    .hookAllConstructors(
+                        csClass,
+                        object : XC_MethodHook() {
+                            override fun afterHookedMethod(param: MethodHookParam) {
+                                rememberConnectivityService(param.thisObject)
+                            }
+                        },
+                    ).size
+            } catch (t: Throwable) {
+                HookLog.e("VpnHide: ConnectivityService constructors hook failed: ${t.message}")
+                0
+            }
+        val resultCounts = installConnectivityServiceResultHooks(csClass)
+        val networkCounts = installConnectivityServiceNetworkHooks(csClass)
 
         // Both methods take the NetworkRequestInfo as their first arg, so the
         // same handler covers the callback-object and PendingIntent paths.
@@ -959,17 +1132,22 @@ class HookEntry : IXposedHookLoadPackage {
                 }
             }
 
+        val callbackCounts = LinkedHashMap<String, Int>()
         for (method in CALLBACK_DISPATCH_METHODS) {
             val hooked = XposedBridge.hookAllMethods(csClass, method, dispatchHook)
+            callbackCounts[method] = hooked.size
             if (hooked.isEmpty()) {
                 HookLog.e("VpnHide: no $method on ${csClass.name}")
             } else {
                 HookLog.i("VpnHide: hooked ConnectivityService.$method (${hooked.size})")
             }
         }
+
+        reportConnectivityAttach(path, csClass, classLoader, ctorCount, resultCounts, networkCounts, callbackCounts)
     }
 
-    private fun installConnectivityServiceResultHooks(csClass: Class<*>) {
+    private fun installConnectivityServiceResultHooks(csClass: Class<*>): Map<String, Int> {
+        val counts = LinkedHashMap<String, Int>()
         for ((method, uidArgIndex) in CONNECTIVITY_RESULT_METHODS) {
             val hooked =
                 XposedBridge.hookAllMethods(
@@ -990,25 +1168,32 @@ class HookEntry : IXposedHookLoadPackage {
                         }
                     },
                 )
+            // Only record methods that exist on this build — a 0 for a method the
+            // AOSP version simply doesn't have is noise; a 0 for one it *does*
+            // have is the signal. Keep every entry; the reader compares to a
+            // known-good device.
+            counts[method] = hooked.size
             if (hooked.isEmpty()) {
                 HookLog.e("VpnHide: no ConnectivityService.$method result hook target on ${csClass.name}")
             } else {
                 HookLog.i("VpnHide: hooked ConnectivityService.$method result (${hooked.size})")
             }
         }
+        return counts
     }
 
-    private fun installConnectivityServiceNetworkHooks(csClass: Class<*>) {
-        hookConnectivityNetworkMethod(csClass, "getActiveNetwork", ::sanitizeActiveNetworkResult)
-        hookConnectivityNetworkMethod(csClass, "getAllNetworks", ::sanitizeAllNetworksResult)
-        hookConnectivityNetworkMethod(csClass, "getNetworkForType", ::sanitizeNetworkForTypeResult)
-    }
+    private fun installConnectivityServiceNetworkHooks(csClass: Class<*>): Map<String, Int> =
+        linkedMapOf(
+            "getActiveNetwork" to hookConnectivityNetworkMethod(csClass, "getActiveNetwork", ::sanitizeActiveNetworkResult),
+            "getAllNetworks" to hookConnectivityNetworkMethod(csClass, "getAllNetworks", ::sanitizeAllNetworksResult),
+            "getNetworkForType" to hookConnectivityNetworkMethod(csClass, "getNetworkForType", ::sanitizeNetworkForTypeResult),
+        )
 
     private fun hookConnectivityNetworkMethod(
         csClass: Class<*>,
         method: String,
         sanitizer: (XC_MethodHook.MethodHookParam) -> Unit,
-    ) {
+    ): Int {
         val hooked =
             XposedBridge.hookAllMethods(
                 csClass,
@@ -1027,6 +1212,7 @@ class HookEntry : IXposedHookLoadPackage {
         } else {
             HookLog.i("VpnHide: hooked ConnectivityService.$method network result (${hooked.size})")
         }
+        return hooked.size
     }
 
     private fun sanitizeActiveNetworkResult(param: XC_MethodHook.MethodHookParam) {
@@ -1122,6 +1308,13 @@ class HookEntry : IXposedHookLoadPackage {
     companion object {
         private const val SYSTEM_UID = 1000
         private const val CALLBACK_BUNDLE_ARG_INDEX = 2
+
+        // Path D poll cadence: connectivity registers within a few seconds of
+        // boot; retry getService("connectivity") every 500ms for up to ~90s
+        // (180 tries), stopping — and tearing down the poller thread — as soon as
+        // the hooks attach.
+        private const val CS_RETRY_DELAY_MS = 500L
+        private const val CS_RETRY_MAX_ATTEMPTS = 180
         private val RECIPIENT_UID_FIELDS = listOf("mAsUid", "mUid", "uid")
         private val CALLBACK_DISPATCH_METHODS = listOf("callCallbackForRequest", "sendPendingIntentForRequest")
 

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/LsposedState.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/LsposedState.kt
@@ -78,6 +78,30 @@ internal object LsposedStats {
 
     @Volatile private var installFailures: List<String> = emptyList()
 
+    // ConnectivityService hooks attach asynchronously (the reliable path only
+    // fires when "connectivity" registers, after handleLoadPackage returns), so
+    // their bits and diagnostics can't be known at setStatus() time. The attach
+    // path reports them here; both are merged into the published state whenever
+    // they land. cs_* meta keys are persisted install telemetry — they survive
+    // from boot to the next debug capture without depending on logcat or the
+    // debug-logging toggle, which is what makes "hook didn't attach" diagnosable.
+    @Volatile private var connectivityBits: Int = 0
+
+    @Volatile private var connectivityMeta: Map<String, String> = emptyMap()
+
+    fun setConnectivityDiagnostics(
+        attachedBits: Int,
+        meta: Map<String, String>,
+    ) {
+        connectivityBits = attachedBits
+        connectivityMeta = meta.mapValues { sanitizeMetadataValue(it.value) }
+        // Publish promptly: attach events are rare and each one changes the
+        // honest hook mask, so don't wait for the debounced counter flush.
+        writeHandler.removeCallbacks(flushRunnable)
+        flushPending.set(false)
+        writeHandler.post(flushRunnable)
+    }
+
     fun setStatus(
         installedHookMask: Int,
         broken: List<String>,
@@ -126,7 +150,10 @@ internal object LsposedStats {
     }
 
     private fun buildStateText(): String {
-        val installed = installedHooks
+        // Fold in the connectivity bits reported once those hooks actually
+        // attach, so the published mask reflects reality (not the optimistic
+        // "install call didn't throw").
+        val installed = installedHooks or connectivityBits
         val error =
             if (installed == HookIds.LSPOSED_HOOK_MASK) {
                 HookIds.StatusError.OK.code
@@ -165,6 +192,10 @@ internal object LsposedStats {
         if (failures.isNotEmpty()) {
             meta[LsposedStateMetadata.INSTALL_FAILURES] = failures.joinToString("; ")
         }
+        // cs_* connectivity attach telemetry (resolved class, classloader chain,
+        // path, per-method hooked counts, attempt log). hook_report.txt renders
+        // every meta key, so these appear automatically in a debug bundle.
+        meta.putAll(connectivityMeta)
         return meta
     }
 
@@ -199,5 +230,9 @@ internal object LsposedStats {
             .take(MAX_METADATA_VALUE_CHARS)
 
     private const val MAX_METADATA_FAILURES = 24
-    private const val MAX_METADATA_VALUE_CHARS = 240
+
+    // Roomy enough for the cs_attempts trail (per-path attach log incl. class-not-
+    // ready reasons) to land intact on a total-failure device — that trail is the
+    // only signal when nothing attaches, so it must not get truncated.
+    private const val MAX_METADATA_VALUE_CHARS = 800
 }


### PR DESCRIPTION
Closes #230

On Android 13+ ConnectivityService lives in the Connectivity APEX, so its method hooks can only be attached from the service binder's classloader. That was done solely by catching `ServiceManager.addService("connectivity", …)`, which never fires on many MediaTek/OEM ROMs — they publish the service off that path — so the ConnectivityService hooks never attached and `getNetworkForType`, the active/all-networks handles, `getNetworkInfo(TYPE_VPN)` and pushed `NetworkCallback`s leaked the VPN (five Java-API diagnostics red), while the `writeToParcel` hooks kept passing. Reported on POCO/Xiaomi/OnePlus/realme; not reproducible on stock Pixels.

- Add path D: a deferred `getService("connectivity")` poll on a short-lived background thread that retries (every 500 ms, ~90 s budget) until the live binder appears and attaches from its classloader, independent of how the service was registered. In-process `getService` returns the local ConnectivityService instance (not a proxy), so its APEX classloader resolves the class. The thread is torn down as soon as the hooks attach (any path) or the budget is exhausted.
- Make the published hook mask honest: the connectivity bits are set only once those hooks actually attach, so a device where they don't shows `PARTIAL_HOOKS` and lists them under missing owned hooks instead of a false "8/8 installed".
- Record per-attempt install telemetry (`cs_*` keys: resolved class, classloader chain, attach path, per-method match counts, full attempt trail) in the LSPosed state file, so this class of attach failure is diagnosable from a debug bundle without depending on logcat or the debug-logging toggle.
- Add `docs/lsposed-hook-debugging.md` — a guide to the two hook families, the `cs_*` telemetry, and diagnosing why a hook didn't attach on a given ROM.

## Testing
- Pixel 4a (A13, stock + Vector): forcing the addService path observe-only (to mimic the affected ROMs) makes path D fetch the live ConnectivityService on the 3rd poll and attach every method; all five previously-leaking checks pass, the mask reads full, and the poller thread is torn down after attach. In the normal (unforced) build path C wins and D stays dormant.
- Confirmed by an affected user on a POCO X3 GT (A13, MediaTek/MIUI): diagnostics go green.
