### PR TITLE
fix: block socket binds to hidden VPN interfaces

### DIFF
--- a/.github/docker/ddk-qemu/Dockerfile
+++ b/.github/docker/ddk-qemu/Dockerfile
@@ -30,10 +30,13 @@ RUN curl -fsSL "https://dl.google.com/android/repository/android-ndk-${NDK_VER}-
         -d /opt && rm /tmp/ndk.zip
 COPY kmod/test/gai-probe.c /tmp/gai-probe.c
 COPY kmod/test/ifconf-probe.c /tmp/ifconf-probe.c
+COPY kmod/test/bind-probe.c /tmp/bind-probe.c
 RUN TC="/opt/android-ndk-${NDK_VER}/toolchains/llvm/prebuilt/linux-x86_64/bin" && \
     "$TC/aarch64-linux-android24-clang" -static -O2 -o /opt/gai /tmp/gai-probe.c && \
     "$TC/aarch64-linux-android24-clang" -static -O2 -o /opt/ifconf /tmp/ifconf-probe.c && \
-    "$TC/llvm-strip" /opt/gai /opt/ifconf
+    "$TC/aarch64-linux-android24-clang" -static -O2 -Wall -Wextra -Werror \
+        -o /opt/bind-probe /tmp/bind-probe.c && \
+    "$TC/llvm-strip" /opt/gai /opt/ifconf /opt/bind-probe
 
 FROM ghcr.io/ylarod/ddk-min:${KMI}-20260313
 ARG KMI
@@ -81,21 +84,23 @@ RUN mkdir -p /opt/qemu/kp && \
             -o "/opt/qemu/kp/$a"; \
     done && chmod +x /opt/qemu/kp/kptools-linux
 
-# Prebuilt bionic getifaddrs + SIOCGIFCONF probes (built from *-probe.c with the
-# NDK in the `gai` stage). run.sh / run-kpm.sh pick them up via VPNHIDE_GAI_BIN /
-# VPNHIDE_IFC_BIN so the addr-fill hook and the ifconf size-query path are
-# validated in CI on every KMI — not skipped.
+# Prebuilt bionic getifaddrs, SIOCGIFCONF, and raw-syscall socket bind probes
+# (built from *-probe.c with the NDK in the `gai` stage). The harnesses pick
+# them up via VPNHIDE_*_BIN so all three native paths are mandatory in CI.
 COPY --from=gai /opt/gai /opt/qemu/gai
 COPY --from=gai /opt/ifconf /opt/qemu/ifconf
+COPY --from=gai /opt/bind-probe /opt/qemu/bind-probe
 
 # run.sh / run-kpm.sh read these to use the baked artifacts instead of the local
 # cache. VPNHIDE_QEMU_KSRC is the kernel tree to build the test module against;
 # VPNHIDE_KP_BIN is the baked KernelPatch tool/runtime dir (KPM only);
 # VPNHIDE_GAI_BIN is the prebuilt bionic getifaddrs probe;
-# VPNHIDE_IFC_BIN is the prebuilt SIOCGIFCONF size-query probe.
+# VPNHIDE_IFC_BIN is the prebuilt SIOCGIFCONF size-query probe;
+# VPNHIDE_BIND_BIN is the state-aware raw-syscall socket bind probe.
 ENV VPNHIDE_QEMU_IMAGE=/opt/qemu/Image
 ENV VPNHIDE_QEMU_ROOTFS=/opt/qemu/alpine-minirootfs.tar.gz
 ENV VPNHIDE_QEMU_KSRC=/opt/qemu/linux
 ENV VPNHIDE_KP_BIN=/opt/qemu/kp
 ENV VPNHIDE_GAI_BIN=/opt/qemu/gai
 ENV VPNHIDE_IFC_BIN=/opt/qemu/ifconf
+ENV VPNHIDE_BIND_BIN=/opt/qemu/bind-probe

--- a/.github/docker/kpm-qemu-legacy/Dockerfile
+++ b/.github/docker/kpm-qemu-legacy/Dockerfile
@@ -28,9 +28,12 @@ RUN curl -fsSL "https://dl.google.com/android/repository/android-ndk-${NDK_VER}-
     unzip -q /tmp/ndk.zip "android-ndk-${NDK_VER}/toolchains/llvm/prebuilt/linux-x86_64/*" \
         -d /opt && rm /tmp/ndk.zip
 COPY kmod/test/gai-probe.c /tmp/gai-probe.c
+COPY kmod/test/bind-probe.c /tmp/bind-probe.c
 RUN TC="/opt/android-ndk-${NDK_VER}/toolchains/llvm/prebuilt/linux-x86_64/bin" && \
     "$TC/aarch64-linux-android24-clang" -static -O2 -o /opt/gai /tmp/gai-probe.c && \
-    "$TC/llvm-strip" /opt/gai
+    "$TC/aarch64-linux-android24-clang" -static -O2 -Wall -Wextra -Werror \
+        -o /opt/bind-probe /tmp/bind-probe.c && \
+    "$TC/llvm-strip" /opt/gai /opt/bind-probe
 
 FROM debian:trixie-slim
 
@@ -62,10 +65,11 @@ RUN mkdir -p /opt/qemu/kp && \
             -o "/opt/qemu/kp/$a"; \
     done && chmod +x /opt/qemu/kp/kptools-linux
 
-# Prebuilt bionic getifaddrs probe (built from gai-probe.c with the NDK in the
-# `gai` stage). run-kpm.sh picks it up via VPNHIDE_GAI_BIN so the addr-fill
-# hook is validated in CI on every legacy kernel — not skipped.
+# Prebuilt bionic getifaddrs and raw-syscall socket bind probes. Old kernels
+# normally deny the first bind natively; running the probe still guards that
+# assumption and makes any future behavior change visible.
 COPY --from=gai /opt/gai /opt/qemu/gai
+COPY --from=gai /opt/bind-probe /opt/qemu/bind-probe
 
 # run-kpm.sh reads these. The per-version Image lives at
 # /opt/qemu/legacy/<ver>/Image — the CI job sets VPNHIDE_QEMU_IMAGE +
@@ -73,3 +77,4 @@ COPY --from=gai /opt/gai /opt/qemu/gai
 ENV VPNHIDE_QEMU_ROOTFS=/opt/qemu/alpine-minirootfs.tar.gz
 ENV VPNHIDE_KP_BIN=/opt/qemu/kp
 ENV VPNHIDE_GAI_BIN=/opt/qemu/gai
+ENV VPNHIDE_BIND_BIN=/opt/qemu/bind-probe

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,37 @@ jobs:
           echo "ddkqemu=ghcr.io/${REPO,,}/ddk-qemu" >> "$GITHUB_OUTPUT"
           echo "kpmlegacy=ghcr.io/${REPO,,}/kpm-qemu-legacy:latest" >> "$GITHUB_OUTPUT"
 
+  # Build the raw-syscall probe from the PR checkout once, then feed that exact
+  # binary to every QEMU job. The long-lived QEMU images also carry a fallback
+  # copy, but relying on it makes a PR that adds/changes a probe fail until the
+  # post-merge image rebuild catches up.
+  qemu-native-probes:
+    needs: setup
+    runs-on: ubuntu-latest
+    container:
+      image: ${{ needs.setup.outputs.image }}
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Build state-aware socket bind probe
+        run: |
+          TC="$ANDROID_NDK_HOME/toolchains/llvm/prebuilt/linux-x86_64/bin"
+          mkdir -p .artifacts/qemu-native-probes
+          "$TC/aarch64-linux-android24-clang" -static -O2 -Wall -Wextra -Werror \
+            -o .artifacts/qemu-native-probes/bind-probe kmod/test/bind-probe.c
+          "$TC/llvm-strip" .artifacts/qemu-native-probes/bind-probe
+
+      - name: Upload QEMU native probes
+        uses: actions/upload-artifact@v7
+        with:
+          name: qemu-native-probes
+          path: .artifacts/qemu-native-probes
+          if-no-files-found: error
+
   lint:
     needs: setup
     runs-on: ubuntu-latest
@@ -274,7 +305,7 @@ jobs:
   # tree; the module is built here against that tree so it matches the kernel.
   # QEMU runs under TCG (no KVM on hosted runners) — slow but fine. See kmod/test/.
   kmod-qemu:
-    needs: setup
+    needs: [setup, qemu-native-probes]
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -297,12 +328,22 @@ jobs:
     env:
       KMI: ${{ matrix.kmi }}
       VPNHIDE_BIND_REQUIRED: "1"
+      VPNHIDE_BIND_BIN: ${{ github.workspace }}/.artifacts/qemu-native-probes/bind-probe
 
     steps:
       - uses: actions/checkout@v7
 
       - name: Mark workspace safe
         run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
+
+      - name: Download QEMU native probes
+        uses: actions/download-artifact@v7
+        with:
+          name: qemu-native-probes
+          path: .artifacts/qemu-native-probes
+
+      - name: Mark QEMU native probes executable
+        run: chmod +x "$VPNHIDE_BIND_BIN"
 
       - name: Build module + QEMU runtime test
         # Build the module against the BAKED kernel tree (VPNHIDE_QEMU_KSRC) so
@@ -319,7 +360,7 @@ jobs:
   # baked Image/rootfs + KernelPatch tool/runtime (VPNHIDE_KP_BIN) make this
   # hermetic. Legacy pre-GKI kernels (4.14/4.19/5.4) are a separate job/image.
   kpm-qemu:
-    needs: setup
+    needs: [setup, qemu-native-probes]
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -339,6 +380,7 @@ jobs:
         password: ${{ secrets.GITHUB_TOKEN }}
     env:
       KMI: ${{ matrix.kmi }}
+      VPNHIDE_BIND_BIN: ${{ github.workspace }}/.artifacts/qemu-native-probes/bind-probe
 
     steps:
       - uses: actions/checkout@v7
@@ -347,6 +389,15 @@ jobs:
 
       - name: Mark workspace safe
         run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
+
+      - name: Download QEMU native probes
+        uses: actions/download-artifact@v7
+        with:
+          name: qemu-native-probes
+          path: .artifacts/qemu-native-probes
+
+      - name: Mark QEMU native probes executable
+        run: chmod +x "$VPNHIDE_BIND_BIN"
 
       - name: Build .kpm + KPM QEMU runtime test
         # `make kpm` builds the relocatable .kpm against the KernelPatch
@@ -368,7 +419,7 @@ jobs:
   # compiled in, so the user/kernel pointer-domain bug class is caught here on
   # the exact cores where it lives.
   kpm-qemu-legacy:
-    needs: setup
+    needs: [setup, qemu-native-probes]
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -379,6 +430,8 @@ jobs:
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
+    env:
+      VPNHIDE_BIND_BIN: ${{ github.workspace }}/.artifacts/qemu-native-probes/bind-probe
 
     steps:
       - uses: actions/checkout@v7
@@ -387,6 +440,15 @@ jobs:
 
       - name: Mark workspace safe
         run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
+
+      - name: Download QEMU native probes
+        uses: actions/download-artifact@v7
+        with:
+          name: qemu-native-probes
+          path: .artifacts/qemu-native-probes
+
+      - name: Mark QEMU native probes executable
+        run: chmod +x "$VPNHIDE_BIND_BIN"
 
       - name: Build .kpm + legacy KPM QEMU test
         # plain clang from the legacy image; the baked Image + rootfs + KP tools

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -296,6 +296,7 @@ jobs:
         password: ${{ secrets.GITHUB_TOKEN }}
     env:
       KMI: ${{ matrix.kmi }}
+      VPNHIDE_BIND_REQUIRED: "1"
 
     steps:
       - uses: actions/checkout@v7
@@ -355,6 +356,7 @@ jobs:
         # image, so a skip means it's missing — fail rather than drop coverage.
         env:
           VPNHIDE_GAI_REQUIRED: "1"
+          VPNHIDE_BIND_REQUIRED: "1"
         run: |
           CLANG_BIN="$(ls -d /opt/ddk/clang/*/bin | head -1)"
           make -C kmod kpm CLANG_DIR="$CLANG_BIN"
@@ -394,6 +396,7 @@ jobs:
         # image, so a skip means it's missing — fail rather than drop coverage.
         env:
           VPNHIDE_GAI_REQUIRED: "1"
+          VPNHIDE_BIND_REQUIRED: "1"
         run: |
           make -C kmod kpm
           VPNHIDE_QEMU_IMAGE="/opt/qemu/legacy/${{ matrix.ver }}/Image" \

--- a/.github/workflows/qemu-image.yml
+++ b/.github/workflows/qemu-image.yml
@@ -13,6 +13,7 @@ on:
       - .github/workflows/qemu-image.yml
       - kmod/test/gai-probe.c
       - kmod/test/ifconf-probe.c
+      - kmod/test/bind-probe.c
       - kmod/test/qemu.config
       - kmod/test/build-source-kernel.sh
   schedule:

--- a/changelog.d/changed-made-the-gki-kernel-module-remain-4688.md
+++ b/changelog.d/changed-made-the-gki-kernel-module-remain-4688.md
@@ -1,0 +1,9 @@
+_2026-08-10_
+
+## English
+
+Made the GKI kernel module remain loaded until reboot, matching Magisk, KernelSU, and APatch module lifecycle.
+
+## Русский
+
+Модуль ядра GKI теперь остаётся загруженным до перезагрузки в соответствии с жизненным циклом модулей Magisk, KernelSU и APatch.

--- a/changelog.d/fixed-blocked-selected-apps-from-binding-sockets-ca2d.md
+++ b/changelog.d/fixed-blocked-selected-apps-from-binding-sockets-ca2d.md
@@ -1,0 +1,9 @@
+_2026-07-13_
+
+## English
+
+Blocked selected apps from binding sockets to hidden VPN interfaces through SO_BINDTODEVICE or SO_BINDTOIFINDEX on the kernel backends.
+
+## Русский
+
+Запрещена привязка сокетов выбранных приложений к скрытым VPN-интерфейсам через SO_BINDTODEVICE и SO_BINDTOIFINDEX в ядерных бэкендах.

--- a/changelog.d/fixed-blocked-selected-apps-from-binding-sockets-ca2d.md
+++ b/changelog.d/fixed-blocked-selected-apps-from-binding-sockets-ca2d.md
@@ -2,8 +2,8 @@ _2026-07-13_
 
 ## English
 
-Blocked selected apps from binding sockets to hidden VPN interfaces through SO_BINDTODEVICE or SO_BINDTOIFINDEX on the kernel backends.
+Blocked selected apps from binding sockets to hidden VPN interfaces through SO_BINDTODEVICE or SO_BINDTOIFINDEX on the kernel backends, with a best-effort libc fallback for Zygisk-only installs.
 
 ## Русский
 
-Запрещена привязка сокетов выбранных приложений к скрытым VPN-интерфейсам через SO_BINDTODEVICE и SO_BINDTOIFINDEX в ядерных бэкендах.
+Запрещена привязка сокетов выбранных приложений к скрытым VPN-интерфейсам через SO_BINDTODEVICE и SO_BINDTOIFINDEX в ядерных бэкендах; для установок только с Zygisk добавлен best-effort fallback на уровне libc.

--- a/changelog.d/fixed-made-the-kpm-reject-unsupported-kernels-8822.md
+++ b/changelog.d/fixed-made-the-kpm-reject-unsupported-kernels-8822.md
@@ -1,0 +1,9 @@
+_2026-08-10_
+
+## English
+
+Made the KPM reject kernels outside its supported 4.14–6.12 range and unsafe user-copy fallbacks.
+
+## Русский
+
+KPM теперь отклоняет ядра вне поддерживаемого диапазона 4.14–6.12 и небезопасные резервные функции копирования пользовательской памяти.

--- a/changelog.d/fixed-made-the-kpm-reject-unsupported-kernels-8822.md
+++ b/changelog.d/fixed-made-the-kpm-reject-unsupported-kernels-8822.md
@@ -2,8 +2,8 @@ _2026-08-10_
 
 ## English
 
-Made the KPM reject kernels outside its supported 4.14–6.12 range and unsafe user-copy fallbacks.
+Made the KPM reject kernels outside its supported 4.14–6.12 range and use raw user-copy routines only when the kernel or hardware PAN makes them safe.
 
 ## Русский
 
-KPM теперь отклоняет ядра вне поддерживаемого диапазона 4.14–6.12 и небезопасные резервные функции копирования пользовательской памяти.
+KPM теперь отклоняет ядра вне поддерживаемого диапазона 4.14–6.12 и использует низкоуровневые функции копирования пользовательской памяти только когда ядро или аппаратный PAN делают их безопасными.

--- a/crates/activator/src/tests.rs
+++ b/crates/activator/src/tests.rs
@@ -72,7 +72,7 @@ fn projects_backend_specific_native_hook_overrides() {
               "native": {
                 "enabled": true,
                 "kernel": ["sock_ioctl"],
-                "zygisk": ["zygisk_ioctl", "zygisk_recvfrom_chk"]
+                "zygisk": ["zygisk_ioctl", "zygisk_recvfrom_chk", "zygisk_setsockopt"]
               }
             }
           }
@@ -91,7 +91,7 @@ fn projects_backend_specific_native_hook_overrides() {
         project_native_with_resolver_for_family(&cfg, &resolver, NativeHookFamily::Zygisk),
         "vpnhide 1 config\n\
          debug 0\n\
-         target 0x27fa 0x1040000\n",
+         target 0x27fa 0x5040000\n",
     );
 }
 
@@ -118,7 +118,7 @@ fn legacy_native_hook_list_is_kernel_only_and_zygisk_defaults_to_all() {
         project_native_with_resolver_for_family(&cfg, &resolver, NativeHookFamily::Zygisk),
         "vpnhide 1 config\n\
          debug 0\n\
-         target 0x27fa 0x1fc0000\n",
+         target 0x27fa 0x5fc0000\n",
     );
 }
 

--- a/crates/activator/src/tests.rs
+++ b/crates/activator/src/tests.rs
@@ -36,9 +36,9 @@ fn projects_native_roles_to_wire() {
         project_native_with_resolver(&cfg, &resolver),
         "vpnhide 1 config\n\
          debug 1\n\
-         target 0x278b 0x3ff\n\
+         target 0x278b 0x20003ff\n\
          target 0x27fa 0x40\n\
-         target 0xf69cb 0x3ff\n",
+         target 0xf69cb 0x20003ff\n",
     );
 }
 
@@ -199,8 +199,8 @@ fn parses_per_hook_java_selection_without_breaking_native() {
         project_native_with_resolver(&cfg, &resolver),
         "vpnhide 1 config\n\
          debug 0\n\
-         target 0x278b 0x3ff\n\
-         target 0x278c 0x3ff\n",
+         target 0x278b 0x20003ff\n\
+         target 0x278c 0x20003ff\n",
     );
 }
 

--- a/crates/protocol/src/generated/hook_ids.rs
+++ b/crates/protocol/src/generated/hook_ids.rs
@@ -58,13 +58,15 @@ pub enum Hook {
     ZygiskRecvfromChk = 24,
     /// SO_BINDTODEVICE / SO_BINDTOIFINDEX pre-mutation denial
     SocketBindInterface = 25,
+    /// libc setsockopt() best-effort socket-interface bind denial
+    ZygiskSetsockopt = 26,
 }
 
-pub const HOOK_COUNT: u32 = 26;
+pub const HOOK_COUNT: u32 = 27;
 
 /// Hooks owned by each backend: apply `mask & own`.
 pub const KERNEL_HOOK_MASK: u32 = 0x20003ff;
-pub const ZYGISK_HOOK_MASK: u32 = 0x1fc0000;
+pub const ZYGISK_HOOK_MASK: u32 = 0x5fc0000;
 pub const LSPOSED_HOOK_MASK: u32 = 0x3fc00;
 
 /// status error codes (protocol §5.1).
@@ -97,7 +99,7 @@ pub enum Backend {
     Lsposed = 3,
 }
 
-pub const HOOK_NAMES: [&str; 26] = [
+pub const HOOK_NAMES: [&str; 27] = [
     "fib_route_seq_show",
     "ipv6_route_seq_show",
     "rtnl_fill_ifinfo",
@@ -124,4 +126,5 @@ pub const HOOK_NAMES: [&str; 26] = [
     "zygisk_recvfrom",
     "zygisk_recvfrom_chk",
     "socket_bind_interface",
+    "zygisk_setsockopt",
 ];

--- a/crates/protocol/src/generated/hook_ids.rs
+++ b/crates/protocol/src/generated/hook_ids.rs
@@ -56,12 +56,14 @@ pub enum Hook {
     ZygiskRecvfrom = 23,
     /// __recvfrom_chk() fortified netlink dump filtering
     ZygiskRecvfromChk = 24,
+    /// SO_BINDTODEVICE / SO_BINDTOIFINDEX pre-mutation denial
+    SocketBindInterface = 25,
 }
 
-pub const HOOK_COUNT: u32 = 25;
+pub const HOOK_COUNT: u32 = 26;
 
 /// Hooks owned by each backend: apply `mask & own`.
-pub const KERNEL_HOOK_MASK: u32 = 0x3ff;
+pub const KERNEL_HOOK_MASK: u32 = 0x20003ff;
 pub const ZYGISK_HOOK_MASK: u32 = 0x1fc0000;
 pub const LSPOSED_HOOK_MASK: u32 = 0x3fc00;
 
@@ -95,7 +97,7 @@ pub enum Backend {
     Lsposed = 3,
 }
 
-pub const HOOK_NAMES: [&str; 25] = [
+pub const HOOK_NAMES: [&str; 26] = [
     "fib_route_seq_show",
     "ipv6_route_seq_show",
     "rtnl_fill_ifinfo",
@@ -121,4 +123,5 @@ pub const HOOK_NAMES: [&str; 25] = [
     "zygisk_recv",
     "zygisk_recvfrom",
     "zygisk_recvfrom_chk",
+    "socket_bind_interface",
 ];

--- a/data/hooks.toml
+++ b/data/hooks.toml
@@ -172,6 +172,14 @@ name = "zygisk_recvfrom_chk"
 backend = "zygisk"
 note = "__recvfrom_chk() fortified netlink dump filtering"
 
+# Added after the original backend ranges were assigned. The registry is
+# append-only, so this kernel hook deliberately lives after the Zygisk ids.
+[[hook]]
+id = 25
+name = "socket_bind_interface"
+backend = "kernel"
+note = "SO_BINDTODEVICE / SO_BINDTOIFINDEX pre-mutation denial"
+
 # --- backend ids (protocol §4.3 `status backend <id>`) ----------------------
 # Which backend answered a `status` read. Distinct from the hook `backend`
 # field above (.ko and KPM both own "kernel" hooks but are separate backends).

--- a/data/hooks.toml
+++ b/data/hooks.toml
@@ -180,6 +180,15 @@ name = "socket_bind_interface"
 backend = "kernel"
 note = "SO_BINDTODEVICE / SO_BINDTOIFINDEX pre-mutation denial"
 
+# Zygisk fallback for the same vector. This remains a separate id because it
+# only covers callers routed through bionic's setsockopt() entry point; raw
+# syscalls still require one of the kernel backends.
+[[hook]]
+id = 26
+name = "zygisk_setsockopt"
+backend = "zygisk"
+note = "libc setsockopt() best-effort socket-interface bind denial"
+
 # --- backend ids (protocol §4.3 `status backend <id>`) ----------------------
 # Which backend answered a `status` read. Distinct from the hook `backend`
 # field above (.ko and KPM both own "kernel" hooks but are separate backends).

--- a/docs/detection-vectors.md
+++ b/docs/detection-vectors.md
@@ -41,7 +41,7 @@ Coverage comes from vpnhide components plus the platform. They differ in
 
 | Layer | Where it runs | Selects targets by | Sees | Bypassable by raw syscalls? |
 |---|---|---|---|---|
-| **kmod** | Linux kernel (kretprobes) | **UID** (`/proc/vpnhide_ctl`) | Everything below libc — the syscall/skb/seq_file source | **No** — filters at the source regardless of how userspace calls |
+| **kmod** | Linux kernel (kretprobes + entry redirection) | **UID** (`/proc/vpnhide_ctl`) | Everything below libc — the syscall/socket/skb/seq_file source | **No** — filters at the source regardless of how userspace calls |
 | **KPM** | Linux kernel (KernelPatch inline hooks) | **UID** (KPM `ctl0` supercall) | Same kernel sources as kmod, delivered through KernelPatch instead of `.ko` loading | **No** — filters at the source regardless of how userspace calls |
 | **zygisk** | target process, inline `libc` hooks (shadowhook) | **package** (canonical JSON -> module-dir runtime wire, per-fork) | Only calls routed through the hooked `libc` symbols | **Yes** — a direct `svc #0` / unhooked libc entry slips past |
 | **lsposed** | `system_server`, Binder hooks (Vector framework) | **package/appId** (`vpnhide_config.json` + `/data/system/packages.list`) | Java/framework Binder results *before* serialization to the app | N/A — the data is built in another process; the app only gets the sanitized parcel |
@@ -186,12 +186,31 @@ cheap and correct when such a route is present; see issue discussion.
 
 | Vector | How it manifests | kmod | KPM | Zygisk | lsposed | SELinux |
 |---|---|:--:|:--:|:--:|:--:|:--:|
+| `setsockopt(SO_BINDTODEVICE)` / `SO_BINDTOIFINDEX` | bind success and `getsockopt` state reveal or select a hidden iface | ✅ pre-mutation entry redirect | ✅ pre-hook `skip_origin` | — | — | |
 | `/proc/net/tcp` | local addr hex per socket | — | — | ✅ `filter_tcp4_buf` (by VPN addr) | — | 🔒 often denied |
 | `/proc/net/tcp6` | 32-hex local addr | — | — | ✅ `filter_tcp6_buf` | — | 🔒 |
 | `/proc/net/if_inet6` | IPv6 addrs, iface last field | — | — | ✅ `filter_if_inet6_buf` | — | 🔒 |
 
-These three are **Zygisk-only** today: kernel backends hide IPv6 addresses on
-the netlink `RTM_GETADDR` path but do **not** hook `if_inet6_seq_show`,
+Since Linux 5.7, an unprivileged process can perform the first interface
+bind, so `curl --interface tun0 ...` or a raw `setsockopt` syscall is a real
+local oracle even without root. The kernel backends deny VPN names and indices
+with `ENODEV` **before** `sk_bound_dev_if` changes. The `.ko` redirects
+`sock_setsockopt` (and `sk_setsockopt` on 6.1+) to a typed wrapper because a
+return-only kretprobe would be too late; KPM uses KernelPatch's pre-hook
+`skip_origin`. Both freeze the 5.9+ `sockptr_t` input before validation to close
+userspace TOCTOU. On 5.7-5.8, KPM instead hooks the resolved-ifindex mutation
+helper; if LTO removes that static symbol, status is deliberately partial.
+Before 5.7, the kernel itself rejects the first interface bind without
+`CAP_NET_RAW`, and KPM preserves that native result exactly rather than adding
+a distinguishable errno. 4.x also lacks `SO_BINDTOIFINDEX`. The legacy QEMU
+checks record these paths as native protection.
+
+This vector is deliberately tested by a raw `svc` probe. A second, non-target
+UID inspects the same inherited socket after the target call, so a backend that
+only rewrites errno while leaving the socket bound fails the test.
+
+The three procfs rows remain **Zygisk-only** today: kernel backends hide IPv6
+addresses on the netlink `RTM_GETADDR` path but do **not** hook `if_inet6_seq_show`,
 `tcp4_seq_show`, or `tcp6_seq_show`, so the procfs equivalents leak under a
 raw-syscall reader that SELinux happens to allow. Candidate kernel-backend work
 if a real detector uses them.
@@ -235,7 +254,7 @@ being hidden from other observer apps.
 Rough priority when triaging "which vector matters", based on what real
 detectors actually probe:
 
-1. **Interface enumeration + route dump (3A, 3B).** The first thing every native
+1. **Interface enumeration + route dump + interface bind (3A–3C).** The first thing every native
    detector checks. Must be airtight across libc *and* raw-syscall readers →
    needs a kernel backend (`.ko` or KPM) for the bypass-proof guarantee, Zygisk
    for kernel-backend-less installs.
@@ -255,6 +274,9 @@ detectors actually probe:
 - **Raw-syscall native readers defeat Zygisk.** Only the kernel backends
   (`.ko`/KPM) are bypass-proof. Document any "covered" claim with the layer; a
   Zygisk-only install is not raw-syscall-proof.
+- **Zygisk does not intercept socket interface binding.** Its libc hooks do not
+  cover `SO_BINDTODEVICE` / `SO_BINDTOIFINDEX`, and a direct syscall would bypass
+  an in-process libc hook anyway. Use a kernel backend for this vector.
 - **zygisk netlink filtering is recv-family-scoped.** It hooks `recvmsg`,
   `recv`, `recvfrom`, `__recvfrom_chk`. A detector reading a netlink socket via
   plain `read()`/`readv()` or `recvmmsg` would slip past. Not seen in the wild
@@ -280,7 +302,7 @@ detectors actually probe:
 
 | Layer | Entry points |
 |---|---|
-| kmod | `kmod/vpnhide_kmod.c` (10 kretprobes); iface matcher `kmod/generated/iface_lists.h` |
+| kmod | `kmod/vpnhide_kmod.c` (10 kretprobes + the socket-bind entry redirect); iface matcher `kmod/generated/iface_lists.h` |
 | KPM | `kmod/kpm/vpnhide_kpm.c` (KernelPatch inline hooks + ctl0); offsets in `kmod/kpm/kver_offsets.h` |
 | zygisk | `zygisk/src/hooks.rs` (ioctl/getifaddrs/openat/recv*); `zygisk/src/filter.rs` (procfs + netlink filters) |
 | lsposed | `lsposed/app/.../HookEntry.kt`, `PackageVisibilityHooks.kt`; iface matcher `.../generated/IfaceLists.kt` |

--- a/docs/detection-vectors.md
+++ b/docs/detection-vectors.md
@@ -186,7 +186,7 @@ cheap and correct when such a route is present; see issue discussion.
 
 | Vector | How it manifests | kmod | KPM | Zygisk | lsposed | SELinux |
 |---|---|:--:|:--:|:--:|:--:|:--:|
-| `setsockopt(SO_BINDTODEVICE)` / `SO_BINDTOIFINDEX` | bind success and `getsockopt` state reveal or select a hidden iface | ✅ pre-mutation entry redirect | ✅ pre-hook `skip_origin` | — | — | |
+| `setsockopt(SO_BINDTODEVICE)` / `SO_BINDTOIFINDEX` | bind success and `getsockopt` state reveal or select a hidden iface | ✅ pre-mutation entry redirect | ✅ pre-hook `skip_origin` | ⚠️ bionic `setsockopt` only | — | |
 | `/proc/net/tcp` | local addr hex per socket | — | — | ✅ `filter_tcp4_buf` (by VPN addr) | — | 🔒 often denied |
 | `/proc/net/tcp6` | 32-hex local addr | — | — | ✅ `filter_tcp6_buf` | — | 🔒 |
 | `/proc/net/if_inet6` | IPv6 addrs, iface last field | — | — | ✅ `filter_if_inet6_buf` | — | 🔒 |
@@ -204,6 +204,16 @@ Before 5.7, the kernel itself rejects the first interface bind without
 `CAP_NET_RAW`, and KPM preserves that native result exactly rather than adding
 a distinguishable errno. 4.x also lacks `SO_BINDTOIFINDEX`. The legacy QEMU
 checks record these paths as native protection.
+
+When neither kernel backend is available, Zygisk inline-hooks bionic's
+`setsockopt` entry point and applies the same pre-syscall `ENODEV` policy. It
+copies the untrusted option value through a fault-contained self-read, so a bad
+pointer still reaches the kernel for native `EFAULT` handling instead of
+crashing the target process. This is deliberately **best effort**: a caller
+issuing `__NR_setsockopt` through raw `svc #0` never enters bionic and bypasses
+the hook. On pre-5.7 kernels it stays inert because the kernel rejects an
+unprivileged bind before inspecting the name; returning a name-dependent error
+there would create a new oracle.
 
 This vector is deliberately tested by a raw `svc` probe. A second, non-target
 UID inspects the same inherited socket after the target call, so a backend that
@@ -274,9 +284,10 @@ detectors actually probe:
 - **Raw-syscall native readers defeat Zygisk.** Only the kernel backends
   (`.ko`/KPM) are bypass-proof. Document any "covered" claim with the layer; a
   Zygisk-only install is not raw-syscall-proof.
-- **Zygisk does not intercept socket interface binding.** Its libc hooks do not
-  cover `SO_BINDTODEVICE` / `SO_BINDTOIFINDEX`, and a direct syscall would bypass
-  an in-process libc hook anyway. Use a kernel backend for this vector.
+- **Zygisk socket-interface binding coverage is libc-only.** Its `setsockopt`
+  hook covers bionic-routed `SO_BINDTODEVICE` / `SO_BINDTOIFINDEX` calls, but a
+  direct syscall bypasses any in-process libc hook. Use a kernel backend for a
+  bypass-proof guarantee.
 - **zygisk netlink filtering is recv-family-scoped.** It hooks `recvmsg`,
   `recv`, `recvfrom`, `__recvfrom_chk`. A detector reading a netlink socket via
   plain `read()`/`readv()` or `recvmmsg` would slip past. Not seen in the wild

--- a/docs/detection-vectors.md
+++ b/docs/detection-vectors.md
@@ -149,8 +149,7 @@ the filtered fill. Validated by the harness `ifconf_size_probe` vector.
 The KPM backend's `filter_ifconf` compacts the fill the same way the `.ko` does,
 but does not yet reduce the `ifc_req == NULL` size query (it would need raw netdev
 walking by per-kver offset rather than the `.ko`'s rcu helpers); the size-query
-subcase is therefore `.ko`-only for now, tracked with the KPM's other WIP parity
-items.
+subcase is therefore `.ko`-only for now and remains a known KPM gap.
 
 ### 3B. Route table — "is the default route a tunnel?"
 

--- a/docs/diagnostics.md
+++ b/docs/diagnostics.md
@@ -140,6 +140,9 @@ inspect the socket from a non-target UID; simply checking the returned errno
 would bless the broken return-only implementation this hook was designed to
 avoid. The QEMU `bind-probe` performs that full state-level test with a raw
 syscall and an inherited socket. Runtime hits still appear in Statistics.
+The Zygisk fallback has a separate `zygisk_setsockopt` hook for libc-routed
+calls, but the raw diagnostic probe bypasses it by design; Zygisk does not emit
+per-hook statistics yet.
 
 Java-level checks (LSPosed) cover the framework side — `hasTransport(VPN)`,
 `NET_CAPABILITY_NOT_VPN`, `VpnTransportInfo`, `getAllNetworks`, `LinkProperties`,

--- a/docs/diagnostics.md
+++ b/docs/diagnostics.md
@@ -116,7 +116,7 @@ results. A `null` answer (no root) does not block.
 
 ## 7. Native check → owning hook (KPM/kmod), verified on Pixel 4a
 
-The kernel backend's 10 hooks map to the diagnostic checks below; the "gaps" rows are
+The kernel backend's 11 logical hooks map to the diagnostic checks below; the "gaps" rows are
 SELinux/zygisk territory by design, not bugs. Full hiding matrix in
 [detection-vectors.md](detection-vectors.md).
 
@@ -132,6 +132,14 @@ SELinux/zygisk territory by design, not bugs. Full hiding matrix in
 | `proc_if_inet6` | `/proc/net/if_inet6` | **(none)** | no kernel seq_show hook — zygisk `openat` or SELinux only |
 | `proc_dev` | `/proc/net/dev` | **(none)** | zygisk `openat` or SELinux only |
 | `sys_class_net` | `/sys/class/net` | **(none)** | SELinux only |
+
+`socket_bind_interface` intentionally has no app-process root-differential row
+yet. An honest test needs the hidden interface name/index from the root view,
+must pass that exact value into the already-targeted app process, and then must
+inspect the socket from a non-target UID; simply checking the returned errno
+would bless the broken return-only implementation this hook was designed to
+avoid. The QEMU `bind-probe` performs that full state-level test with a raw
+syscall and an inherited socket. Runtime hits still appear in Statistics.
 
 Java-level checks (LSPosed) cover the framework side — `hasTransport(VPN)`,
 `NET_CAPABILITY_NOT_VPN`, `VpnTransportInfo`, `getAllNetworks`, `LinkProperties`,

--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -369,10 +369,11 @@ backend = "kernel"
 Each backend applies `mask & own_hooks` and ignores foreign bits. A config mask
 is global; a backend only acts on its own bits.
 
-Current kernel hooks (`.ko` / KPM, 10): `fib_route_seq_show`,
+Current kernel hooks (`.ko` / KPM, 11): `fib_route_seq_show`,
 `ipv6_route_seq_show`, `rtnl_fill_ifinfo`, `inet_fill_ifaddr`,
 `inet6_fill_ifaddr`, `dev_ioctl`, `sock_ioctl`, `fib_dump_info`, `rt6_fill_node`,
-`fib_nl_fill_rule`. Current LSPosed Java hooks (8): `lsposed_link_properties`,
+`fib_nl_fill_rule`, `socket_bind_interface`. Current LSPosed Java hooks (8):
+`lsposed_link_properties`,
 `lsposed_network_capabilities`, `lsposed_network_info`, `lsposed_network`,
 `lsposed_connectivity_result`, `lsposed_connectivity_callback`,
 `lsposed_connectivity_network`, `lsposed_package_visibility`. Current Zygisk

--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -377,9 +377,9 @@ Current kernel hooks (`.ko` / KPM, 11): `fib_route_seq_show`,
 `lsposed_network_capabilities`, `lsposed_network_info`, `lsposed_network`,
 `lsposed_connectivity_result`, `lsposed_connectivity_callback`,
 `lsposed_connectivity_network`, `lsposed_package_visibility`. Current Zygisk
-libc hooks (7): `zygisk_ioctl`, `zygisk_getifaddrs`, `zygisk_openat`,
+libc hooks (8): `zygisk_ioctl`, `zygisk_getifaddrs`, `zygisk_openat`,
 `zygisk_recvmsg`, `zygisk_recv`, `zygisk_recvfrom`,
-`zygisk_recvfrom_chk`.
+`zygisk_recvfrom_chk`, `zygisk_setsockopt`.
 
 ### 5.1 Error codes (`status`)
 

--- a/docs/storage.md
+++ b/docs/storage.md
@@ -264,7 +264,7 @@ A common confusion (they are *not* the same):
 - **`status`: `hooks <mask>`** — per-backend, what is *actually installed*: did all
   the backend's hooks register this boot? It is capability/health, not per-target.
   Lets the app show "requested vs active" and detect a partial install
-  (`error = partial_hooks`). So `hooks 0x3ff` in a status read means "all 10 kernel
+  (`error = partial_hooks`). So `hooks 0x20003ff` in a status read means "all 11 kernel
   hooks are installed in this backend", **not** "this target's hooks".
 
 ### 5.2 Config and stats don't collide
@@ -275,7 +275,7 @@ emits status+stats (from separate counters). Example on the kmod node:
 
 ```sh
 # write config (kind=config) — kernel parses into targets[]+debug, nothing echoed
-# printf 'vpnhide 1 config\ndebug 0\ntarget 0x27fa 0x3ff\n' > /proc/vpnhide_ctl
+# printf 'vpnhide 1 config\ndebug 0\ntarget 0x27fa 0x20003ff\n' > /proc/vpnhide_ctl
 
 # read status+stats (kind=status, kind=stats) — never returns the config you wrote
 # cat /proc/vpnhide_ctl
@@ -283,7 +283,7 @@ emits status+stats (from separate counters). Example on the kmod node:
 vpnhide 1 status
 backend 0x0
 kver 0x6019d
-hooks 0x3ff
+hooks 0x20003ff
 error 0x0
 vpnhide 1 stats
 0x27fa 0x0:0x5 0x3:0xc 0x9:0x1

--- a/kmod/BUILDING.md
+++ b/kmod/BUILDING.md
@@ -65,7 +65,9 @@ adb shell "su -c 'cat /proc/vpnhide_ctl'"
 
 **`insmod: Exec format error`** — symvers CRC mismatch. Rebuild via the DDK container (`./kmod/build.py --kmi <kmi>`); the container image carries matched symvers.
 
-**`insmod: File exists`** — module already loaded. `rmmod vpnhide_kmod` first.
+**`insmod: File exists`** — module already loaded. The module is intentionally
+non-unloadable because root module managers replace or remove it across a
+reboot; reboot before loading a different build.
 
 **kretprobe not firing** — check `dmesg | grep vpnhide` for registration messages and `/proc/vpnhide_ctl` for correct UIDs. Target app UIDs change on reinstall — re-resolve via the VPN Hide app.
 

--- a/kmod/Makefile
+++ b/kmod/Makefile
@@ -7,6 +7,7 @@ ifeq ($(KERNELRELEASE),)
 
 # clang is needed by both backends; prefer $(CLANG_DIR) if the .env set it.
 CLANG := $(if $(CLANG_DIR),$(CLANG_DIR)/clang,clang)
+VPNHIDE_KPM_BUILD_VERSION ?= $(shell sed -n '1p' $(CURDIR)/../VERSION)
 
 # ================================================================== #
 #  KPM backend — relocatable `.kpm`, KernelPatch headers, NO kernel  #
@@ -39,7 +40,9 @@ KPM_CFLAGS := -target aarch64-linux-android -fuse-ld=lld -nostdlib \
 	-fvisibility=hidden -mno-outline-atomics \
 	-fno-stack-protector -fno-common -fno-builtin -ffreestanding \
 	-fno-asynchronous-unwind-tables -fno-unwind-tables -nostdinc \
-	-D__KERNEL__ -DCONFIG_ARM64 -DMODNAME=\"vpnhide\"
+	-Wall -Wextra -Werror -Wno-unused-parameter \
+	-D__KERNEL__ -DCONFIG_ARM64 -DMODNAME=\"vpnhide\" \
+	-DVPNHIDE_KPM_BUILD_VERSION=\"$(VPNHIDE_KPM_BUILD_VERSION)\"
 
 .PHONY: all strip clean kpm kpm-clean
 

--- a/kmod/README.md
+++ b/kmod/README.md
@@ -1,12 +1,12 @@
 # vpnhide -- Kernel module
 
-kretprobe-based kernel module that hides VPN interfaces from selected apps. Part of [vpnhide](../README.md).
+Kernel-probe module that hides VPN interfaces from selected apps. Part of [vpnhide](../README.md).
 
 Zero footprint in the target app's process -- no modified function prologues, no framework classes, no anonymous memory regions. Invisible to aggressive anti-tamper SDKs.
 
 ## What it hooks
 
-| kretprobe target | What it filters | Detection path covered |
+| Hook target | What it filters | Detection path covered |
 |---|---|---|
 | `dev_ioctl` | `SIOCGIFFLAGS`, `SIOCGIFNAME`, and other per-interface ioctls: returns `-ENODEV` for VPN interfaces | Direct `ioctl()` calls from native code (Flutter/Dart, JNI, C/C++) |
 | `sock_ioctl` | `SIOCGIFCONF`: compacts VPN entries out of the returned interface array | Interface enumeration via `ioctl(SIOCGIFCONF)` |
@@ -18,6 +18,7 @@ Zero footprint in the target app's process -- no modified function prologues, no
 | `fib_dump_info` | Trims IPv4 VPN route entries and public physical-interface host-route hints from netlink route dumps via `skb_trim` | RTM_GETROUTE route table dumps |
 | `rt6_fill_node` | Trims IPv6 VPN route entries from netlink route dump replies via `skb_trim` | IPv6 RTM_GETROUTE dumps |
 | `fib_nl_fill_rule` | Trims target-UID policy rules and VPN interface rules from netlink rule dumps via `skb_trim` | RTM_GETRULE policy routing dumps |
+| `sock_setsockopt` / `sk_setsockopt` entry redirect | Returns `-ENODEV` for hidden VPN names and indices before socket state changes | Raw `SO_BINDTODEVICE` / `SO_BINDTOIFINDEX` calls |
 
 All filtering is **per-UID**: only processes whose UID is a `target` in the config written to `/proc/vpnhide_ctl` see the filtered view. Everyone else (system services, VPN client, NFC subsystem) sees the real data.
 
@@ -50,6 +51,10 @@ See [BUILDING.md](BUILDING.md) for the full guide (DDK Docker build, kernel sour
 1. `adb push vpnhide-kmod-<kmi>.zip /sdcard/Download/` (download the zip matching your device's GKI generation, e.g. `vpnhide-kmod-android14-6.1.zip`)
 2. KernelSU-Next manager -> Modules -> Install from storage
 3. Reboot
+
+The loaded `.ko` intentionally remains resident until reboot. Disable, update,
+or remove it through the root module manager and reboot to apply that change;
+ordinary `rmmod` is not supported.
 
 On boot:
 - `post-fs-data.sh` runs `insmod` to load the kernel module
@@ -119,9 +124,9 @@ int dev_ioctl(struct net *net,       // x0
 
 `SIOCGIFCONF` does NOT go through `dev_ioctl()`. The call path is `sock_ioctl → dev_ifconf()` -- a completely separate function from `dev_ioctl`, which handles `SIOCGIFFLAGS`, `SIOCGIFNAME`, etc.
 
-The natural choice would be to hook `dev_ifconf` directly, but on GKI 5.10 (Clang LTO) the linker inlines `dev_ifconf` into `sock_do_ioctl`. The `dev_ifconf` symbol stays in `kallsyms` as a dead stub, so `register_kretprobe` succeeds but the probe never fires. Confirmed by disassembly on Xiaomi 13 Lite (5.10.136) and Lenovo Legion 2 Pro (5.10.101): no `bl dev_ifconf` in `sock_do_ioctl`. On 6.1+, `SIOCGIFCONF` was moved out of `sock_do_ioctl` and is dispatched directly from `sock_ioctl`, so hooking `sock_do_ioctl` would miss it on newer kernels too.
+The natural choice would be to hook `dev_ifconf` directly, but Clang LTO can inline it into `sock_do_ioctl` while leaving an unused `dev_ifconf` symbol in `kallsyms`. A kretprobe can then register successfully without observing the live path. On 6.1+, `SIOCGIFCONF` is dispatched directly from `sock_ioctl`, so `sock_do_ioctl` is not a cross-version hook point either.
 
-`sock_ioctl` is the correct hook point because (1) it is the `file_operations->unlocked_ioctl` callback for socket fds — used as a function pointer, so LTO can never inline it; (2) all socket ioctls, including `SIOCGIFCONF`, pass through it on every kernel version (5.10 through 6.12+); (3) after `sock_ioctl` returns, the ifconf data (ifreq array + `ifc_len`) is already in userspace, so we filter it uniformly via `copy_from_user`/`copy_to_user` regardless of kernel version.
+`sock_ioctl` is the stable hook point because (1) it is the `file_operations->unlocked_ioctl` callback for socket fds and therefore remains address-taken; (2) the supported GKI paths dispatch socket ioctls through it; and (3) after it returns, the ifconf data (ifreq array + `ifc_len`) is already in userspace, so the module can filter it uniformly via `copy_from_user`/`copy_to_user`.
 
 The entry handler stashes the userspace `argp`; the return handler reads back the buffer, compacts out VPN entries, and updates `ifc_len` via `put_user`. Cost is one `cmd == SIOCGIFCONF` compare per socket ioctl for non-target paths.
 

--- a/kmod/README.md
+++ b/kmod/README.md
@@ -2,7 +2,9 @@
 
 Kernel-probe module that hides VPN interfaces from selected apps. Part of [vpnhide](../README.md).
 
-Zero footprint in the target app's process -- no modified function prologues, no framework classes, no anonymous memory regions. Invisible to aggressive anti-tamper SDKs.
+The module does not modify the target app's process: there are no userspace
+function patches, injected framework classes, or module-owned anonymous memory
+regions. Detection paths outside the hooks listed below remain out of scope.
 
 ## What it hooks
 
@@ -30,7 +32,9 @@ Kernel kretprobes modify kernel function behavior, not userspace code. The targe
 
 ## GKI compatibility
 
-All symbols used (`register_kretprobe`, `proc_create`, `seq_read`, etc.) are part of the stable GKI KMI, so the same `Module.symvers` CRCs work across all devices running the same GKI generation. The C source is identical across generations -- only the kernel headers and CRCs differ.
+The exported symbols used by the module are part of the GKI KMI. A build targets
+one GKI generation and its matching headers/CRCs; the C source stays identical
+across generations.
 
 CI builds are provided for all 7 GKI generations: `android12-5.10` through `android16-6.12`.
 
@@ -81,12 +85,15 @@ The app writes to **two layers** simultaneously:
 
 ## Combined use with system_server hooks
 
-For apps with aggressive anti-tamper SDKs, full VPN hiding requires covering both native and Java API detection paths -- without placing any hooks in the target app's process:
+Covering both native and Java API detection paths requires two layers, without
+placing vpnhide hooks in the target app's process:
 
 - **vpnhide-kmod** (this module) covers the native side: `ioctl`, `getifaddrs()` (netlink), `/proc/net/route`, `/proc/net/ipv6_route`, netlink address/route/rule dumps, and pre-mutation `SO_BINDTODEVICE` / `SO_BINDTOIFINDEX` denial.
 - **[lsposed](../lsposed/)** hooks `writeToParcel()` on `NetworkCapabilities`, `NetworkInfo`, `LinkProperties` inside `system_server` -- stripping VPN data before Binder serialization reaches the app.
 
-Together they provide complete VPN hiding without any hooks in the target app's process.
+Together they cover the detection paths documented in
+[`docs/detection-vectors.md`](../docs/detection-vectors.md). That document also
+lists known gaps and environment-dependent signals.
 
 KPM is the other kernel-level Native backend for this same role. Do not run KPM
 and the `.ko` at the same time; choose one kernel backend, then pair it with
@@ -105,8 +112,11 @@ LSPosed for Java APIs.
 kretprobes instrument kernel functions by replacing their return address on the stack. Unlike userspace inline hooks (which modify instruction bytes), kretprobes:
 
 - Don't modify the target function's code in a way visible to userspace -- `/proc/self/maps` and the function's ELF bytes are unchanged
-- Can't be detected by the target app -- the app can only inspect its own process memory, not kernel data structures
-- Work on any function visible in `/proc/kallsyms`, including static (non-exported) functions
+- Keep the instrumentation outside the target app's process; kernel-level
+  observability still depends on the device's access controls and debug surface
+- Can target eligible non-inlined functions with available symbols, including
+  static functions; kprobe blacklists and compiler inlining can still prevent
+  registration or leave a symbol off the live path
 
 ### dev_ioctl calling convention (GKI 6.1, arm64)
 

--- a/kmod/README.md
+++ b/kmod/README.md
@@ -65,8 +65,9 @@ On boot:
 adb shell su -c '/data/adb/modules/vpnhide_kmod/activator'
 
 # Or push a control-config snapshot straight to the kernel (docs/protocol.md):
-# header + folded debug flag + one target line per UID (0x3ff = all hooks).
-adb shell su -c 'printf "vpnhide 1 config\ndebug 0\ntarget 0x28b7 0x3ff\n" > /proc/vpnhide_ctl'
+# header + folded debug flag + one target line per UID
+# (0x20003ff = all current kernel hooks).
+adb shell su -c 'printf "vpnhide 1 config\ndebug 0\ntarget 0x28b7 0x20003ff\n" > /proc/vpnhide_ctl'
 ```
 
 The app writes to **two layers** simultaneously:
@@ -77,7 +78,7 @@ The app writes to **two layers** simultaneously:
 
 For apps with aggressive anti-tamper SDKs, full VPN hiding requires covering both native and Java API detection paths -- without placing any hooks in the target app's process:
 
-- **vpnhide-kmod** (this module) covers the native side: `ioctl`, `getifaddrs()` (netlink), `/proc/net/route`, `/proc/net/ipv6_route`, netlink address enumeration, netlink route dumps, and policy routing rule dumps.
+- **vpnhide-kmod** (this module) covers the native side: `ioctl`, `getifaddrs()` (netlink), `/proc/net/route`, `/proc/net/ipv6_route`, netlink address/route/rule dumps, and pre-mutation `SO_BINDTODEVICE` / `SO_BINDTOIFINDEX` denial.
 - **[lsposed](../lsposed/)** hooks `writeToParcel()` on `NetworkCapabilities`, `NetworkInfo`, `LinkProperties` inside `system_server` -- stripping VPN data before Binder serialization reaches the app.
 
 Together they provide complete VPN hiding without any hooks in the target app's process.

--- a/kmod/generated/hook_ids.h
+++ b/kmod/generated/hook_ids.h
@@ -29,11 +29,12 @@
 #define VPNHIDE_HOOK_ZYGISK_RECVFROM               23
 #define VPNHIDE_HOOK_ZYGISK_RECVFROM_CHK           24
 #define VPNHIDE_HOOK_SOCKET_BIND_INTERFACE         25
-#define VPNHIDE_HOOK_COUNT                         26
+#define VPNHIDE_HOOK_ZYGISK_SETSOCKOPT             26
+#define VPNHIDE_HOOK_COUNT                         27
 
 /* Hooks owned by each backend: apply `mask & own`, ignore foreign bits. */
 #define VPNHIDE_KERNEL_HOOK_MASK 0x20003ffu
-#define VPNHIDE_ZYGISK_HOOK_MASK 0x1fc0000u
+#define VPNHIDE_ZYGISK_HOOK_MASK 0x5fc0000u
 #define VPNHIDE_LSPOSED_HOOK_MASK 0x3fc00u
 
 /* status error codes (protocol §5.1). */
@@ -80,6 +81,7 @@ static inline const char *vpnhide_hook_name(int id)
 	case 23: return "zygisk_recvfrom";
 	case 24: return "zygisk_recvfrom_chk";
 	case 25: return "socket_bind_interface";
+	case 26: return "zygisk_setsockopt";
 	default: return "?";
 	}
 }

--- a/kmod/generated/hook_ids.h
+++ b/kmod/generated/hook_ids.h
@@ -28,10 +28,11 @@
 #define VPNHIDE_HOOK_ZYGISK_RECV                   22
 #define VPNHIDE_HOOK_ZYGISK_RECVFROM               23
 #define VPNHIDE_HOOK_ZYGISK_RECVFROM_CHK           24
-#define VPNHIDE_HOOK_COUNT                         25
+#define VPNHIDE_HOOK_SOCKET_BIND_INTERFACE         25
+#define VPNHIDE_HOOK_COUNT                         26
 
 /* Hooks owned by each backend: apply `mask & own`, ignore foreign bits. */
-#define VPNHIDE_KERNEL_HOOK_MASK 0x3ffu
+#define VPNHIDE_KERNEL_HOOK_MASK 0x20003ffu
 #define VPNHIDE_ZYGISK_HOOK_MASK 0x1fc0000u
 #define VPNHIDE_LSPOSED_HOOK_MASK 0x3fc00u
 
@@ -78,6 +79,7 @@ static inline const char *vpnhide_hook_name(int id)
 	case 22: return "zygisk_recv";
 	case 23: return "zygisk_recvfrom";
 	case 24: return "zygisk_recvfrom_chk";
+	case 25: return "socket_bind_interface";
 	default: return "?";
 	}
 }

--- a/kmod/kpm/README.md
+++ b/kmod/kpm/README.md
@@ -17,9 +17,9 @@ real gap:
   the KernelPatch supercall, not the module loader.
 
 A KPM is compiled against KernelPatch's *own* headers (`-nostdinc`), needs
-**no kernel headers and no `Module.symvers`**, resolves every kernel symbol
-at load time via `kallsyms_lookup_name`, and installs **inline** hooks
-(cheaper than kretprobe traps, with first-class arg/return rewriting).
+**no kernel headers and no `Module.symvers`**, resolves its required hook targets
+at load time via `kallsyms_lookup_name`, and installs **inline** hooks with
+direct argument and return-value rewriting.
 
 This is **additive, not a replacement.** Mainstream GKI users stay on the
 QEMU-tested `.ko` (no extra dependency). The KPM extends reach to the
@@ -62,8 +62,8 @@ The implementation relies on three design rules:
 - Hooking: `hook_wrap(func, argno, before, after, udata)` /
   `hook_unwrap(...)`; callbacks get `hook_fargsN_t *` with `arg0..argN`,
   writable `ret`, `skip_origin`, and `local.data0..7` (`<hook.h>`).
-- Symbols: runtime `kallsyms_lookup_name` (incl. static functions);
-  `kfunc_match_cfi` for CFI jump tables (`<kallsyms.h>`, `<ksyms.h>`).
+- Symbols: runtime `kallsyms_lookup_name`, with a bounded fallback for GCC
+  `.isra.N` / `.constprop.N` clones (`<kallsyms.h>`).
 - Control: userspace talks to the module via the supercall (`syscall 45`)
   → `sc_kpm_control` → the module's `KPM_CTL0` handler.
 
@@ -133,9 +133,10 @@ or KPatch-Next `kpatch kpm ctl0`.
 
 ## Safety — read before testing on a device
 
-Inline hooks have **no kprobe safety net**: a wrong offset in
-`kver_offsets.h` or a mismatched kernel **corrupts kernel text → panic /
-bootloop**, where the `.ko`'s kretprobe would just fail to register. So:
+Inline hooks have **no kprobe safety net**: a wrong field offset in
+`kver_offsets.h` can cause invalid kernel-memory access or data corruption, and
+a mismatched hook ABI can panic or bootloop the kernel. The `.ko` avoids the
+offset table but can still fail to register a probe. Therefore:
 
 - **Every offset and every hook must pass the QEMU KPM harness first**
   (`../test/run-kpm.sh` — patches a KernelPatch kernel, boots it, runs the
@@ -162,7 +163,9 @@ reference images:
 | 4.19.325 | pinned upstream source, legacy QEMU builder |
 | android11-5.4 | pinned AOSP common source, legacy QEMU builder |
 | android12-5.10 | Android DDK GKI |
+| android13-5.10 | Android DDK GKI |
 | android13-5.15 | Android DDK GKI |
+| android14-5.15 | Android DDK GKI |
 | android14-6.1 | Android DDK GKI |
 | android15-6.6 | Android DDK GKI |
 | android16-6.12 | Android DDK GKI |

--- a/kmod/kpm/README.md
+++ b/kmod/kpm/README.md
@@ -32,7 +32,7 @@ kmod/
   ../data/interfaces.toml        # single source of truth (4 languages)
   generated/iface_lists.h        # shared VPN-name matcher  (incl. if<N>, #86)
   shared/vpnhide_logic.h         # shared filtering algorithms (freestanding)
-  vpnhide_kmod.c                 # backend A: kretprobe .ko (unchanged)
+  vpnhide_kmod.c                 # backend A: kretprobes + bind entry redirect
   kpm/
     vpnhide_kpm.c                # backend C: KPM glue (hooks, proc, lifecycle)
     kver_offsets.h               # runtime per-version struct-offset table
@@ -160,11 +160,14 @@ bootloop**, where the `.ko`'s kretprobe would just fail to register. So:
       PoC hooks PASS on android12-5.10**: root sees `vpn0` when not targeted,
       not when targeted; no panic. Validates the inline hooks + the 5.x
       offsets (skb.len=104) + `fargs->local` state passing on a real kernel.
-- [x] **All 10 hooks ported + QEMU-validated** on android12-5.10 (no panic),
+- [x] **All 11 logical hooks ported + QEMU-validated** on android12-5.10 (no panic),
       full native-vector parity with the `.ko`: `fib_route_seq_show`,
       `ipv6_route_seq_show`, `rtnl_fill_ifinfo`, `inet_fill_ifaddr`,
       `inet6_fill_ifaddr`, `dev_ioctl`, `sock_ioctl`, `fib_dump_info` (#86),
-      `rt6_fill_node`, `fib_nl_fill_rule`. The deep-struct ones use 5.10
+      `rt6_fill_node`, `fib_nl_fill_rule`, plus pre-mutation
+      `SO_BINDTODEVICE` / `SO_BINDTOIFINDEX` denial. The bind probe checks the
+      socket's post-call state from another UID, so errno-only masking cannot
+      pass. The deep-struct ones use 5.10
       offsets derived from source (`fib_info`, `fib6_info`, `inet6_ifaddr`,
       `fib_rule`); a static `getifaddrs()` probe (`gai-probe.c`) proves the
       address path is closed (target getifaddrs vpn0: 3 → 0).

--- a/kmod/kpm/README.md
+++ b/kmod/kpm/README.md
@@ -25,7 +25,7 @@ This is **additive, not a replacement.** Mainstream GKI users stay on the
 QEMU-tested `.ko` (no extra dependency). The KPM extends reach to the
 segment above, at the cost of a KernelPatch runtime dependency.
 
-## Architecture (and how it differs from the community prototypes)
+## Architecture
 
 ```
 kmod/
@@ -34,7 +34,7 @@ kmod/
   shared/vpnhide_logic.h         # shared filtering algorithms (freestanding)
   vpnhide_kmod.c                 # backend A: kretprobes + bind entry redirect
   kpm/
-    vpnhide_kpm.c                # backend C: KPM glue (hooks, proc, lifecycle)
+    vpnhide_kpm.c                # backend C: KPM hooks, control, lifecycle
     kver_offsets.h               # runtime per-version struct-offset table
     README.md                    # this file
 ```
@@ -43,18 +43,17 @@ kmod/
 |---|---|---|
 | VPN-name matcher | ✅ as-is | `generated/iface_lists.h`, from `data/interfaces.toml` |
 | Filtering algorithms | ✅ `shared/vpnhide_logic.h` | seq-buffer compaction, UID parse — freestanding, included by both backends |
-| Hook glue / struct access / proc | ❌ per-backend | incompatible include worlds (`<linux/*.h>` vs KernelPatch `-nostdinc`) |
+| Hook glue / struct access / control | ❌ per-backend | incompatible include worlds (`<linux/*.h>` vs KernelPatch `-nostdinc`) |
 
-Three deliberate improvements over [soranerai's prototype](https://github.com/soranerai/vpnhide/tree/kernelpatch-(outdated)) (which did the
-legwork and tested on-device — credit due):
+The implementation relies on three design rules:
 
-1. **One source + a runtime `kver` offset table** (`kver_offsets.h`), not
-   three near-identical per-version files → one binary for 4.x/5.x/6.x.
-2. **Per-call state via `fargs->local.dataN`**, not a per-CPU MPIDR stash
-   (which races when a thread migrates between the before/after callback).
+1. **One source + a runtime `kver` offset table** (`kver_offsets.h`) produces
+   one binary for the supported 4.14–6.12 kernel families.
+2. **Per-call state via `fargs->local.dataN`** keeps before/after callback
+   state attached to the invocation even if the task migrates between CPUs.
 3. **Reuse the generated matcher** — gets the `if<N>` pattern (#86) the
-   hardcoded community lists miss; and **don't hook `rt_fill_info`** (our
-   QEMU harness proved its arg→register ABI is unstable).
+   generated interface list defines; `rt_fill_info` remains unhooked because
+   its argument/register mapping is not stable across tested kernels.
 
 ## KernelPatch API used
 
@@ -141,98 +140,54 @@ bootloop**, where the `.ko`'s kretprobe would just fail to register. So:
 - **Every offset and every hook must pass the QEMU KPM harness first**
   (`../test/run-kpm.sh` — patches a KernelPatch kernel, boots it, runs the
   A/B vector assertions: target UID sees nothing, non-target sees `vpn0`, no
-  panic). This harness is the whole reason the `.ko` is trusted; the KPM has
-  the equivalent now, and a new offset table for a version is only as
-  trustworthy as a green harness run on that version.
+  panic). This is a repeatable pre-merge regression gate, not a substitute for
+  testing a particular vendor kernel and device configuration.
 - Test with ephemeral **Load** (lost on reboot) before **Embed**.
 - Patch the **inactive A/B slot** so a bad build falls back to the
   unpatched kernel.
 
-## Status & backlog
+## Validation and support boundary
 
-- [x] Shared filtering logic extracted (`../shared/vpnhide_logic.h`)
-- [x] KPM skeleton + 2 PoC hooks (`fib_route_seq_show`, `rtnl_fill_ifinfo`)
-- [x] **Compiles against `bmax121/KernelPatch` → valid `.kpm` ELF** (self-contained matcher; `hook_fargs12_t` is the max bucket — rtnl reads arg0/arg1 only)
-- [x] **Runtime `kver` detection** from KernelPatch's `kver` (common.h)
-- [x] Target UIDs via load-args / `ctl0` supercall (reuses the shared parser)
-- [x] **QEMU KPM harness** (`../test/run-kpm.sh`) — patches a GKI Image with
-      KernelPatch, embeds the `.kpm`, boots under QEMU, two-boot A/B. **Both
-      PoC hooks PASS on android12-5.10**: root sees `vpn0` when not targeted,
-      not when targeted; no panic. Validates the inline hooks + the 5.x
-      offsets (skb.len=104) + `fargs->local` state passing on a real kernel.
-- [x] **All 11 logical hooks ported + QEMU-validated** on android12-5.10 (no panic),
-      full native-vector parity with the `.ko`: `fib_route_seq_show`,
-      `ipv6_route_seq_show`, `rtnl_fill_ifinfo`, `inet_fill_ifaddr`,
-      `inet6_fill_ifaddr`, `dev_ioctl`, `sock_ioctl`, `fib_dump_info` (#86),
-      `rt6_fill_node`, `fib_nl_fill_rule`, plus pre-mutation
-      `SO_BINDTODEVICE` / `SO_BINDTOIFINDEX` denial. The bind probe checks the
-      socket's post-call state from another UID, so errno-only masking cannot
-      pass. The deep-struct ones use 5.10
-      offsets derived from source (`fib_info`, `fib6_info`, `inet6_ifaddr`,
-      `fib_rule`); a static `getifaddrs()` probe (`gai-probe.c`) proves the
-      address path is closed (target getifaddrs vpn0: 3 → 0).
-- [x] Runtime kver offset table (`kver_offsets.h`) — **6.12 + 6.6 + 6.1 + 5.15 + 5.10 + 5.4 + 4.19 + 4.14, all full + QEMU-validated 9/9** (the complete Android kernel range, 8→16)
-- [x] KernelPatch submodule under `kmod/third_party/KernelPatch`; `make kpm`
-      works without an external checkout, and `KP_DIR=...` remains available
-      for local experiments.
-- [x] `kmod/kpm/build.py` packages the cross-version flashable KPM module zip.
-- [x] CI KPM gates build the `.kpm` against the submodule and run the GKI +
-      legacy QEMU KPM harnesses.
-- [x] **6.12 (android16-6.12) — full parity, QEMU-validated 9/9** on a DDK GKI
-      Image. Two version-specific changes vs 6.1: (a) `struct fib6_info` gained
-      `gc_link` → `fib6_nh[]`@192; (b) the big **`struct net_device`
-      cacheline-group reorg** moved `name` off offset 0 → `netdev_name`@296
-      (derived by compiling `offsetof(struct net_device, name)` against the
-      6.12 headers, then harness-confirmed). This is the first version where
-      `name` isn't first, so the table's `netdev_name` field finally earns its
-      keep — every name-based hook (link/addr/route dumps) depends on it.
-- [x] **6.6 (android15-6.6) — full parity, QEMU-validated 9/9** on a DDK GKI
-      Image. Every offset is byte-identical to 6.1 (unlike the 5.10→5.15 jump),
-      so it shares the 6.1 table; the run just confirms it.
-- [x] **5.15 (android13-5.15) — full parity, QEMU-validated 9/9** on a DDK GKI
-      Image. Caught a latent bug: 5.15's `struct fib6_info` gained
-      `offload`/`offload_failed` (like 6.1), so `nh`@160 / `fib6_nh`@176 — the
-      old table silently routed 5.15 through 5.10's 152/168 and would misread
-      the IPv6 route dev. Now its own entry; everything else matches 5.10.
-- [x] **6.1 (android14-6.1) — full parity, QEMU-validated 9/9** on a DDK-built
-      (clang) GKI Image. Derived from source: idev@168 (the `inet6_ifaddr`
-      prefix is byte-identical to 5.10, so the on-device 216 first taken from
-      soranerai was wrong — the `getifaddrs()` probe confirms 168), fib_info
-      96/104/128 + fib_dump via `fib_rt_info*`@arg4 (= 5.10), fib6_info
-      nh@160 / fib6_nh@176 (ANDROID_KABI_RESERVE before fib6_nh), skb.len@112.
-- [x] **4.14 now full parity, QEMU-validated 9/9** (was 7). The oldest/most
-      divergent target: IPv4 route dump via the legacy arg-9 fib_info (no
-      nexthop objects); IPv6 route dump hooks `rt6_fill_node(struct rt6_info*)`
-      — pre-`fib6_info`, so the dev is read straight from the embedded
-      `dst_entry` (`rt6_via_dst`, dev@0); policy rules resolve through the
-      `.isra` fuzzy fallback. `skb.len`@104 (older sk_buff head).
-- [x] **4.19 (vanilla 4.19.325) — full parity, QEMU-validated 9/9.** Pre-nexthop
-      kernel: fib_info/fib6_info have no `struct nexthop` field (the nh guards
-      skip), fib_dump_info uses the legacy `<5.6` prototype (fib_info* at arg 9,
-      shared with 5.4). Already has the `struct fib6_info` IPv6 model (4.14 does
-      not). One config-sensitive offset: `fib6_nh.nh_dev` sits at +16 in
-      `fib6_nh` (pre-`fib_nh_common`), and `CONFIG_IPV6_ROUTER_PREF` (Android-
-      common, validated =y) shifts `fib6_nh` to @160 → dev@176.
-- [x] **5.4 (android11-5.4) — full parity, QEMU-validated 9/9** on a from-source
-      `5.4.302` Image. All vectors pass incl. both route dumps and policy rules.
-      Notable per-version work that landed here:
-      - `fib_dump_info` is the legacy `<5.6` prototype on 5.4 (fib_info passed
-        *directly* at arg 9, not via `fib_rt_info`) — the hook is now
-        table-driven (`fib_dump_fi_arg` / `fib_dump_fi_via_fri`) and unified on
-        a 12-arg frame, so one callback serves 5.4 and 5.10.
-      - `struct fib6_info` has no `ANDROID_KABI_RESERVE` here → `fib6_nh[]`@160
-        (5.10 is 168); `inet6_ifaddr.idev`@168; `skb.len`@112 (conntrack on).
-      - **Fuzzy symbol resolution**: gcc renames static fns to `name.isra.N` /
-        `name.constprop.N`, which `kallsyms_lookup_name` misses. Hook lookups
-        now fall back to the `name.`-prefixed clone (`kallsyms_on_each_symbol`),
-        so e.g. `fib_nl_fill_rule.isra.21` is hooked. Clang device kernels keep
-        the plain name (exact match wins first); this just hardens gcc kernels.
-- [ ] proc_ops vs file_operations mock per kver (the HyperOS-5.4 crash class) — A/B currently uses load-args, so proc isn't on the critical path
-- [ ] Confirm offsets on the closed-kernel targets with soranerai & cyberc3dr (real devices)
-- [ ] Wire the `.ko` to `../shared/vpnhide_logic.h` (mechanical; gate on a local `.ko` harness run)
+The KPM implements the same 11 logical kernel hooks as the `.ko`, including
+pre-mutation denial of `SO_BINDTODEVICE` and `SO_BINDTOIFINDEX`. The bind probe
+checks socket state from another UID so an errno-only override cannot pass.
+Shared host tests cover the filtering and wire-format logic.
+
+CI builds one relocatable `.kpm`, embeds it with KernelPatch, and boots these
+reference images:
+
+| Reference image | Source/build path |
+|---|---|
+| 4.14.336 | pinned upstream source, legacy QEMU builder |
+| 4.19.325 | pinned upstream source, legacy QEMU builder |
+| android11-5.4 | pinned AOSP common source, legacy QEMU builder |
+| android12-5.10 | Android DDK GKI |
+| android13-5.15 | Android DDK GKI |
+| android14-6.1 | Android DDK GKI |
+| android15-6.6 | Android DDK GKI |
+| android16-6.12 | Android DDK GKI |
+
+For each image, the harness runs target/non-target A/B checks for interface,
+address, route, policy-rule, ioctl, and socket-bind behavior and checks for a
+kernel panic. The field offsets in `kver_offsets.h` come from the corresponding
+kernel sources and are accepted only after this harness passes.
+
+This matrix validates those reference kernel configurations under QEMU. Vendor
+trees can change structure layouts, compiler-generated symbols, configs, or CFI
+behavior without changing the reported kernel version. Therefore the version
+selector is a compatibility policy, not certification of every device in that
+range. Test a specific device with an ephemeral KPM load before embedding it.
+
+The KernelPatch submodule makes `make -C kmod kpm` reproducible without an
+external checkout. `kmod/kpm/build.py` packages the same artifact and the
+activator as `vpnhide-kpm.zip`; CI uses those repository entry points.
 
 ## Credits
 
-- [soranerai](https://github.com/soranerai/vpnhide) — first working KPM ports (4.14/5.4/6.1) + on-device testing.
-- [cyberc3dr](https://github.com/cyberc3dr/vpnhide-driver) — in-tree kernel patches + a real proprietary-kernel (HyperOS) test device.
-- [bmax121/KernelPatch](https://github.com/bmax121/KernelPatch) & [KernelSU-Next/KPatch-Next](https://github.com/KernelSU-Next/KPatch-Next) — the runtime.
+- [soranerai](https://github.com/soranerai/vpnhide) — earlier KPM prototype
+  referenced during the initial backend design.
+- [cyberc3dr](https://github.com/cyberc3dr/vpnhide-driver) — earlier in-tree
+  kernel implementation referenced during the initial backend design.
+- [bmax121/KernelPatch](https://github.com/bmax121/KernelPatch) and
+  [KernelSU-Next/KPatch-Next](https://github.com/KernelSU-Next/KPatch-Next) —
+  KernelPatch runtimes and module APIs used by this backend.

--- a/kmod/kpm/README.md
+++ b/kmod/kpm/README.md
@@ -54,6 +54,10 @@ The implementation relies on three design rules:
 3. **Reuse the generated matcher** — gets the `if<N>` pattern (#86) the
    generated interface list defines; `rt_fill_info` remains unhooked because
    its argument/register mapping is not stable across tested kernels.
+4. **Prefer the kernel's user-copy wrappers.** If a build inlines those
+   wrappers and exposes only the raw architecture routines, the KPM uses the
+   raw routines only on 4.14/4.19 (where they bracket user access themselves)
+   or when the kernel reports hardware PAN support.
 
 ## KernelPatch API used
 

--- a/kmod/kpm/build.py
+++ b/kmod/kpm/build.py
@@ -2,9 +2,9 @@
 """Build the vpnhide KPM and package it as an installable KernelSU/Magisk
 module zip — single entry point for CI and local builds.
 
-The `.kpm` is one cross-version relocatable object (it supports kernels
-4.14–6.12 on both KernelPatch runtimes), so unlike the `.ko` there is no
-per-KMI matrix: one build, one zip.
+The `.kpm` is one cross-version relocatable object with reference layouts for
+4.14–6.12 on both KernelPatch runtimes, so unlike the `.ko` there is no per-KMI
+build matrix: one build, one zip.
 
 Build step: `make -C kmod kpm` (host clang, no kernel tree — only the
 KernelPatch submodule headers). Set CLANG_DIR to pick a specific clang;

--- a/kmod/kpm/build.py
+++ b/kmod/kpm/build.py
@@ -2,8 +2,8 @@
 """Build the vpnhide KPM and package it as an installable KernelSU/Magisk
 module zip — single entry point for CI and local builds.
 
-The `.kpm` is one cross-version relocatable object (it loads on every kernel
-3.18–6.12 and on both KernelPatch runtimes), so unlike the `.ko` there is no
+The `.kpm` is one cross-version relocatable object (it supports kernels
+4.14–6.12 on both KernelPatch runtimes), so unlike the `.ko` there is no
 per-KMI matrix: one build, one zip.
 
 Build step: `make -C kmod kpm` (host clang, no kernel tree — only the
@@ -49,10 +49,12 @@ def main() -> int:
     kmod_dir = kpm_dir.parent
     repo_root = kmod_dir.parent
     activator = build_activator_bin(repo_root, "kpm")
+    build_version = get_build_version(repo_root)
 
     # Build the .kpm. `make` decides whether anything needs rebuilding; pass
     # CLANG_DIR through if the caller set it (CI / direnv .env).
     make_cmd = ["make", "-C", str(kmod_dir), "kpm"]
+    make_cmd.append(f"VPNHIDE_KPM_BUILD_VERSION={build_version}")
     clang_dir = os.environ.get("CLANG_DIR")
     if clang_dir:
         make_cmd.append(f"CLANG_DIR={clang_dir}")
@@ -74,7 +76,6 @@ def main() -> int:
 
     # Stamp the effective build version into the staged module.prop without
     # touching the committed file (keeps PR diffs from churning it).
-    build_version = get_build_version(repo_root)
     module_prop = staging / "module.prop"
     content = module_prop.read_text(encoding="utf-8")
     content = re.sub(r"^version=.*", f"version=v{build_version}", content, flags=re.MULTILINE)

--- a/kmod/kpm/kver_offsets.h
+++ b/kmod/kpm/kver_offsets.h
@@ -37,6 +37,14 @@ struct vpnhide_offsets {
 	 * the new cacheline-group reorg (@296). */
 	unsigned int netdev_name;
 
+	/* Socket binding interception. `socket_sk` is offsetof(struct socket,
+	 * sk); `sock_net` is offsetof(struct sock_common, skc_net), whose
+	 * possible_net_t payload is the struct net*. The sockptr_t and additional
+	 * sk_setsockopt ABI gates are version-derived in vpnhide_kpm.c because they
+	 * are function-signature changes, not struct offsets. */
+	unsigned int socket_sk;
+	unsigned int sock_net;
+
 	/* seq_file.{buf,count} — stable across the seq_file lifetime. */
 	unsigned int seqfile_buf;
 	unsigned int seqfile_count;
@@ -119,6 +127,8 @@ struct vpnhide_offsets {
 static const struct vpnhide_offsets vpnhide_off_6_1 = {
 	.skb_len = 112, /* modern head + _nfct (conntrack on in GKI 6.1) */
 	.netdev_name = 0,
+	.socket_sk = 24,
+	.sock_net = 48,
 	.seqfile_buf = 0,
 	.seqfile_count = 24,
 	.in_ifaddr_ifa_dev = 24,
@@ -158,6 +168,8 @@ static const struct vpnhide_offsets vpnhide_off_6_12 = {
 	 * compiling offsetof(struct net_device, name) against the gki_defconfig
 	 * 6.12 headers). Every other version keeps name@0. */
 	.netdev_name = 296,
+	.socket_sk = 24,
+	.sock_net = 48,
 	.seqfile_buf = 0,
 	.seqfile_count = 24,
 	.in_ifaddr_ifa_dev = 24,
@@ -190,6 +202,8 @@ static const struct vpnhide_offsets vpnhide_off_5_x = {
 			 * len@112. Reading 104 trims netlink dumps to garbage and
 			 * drops non-VPN rows alongside vpn0. */
 	.netdev_name = 0,
+	.socket_sk = 24,
+	.sock_net = 48,
 	.seqfile_buf = 0,
 	.seqfile_count = 24,
 	/* in_ifaddr: hash(16)+ifa_next(8) -> ifa_dev@24; in_device.dev@0. */
@@ -234,6 +248,8 @@ static const struct vpnhide_offsets vpnhide_off_5_15 = {
 	.skb_len = 112, /* GKI 5.15 has CONFIG_NF_CONNTRACK=y: _nfct@104,
 			 * len@112. Same rollback requirement as 5.10. */
 	.netdev_name = 0,
+	.socket_sk = 24,
+	.sock_net = 48,
 	.seqfile_buf = 0,
 	.seqfile_count = 24,
 	.in_ifaddr_ifa_dev = 24,
@@ -272,6 +288,8 @@ static const struct vpnhide_offsets vpnhide_off_5_4 = {
 			 * the device-faithful value; a conntrack-less kernel would
 			 * be @104 (cf. the 5.10 test kernel). */
 	.netdev_name = 0,
+	.socket_sk = 24,
+	.sock_net = 48,
 	.seqfile_buf = 0,
 	.seqfile_count = 24,
 	.in_ifaddr_ifa_dev = 24, /* hash(16)+ifa_next(8) — same as 5.10 */
@@ -315,6 +333,8 @@ static const struct vpnhide_offsets vpnhide_off_4_19 = {
 	 * back to a pointer field and can make getifaddrs() look completely empty. */
 	.skb_len = 128,
 	.netdev_name = 0,
+	.socket_sk = 32,
+	.sock_net = 48,
 	.seqfile_buf = 0,
 	.seqfile_count = 24,
 	.in_ifaddr_ifa_dev = 24,
@@ -360,6 +380,8 @@ static const struct vpnhide_offsets vpnhide_off_4_x = {
 	 * the 4.14 images we validate with, including sunfish 4.14.302. */
 	.skb_len = 128,
 	.netdev_name = 0,
+	.socket_sk = 32,
+	.sock_net = 48,
 	.seqfile_buf = 0,
 	.seqfile_count = 24,
 	.in_ifaddr_ifa_dev =

--- a/kmod/kpm/kver_offsets.h
+++ b/kmod/kpm/kver_offsets.h
@@ -11,16 +11,12 @@
  * the real kernel headers (`-nostdinc`). So we keep a small offset table
  * keyed on the running kernel version, selected at init.
  *
- * This is the difference between our approach and soranerai's KPM, which
- * ships three near-identical source files (4.14 / 5.4 / 6.1) with the
- * offsets baked in. One source + one runtime table = one binary for all.
- *
- * VALUES MUST BE PROVEN, NOT GUESSED. Each non-TODO value below is either
- * (a) confirmed by soranerai on a real device, or (b) trivially stable
- * (e.g. net_device.name is the first member on every version). Every new
- * value has to pass the QEMU KPM harness (see kmod/kpm/README.md) before
- * it ships — a wrong offset here is a kernel panic / bootloop, not a soft
- * failure like a kretprobe that won't register.
+ * One source plus this runtime table produces one binary for the supported
+ * kernel families. Offsets are derived from the matching AOSP, upstream, or
+ * DDK kernel sources and then exercised by a booted QEMU image. A new or
+ * changed table must pass the KPM harness (see kmod/kpm/README.md) before it
+ * ships. This validates the reference configurations used by CI; it does not
+ * imply testing on every vendor kernel or physical device.
  */
 #ifndef VPNHIDE_KVER_OFFSETS_H
 #define VPNHIDE_KVER_OFFSETS_H
@@ -49,11 +45,11 @@ struct vpnhide_offsets {
 	unsigned int seqfile_buf;
 	unsigned int seqfile_count;
 
-	/* in_ifaddr.ifa_dev (-> in_device.dev -> net_device).  [TODO 5.4/4.14] */
+	/* in_ifaddr.ifa_dev (-> in_device.dev -> net_device). */
 	unsigned int in_ifaddr_ifa_dev;
 	unsigned int in_device_dev;
 
-	/* inet6_ifaddr.idev (-> inet6_dev.dev -> net_device). [TODO 5.4/4.14] */
+	/* inet6_ifaddr.idev (-> inet6_dev.dev -> net_device). */
 	unsigned int inet6_ifaddr_idev;
 	unsigned int inet6_dev_dev;
 
@@ -107,22 +103,17 @@ struct vpnhide_offsets {
 	unsigned int fib_rule_oifname;
 	unsigned int fib_rule_uid_start;
 	unsigned int fib_rule_uid_end;
-
-	/* 1 if procfs uses `struct proc_ops` (>=5.6), 0 if `file_operations`
-	 * (<5.6). Mixing these up is the most likely cause of the
-	 * /proc/vpnhide_targets crash reported on HyperOS 5.4. */
-	int proc_uses_proc_ops;
 };
 
 /*
  * GKI 6.1 (android14-6.1, derived from AOSP common source + QEMU-validated).
  * Also covers 6.6 (android15-6.6): every offset here is byte-identical on 6.6,
- * confirmed by a separate 9/9 harness run on a DDK-built 6.6 GKI Image.
+ * exercised by a separate harness run on a DDK-built 6.6 GKI Image.
  * inet6_ifaddr's prefix up to dad_work is identical to 5.10, so idev@168
- * (NOT the 216 first taken from soranerai — left a note, the harness decides).
+ * The getifaddrs harness confirms inet6_ifaddr.idev at 168 for these images.
  * fib_dump_info uses the fib_rt_info* form (arg 4, like 5.10); fib_info and
  * fib_rule layouts match 5.10; fib6_info has an ANDROID_KABI_RESERVE before
- * fib6_nh[]. procfs is proc_ops (>=5.6).
+ * fib6_nh[].
  */
 static const struct vpnhide_offsets vpnhide_off_6_1 = {
 	.skb_len = 112, /* modern head + _nfct (conntrack on in GKI 6.1) */
@@ -154,10 +145,9 @@ static const struct vpnhide_offsets vpnhide_off_6_1 = {
 	.fib_rule_oifname = 104,
 	.fib_rule_uid_start = 120,
 	.fib_rule_uid_end = 124,
-	.proc_uses_proc_ops = 1,
 };
 
-/* 6.12 (android16-6.12) — QEMU-validated 9/9. Identical to 6.1 EXCEPT struct
+/* 6.12 (android16-6.12) — QEMU-validated. Identical to 6.1 EXCEPT struct
  * fib6_info inserted `struct hlist_node gc_link` (16 B) after `expires`,
  * shifting nh@176 and fib6_nh[]@192 (6.1 is 160/176). (fib_info also gained a
  * `pfsrc_removed` bool, but it fits the existing pad so nh stays @104.) */
@@ -192,10 +182,9 @@ static const struct vpnhide_offsets vpnhide_off_6_12 = {
 	.fib_rule_oifname = 104,
 	.fib_rule_uid_start = 120,
 	.fib_rule_uid_end = 124,
-	.proc_uses_proc_ops = 1,
 };
 
-/* 5.10 (android12-5.10) — QEMU-validated 9/9. (5.15 has a different fib6_info
+/* 5.10 (android12-5.10) — QEMU-validated. (5.15 has a different fib6_info
  * and gets its own table below.) */
 static const struct vpnhide_offsets vpnhide_off_5_x = {
 	.skb_len = 112, /* GKI 5.10 has CONFIG_NF_CONNTRACK=y: _nfct@104,
@@ -235,7 +224,6 @@ static const struct vpnhide_offsets vpnhide_off_5_x = {
 	.fib_rule_oifname = 104,
 	.fib_rule_uid_start = 120,
 	.fib_rule_uid_end = 124,
-	.proc_uses_proc_ops = 1, /* 5.6+; for <5.6 use file_operations below */
 };
 
 /* 5.15 (android13-5.15, derived from source + QEMU-validated). Identical to
@@ -272,7 +260,6 @@ static const struct vpnhide_offsets vpnhide_off_5_15 = {
 	.fib_rule_oifname = 104,
 	.fib_rule_uid_start = 120,
 	.fib_rule_uid_end = 124,
-	.proc_uses_proc_ops = 1,
 };
 
 /* 5.4 (android11-5.4, derived from AOSP common source + QEMU-validated).
@@ -281,12 +268,11 @@ static const struct vpnhide_offsets vpnhide_off_5_15 = {
  *     directly at arg 9, 11 args) — not the fib_rt_info* form 5.10 has.
  *   - struct fib6_info has no ANDROID_KABI_RESERVE before fib6_nh[] here, so
  *     fib6_nh[]@160 (vs 5.10's 168).
- * procfs is file_operations (<5.6). */
+ */
 static const struct vpnhide_offsets vpnhide_off_5_4 = {
 	.skb_len = 112, /* modern sk_buff head + _nfct (CONFIG_NF_CONNTRACK) ->
-			 * len@112. Real 5.4 devices carry conntrack, so this is
-			 * the device-faithful value; a conntrack-less kernel would
-			 * be @104 (cf. the 5.10 test kernel). */
+			 * len@112 in the android11-5.4 reference config. A
+			 * conntrack-less vendor config would instead use @104. */
 	.netdev_name = 0,
 	.socket_sk = 24,
 	.sock_net = 48,
@@ -318,15 +304,14 @@ static const struct vpnhide_offsets vpnhide_off_5_4 = {
 	.fib_rule_oifname = 104,
 	.fib_rule_uid_start = 120,
 	.fib_rule_uid_end = 124,
-	.proc_uses_proc_ops = 0, /* <5.6 → file_operations */
 };
 
 /* 4.19 (vanilla 4.19.325, derived from source + QEMU-validated). Pre-nexthop
  * kernel: fib_info/fib6_info have NO `struct nexthop *nh` field (so the nh
  * guards in dev_from_fib*_info skip), and fib_dump_info uses the legacy <5.6
  * prototype (fib_info* directly at arg 9). Unlike 4.14 it already has the
- * struct fib6_info IPv6 route model (4.14 still uses rt6_info). procfs is
- * file_operations (<5.6). */
+ * struct fib6_info IPv6 route model (4.14 still uses rt6_info).
+ */
 static const struct vpnhide_offsets vpnhide_off_4_19 = {
 	/* XFRM + conntrack + bridge-netfilter fields put sk_buff.len at 128 on
 	 * the 4.19 image we validate with. A smaller value trims netlink dumps
@@ -366,18 +351,17 @@ static const struct vpnhide_offsets vpnhide_off_4_19 = {
 	.fib_rule_oifname = 104,
 	.fib_rule_uid_start = 120,
 	.fib_rule_uid_end = 124,
-	.proc_uses_proc_ops = 0, /* <5.6 → file_operations */
 };
 
-/* 4.14 (vanilla 4.14.336, derived from source + QEMU-validated, 9/9). Oldest
+/* 4.14 (vanilla 4.14.336, derived from source + QEMU-validated). Oldest
  * target and the most structurally different: fib_dump_info uses the legacy
  * <5.6 prototype (fi at arg 9), there are no nexthop objects, and IPv6 still
  * uses struct rt6_info (not fib6_info) — so the IPv6 dev comes from the
- * embedded dst_entry (rt6_via_dst) rather than a fib6_nh walk. procfs is
- * file_operations (<5.6). */
+ * embedded dst_entry (rt6_via_dst) rather than a fib6_nh walk.
+ */
 static const struct vpnhide_offsets vpnhide_off_4_x = {
-	/* XFRM + conntrack + bridge-netfilter fields put sk_buff.len at 128 on
-	 * the 4.14 images we validate with, including sunfish 4.14.302. */
+	/* XFRM + conntrack + bridge-netfilter fields put sk_buff.len at 128 in
+	 * the 4.14 reference image. */
 	.skb_len = 128,
 	.netdev_name = 0,
 	.socket_sk = 32,
@@ -417,13 +401,12 @@ static const struct vpnhide_offsets vpnhide_off_4_x = {
 	.fib_rule_oifname = 104,
 	.fib_rule_uid_start = 120,
 	.fib_rule_uid_end = 124,
-	.proc_uses_proc_ops = 0, /* <5.6 → file_operations */
 };
 
 /*
  * Select the offset table for the running kernel. Returns NULL for an
  * unsupported version — the caller MUST refuse to install hooks then
- * (kpm-spore does the same: unknown version → bail, never guess).
+ * rather than selecting an unverified layout.
  */
 static inline const struct vpnhide_offsets *
 vpnhide_select_offsets(unsigned int kver)
@@ -431,13 +414,13 @@ vpnhide_select_offsets(unsigned int kver)
 	if (kver >= VPNHIDE_KVER(6, 12, 0))
 		return &vpnhide_off_6_12; /* 6.12: fib6_info gained gc_link */
 	if (kver >= VPNHIDE_KVER(6, 0, 0))
-		return &vpnhide_off_6_1; /* 6.0–6.11 — 6.1 + 6.6 proven identical */
+		return &vpnhide_off_6_1; /* 6.0–6.11; validated on 6.1 + 6.6 images */
 	if (kver >= VPNHIDE_KVER(5, 15, 0))
 		return &vpnhide_off_5_15; /* 5.15+: fib6_info gained offload fields */
 	if (kver >= VPNHIDE_KVER(5, 6, 0))
 		return &vpnhide_off_5_x; /* 5.6–5.14 */
 	if (kver >= VPNHIDE_KVER(5, 0, 0))
-		return &vpnhide_off_5_4; /* 5.0–5.5: legacy fib_dump_info + proc */
+		return &vpnhide_off_5_4; /* 5.0–5.5: legacy fib_dump_info */
 	if (kver >= VPNHIDE_KVER(4, 19, 0))
 		return &vpnhide_off_4_19; /* 4.19: fib6_info, no nexthop objects */
 	if (kver >= VPNHIDE_KVER(4, 0, 0))

--- a/kmod/kpm/kver_offsets.h
+++ b/kmod/kpm/kver_offsets.h
@@ -109,8 +109,8 @@ struct vpnhide_offsets {
  * GKI 6.1 (android14-6.1, derived from AOSP common source + QEMU-validated).
  * Also covers 6.6 (android15-6.6): every offset here is byte-identical on 6.6,
  * exercised by a separate harness run on a DDK-built 6.6 GKI Image.
- * inet6_ifaddr's prefix up to dad_work is identical to 5.10, so idev@168
- * The getifaddrs harness confirms inet6_ifaddr.idev at 168 for these images.
+ * inet6_ifaddr's prefix up to dad_work is identical to 5.10, so idev@168; the
+ * getifaddrs harness confirms that offset for these reference images.
  * fib_dump_info uses the fib_rt_info* form (arg 4, like 5.10); fib_info and
  * fib_rule layouts match 5.10; fib6_info has an ANDROID_KABI_RESERVE before
  * fib6_nh[].
@@ -411,6 +411,8 @@ static const struct vpnhide_offsets vpnhide_off_4_x = {
 static inline const struct vpnhide_offsets *
 vpnhide_select_offsets(unsigned int kver)
 {
+	if (kver < VPNHIDE_KVER(4, 14, 0) || kver >= VPNHIDE_KVER(6, 13, 0))
+		return 0;
 	if (kver >= VPNHIDE_KVER(6, 12, 0))
 		return &vpnhide_off_6_12; /* 6.12: fib6_info gained gc_link */
 	if (kver >= VPNHIDE_KVER(6, 0, 0))
@@ -423,9 +425,7 @@ vpnhide_select_offsets(unsigned int kver)
 		return &vpnhide_off_5_4; /* 5.0–5.5: legacy fib_dump_info */
 	if (kver >= VPNHIDE_KVER(4, 19, 0))
 		return &vpnhide_off_4_19; /* 4.19: fib6_info, no nexthop objects */
-	if (kver >= VPNHIDE_KVER(4, 0, 0))
-		return &vpnhide_off_4_x;
-	return 0; /* unsupported → do not install */
+	return &vpnhide_off_4_x; /* 4.14–4.18 */
 }
 
 #endif /* VPNHIDE_KVER_OFFSETS_H */

--- a/kmod/kpm/vpnhide_kpm.c
+++ b/kmod/kpm/vpnhide_kpm.c
@@ -9,9 +9,9 @@
  * NOT insmod — so it also works where module signing blocks a `.ko`.
  *
  * STATUS: builds (`make kpm`) and runs end-to-end under QEMU via the KPM
- * harness (../test/run-kpm.sh). All 10 hooks are A/B-validated with no panic
- * (full native-vector parity with the .ko) on FIVE kernels, each a separate
- * from-source QEMU Image: 4.14, 4.19, 5.4, 5.10 and 6.1 (9/9 vectors apiece).
+ * harness (../test/run-kpm.sh). The original 10 enumeration hooks are
+ * A/B-validated across the complete supported range; socket-bind denial adds
+ * state-level checks that verify the socket stayed unbound, not just errno.
  * The procfs control plane is still TODO (A/B uses load-args). Every per-kver
  * offset must pass the harness before that version ships — a wrong offset is a
  * contained QEMU panic / A/B failure here, but a bootloop on a real device.
@@ -111,6 +111,7 @@ static void (*_seq_printf)(void *, const char *, ...);
 static unsigned long (*_copy_from_user)(void *, const void *, unsigned long);
 static unsigned long (*_copy_to_user)(void *, const void *, unsigned long);
 static void (*_skb_trim)(void *, unsigned int);
+static int (*_netdev_get_name)(void *, char *, int);
 
 #define vpnhide_dbg(fmt, ...)                                   \
 	do {                                                    \
@@ -477,6 +478,200 @@ static void rtnl_fill_after(hook_fargs12_t *fargs, void *udata)
 static int ptr_is_kernel(const void *p)
 {
 	return ((unsigned long)p >> 48) == 0xffffUL;
+}
+
+/* ================================================================== */
+/*  Hook 11: socket interface binding                                 */
+/*                                                                    */
+/*  A target must not be able to use SO_BINDTODEVICE or               */
+/*  SO_BINDTOIFINDEX as an oracle for a hidden VPN interface. KPM can */
+/*  refuse before the original function mutates sk_bound_dev_if: set  */
+/*  skip_origin and return ENODEV.                                    */
+/*                                                                    */
+/*  5.9+ passes optval as the two-register sockptr_t aggregate. We    */
+/*  copy it once into hook_fargs.local and rewrite the aggregate to a  */
+/*  KERNEL_SOCKPTR pointing at that per-call snapshot. Thus a second   */
+/*  userspace thread cannot swap a checked physical name/index for a  */
+/*  VPN one between this callback and the kernel's own copy. Before   */
+/*  5.7 the first bind already requires CAP_NET_RAW, so KPM leaves it */
+/*  entirely to the native path and preserves its exact errno. On     */
+/*  5.7-5.8 a deeper *_bindto*_locked hook sees the resolved ifindex  */
+/*  after the user copy but still before the socket mutation.          */
+/* ================================================================== */
+
+#define VPNHIDE_SOL_SOCKET 1u
+#define VPNHIDE_SO_BINDTODEVICE 25u
+#define VPNHIDE_SO_BINDTOIFINDEX 62u
+
+static int sockopt_uses_sockptr(void)
+{
+	return (unsigned int)kver >= VPNHIDE_KVER(5, 9, 0);
+}
+
+static int sockopt_takes_sk(void)
+{
+	return (unsigned int)kver >= VPNHIDE_KVER(6, 1, 0);
+}
+
+static int socket_bind_uses_index_hook(void)
+{
+	return (unsigned int)kver >= VPNHIDE_KVER(5, 7, 0) &&
+	       (unsigned int)kver < VPNHIDE_KVER(5, 9, 0);
+}
+
+static const char *socket_bind_index_hook_name(void)
+{
+	return (unsigned int)kver < VPNHIDE_KVER(5, 8, 0) ?
+		       "sock_setbindtodevice_locked" :
+		       "sock_bindtoindex_locked";
+}
+
+static int copy_sockopt_bytes(hook_fargs8_t *fargs, void *dst, unsigned int len)
+{
+	const unsigned char *src = (const unsigned char *)fargs->arg3;
+	unsigned char *out = (unsigned char *)dst;
+	unsigned int i;
+
+	if (!src)
+		return -1;
+	/* sockptr_t.is_kernel is the second eightbyte (arg4). It is trustworthy
+	 * because the syscall wrapper, not userspace, constructs sockptr_t. Never
+	 * infer this from the numeric pointer value: an app may pass a 0xffff...
+	 * address deliberately, and directly dereferencing it would panic instead
+	 * of producing the native EFAULT. This wrapper is used only on 5.9+. */
+	if (sockopt_uses_sockptr() && fargs->arg4) {
+		for (i = 0; i < len; i++)
+			out[i] = src[i];
+		return 0;
+	}
+	if (!_copy_from_user || _copy_from_user(dst, src, len) != 0)
+		return -1;
+	return 0;
+}
+
+static unsigned int sockopt_len(const hook_fargs8_t *fargs)
+{
+	return (unsigned int)(sockopt_uses_sockptr() ? fargs->arg5 :
+						       fargs->arg4);
+}
+
+static void *sockopt_sk(const hook_fargs8_t *fargs, int takes_sk)
+{
+	void *sock;
+
+	if (takes_sk)
+		return (void *)fargs->arg0;
+	sock = (void *)fargs->arg0;
+	return sock ? *(void **)((char *)sock + off->socket_sk) : 0;
+}
+
+static void freeze_sockptr(hook_fargs8_t *fargs, void *snapshot)
+{
+	if (!sockopt_uses_sockptr())
+		return;
+	/* sockptr_t { pointer, is_kernel:1 } occupies x3+x4 on arm64. */
+	fargs->arg3 = (uint64_t)snapshot;
+	fargs->arg4 = 1;
+}
+
+static void deny_socket_bind(void *raw_fargs)
+{
+	hook_fargs0_t *fargs = (hook_fargs0_t *)raw_fargs;
+
+	fargs->ret = VPNHIDE_ENODEV;
+	fargs->skip_origin = 1;
+	record_hook_hit(VPNHIDE_HOOK_SOCKET_BIND_INTERFACE);
+}
+
+/* Return true for a hidden or currently unknown positive index. Linux accepts
+ * an unknown positive index and leaves the socket waiting for a future device,
+ * so allowing it would bypass a name/index check performed only once. */
+static int socket_bind_ifindex_hidden(void *sk, int ifindex)
+{
+	void *net = sk ? *(void **)((char *)sk + off->sock_net) : 0;
+	char name[VPNHIDE_IFNAMSIZ];
+	unsigned int i;
+
+	if (ifindex <= 0)
+		return 0;
+	if (!net || !_netdev_get_name)
+		return 1;
+	for (i = 0; i < VPNHIDE_IFNAMSIZ; i++)
+		name[i] = 0;
+	return _netdev_get_name(net, name, ifindex) != 0 || iface_is_vpn(name);
+}
+
+static void socket_bind_index_before(hook_fargs4_t *fargs, void *udata)
+{
+	int ifindex = (int)fargs->arg1;
+
+	if (!hook_active(VPNHIDE_HOOK_SOCKET_BIND_INTERFACE))
+		return;
+	if (socket_bind_ifindex_hidden((void *)fargs->arg0, ifindex))
+		deny_socket_bind(fargs);
+}
+
+static void socket_bind_before_common(hook_fargs8_t *fargs, int takes_sk)
+{
+	unsigned int optname = (unsigned int)fargs->arg2;
+	unsigned int optlen;
+	unsigned char *snapshot = (unsigned char *)&fargs->local;
+	unsigned int i;
+
+	if ((unsigned int)fargs->arg1 != VPNHIDE_SOL_SOCKET ||
+	    !hook_active(VPNHIDE_HOOK_SOCKET_BIND_INTERFACE))
+		return;
+	if (optname != VPNHIDE_SO_BINDTODEVICE &&
+	    optname != VPNHIDE_SO_BINDTOIFINDEX)
+		return;
+	/* Before 5.7 the native capability gate owns this vector. On 5.7-5.8
+	 * the resolved-index hook owns it so the old user-pointer ABI cannot
+	 * introduce a check/use race. This wrapper is authoritative only once
+	 * sockptr_t can carry our immutable kernel snapshot. */
+	if (!sockopt_uses_sockptr())
+		return;
+
+	optlen = sockopt_len(fargs);
+	if (optname == VPNHIDE_SO_BINDTODEVICE) {
+		unsigned int copy_len = optlen;
+
+		/* The downstream helper takes int and returns EINVAL first. */
+		if ((int)optlen < 0)
+			return;
+		if (copy_len > VPNHIDE_IFNAMSIZ - 1)
+			copy_len = VPNHIDE_IFNAMSIZ - 1;
+		for (i = 0; i < VPNHIDE_IFNAMSIZ; i++)
+			snapshot[i] = 0;
+		if (copy_len && copy_sockopt_bytes(fargs, snapshot, copy_len))
+			return; /* let the original produce EFAULT */
+		freeze_sockptr(fargs, snapshot);
+		if (snapshot[0] && iface_is_vpn((const char *)snapshot))
+			deny_socket_bind(fargs);
+		return;
+	}
+
+	if (optlen < sizeof(int))
+		return;
+	if (copy_sockopt_bytes(fargs, snapshot, sizeof(int)))
+		return;
+	freeze_sockptr(fargs, snapshot);
+	{
+		int ifindex = *(int *)snapshot;
+		void *sk = sockopt_sk(fargs, takes_sk);
+
+		if (socket_bind_ifindex_hidden(sk, ifindex))
+			deny_socket_bind(fargs);
+	}
+}
+
+static void socket_bind_sock_before(hook_fargs8_t *fargs, void *udata)
+{
+	socket_bind_before_common(fargs, 0);
+}
+
+static void socket_bind_sk_before(hook_fargs8_t *fargs, void *udata)
+{
+	socket_bind_before_common(fargs, 1);
 }
 
 /* SIOCGIF* range (0x8910..0x8930). SIOCGIFCONF (0x8912) goes via sock_ioctl,
@@ -861,11 +1056,11 @@ static void fib_rule_after(hook_fargs8_t *fargs, void *udata)
 }
 
 /*
- * HOOK COVERAGE — full parity with vpnhide_kmod.c (the .ko). All 10 hooks
- * ported and QEMU-validated A/B on android12-5.10 (no panic). Mirror the
- * .ko's logic; reuse shared/vpnhide_logic.h. Per-version struct offsets live
- * in kver_offsets.h (5.10 only so far) — a wrong offset is a contained QEMU
- * A/B fail / panic here, a bootloop on a real device.
+ * HOOK COVERAGE — full parity with vpnhide_kmod.c (the .ko). The original 10
+ * enumeration hooks are QEMU-validated A/B on android12-5.10 (no panic).
+ * Mirror the .ko's logic; reuse shared/vpnhide_logic.h. Per-version struct
+ * offsets live in kver_offsets.h — a wrong offset is a contained QEMU A/B fail
+ * or panic here, a bootloop on a real device.
  *
  *   fib_route_seq_show     /proc/net/route        ✓ (seq compactor)
  *   ipv6_route_seq_show    /proc/net/ipv6_route   ✓ (seq compactor)
@@ -889,6 +1084,8 @@ static void fib_rule_after(hook_fargs8_t *fargs, void *udata)
  *                                                   5.10/5.15/6.1/6.12 + legacy
  *                                                   5.4/4.19/4.14)
  *   fib_nl_fill_rule       RTM_GETRULE            ✓ (fib_rule iif/oif/uid)
+ *   socket_bind_interface SO_BINDTODEVICE/index  ✓ (pre-mutation ENODEV;
+ *                                                   state-aware raw-syscall test)
  *   ( rt_fill_info — intentionally NOT hooked; unstable arg->reg ABI )
  *
  * Both host-route predicates (v4 + v6) and their address/iface logic are now
@@ -1011,6 +1208,7 @@ static int resolve_symbols(void)
 	_skb_trim = (void *)kallsyms_lookup_name("__skb_trim");
 	if (!_skb_trim)
 		_skb_trim = (void *)kallsyms_lookup_name("skb_trim");
+	_netdev_get_name = (void *)lookup_fn("netdev_get_name");
 
 	/* Hooks need these; proc is best-effort. */
 	return _skb_trim ? 0 : -1;
@@ -1049,15 +1247,18 @@ static void apply_targets(const char *s)
 
 /* Resolve `name`, wrap it, and record the install in `installed_hooks` so the
  * status channel (§4.3 `hooks`) reflects what actually took. */
-static void install_hook(const char *name, int argno, void *before, void *after,
-			 uint32_t hook_id)
+static int install_hook(const char *name, int argno, void *before, void *after,
+			uint32_t hook_id)
 {
 	unsigned long fn = lookup_fn(name);
 
 	if (!fn)
-		return;
-	if (hook_wrap((void *)fn, argno, before, after, 0) == HOOK_NO_ERR)
+		return 0;
+	if (hook_wrap((void *)fn, argno, before, after, 0) == HOOK_NO_ERR) {
 		installed_hooks |= (1u << hook_id);
+		return 1;
+	}
+	return 0;
 }
 
 static long vpnhide_kpm_init(const char *args, const char *event,
@@ -1137,6 +1338,40 @@ static long vpnhide_kpm_init(const char *args, const char *event,
 		install_hook("fib_nl_fill_rule", 7, (void *)fib_rule_before,
 			     (void *)fib_rule_after,
 			     VPNHIDE_HOOK_FIB_NL_FILL_RULE);
+	if (_netdev_get_name && off->sock_net && off->socket_sk) {
+		int bind_ok;
+
+		if (socket_bind_uses_index_hook()) {
+			/* 5.7-5.8 still pass a raw user pointer to sock_setsockopt.
+			 * Hook the resolved index instead, after the user copy and name
+			 * lookup but before sk_bound_dev_if changes. A missing static
+			 * symbol leaves status partial rather than accepting a TOCTOU. */
+			bind_ok = install_hook(
+				socket_bind_index_hook_name(), 2,
+				(void *)socket_bind_index_before, 0,
+				VPNHIDE_HOOK_SOCKET_BIND_INTERFACE);
+		} else {
+			bind_ok = install_hook(
+				"sock_setsockopt", 6,
+				(void *)socket_bind_sock_before, 0,
+				VPNHIDE_HOOK_SOCKET_BIND_INTERFACE);
+
+			/* 6.1+ generic sockets may have sk_setsockopt inlined into
+			 * the exported wrapper under LTO, while MPTCP calls the
+			 * standalone symbol directly. Cover both call graphs. */
+			if (sockopt_takes_sk())
+				bind_ok =
+					install_hook(
+						"sk_setsockopt", 6,
+						(void *)socket_bind_sk_before,
+						0,
+						VPNHIDE_HOOK_SOCKET_BIND_INTERFACE) &&
+					bind_ok;
+		}
+		if (!bind_ok)
+			installed_hooks &=
+				~(1u << VPNHIDE_HOOK_SOCKET_BIND_INTERFACE);
+	}
 
 	/* Healthy iff every kernel-owned hook installed; otherwise honestly
 	 * report partial — the `hooks` mask carries which ones (§5.1). A kver
@@ -1284,6 +1519,23 @@ static long vpnhide_kpm_exit(void *__user reserved)
 	if (fn)
 		hook_unwrap((void *)fn, (void *)fib_rule_before,
 			    (void *)fib_rule_after);
+	if (off && socket_bind_uses_index_hook()) {
+		fn = lookup_fn(socket_bind_index_hook_name());
+		if (fn)
+			hook_unwrap((void *)fn,
+				    (void *)socket_bind_index_before, 0);
+	} else {
+		fn = lookup_fn("sock_setsockopt");
+		if (fn)
+			hook_unwrap((void *)fn, (void *)socket_bind_sock_before,
+				    0);
+		if (off && sockopt_takes_sk()) {
+			fn = lookup_fn("sk_setsockopt");
+			if (fn)
+				hook_unwrap((void *)fn,
+					    (void *)socket_bind_sk_before, 0);
+		}
+	}
 
 	/* No /proc node to remove: the KPM's control channel is the ctl0
 	 * supercall, not procfs (the optional mirror was never created). */

--- a/kmod/kpm/vpnhide_kpm.c
+++ b/kmod/kpm/vpnhide_kpm.c
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 /*
- * vpnhide — KernelPatch Module (KPM) backend.  *** WIP ***
+ * vpnhide — KernelPatch Module (KPM) backend.  *** BETA ***
  *
  * A third native backend alongside the kretprobe `.ko`, for kernels the
  * `.ko` can't serve: non-GKI / proprietary kernels with no published
@@ -9,25 +9,25 @@
  * NOT insmod — so it also works where module signing blocks a `.ko`.
  *
  * STATUS: builds (`make kpm`) and runs end-to-end under QEMU via the KPM
- * harness (../test/run-kpm.sh). The original 10 enumeration hooks are
- * A/B-validated across the complete supported range; socket-bind denial adds
- * state-level checks that verify the socket stayed unbound, not just errno.
- * The procfs control plane is still TODO (A/B uses load-args). Every per-kver
+ * harness (../test/run-kpm.sh). CI boots representative images for every
+ * offset table and checks all enumeration vectors; socket-bind denial adds a
+ * state-level check that verifies the socket stayed unbound, not just errno.
+ * Runtime config/status/stats use KernelPatch's ctl0 supercall; the QEMU A/B
+ * harness also retains decimal load-args for headless bring-up. Every per-kver
  * offset must pass the harness before that version ships — a wrong offset is a
  * contained QEMU panic / A/B failure here, but a bootloop on a real device.
  *
- * DESIGN (how this differs from soranerai's prototype, deliberately):
- *   - ONE source + a runtime kver offset table (kver_offsets.h), not three
- *     per-version copies → one binary across 4.x/5.x/6.x.
- *   - Per-call state via `fargs->local.dataN`, NOT a per-CPU MPIDR stash
- *     (which races when a thread migrates between the before/after callback).
+ * DESIGN:
+ *   - One source plus a runtime kver offset table (kver_offsets.h), producing
+ *     one binary across the supported 4.14-6.12 kernel families.
+ *   - Per-call state lives in `fargs->local.dataN`, so a task migrating CPUs
+ *     between the before/after callbacks cannot mix state with another call.
  *   - Filtering algorithms shared with the `.ko` via ../shared/vpnhide_logic.h.
  *   - VPN-name matching from the generated single source of truth
  *     (../generated/iface_lists.h → data/interfaces.toml), incl. the `if<N>`
- *     pattern (issue #86) that the hardcoded community lists miss.
- *   - rt_fill_info (single-route lookup) is intentionally NOT hooked: the
- *     QEMU harness proved its arg→register ABI is unstable. soranerai hooks
- *     it; we don't.
+ *     pattern (issue #86).
+ *   - rt_fill_info (single-route lookup) is intentionally not hooked because
+ *     its argument/register mapping is not stable across tested kernels.
  */
 #pragma GCC visibility push(hidden)
 #include <compiler.h>
@@ -46,10 +46,10 @@
 #include "kver_offsets.h"
 
 KPM_NAME("vpnhide");
-KPM_VERSION("0.0.1-wip");
+KPM_VERSION(VPNHIDE_KPM_BUILD_VERSION);
 KPM_LICENSE("GPL v2"); /* GPL to use GPL-only kernel symbols at runtime */
 KPM_AUTHOR("okhsunrog");
-KPM_DESCRIPTION("Hide VPN interfaces from selected UIDs (KPM backend, WIP)");
+KPM_DESCRIPTION("Hide VPN interfaces from selected UIDs (KPM backend, beta)");
 
 #define MODNAME "vpnhide"
 /* Mirror of vpnhide_protocol::MAX_TARGET_UIDS (crates/protocol/src/lib.rs); the
@@ -100,14 +100,7 @@ static unsigned long long stats_counts[MAX_TARGET_UIDS][VPNHIDE_HOOK_COUNT];
 static struct vpnhide_stat_entry
 	stats_snapshot[MAX_TARGET_UIDS * VPNHIDE_HOOK_COUNT];
 
-/* kernel functions resolved at init via kallsyms */
-static void *(*_proc_create_data)(const char *, uint16_t, void *, void *,
-				  void *);
-static void (*_remove_proc_entry)(const char *, void *);
-static int (*_single_open)(void *, void *, void *);
-static int (*_single_release)(void *, void *);
-static void *_seq_read, *_seq_lseek;
-static void (*_seq_printf)(void *, const char *, ...);
+/* Kernel functions resolved at init via kallsyms. */
 static unsigned long (*_copy_from_user)(void *, const void *, unsigned long);
 static unsigned long (*_copy_to_user)(void *, const void *, unsigned long);
 static void (*_skb_trim)(void *, unsigned int);
@@ -360,16 +353,15 @@ static int kpm_is_public_host_route6(void *rt, void *dev)
 }
 
 /* ================================================================== */
-/*  Hook 1 (PoC): fib_route_seq_show — /proc/net/route                */
+/*  Hook 1: fib_route_seq_show — /proc/net/route                      */
 /*  arg0 = struct seq_file *.  Compact VPN lines out of this call's    */
 /*  newly-written region using the shared seq-line compactor.          */
 /* ================================================================== */
 
 static void fib_route_before(hook_fargs2_t *fargs, void *udata)
 {
-	/* Stash seq_file->count at entry so the after-callback only touches
-	 * THIS call's output, not earlier entries. (Correctness fix the .ko
-	 * already does; soranerai re-scans the whole buffer each call.) */
+	/* Stash seq_file->count at entry so the after-callback only touches this
+	 * call's output, not entries already present in the buffer. */
 	void *seq = (void *)fargs->arg0;
 	unsigned long count =
 		seq ? *(unsigned long *)((char *)seq + off->seqfile_count) : 0;
@@ -425,7 +417,7 @@ static void ipv6_route_after(hook_fargs2_t *fargs, void *udata)
 }
 
 /* ================================================================== */
-/*  Hook 2 (PoC): rtnl_fill_ifinfo — RTM_NEWLINK (getifaddrs path)    */
+/*  Hook 2: rtnl_fill_ifinfo — RTM_NEWLINK (getifaddrs path)          */
 /*  arg0 = skb, arg1 = net_device.  If the dev is a VPN iface and the  */
 /*  caller is a target, undo whatever the fill wrote (skb_trim back to  */
 /*  the saved length) and return 0 — same approach as the .ko.         */
@@ -1056,11 +1048,12 @@ static void fib_rule_after(hook_fargs8_t *fargs, void *udata)
 }
 
 /*
- * HOOK COVERAGE — full parity with vpnhide_kmod.c (the .ko). The original 10
- * enumeration hooks are QEMU-validated A/B on android12-5.10 (no panic).
- * Mirror the .ko's logic; reuse shared/vpnhide_logic.h. Per-version struct
- * offsets live in kver_offsets.h — a wrong offset is a contained QEMU A/B fail
- * or panic here, a bootloop on a real device.
+ * HOOK COVERAGE — parity with vpnhide_kmod.c (the .ko). CI exercises these
+ * paths in booted QEMU images for 4.14, 4.19, 5.4, 5.10, 5.15, 6.1, 6.6, and
+ * 6.12. Filtering logic shared with the .ko lives in
+ * shared/vpnhide_logic.h; version-specific field offsets live in
+ * kver_offsets.h. QEMU coverage is the pre-merge safety gate, not a claim of
+ * testing every vendor kernel or device configuration.
  *
  *   fib_route_seq_show     /proc/net/route        ✓ (seq compactor)
  *   ipv6_route_seq_show    /proc/net/ipv6_route   ✓ (seq compactor)
@@ -1073,14 +1066,14 @@ static void fib_rule_after(hook_fargs8_t *fargs, void *udata)
  *                                                   public /32 host-route via a
  *                                                   physical uplink, the .ko's
  *                                                   is_public_host_route_via_
- *                                                   physical — A/B on every kver
+ *                                                   physical — QEMU matrix:
  *                                                   5.10/5.15/6.1/6.12 + legacy
  *                                                   5.4/4.19/4.14)
  *   rt6_fill_node          RTM_GETROUTE v6 dump   ✓ (fib6_info nexthop +
  *                                                   public /128 host-route via a
  *                                                   physical uplink, the .ko's
  *                                                   is_public_host_route6_via_
- *                                                   physical — A/B on every kver
+ *                                                   physical — QEMU matrix:
  *                                                   5.10/5.15/6.1/6.12 + legacy
  *                                                   5.4/4.19/4.14)
  *   fib_nl_fill_rule       RTM_GETRULE            ✓ (fib_rule iif/oif/uid)
@@ -1088,8 +1081,9 @@ static void fib_rule_after(hook_fargs8_t *fargs, void *udata)
  *                                                   state-aware raw-syscall test)
  *   ( rt_fill_info — intentionally NOT hooked; unstable arg->reg ABI )
  *
- * Both host-route predicates (v4 + v6) and their address/iface logic are now
- * shared with the .ko via shared/vpnhide_logic.h, and cover EVERY supported kver.
+ * Both host-route predicates (v4 + v6) and their address/iface logic are
+ * shared with the .ko via shared/vpnhide_logic.h and used by every selected
+ * offset table.
  * IPv4 needs no offset (fib_rt_info.dst/dst_len at a constant +12/+16 on 5.6+;
  * dst/dst_len passed as args 6/7 on <5.6). IPv6 reads the route's rt6key from
  * fib6_info.fib6_dst (64 on 5.4/4.19/5.10..6.6, 80 on 6.12) or, on the 4.14
@@ -1103,22 +1097,9 @@ static void fib_rule_after(hook_fargs8_t *fargs, void *udata)
 /*
  * The KPM has no file or node: its control/stats channel is the KernelPatch
  * `ctl0` supercall, carrying the §4 wire format (config in, stats/status out —
- * see vpnhide_kpm_ctl0). A procfs mirror is intentionally NOT created: it would
- * need the version-specific proc_ops/file_operations ABI guessed without real
- * headers (the likely cause of the HyperOS-5.4 crash report), and ctl0 needs no
- * such guessing.
- *
- * proc create/remove glue stub left below for the (deferred) optional mirror.
- */
-
-/*
- * proc_create needs a `struct proc_ops` (>=5.6) or a `struct file_operations`
- * (<5.6). We don't have the real headers, so the field layout is a mock —
- * and getting it wrong is the likely cause of the HyperOS-5.4 crash report.
- * off->proc_uses_proc_ops selects which mock to register.
- * TODO: define both mock layouts + the targets/debug show/open handlers, and
- * register the matching one. Kept as a stub here so the skeleton stays focused
- * on the hooks; see kver_offsets.h for the ABI flag.
+ * see vpnhide_kpm_ctl0). A procfs mirror is intentionally not created because
+ * its proc_ops/file_operations ABI would add another kernel-version-dependent
+ * structure layout. ctl0 avoids that dependency entirely.
  */
 
 /* ------------------------------------------------------------------ */
@@ -1128,9 +1109,9 @@ static void fib_rule_after(hook_fargs8_t *fargs, void *udata)
 /*
  * Resolve a hook target by name, tolerating compiler-renamed clones. GCC may
  * emit a static function as `name.isra.N` / `name.constprop.N` (a specialised
- * clone) — kallsyms_lookup_name("name") then misses it. Android *device*
- * kernels are clang-built (name intact), but a gcc-built kernel (incl. our
- * QEMU test kernels) renames e.g. fib_nl_fill_rule -> fib_nl_fill_rule.isra.N.
+ * clone) — kallsyms_lookup_name("name") then misses it. The clang-built GKI
+ * images usually retain the plain name, while gcc-built legacy QEMU images can
+ * rename e.g. fib_nl_fill_rule -> fib_nl_fill_rule.isra.N.
  * Fall back to the first symbol equal to `name`, or `name.` + suffix — the
  * dot only appears on compiler clones, so this never matches an unrelated fn.
  */
@@ -1177,14 +1158,6 @@ static unsigned long lookup_fn(const char *name)
 
 static int resolve_symbols(void)
 {
-	_proc_create_data = (void *)kallsyms_lookup_name("proc_create_data");
-	_remove_proc_entry = (void *)kallsyms_lookup_name("remove_proc_entry");
-	_single_open = (void *)kallsyms_lookup_name("single_open");
-	_single_release = (void *)kallsyms_lookup_name("single_release");
-	_seq_read = (void *)kallsyms_lookup_name("seq_read");
-	_seq_lseek = (void *)kallsyms_lookup_name("seq_lseek");
-	_seq_printf = (void *)kallsyms_lookup_name("seq_printf");
-
 	/* Prefer the generic `_copy_*_user` wrappers, NOT the raw
 	 * `__arch_copy_*_user`. The wrapper does the uaccess enable/disable
 	 * (access_ok + the TTBR0 switch / PAN toggle) around the copy; the raw
@@ -1210,7 +1183,8 @@ static int resolve_symbols(void)
 		_skb_trim = (void *)kallsyms_lookup_name("skb_trim");
 	_netdev_get_name = (void *)lookup_fn("netdev_get_name");
 
-	/* Hooks need these; proc is best-effort. */
+	/* skb trimming is the only global prerequisite. Hooks that need another
+	 * helper gate their own behavior or registration below. */
 	return _skb_trim ? 0 : -1;
 }
 
@@ -1537,8 +1511,6 @@ static long vpnhide_kpm_exit(void *__user reserved)
 		}
 	}
 
-	/* No /proc node to remove: the KPM's control channel is the ctl0
-	 * supercall, not procfs (the optional mirror was never created). */
 	logki(MODNAME ": KPM unloaded\n");
 	return 0;
 }

--- a/kmod/kpm/vpnhide_kpm.c
+++ b/kmod/kpm/vpnhide_kpm.c
@@ -5,8 +5,8 @@
  * A third native backend alongside the kretprobe `.ko`, for kernels the
  * `.ko` can't serve: non-GKI / proprietary kernels with no published
  * headers or Module.symvers (e.g. kernel 4.14 — issue #33; HyperOS 5.4).
- * Loaded by the KernelPatch runtime (target: KPatch-Next on KernelSU-Next),
- * NOT insmod — so it also works where module signing blocks a `.ko`.
+ * Loaded by the KernelPatch runtime used by APatch or KPatch-Next, NOT insmod
+ * — so it also works where module signing blocks a `.ko`.
  *
  * STATUS: builds (`make kpm`) and runs end-to-end under QEMU via the KPM
  * harness (../test/run-kpm.sh). CI boots representative images for every
@@ -14,8 +14,8 @@
  * state-level check that verifies the socket stayed unbound, not just errno.
  * Runtime config/status/stats use KernelPatch's ctl0 supercall; the QEMU A/B
  * harness also retains decimal load-args for headless bring-up. Every per-kver
- * offset must pass the harness before that version ships — a wrong offset is a
- * contained QEMU panic / A/B failure here, but a bootloop on a real device.
+ * offset must pass the harness before that version ships — a wrong offset can
+ * become a contained QEMU panic / A/B failure here or a bootloop on a device.
  *
  * DESIGN:
  *   - One source plus a runtime kver offset table (kver_offsets.h), producing
@@ -274,7 +274,7 @@ static int iface_is_vpn(const char *name)
 	return vpnhide_iface_is_vpn(buf);
 }
 
-/* Read net_device.name given a net_device* (name is at offset 0 everywhere). */
+/* Read net_device.name at the selected table's version-specific offset. */
 static const char *netdev_name(void *dev)
 {
 	return dev ? (const char *)((char *)dev + off->netdev_name) : 0;
@@ -1112,8 +1112,9 @@ static void fib_rule_after(hook_fargs8_t *fargs, void *udata)
  * clone) — kallsyms_lookup_name("name") then misses it. The clang-built GKI
  * images usually retain the plain name, while gcc-built legacy QEMU images can
  * rename e.g. fib_nl_fill_rule -> fib_nl_fill_rule.isra.N.
- * Fall back to the first symbol equal to `name`, or `name.` + suffix — the
- * dot only appears on compiler clones, so this never matches an unrelated fn.
+ * Fall back only to compiler clone forms observed in supported reference
+ * kernels. Other dotted symbols (for example cold fragments) are not valid
+ * substitutes for the complete function.
  */
 struct vpnhide_sym_q {
 	const char *base;
@@ -1121,17 +1122,43 @@ struct vpnhide_sym_q {
 	unsigned long addr;
 };
 
+static const char *vpnhide_skip_prefix(const char *value, const char *prefix)
+{
+	int i;
+
+	for (i = 0; prefix[i]; i++)
+		if (value[i] != prefix[i])
+			return 0;
+	return value + i;
+}
+
+static int vpnhide_is_clone_suffix(const char *suffix)
+{
+	const char *number = vpnhide_skip_prefix(suffix, ".isra.");
+
+	if (!number)
+		number = vpnhide_skip_prefix(suffix, ".constprop.");
+	if (!number || *number < '0' || *number > '9')
+		return 0;
+	do {
+		number++;
+	} while (*number >= '0' && *number <= '9');
+	return *number == '\0';
+}
+
 static int vpnhide_sym_cb(void *data, const char *name, struct module *mod,
 			  unsigned long addr)
 {
 	struct vpnhide_sym_q *q = data;
+	const char *suffix;
 	int i;
 
 	(void)mod;
 	for (i = 0; i < q->baselen; i++)
 		if (name[i] != q->base[i])
 			return 0;
-	if (name[q->baselen] == '\0' || name[q->baselen] == '.') {
+	suffix = name + q->baselen;
+	if (vpnhide_is_clone_suffix(suffix)) {
 		q->addr = addr;
 		return 1; /* found — stop iterating */
 	}
@@ -1158,7 +1185,7 @@ static unsigned long lookup_fn(const char *name)
 
 static int resolve_symbols(void)
 {
-	/* Prefer the generic `_copy_*_user` wrappers, NOT the raw
+	/* Require the generic `_copy_*_user` wrappers, NOT the raw
 	 * `__arch_copy_*_user`. The wrapper does the uaccess enable/disable
 	 * (access_ok + the TTBR0 switch / PAN toggle) around the copy; the raw
 	 * asm only copies. On a kernel using software PAN
@@ -1166,26 +1193,25 @@ static int resolve_symbols(void)
 	 * and the QEMU harness on `-cpu cortex-a57`) the TTBR0 switch lives in
 	 * the C wrapper on >=5.x, so calling the raw routine directly faults on
 	 * the unmapped user page (caught by the 5.4 harness run). The wrapper is
-	 * correct under both hardware and software PAN; fall back to the raw
-	 * symbol only if the wrapper is absent. */
+	 * correct under both hardware and software PAN. Loading without both
+	 * wrappers would make ioctl and ctl0 user-memory access unsafe. */
 	_copy_from_user = (void *)kallsyms_lookup_name("_copy_from_user");
-	if (!_copy_from_user)
-		_copy_from_user =
-			(void *)kallsyms_lookup_name("__arch_copy_from_user");
-
 	_copy_to_user = (void *)kallsyms_lookup_name("_copy_to_user");
-	if (!_copy_to_user)
-		_copy_to_user =
-			(void *)kallsyms_lookup_name("__arch_copy_to_user");
+	if (!_copy_from_user || !_copy_to_user) {
+		logki(MODNAME ": required uaccess wrappers unavailable\n");
+		return -1;
+	}
 
 	_skb_trim = (void *)kallsyms_lookup_name("__skb_trim");
 	if (!_skb_trim)
 		_skb_trim = (void *)kallsyms_lookup_name("skb_trim");
 	_netdev_get_name = (void *)lookup_fn("netdev_get_name");
 
-	/* skb trimming is the only global prerequisite. Hooks that need another
-	 * helper gate their own behavior or registration below. */
-	return _skb_trim ? 0 : -1;
+	if (!_skb_trim) {
+		logki(MODNAME ": skb trim helper unavailable\n");
+		return -1;
+	}
+	return 0;
 }
 
 /*
@@ -1268,12 +1294,12 @@ static long vpnhide_kpm_init(const char *args, const char *event,
 	apply_targets(args);
 
 	/*
-	 * Install hooks. Each one is gated on the offset(s) it dereferences
-	 * being known for this kernel version (0 => not installed), so a
-	 * partially-filled offset table is SAFE: a hook never runs with a
-	 * wrong/zero offset and panics. seq_file + ioctl hooks need only
-	 * stable offsets (seqfile_count, uapi ifreq) so they install whenever
-	 * the symbol exists. install_hook records each into installed_hooks.
+	 * Install hooks. Fields used as availability gates are nonzero only where
+	 * the corresponding layout is defined. Zero is also a valid offset for
+	 * several fields, so it is not a general validity marker; every selected
+	 * table must still be derived and tested as a complete unit. seq_file and
+	 * ioctl hooks use layouts shared by all supported tables. install_hook
+	 * records each successful registration in installed_hooks.
 	 */
 	if (off->seqfile_count) {
 		install_hook("fib_route_seq_show", 2, (void *)fib_route_before,

--- a/kmod/kpm/vpnhide_kpm.c
+++ b/kmod/kpm/vpnhide_kpm.c
@@ -103,8 +103,13 @@ static struct vpnhide_stat_entry
 /* Kernel functions resolved at init via kallsyms. */
 static unsigned long (*_copy_from_user)(void *, const void *, unsigned long);
 static unsigned long (*_copy_to_user)(void *, const void *, unsigned long);
+static uint64_t (*_read_sanitised_ftr_reg)(uint32_t);
 static void (*_skb_trim)(void *, unsigned int);
 static int (*_netdev_get_name)(void *, char *, int);
+
+/* Linux sys_reg(3, 0, 0, 7, 1); ID_AA64MMFR1_EL1.PAN is bits [23:20]. */
+#define VPNHIDE_SYS_ID_AA64MMFR1_EL1 0x180720u
+#define VPNHIDE_ID_AA64MMFR1_PAN_SHIFT 20u
 
 #define vpnhide_dbg(fmt, ...)                                   \
 	do {                                                    \
@@ -1183,23 +1188,50 @@ static unsigned long lookup_fn(const char *name)
 	return q.addr;
 }
 
+static int raw_usercopy_is_safe(void)
+{
+	uint64_t mmfr1;
+
+	/* 4.14/4.19 __arch_copy_*_user assembly brackets the copy with
+	 * uaccess_enable_not_uao itself. From 5.x onward that moved into the
+	 * inline raw_copy_*_user wrapper, which may not have a callable symbol. */
+	if ((unsigned int)kver < VPNHIDE_KVER(5, 0, 0))
+		return 1;
+	if (!_read_sanitised_ftr_reg)
+		return 0;
+	mmfr1 = _read_sanitised_ftr_reg(VPNHIDE_SYS_ID_AA64MMFR1_EL1);
+	/* With hardware PAN, __arch_copy_*_user uses unprivileged LDTR/STTR
+	 * accesses and does not need the software-PAN TTBR0 switch. */
+	return ((mmfr1 >> VPNHIDE_ID_AA64MMFR1_PAN_SHIFT) & 0xfu) != 0;
+}
+
 static int resolve_symbols(void)
 {
-	/* Require the generic `_copy_*_user` wrappers, NOT the raw
-	 * `__arch_copy_*_user`. The wrapper does the uaccess enable/disable
-	 * (access_ok + the TTBR0 switch / PAN toggle) around the copy; the raw
-	 * asm only copies. On a kernel using software PAN
-	 * (CONFIG_ARM64_SW_TTBR0_PAN — old ARMv8.0 cores with no hardware PAN,
-	 * and the QEMU harness on `-cpu cortex-a57`) the TTBR0 switch lives in
-	 * the C wrapper on >=5.x, so calling the raw routine directly faults on
-	 * the unmapped user page (caught by the 5.4 harness run). The wrapper is
-	 * correct under both hardware and software PAN. Loading without both
-	 * wrappers would make ioctl and ctl0 user-memory access unsafe. */
+	/* Prefer the generic wrappers: they perform the software-PAN TTBR0 switch
+	 * where required. Some builds inline every wrapper and expose only the raw
+	 * architecture routines, so accept those only where raw_usercopy_is_safe()
+	 * can prove they do not bypass software PAN. */
 	_copy_from_user = (void *)kallsyms_lookup_name("_copy_from_user");
 	_copy_to_user = (void *)kallsyms_lookup_name("_copy_to_user");
 	if (!_copy_from_user || !_copy_to_user) {
-		logki(MODNAME ": required uaccess wrappers unavailable\n");
-		return -1;
+		_read_sanitised_ftr_reg =
+			(void *)kallsyms_lookup_name("read_sanitised_ftr_reg");
+		if (!raw_usercopy_is_safe()) {
+			logki(MODNAME
+			      ": uaccess wrappers absent and raw copy is unsafe\n");
+			return -1;
+		}
+		if (!_copy_from_user)
+			_copy_from_user = (void *)kallsyms_lookup_name(
+				"__arch_copy_from_user");
+		if (!_copy_to_user)
+			_copy_to_user = (void *)kallsyms_lookup_name(
+				"__arch_copy_to_user");
+		if (!_copy_from_user || !_copy_to_user) {
+			logki(MODNAME ": user-copy symbols unavailable\n");
+			return -1;
+		}
+		logki(MODNAME ": using safe raw user-copy routines\n");
 	}
 
 	_skb_trim = (void *)kallsyms_lookup_name("__skb_trim");

--- a/kmod/module/module.prop
+++ b/kmod/module/module.prop
@@ -3,4 +3,4 @@ name=VPN Hide (kernel)
 version=v1.1.1
 versionCode=10101
 author=okhsunrog
-description=Hides VPN interfaces from selected apps at the kernel level via kretprobe. Invisible to anti-tamper SDKs. Manage targets via VPN Hide app.
+description=Hides VPN interfaces from selected apps at the kernel level via kernel probes. Invisible to anti-tamper SDKs. Manage targets via VPN Hide app.

--- a/kmod/module/module.prop
+++ b/kmod/module/module.prop
@@ -3,4 +3,4 @@ name=VPN Hide (kernel)
 version=v1.1.1
 versionCode=10101
 author=okhsunrog
-description=Hides VPN interfaces from selected apps at the kernel level via kernel probes. Invisible to anti-tamper SDKs. Manage targets via VPN Hide app.
+description=Hides documented VPN interface signals from selected apps via kernel probes. Manage targets via VPN Hide app.

--- a/kmod/shared/vpnhide_logic.h
+++ b/kmod/shared/vpnhide_logic.h
@@ -13,9 +13,8 @@
  * this header `#include`s anything, one of the two backends stops
  * compiling.
  *
- * The algorithms here are intentionally byte-identical to the seq-file
- * compaction in `vpnhide_kmod.c` (`fib_route_ret` / `ipv6_route_ret`),
- * so adopting this header in the `.ko` later is a mechanical change.
+ * Both native backends call these implementations directly so their route
+ * filtering and configuration parsing stay behaviorally aligned.
  */
 #ifndef VPNHIDE_SHARED_LOGIC_H
 #define VPNHIDE_SHARED_LOGIC_H

--- a/kmod/test/README.md
+++ b/kmod/test/README.md
@@ -1,8 +1,9 @@
 # kmod QEMU test harness
 
-Boots a real GKI kernel under `qemu-system-aarch64` and runs the vpnhide
-kernel module against fabricated VPN state, asserting that every detection
-vector is hidden from a *target* UID but still visible to a *non-target* UID.
+Boots a reference kernel under `qemu-system-aarch64` and runs the vpnhide
+kernel module against fabricated VPN state. It compares the enabled vectors for
+a *target* UID and a *non-target* UID; optional native probes are reported as
+skipped when their binaries are unavailable.
 
 This exists because compilation and source-level signature checks are **not
 sufficient** for this module: it reads syscall/netlink arguments straight out
@@ -17,7 +18,7 @@ register bug was found — see Design decisions.)
 Per kernel version, the harness validates:
 
 - the module **loads** (symbol resolution against that kernel),
-- all hooks **register**,
+- hook registration is reported for diagnosis,
 - each detection vector is actually **filtered** for a target UID (A/B: a
   non-target sees the fabricated `vpn0`, a target does not),
 - non-VPN entries such as `eth0`, the main policy rule, and bionic
@@ -68,14 +69,17 @@ kmod/test/build-kernel.sh android12-5.10
 kmod/test/run.sh android12-5.10
 ```
 
-`run.sh` exits 0 only if every vector passes and there was no panic. Artifacts
+`run.sh` exits 0 when every emitted vector passes and there was no panic.
+Optional probes can be made mandatory with their `*_REQUIRED` variables.
+Artifacts
 (kernels, modules, the Alpine rootfs) are cached under `.cache/` (gitignored).
 `run.sh` honors `VPNHIDE_QEMU_IMAGE` / `VPNHIDE_QEMU_ROOTFS` / `VPNHIDE_QEMU_KO`
 to use prebuilt artifacts (CI) instead of the local cache. It also honors
 `VPNHIDE_GAI_BIN` for a prebuilt static bionic `getifaddrs()` probe and
 `VPNHIDE_GAI_REQUIRED=1` to fail instead of silently skipping that native probe.
-`VPNHIDE_BIND_BIN` / `VPNHIDE_BIND_REQUIRED=1` provide the equivalent control
-for the state-aware socket-bind probe.
+`VPNHIDE_IFC_BIN` / `VPNHIDE_IFC_REQUIRED=1` control the `SIOCGIFCONF`
+size-query probe, and `VPNHIDE_BIND_BIN` / `VPNHIDE_BIND_REQUIRED=1` provide the
+equivalent control for the state-aware socket-bind probe.
 
 Requirements: `docker` (for build-kernel.sh), `qemu-system-aarch64`, `cpio`,
 `curl`.
@@ -107,7 +111,7 @@ is no insmod and no `/proc` dependency — target UIDs are passed via the
 embedded extra-args (`kptools -A`). The A/B is done across **two boots**
 (no target → root sees `vpn0`; target=0 → root doesn't), driven by
 `init-kpm.sh`. The original 10 enumeration hooks plus socket-bind state checks
-run with no panic across the full kernel range — 4.14, 4.19, 5.4, 5.10, 5.15,
+run with no panic across the CI reference set — 4.14, 4.19, 5.4, 5.10, 5.15,
 6.1, 6.6, 6.12 (the GKI ones via
 the DDK `Image`, the older ones via a from-source `Image` passed with
 `VPNHIDE_QEMU_IMAGE=`). Legacy kernels that natively require `CAP_NET_RAW` for

--- a/kmod/test/README.md
+++ b/kmod/test/README.md
@@ -31,8 +31,8 @@ Per kernel version, the harness validates:
   leave the socket unbound for a target; binding physical `eth0` still works,
 - malformed option pointers and lengths preserve native errors and leave the
   socket unbound instead of being dereferenced or fingerprinting the hook,
-- unloading the `.ko` while target bind probes are active drains redirected
-  entry-kprobe paths before module text is freed,
+- ordinary `rmmod` is refused and leaves the module/control plane active — the
+  entry-kprobe replacement text intentionally remains resident until reboot,
 - **no kernel panic** across the whole hook set.
 
 Vectors exercised (`init.sh`):

--- a/kmod/test/README.md
+++ b/kmod/test/README.md
@@ -26,6 +26,13 @@ Per kernel version, the harness validates:
   `dev_ioctl`, and the main policy rule) are **exactly unchanged** between the
   non-target and target passes; aggregate counters (`ip route show table all`
   and bionic `getifaddrs()` non-vpn rows) must stay positive,
+- raw `SO_BINDTODEVICE` (with and without a trailing NUL) and
+  `SO_BINDTOIFINDEX` calls bind `vpn0` for a non-target but return `ENODEV` and
+  leave the socket unbound for a target; binding physical `eth0` still works,
+- malformed option pointers and lengths preserve native errors and leave the
+  socket unbound instead of being dereferenced or fingerprinting the hook,
+- unloading the `.ko` while target bind probes are active drains redirected
+  entry-kprobe paths before module text is freed,
 - **no kernel panic** across the whole hook set.
 
 Vectors exercised (`init.sh`):
@@ -41,6 +48,7 @@ Vectors exercised (`init.sh`):
 | netlink route dump v4 | `ip route show table all` | `fib_dump_info` |
 | netlink route dump v6 | `ip -6 route show table all` | `rt6_fill_node` |
 | policy rules | `ip rule show` | `fib_nl_fill_rule` |
+| socket bind by name/index | `/bind-probe` static NDK raw-syscall probe | `socket_bind_interface` |
 
 **Limits:** GitHub/QEMU runners have no KVM, so the VM runs under TCG (software
 emulation) — correct, just slow. The test kernel is *our* `kernel/common` build
@@ -66,6 +74,8 @@ kmod/test/run.sh android12-5.10
 to use prebuilt artifacts (CI) instead of the local cache. It also honors
 `VPNHIDE_GAI_BIN` for a prebuilt static bionic `getifaddrs()` probe and
 `VPNHIDE_GAI_REQUIRED=1` to fail instead of silently skipping that native probe.
+`VPNHIDE_BIND_BIN` / `VPNHIDE_BIND_REQUIRED=1` provide the equivalent control
+for the state-aware socket-bind probe.
 
 Requirements: `docker` (for build-kernel.sh), `qemu-system-aarch64`, `cpio`,
 `curl`.
@@ -96,10 +106,14 @@ setup. The KPM loads at boot (KernelPatch hijacks `paging_init`), so there
 is no insmod and no `/proc` dependency — target UIDs are passed via the
 embedded extra-args (`kptools -A`). The A/B is done across **two boots**
 (no target → root sees `vpn0`; target=0 → root doesn't), driven by
-`init-kpm.sh`. All 10 hooks are validated 9/9 with no panic across the full
-kernel range — 4.14, 4.19, 5.4, 5.10, 5.15, 6.1, 6.6, 6.12 (the GKI ones via
+`init-kpm.sh`. The original 10 enumeration hooks plus socket-bind state checks
+run with no panic across the full kernel range — 4.14, 4.19, 5.4, 5.10, 5.15,
+6.1, 6.6, 6.12 (the GKI ones via
 the DDK `Image`, the older ones via a from-source `Image` passed with
-`VPNHIDE_QEMU_IMAGE=`).
+`VPNHIDE_QEMU_IMAGE=`). Legacy kernels that natively require `CAP_NET_RAW` for
+the first bind (or predate `SO_BINDTOIFINDEX`) must preserve the same errno and
+socket state for targets, and report that vector as protected-by-kernel rather
+than pretending the KPM hook fired.
 
 ```sh
 make -C kmod kpm                 # build vpnhide.kpm

--- a/kmod/test/bind-probe.c
+++ b/kmod/test/bind-probe.c
@@ -1,0 +1,362 @@
+// SPDX-License-Identifier: MIT
+/*
+ * State-aware SO_BINDTODEVICE / SO_BINDTOIFINDEX probe for the QEMU harness.
+ *
+ * The actor runs as uid 5555 and issues setsockopt through an inline arm64
+ * `svc`, bypassing libc.  The socket itself is created by the root parent before
+ * fork, so after the actor exits a separate non-target observer (uid 5556) can
+ * inspect the very same open file description.  This catches the dangerous
+ * failure mode where a hook returns ENODEV after the kernel has already changed
+ * sk_bound_dev_if; checking errno alone cannot distinguish that from a real
+ * pre-mutation denial.
+ *
+ * Output is deliberately line-oriented for init.sh / init-kpm.sh:
+ *
+ *   BIND_NAME_RAW_ERRNO=0
+ *   BIND_NAME_RAW_STATE=1
+ *
+ * errno is positive (0 on success).  STATE is 0 for unbound, 1 for the
+ * expected interface, 2 for a different interface, or a negative errno if the
+ * observation itself failed.
+ */
+
+#include <errno.h>
+#include <linux/if.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/socket.h>
+#include <sys/syscall.h>
+#include <sys/types.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+#ifndef SO_BINDTODEVICE
+#define SO_BINDTODEVICE 25
+#endif
+
+#ifndef SO_BINDTOIFINDEX
+#define SO_BINDTOIFINDEX 62
+#endif
+
+#ifndef __NR_setsockopt
+#define __NR_setsockopt 208
+#endif
+
+#ifndef __NR_getsockopt
+#define __NR_getsockopt 209
+#endif
+
+#define ACTOR_UID 5555
+#define OBSERVER_UID 5556
+
+struct call_result {
+	int ret;
+	int err;
+};
+
+static long raw_syscall5(long nr, long a0, long a1, long a2, long a3, long a4)
+{
+#if defined(__aarch64__)
+	register long x0 __asm__("x0") = a0;
+	register long x1 __asm__("x1") = a1;
+	register long x2 __asm__("x2") = a2;
+	register long x3 __asm__("x3") = a3;
+	register long x4 __asm__("x4") = a4;
+	register long x8 __asm__("x8") = nr;
+
+	__asm__ volatile("svc #0"
+			 : "+r"(x0)
+			 : "r"(x1), "r"(x2), "r"(x3), "r"(x4), "r"(x8)
+			 : "memory", "cc");
+	return x0;
+#else
+#error "bind-probe is intentionally arm64-only"
+#endif
+}
+
+static long raw_setsockopt(int fd, int level, int optname, const void *optval,
+			   socklen_t optlen)
+{
+	return raw_syscall5(__NR_setsockopt, fd, level, optname, (long)optval,
+			    optlen);
+}
+
+static long raw_getsockopt(int fd, int level, int optname, void *optval,
+			   socklen_t *optlen)
+{
+	return raw_syscall5(__NR_getsockopt, fd, level, optname, (long)optval,
+			    (long)optlen);
+}
+
+static int write_full(int fd, const void *buf, size_t len)
+{
+	const char *p = buf;
+
+	while (len) {
+		ssize_t n = write(fd, p, len);
+		if (n < 0) {
+			if (errno == EINTR)
+				continue;
+			return -1;
+		}
+		p += n;
+		len -= (size_t)n;
+	}
+	return 0;
+}
+
+static int read_full(int fd, void *buf, size_t len)
+{
+	char *p = buf;
+
+	while (len) {
+		ssize_t n = read(fd, p, len);
+		if (n < 0) {
+			if (errno == EINTR)
+				continue;
+			return -1;
+		}
+		if (n == 0)
+			return -1;
+		p += n;
+		len -= (size_t)n;
+	}
+	return 0;
+}
+
+static struct call_result actor_setsockopt(int fd, int optname,
+					   const void *optval, socklen_t optlen)
+{
+	int pipefd[2];
+	pid_t pid;
+	struct call_result result = { .ret = -1, .err = EIO };
+	int status;
+
+	if (pipe(pipefd) != 0)
+		return result;
+	pid = fork();
+	if (pid < 0) {
+		close(pipefd[0]);
+		close(pipefd[1]);
+		return result;
+	}
+	if (pid == 0) {
+		long rc;
+
+		close(pipefd[0]);
+		if (setuid(ACTOR_UID) != 0) {
+			result.ret = -1;
+			result.err = errno;
+		} else {
+			rc = raw_setsockopt(fd, SOL_SOCKET, optname, optval,
+					    optlen);
+			if (rc < 0) {
+				result.ret = -1;
+				result.err = (int)-rc;
+			} else {
+				result.ret = (int)rc;
+				result.err = 0;
+			}
+		}
+		(void)write_full(pipefd[1], &result, sizeof(result));
+		close(pipefd[1]);
+		_exit(0);
+	}
+
+	close(pipefd[1]);
+	if (read_full(pipefd[0], &result, sizeof(result)) != 0) {
+		result.ret = -1;
+		result.err = EIO;
+	}
+	close(pipefd[0]);
+	while (waitpid(pid, &status, 0) < 0 && errno == EINTR)
+		;
+	return result;
+}
+
+static int observer_name_state(int fd, const char *expected)
+{
+	int pipefd[2];
+	pid_t pid;
+	int state = -EIO;
+	int status;
+
+	if (pipe(pipefd) != 0)
+		return state;
+	pid = fork();
+	if (pid < 0) {
+		close(pipefd[0]);
+		close(pipefd[1]);
+		return state;
+	}
+	if (pid == 0) {
+		char name[IFNAMSIZ] = { 0 };
+		socklen_t len = sizeof(name);
+		long rc;
+
+		close(pipefd[0]);
+		if (setuid(OBSERVER_UID) != 0) {
+			state = -errno;
+		} else {
+			rc = raw_getsockopt(fd, SOL_SOCKET, SO_BINDTODEVICE,
+					    name, &len);
+			if (rc < 0)
+				state = (int)rc;
+			else if (len == 0 || name[0] == '\0')
+				state = 0;
+			else if (strcmp(name, expected) == 0)
+				state = 1;
+			else
+				state = 2;
+		}
+		(void)write_full(pipefd[1], &state, sizeof(state));
+		close(pipefd[1]);
+		_exit(0);
+	}
+
+	close(pipefd[1]);
+	if (read_full(pipefd[0], &state, sizeof(state)) != 0)
+		state = -EIO;
+	close(pipefd[0]);
+	while (waitpid(pid, &status, 0) < 0 && errno == EINTR)
+		;
+	return state;
+}
+
+static int observer_index_state(int fd, int expected)
+{
+	int pipefd[2];
+	pid_t pid;
+	int state = -EIO;
+	int status;
+
+	if (pipe(pipefd) != 0)
+		return state;
+	pid = fork();
+	if (pid < 0) {
+		close(pipefd[0]);
+		close(pipefd[1]);
+		return state;
+	}
+	if (pid == 0) {
+		int ifindex = -1;
+		socklen_t len = sizeof(ifindex);
+		long rc;
+
+		close(pipefd[0]);
+		if (setuid(OBSERVER_UID) != 0) {
+			state = -errno;
+		} else {
+			rc = raw_getsockopt(fd, SOL_SOCKET, SO_BINDTOIFINDEX,
+					    &ifindex, &len);
+			if (rc < 0)
+				state = (int)rc;
+			else if (ifindex == 0)
+				state = 0;
+			else if (ifindex == expected)
+				state = 1;
+			else
+				state = 2;
+		}
+		(void)write_full(pipefd[1], &state, sizeof(state));
+		close(pipefd[1]);
+		_exit(0);
+	}
+
+	close(pipefd[1]);
+	if (read_full(pipefd[0], &state, sizeof(state)) != 0)
+		state = -EIO;
+	close(pipefd[0]);
+	while (waitpid(pid, &status, 0) < 0 && errno == EINTR)
+		;
+	return state;
+}
+
+static void run_name_case(const char *label, const char *ifname,
+			  socklen_t optlen)
+{
+	int fd = socket(AF_INET, SOCK_STREAM | SOCK_CLOEXEC, 0);
+	struct call_result result;
+	int state;
+
+	if (fd < 0) {
+		printf("%s_ERRNO=%d\n%s_STATE=%d\n", label, errno, label,
+		       -errno);
+		return;
+	}
+	result = actor_setsockopt(fd, SO_BINDTODEVICE, ifname, optlen);
+	state = observer_name_state(fd, ifname);
+	printf("%s_ERRNO=%d\n%s_STATE=%d\n", label, result.err, label, state);
+	close(fd);
+}
+
+static void run_index_case(const char *label, int ifindex)
+{
+	int fd = socket(AF_INET, SOCK_STREAM | SOCK_CLOEXEC, 0);
+	struct call_result result;
+	int state;
+
+	if (fd < 0) {
+		printf("%s_ERRNO=%d\n%s_STATE=%d\n", label, errno, label,
+		       -errno);
+		return;
+	}
+	result = actor_setsockopt(fd, SO_BINDTOIFINDEX, &ifindex,
+				  sizeof(ifindex));
+	state = observer_index_state(fd, ifindex);
+	printf("%s_ERRNO=%d\n%s_STATE=%d\n", label, result.err, label, state);
+	close(fd);
+}
+
+static void run_bad_pointer_case(const char *label, const char *expected)
+{
+	const void *bad = (const void *)(uintptr_t)0xfffffffffffff000ULL;
+	int fd = socket(AF_INET, SOCK_STREAM | SOCK_CLOEXEC, 0);
+	struct call_result result;
+	int state;
+
+	if (fd < 0) {
+		printf("%s_ERRNO=%d\n%s_STATE=%d\n", label, errno, label,
+		       -errno);
+		return;
+	}
+	result = actor_setsockopt(fd, SO_BINDTODEVICE, bad, 4);
+	state = observer_name_state(fd, expected);
+	printf("%s_ERRNO=%d\n%s_STATE=%d\n", label, result.err, label, state);
+	close(fd);
+}
+
+int main(int argc, char **argv)
+{
+	const char *vpn_name;
+	int vpn_ifindex;
+
+	if (argc != 3) {
+		fprintf(stderr, "usage: %s <vpn-ifname> <vpn-ifindex>\n",
+			argv[0]);
+		return 2;
+	}
+	vpn_name = argv[1];
+	vpn_ifindex = atoi(argv[2]);
+	if (vpn_ifindex <= 0) {
+		fprintf(stderr, "invalid vpn ifindex: %s\n", argv[2]);
+		return 2;
+	}
+
+	/* Linux accepts both lengths.  Exercise both so a hook cannot accidentally
+	 * depend on callers including a trailing NUL. */
+	run_name_case("BIND_NAME_RAW", vpn_name, (socklen_t)strlen(vpn_name));
+	run_name_case("BIND_NAME_NUL", vpn_name,
+		      (socklen_t)strlen(vpn_name) + 1);
+	/* A userspace pointer whose numeric value is in the kernel range must be
+	 * rejected through the uaccess path, never dereferenced by a hook. */
+	run_bad_pointer_case("BIND_BADPTR", vpn_name);
+	/* sock_setbindtodevice treats the unsigned syscall length as int and must
+	 * reject this before a hook classifies the otherwise valid VPN name. */
+	run_name_case("BIND_BADLEN", vpn_name, (socklen_t)-1);
+	run_index_case("BIND_INDEX", vpn_ifindex);
+	run_name_case("BIND_KEEP", "eth0", 4);
+	return 0;
+}

--- a/kmod/test/init-kpm.sh
+++ b/kmod/test/init-kpm.sh
@@ -53,7 +53,8 @@ fi
 # public IP through an RTM_GETROUTE dump even though vpn0 is hidden, so they must
 # be hidden for a target the way the .ko hides them. eth0 is not a VPN iface, so
 # this exercises the public-host-route path, not iface_is_vpn. The KPM now covers
-# both v4 and v6 on every supported kernel (5.x/6.x fib6_info + 4.14 rt6_info), so
+# both v4 and v6 on every reference kernel in the CI matrix (5.x/6.x fib6_info
+# plus the 4.14 rt6_info path), so
 # no per-kver gate is needed here.
 ip route add 1.2.3.4/32 dev eth0 2>/dev/null
 ip -6 route add 2001:4860:4860::8888/128 dev eth0 2>/dev/null

--- a/kmod/test/init-kpm.sh
+++ b/kmod/test/init-kpm.sh
@@ -40,6 +40,14 @@ ip -6 addr add fd00:9::1/64 dev vpn0 2>/dev/null
 ip -6 route add fd00:99::/64 dev vpn0 2>/dev/null
 ip rule add uidrange 0-0 table 199 2>/dev/null
 
+# The bind probe's actor runs as uid 5555 and issues a raw setsockopt syscall;
+# a separate non-target observer inspects the same socket afterwards.  The host
+# harness compares these raw fields across the notarget and target boots.
+VPN0_IFINDEX=$(cat /sys/class/net/vpn0/ifindex 2>/dev/null)
+if [ -x /bind-probe ] && [ -n "$VPN0_IFINDEX" ]; then
+	/bind-probe vpn0 "$VPN0_IFINDEX" 2>/dev/null
+fi
+
 # Public /32 + /128 host-routes pinned to the physical uplink (eth0) — the routes
 # a VPN client installs so tunnel packets reach the server. They leak the server's
 # public IP through an RTM_GETROUTE dump even though vpn0 is hidden, so they must

--- a/kmod/test/init-kpm.sh
+++ b/kmod/test/init-kpm.sh
@@ -22,6 +22,7 @@ echo "KREL=$(uname -r)"
 # Did KernelPatch load our KPM and install hooks?
 if dmesg | grep -q "KPM hooks installed"; then echo "KPMLOAD=ok"; else echo "KPMLOAD=FAIL"; fi
 echo "KVER=$(dmesg | grep -oE 'kver=0x[0-9a-f]+' | head -1)"
+dmesg | grep 'vpnhide:' | tail -20 | sed 's/^/KPMLOG=/'
 
 # user-mode net so apk can fetch iproute2 (busybox ip can't add dummy devs)
 ip link set eth0 up 2>/dev/null

--- a/kmod/test/init.sh
+++ b/kmod/test/init.sh
@@ -3,10 +3,11 @@
 #
 # Boots inside a minimal Alpine initramfs, loads /vpnhide_kmod.ko, fabricates
 # a VPN-like interface (`vpn0`, a dummy netdev whose name matches the VPN
-# prefix list), then exercises every detection vector twice — once as a
-# non-target UID (must still see vpn0) and once as a target UID (must NOT
-# see vpn0). Emits machine-parseable `RESULT <vector>=PASS|FAIL` lines plus a
-# final `SUMMARY` line, then powers off so QEMU exits.
+# prefix list), then exercises the available detection vectors twice — once as
+# a non-target UID (must still see vpn0) and once as a target UID (must NOT see
+# vpn0). Optional native probes emit SKIP when not supplied. The driver emits
+# machine-parseable `RESULT <vector>=PASS|FAIL|SKIP` lines plus a final `SUMMARY`
+# line, then powers off so QEMU exits.
 #
 # Output is consumed by run.sh on the host via the serial console.
 set +e

--- a/kmod/test/init.sh
+++ b/kmod/test/init.sh
@@ -33,11 +33,11 @@ REGISTERED=$(dmesg | grep -c 'vpnhide:.*registered')
 echo "REGISTERED=$REGISTERED"
 
 # Write a control-protocol config snapshot (docs/protocol.md) enabling every
-# kernel hook (mask 0x3ff) for a single UID, with debug logging on. Replaces
+# kernel hook (mask 0x20003ff) for a single UID, with debug logging on. Replaces
 # the old `echo <uid> > /proc/vpnhide_targets` + `echo 1 > /proc/vpnhide_debug`
 # — both folded into the one /proc/vpnhide_ctl node.
 set_target() {
-	printf 'vpnhide 1 config\ndebug 1\ntarget 0x%x 0x3ff\n' "$1" \
+	printf 'vpnhide 1 config\ndebug 1\ntarget 0x%x 0x20003ff\n' "$1" \
 		> /proc/vpnhide_ctl 2>/dev/null
 }
 
@@ -190,6 +190,115 @@ check_ifconf_size() {
 	fi
 }
 
+bind_field() {
+	_output=$1
+	_key=$2
+	printf '%s\n' "$_output" | sed -n "s/^${_key}=//p" | head -1
+}
+
+# A return code is not enough for a bind-denial test: a return-only kretprobe
+# can report ENODEV after the kernel has already set sk_bound_dev_if.  The
+# native probe has a target child perform a raw syscall and a non-target child
+# inspect the same socket afterwards.
+check_socket_bind() {
+	if [ ! -x /bind-probe ]; then
+		for _vec in bind_device_raw bind_device_nul bind_bad_pointer bind_bad_length bind_ifindex keep_bind_device; do
+			echo "RESULT $_vec=SKIP (no socket bind probe available)"
+		done
+		return
+	fi
+
+	_vpn_ifindex=$(cat /sys/class/net/vpn0/ifindex 2>/dev/null)
+	if [ -z "$_vpn_ifindex" ]; then
+		for _vec in bind_device_raw bind_device_nul bind_bad_pointer bind_bad_length bind_ifindex keep_bind_device; do
+			echo "RESULT $_vec=FAIL (vpn0 ifindex unavailable)"
+			FAIL=$((FAIL + 1))
+		done
+		return
+	fi
+
+	# The probe actor is uid 5555.  First make it a non-target, then target it.
+	set_target 0
+	_nt=$(/bind-probe vpn0 "$_vpn_ifindex" 2>/dev/null)
+	set_target 5555
+	_tg=$(/bind-probe vpn0 "$_vpn_ifindex" 2>/dev/null)
+
+	for _case in \
+		"bind_device_raw BIND_NAME_RAW" \
+		"bind_device_nul BIND_NAME_NUL" \
+		"bind_ifindex BIND_INDEX"; do
+		_vec=${_case%% *}
+		_prefix=${_case#* }
+		_nt_errno=$(bind_field "$_nt" "${_prefix}_ERRNO")
+		_nt_state=$(bind_field "$_nt" "${_prefix}_STATE")
+		_tg_errno=$(bind_field "$_tg" "${_prefix}_ERRNO")
+		_tg_state=$(bind_field "$_tg" "${_prefix}_STATE")
+		[ -n "$_nt_errno" ] || _nt_errno=-1
+		[ -n "$_nt_state" ] || _nt_state=-1
+		[ -n "$_tg_errno" ] || _tg_errno=-1
+		[ -n "$_tg_state" ] || _tg_state=-1
+		if [ "$_nt_errno" -eq 0 ] && [ "$_nt_state" -eq 1 ] && \
+			[ "$_tg_errno" -eq 19 ] && [ "$_tg_state" -eq 0 ]; then
+			echo "RESULT $_vec=PASS (notarget=bound target=ENODEV+unbound)"
+			PASS=$((PASS + 1))
+		else
+			echo "RESULT $_vec=FAIL (nt_errno=$_nt_errno nt_state=$_nt_state tg_errno=$_tg_errno tg_state=$_tg_state)"
+			FAIL=$((FAIL + 1))
+		fi
+	done
+
+	_nt_errno=$(bind_field "$_nt" BIND_BADPTR_ERRNO)
+	_nt_state=$(bind_field "$_nt" BIND_BADPTR_STATE)
+	_tg_errno=$(bind_field "$_tg" BIND_BADPTR_ERRNO)
+	_tg_state=$(bind_field "$_tg" BIND_BADPTR_STATE)
+	[ -n "$_nt_errno" ] || _nt_errno=-1
+	[ -n "$_nt_state" ] || _nt_state=-1
+	[ -n "$_tg_errno" ] || _tg_errno=-1
+	[ -n "$_tg_state" ] || _tg_state=-1
+	if [ "$_nt_errno" -eq 14 ] && [ "$_nt_state" -eq 0 ] && \
+		[ "$_tg_errno" -eq 14 ] && [ "$_tg_state" -eq 0 ]; then
+		echo "RESULT bind_bad_pointer=PASS (EFAULT+unbound)"
+		PASS=$((PASS + 1))
+	else
+		echo "RESULT bind_bad_pointer=FAIL (nt_errno=$_nt_errno nt_state=$_nt_state tg_errno=$_tg_errno tg_state=$_tg_state)"
+		FAIL=$((FAIL + 1))
+	fi
+
+	_nt_errno=$(bind_field "$_nt" BIND_BADLEN_ERRNO)
+	_nt_state=$(bind_field "$_nt" BIND_BADLEN_STATE)
+	_tg_errno=$(bind_field "$_tg" BIND_BADLEN_ERRNO)
+	_tg_state=$(bind_field "$_tg" BIND_BADLEN_STATE)
+	[ -n "$_nt_errno" ] || _nt_errno=-1
+	[ -n "$_nt_state" ] || _nt_state=-1
+	[ -n "$_tg_errno" ] || _tg_errno=-1
+	[ -n "$_tg_state" ] || _tg_state=-1
+	if [ "$_nt_errno" -eq 22 ] && [ "$_nt_state" -eq 0 ] && \
+		[ "$_tg_errno" -eq 22 ] && [ "$_tg_state" -eq 0 ]; then
+		echo "RESULT bind_bad_length=PASS (EINVAL+unbound)"
+		PASS=$((PASS + 1))
+	else
+		echo "RESULT bind_bad_length=FAIL (nt_errno=$_nt_errno nt_state=$_nt_state tg_errno=$_tg_errno tg_state=$_tg_state)"
+		FAIL=$((FAIL + 1))
+	fi
+
+	_nt_errno=$(bind_field "$_nt" BIND_KEEP_ERRNO)
+	_nt_state=$(bind_field "$_nt" BIND_KEEP_STATE)
+	_tg_errno=$(bind_field "$_tg" BIND_KEEP_ERRNO)
+	_tg_state=$(bind_field "$_tg" BIND_KEEP_STATE)
+	[ -n "$_nt_errno" ] || _nt_errno=-1
+	[ -n "$_nt_state" ] || _nt_state=-1
+	[ -n "$_tg_errno" ] || _tg_errno=-1
+	[ -n "$_tg_state" ] || _tg_state=-1
+	if [ "$_nt_errno" -eq 0 ] && [ "$_nt_state" -eq 1 ] && \
+		[ "$_tg_errno" -eq 0 ] && [ "$_tg_state" -eq 1 ]; then
+		echo "RESULT keep_bind_device=PASS (physical bind preserved)"
+		PASS=$((PASS + 1))
+	else
+		echo "RESULT keep_bind_device=FAIL (nt_errno=$_nt_errno nt_state=$_nt_state tg_errno=$_tg_errno tg_state=$_tg_state)"
+		FAIL=$((FAIL + 1))
+	fi
+}
+
 # vector -> hook it exercises
 check_hide getifaddrs      "ip addr show"                 "vpn0"   # rtnl_fill_ifinfo + inet*_fill_ifaddr
 check_hide siocgifconf     "ifconfig -a"                  "vpn0"   # sock_ioctl
@@ -203,6 +312,7 @@ check_hide hostroute6      "ip -6 route show table all"   "2001:4860" # rt6_fill
 check_hide policy_rule     "ip rule show"                 "199"    # fib_nl_fill_rule
 check_gai
 check_ifconf_size                                                  # sock_ioctl size-query
+check_socket_bind                                                  # interface socket binding
 
 # Non-VPN entries must survive target filtering. This catches over-trimming
 # regressions where a hook hides the whole dump instead of only vpn0 rows.
@@ -212,6 +322,62 @@ check_keep_exact keep_siocgifconf     "ifconfig -a"             "^eth0"
 check_keep_exact keep_dev_ioctl       "ifconfig eth0"           "^eth0"
 check_keep keep_netlink_route4  "ip route show table all" "dev eth0"
 check_keep_exact keep_policy_rule     "ip rule show"            "lookup main"
+
+# Entry-kprobe redirection continues outside the exception handler. Stress an
+# unload while target bind calls are in flight; the module must unregister the
+# entry probes and drain those redirected task paths before its text is freed.
+_bind_pids=""
+if [ -x /bind-probe ] && [ -n "$_vpn_ifindex" ]; then
+	set_target 5555
+	for _worker in 1 2 3 4; do
+		(
+			while /bind-probe vpn0 "$_vpn_ifindex" >/dev/null 2>&1; do :; done
+		) &
+		_bind_pids="$_bind_pids $!"
+	done
+	sleep 1
+fi
+_unload_attempt=1
+_unload_ok=0
+_rmmod_error=""
+while [ "$_unload_attempt" -le 50 ]; do
+	if rmmod vpnhide_kmod >/tmp/vpnhide-rmmod.log 2>&1; then
+		_unload_ok=1
+		break
+	fi
+	_rmmod_error=$(tr '\n' ' ' </tmp/vpnhide-rmmod.log)
+	case "$_rmmod_error" in
+		*"Resource busy"*|*"temporarily unavailable"*) ;;
+		*) break ;;
+	esac
+	_unload_attempt=$((_unload_attempt + 1))
+done
+if [ "$_unload_ok" -eq 1 ]; then
+	echo "RESULT unload=PASS (redirected paths drained; attempts=$_unload_attempt)"
+	PASS=$((PASS + 1))
+else
+	_module_refcnt=$(cat /sys/module/vpnhide_kmod/refcnt 2>/dev/null || echo unavailable)
+	_module_state=$(cat /sys/module/vpnhide_kmod/initstate 2>/dev/null || echo unavailable)
+	_module_holders=""
+	for _holder in /sys/module/vpnhide_kmod/holders/*; do
+		[ -e "$_holder" ] || continue
+		_module_holders="$_module_holders $(basename "$_holder")"
+	done
+	echo "RESULT unload=FAIL (attempts=$_unload_attempt refcnt=$_module_refcnt state=$_module_state holders=${_module_holders:-none}; ${_rmmod_error:-no rmmod diagnostic})"
+	FAIL=$((FAIL + 1))
+fi
+for _pid in $_bind_pids; do
+	kill "$_pid" 2>/dev/null
+	wait "$_pid" 2>/dev/null
+done
+if [ "$_unload_ok" -eq 0 ]; then
+	if rmmod vpnhide_kmod >/tmp/vpnhide-rmmod-after-stop.log 2>&1; then
+		echo "UNLOAD_AFTER_WORKERS_STOP=PASS"
+	else
+		_rmmod_after_stop=$(tr '\n' ' ' </tmp/vpnhide-rmmod-after-stop.log)
+		echo "UNLOAD_AFTER_WORKERS_STOP=FAIL (${_rmmod_after_stop:-no rmmod diagnostic})"
+	fi
+fi
 
 PANIC=$(dmesg | grep -ci 'Unable to handle\|Internal error\|Oops\|BUG:\|Kernel panic')
 echo "PANIC=$PANIC"

--- a/kmod/test/init.sh
+++ b/kmod/test/init.sh
@@ -323,60 +323,20 @@ check_keep_exact keep_dev_ioctl       "ifconfig eth0"           "^eth0"
 check_keep keep_netlink_route4  "ip route show table all" "dev eth0"
 check_keep_exact keep_policy_rule     "ip rule show"            "lookup main"
 
-# Entry-kprobe redirection continues outside the exception handler. Stress an
-# unload while target bind calls are in flight; the module must unregister the
-# entry probes and drain those redirected task paths before its text is freed.
-_bind_pids=""
-if [ -x /bind-probe ] && [ -n "$_vpn_ifindex" ]; then
-	set_target 5555
-	for _worker in 1 2 3 4; do
-		(
-			while /bind-probe vpn0 "$_vpn_ifindex" >/dev/null 2>&1; do :; done
-		) &
-		_bind_pids="$_bind_pids $!"
-	done
-	sleep 1
-fi
-_unload_attempt=1
-_unload_ok=0
-_rmmod_error=""
-while [ "$_unload_attempt" -le 50 ]; do
-	if rmmod vpnhide_kmod >/tmp/vpnhide-rmmod.log 2>&1; then
-		_unload_ok=1
-		break
-	fi
+# Root module managers replace or remove the backend across a reboot. Keep the
+# entry-kprobe replacement text resident for that whole lifetime: ordinary
+# rmmod must fail and leave both the module and its control plane intact.
+if rmmod vpnhide_kmod >/tmp/vpnhide-rmmod.log 2>&1; then
+	echo "RESULT permanent_module=FAIL (rmmod unexpectedly succeeded)"
+	FAIL=$((FAIL + 1))
+elif [ -d /sys/module/vpnhide_kmod ] && [ -e /proc/vpnhide_ctl ]; then
 	_rmmod_error=$(tr '\n' ' ' </tmp/vpnhide-rmmod.log)
-	case "$_rmmod_error" in
-		*"Resource busy"*|*"temporarily unavailable"*) ;;
-		*) break ;;
-	esac
-	_unload_attempt=$((_unload_attempt + 1))
-done
-if [ "$_unload_ok" -eq 1 ]; then
-	echo "RESULT unload=PASS (redirected paths drained; attempts=$_unload_attempt)"
+	echo "RESULT permanent_module=PASS (${_rmmod_error:-removal refused})"
 	PASS=$((PASS + 1))
 else
-	_module_refcnt=$(cat /sys/module/vpnhide_kmod/refcnt 2>/dev/null || echo unavailable)
-	_module_state=$(cat /sys/module/vpnhide_kmod/initstate 2>/dev/null || echo unavailable)
-	_module_holders=""
-	for _holder in /sys/module/vpnhide_kmod/holders/*; do
-		[ -e "$_holder" ] || continue
-		_module_holders="$_module_holders $(basename "$_holder")"
-	done
-	echo "RESULT unload=FAIL (attempts=$_unload_attempt refcnt=$_module_refcnt state=$_module_state holders=${_module_holders:-none}; ${_rmmod_error:-no rmmod diagnostic})"
+	_rmmod_error=$(tr '\n' ' ' </tmp/vpnhide-rmmod.log)
+	echo "RESULT permanent_module=FAIL (module/control plane missing after refusal; ${_rmmod_error:-no rmmod diagnostic})"
 	FAIL=$((FAIL + 1))
-fi
-for _pid in $_bind_pids; do
-	kill "$_pid" 2>/dev/null
-	wait "$_pid" 2>/dev/null
-done
-if [ "$_unload_ok" -eq 0 ]; then
-	if rmmod vpnhide_kmod >/tmp/vpnhide-rmmod-after-stop.log 2>&1; then
-		echo "UNLOAD_AFTER_WORKERS_STOP=PASS"
-	else
-		_rmmod_after_stop=$(tr '\n' ' ' </tmp/vpnhide-rmmod-after-stop.log)
-		echo "UNLOAD_AFTER_WORKERS_STOP=FAIL (${_rmmod_after_stop:-no rmmod diagnostic})"
-	fi
 fi
 
 PANIC=$(dmesg | grep -ci 'Unable to handle\|Internal error\|Oops\|BUG:\|Kernel panic')

--- a/kmod/test/qemu.config
+++ b/kmod/test/qemu.config
@@ -10,7 +10,8 @@
 #   - android14-6.1+: CONFIG_LTO_NONE=y       + CFI via KCFI (no LTO needed)
 # (the 6.1 value is confirmed against the shipped Pixel 8 Pro factory image).
 # Forcing a single mode breaks fidelity AND the build: forcing LTO_NONE on 5.10
-# also drops CFI (an unmet dependency), producing a kernel no real device runs,
+# also drops CFI (an unmet dependency), producing a configuration that is not
+# representative of supported device kernels,
 # on which a GKI-built (CFI/LTO) module won't register its kretprobes. So we
 # inherit the defconfig default and let the full-LTO generations be heavy — the
 # CI bake (qemu-image.yml) frees disk + adds swap to fit them; if a full-LTO

--- a/kmod/test/run-kpm.sh
+++ b/kmod/test/run-kpm.sh
@@ -116,6 +116,27 @@ if [ -z "$GAI" ] && [ -n "${VPNHIDE_GAI_REQUIRED:-}" ]; then
 	exit 2
 fi
 
+# --- state-aware socket binding probe ----------------------------------------
+BIND=""
+if [ -n "${VPNHIDE_BIND_BIN:-}" ] && [ -x "${VPNHIDE_BIND_BIN:-}" ]; then
+	BIND="$VPNHIDE_BIND_BIN"
+	echo "[run-kpm] socket bind probe: prebuilt ($BIND)"
+else
+	BIND_CC="${VPNHIDE_BIND_CC:-$(find "$HOME/Android/Sdk/ndk" -type f -path '*/toolchains/llvm/prebuilt/*/bin/aarch64-linux-android*-clang' 2>/dev/null | sort | tail -1 || true)}"
+	if [ -n "$BIND_CC" ] && [ -x "$BIND_CC" ]; then
+		BIND="$CACHE/bind-probe"
+		"$BIND_CC" -static -O2 -Wall -Wextra -Werror \
+			-o "$BIND" "$HERE/bind-probe.c" 2>/dev/null || BIND=""
+	fi
+	[ -n "$BIND" ] && echo "[run-kpm] socket bind probe built ($(basename "$BIND_CC"))" || \
+		echo "[run-kpm] no bionic toolchain/binary — skipping socket bind vectors"
+fi
+
+if [ -z "$BIND" ] && [ -n "${VPNHIDE_BIND_REQUIRED:-}" ]; then
+	echo "ERROR: socket bind probe is required here (VPNHIDE_BIND_REQUIRED set) but unavailable."
+	exit 2
+fi
+
 WORK="$(mktemp -d)"
 trap 'rm -rf "$WORK"' EXIT
 
@@ -133,6 +154,7 @@ boot_phase() {
 	cp "$HERE/init-kpm.sh" "$rfs/init"
 	chmod +x "$rfs/init"
 	[ -n "$GAI" ] && { cp "$GAI" "$rfs/gai"; chmod +x "$rfs/gai"; }
+	[ -n "$BIND" ] && { cp "$BIND" "$rfs/bind-probe"; chmod +x "$rfs/bind-probe"; }
 	( cd "$rfs" && find . | cpio -o -H newc 2>/dev/null | gzip > "$WORK/initramfs.$tag.gz" )
 
 	echo "[run-kpm] $KMI: booting phase '$tag' (args='${args}')…" >&2
@@ -147,7 +169,10 @@ boot_phase() {
 }
 
 NT_LOG="$(boot_phase "" notarget)"
-TG_LOG="$(boot_phase "0" target)"
+# Keep uid 0 targeted for the existing shell vectors and add uid 5555 for the
+# state-aware bind probe's raw-syscall actor. The legacy load-args grammar is
+# one decimal UID per line (the runtime protocol is a separate channel).
+TG_LOG="$(boot_phase $'0\n5555' target)"
 
 vec_count() { grep -oE "VEC $1=[0-9]+" "$2" | head -1 | grep -oE '[0-9]+$' || echo "-1"; }
 panic_count() { grep -oE 'PANIC=[0-9]+' "$1" | head -1 | grep -oE '[0-9]+$' || echo "1"; }
@@ -165,7 +190,7 @@ keep_mode() {
 
 echo "------------------------- KPM test output -------------------------"
 for log in "$NT_LOG" "$TG_LOG"; do
-	grep -E 'KREL|KPMLOAD|KVER|IPROUTE2|VEC |PANIC' "$log" 2>/dev/null | sed "s|^|[$(basename "$log")] |" || true
+	grep -E 'KREL|KPMLOAD|KVER|IPROUTE2|VEC |BIND_|PANIC' "$log" 2>/dev/null | sed "s|^|[$(basename "$log")] |" || true
 done
 echo "-------------------------------------------------------------------"
 
@@ -173,6 +198,94 @@ echo "-------------------------------------------------------------------"
 [ "$(kpmload "$TG_LOG")" = ok ] || { echo "ERROR: KPM did not load (target boot)"; tail -20 "$TG_LOG"; exit 1; }
 
 PASS=0; FAIL=0
+
+bind_field() {
+	local key="$1" log="$2"
+	sed -n "s/^${key}=//p" "$log" | tr -d '\r' | head -1
+}
+
+check_bind_pair() {
+	local vec="$1" prefix="$2"
+	local nt_errno nt_state tg_errno tg_state
+	nt_errno="$(bind_field "${prefix}_ERRNO" "$NT_LOG")"
+	nt_state="$(bind_field "${prefix}_STATE" "$NT_LOG")"
+	tg_errno="$(bind_field "${prefix}_ERRNO" "$TG_LOG")"
+	tg_state="$(bind_field "${prefix}_STATE" "$TG_LOG")"
+
+	if [ -z "$nt_errno" ] || [ -z "$nt_state" ] || [ -z "$tg_errno" ] || [ -z "$tg_state" ]; then
+		echo "RESULT $vec=SKIP (socket bind probe unavailable)"
+		return
+	fi
+	# SO_BINDTODEVICE needs CAP_NET_RAW on 4.14/4.19/5.4; SO_BINDTOIFINDEX is
+	# absent before 5.4 (ENOPROTOOPT from both set and get). Either native result
+	# already closes this vector, so there is no target A/B distinction to demand.
+	if [ "$nt_errno" -ne 0 ] &&
+		{ [ "$nt_state" -eq 0 ] || [ "$nt_state" -eq "$((-nt_errno))" ]; }; then
+		if [ "$tg_errno" -eq "$nt_errno" ] && [ "$tg_state" -eq "$nt_state" ]; then
+			echo "RESULT $vec=SKIP (identical kernel-native denial/unsupported errno=$nt_errno)"
+			return
+		fi
+		echo "RESULT $vec=FAIL (native result changed: nt_errno=$nt_errno nt_state=$nt_state tg_errno=$tg_errno tg_state=$tg_state)"
+		FAIL=$((FAIL+1))
+		return
+	fi
+	if [ "$nt_errno" -eq 0 ] && [ "$nt_state" -eq 1 ] && \
+		[ "$tg_errno" -eq 19 ] && [ "$tg_state" -eq 0 ]; then
+		echo "RESULT $vec=PASS (notarget=bound target=ENODEV+unbound)"
+		PASS=$((PASS+1))
+	else
+		echo "RESULT $vec=FAIL (nt_errno=$nt_errno nt_state=$nt_state tg_errno=$tg_errno tg_state=$tg_state)"
+		FAIL=$((FAIL+1))
+	fi
+}
+
+check_bind_pair bind_device_raw BIND_NAME_RAW
+check_bind_pair bind_device_nul BIND_NAME_NUL
+check_bind_pair bind_ifindex BIND_INDEX
+
+nt_bad_errno="$(bind_field BIND_BADPTR_ERRNO "$NT_LOG")"
+nt_bad_state="$(bind_field BIND_BADPTR_STATE "$NT_LOG")"
+tg_bad_errno="$(bind_field BIND_BADPTR_ERRNO "$TG_LOG")"
+tg_bad_state="$(bind_field BIND_BADPTR_STATE "$TG_LOG")"
+if [ -z "$nt_bad_errno" ] || [ -z "$nt_bad_state" ] || \
+	[ -z "$tg_bad_errno" ] || [ -z "$tg_bad_state" ]; then
+	echo "RESULT bind_bad_pointer=SKIP (socket bind probe unavailable)"
+elif [ "$nt_bad_errno" -ne 0 ] && [ "$nt_bad_state" -eq 0 ] && \
+	[ "$tg_bad_errno" -ne 0 ] && [ "$tg_bad_state" -eq 0 ]; then
+	echo "RESULT bind_bad_pointer=PASS (safe rejection+unbound)"; PASS=$((PASS+1))
+else
+	echo "RESULT bind_bad_pointer=FAIL (nt_errno=$nt_bad_errno nt_state=$nt_bad_state tg_errno=$tg_bad_errno tg_state=$tg_bad_state)"; FAIL=$((FAIL+1))
+fi
+
+nt_badlen_errno="$(bind_field BIND_BADLEN_ERRNO "$NT_LOG")"
+nt_badlen_state="$(bind_field BIND_BADLEN_STATE "$NT_LOG")"
+tg_badlen_errno="$(bind_field BIND_BADLEN_ERRNO "$TG_LOG")"
+tg_badlen_state="$(bind_field BIND_BADLEN_STATE "$TG_LOG")"
+if [ -z "$nt_badlen_errno" ] || [ -z "$nt_badlen_state" ] || \
+	[ -z "$tg_badlen_errno" ] || [ -z "$tg_badlen_state" ]; then
+	echo "RESULT bind_bad_length=SKIP (socket bind probe unavailable)"
+elif [ "$nt_badlen_errno" -ne 0 ] && [ "$nt_badlen_state" -eq 0 ] && \
+	[ "$tg_badlen_errno" -eq "$nt_badlen_errno" ] && [ "$tg_badlen_state" -eq 0 ]; then
+	echo "RESULT bind_bad_length=PASS (identical native rejection+unbound)"; PASS=$((PASS+1))
+else
+	echo "RESULT bind_bad_length=FAIL (nt_errno=$nt_badlen_errno nt_state=$nt_badlen_state tg_errno=$tg_badlen_errno tg_state=$tg_badlen_state)"; FAIL=$((FAIL+1))
+fi
+
+nt_keep_errno="$(bind_field BIND_KEEP_ERRNO "$NT_LOG")"
+nt_keep_state="$(bind_field BIND_KEEP_STATE "$NT_LOG")"
+tg_keep_errno="$(bind_field BIND_KEEP_ERRNO "$TG_LOG")"
+tg_keep_state="$(bind_field BIND_KEEP_STATE "$TG_LOG")"
+if [ -z "$nt_keep_errno" ] || [ -z "$tg_keep_errno" ]; then
+	echo "RESULT keep_bind_device=SKIP (socket bind probe unavailable)"
+elif [ "$nt_keep_errno" -ne 0 ] && [ "${nt_keep_state:--1}" -eq 0 ] && \
+	[ "$tg_keep_errno" -eq "$nt_keep_errno" ] && [ "${tg_keep_state:--1}" -eq "$nt_keep_state" ]; then
+	echo "RESULT keep_bind_device=SKIP (identical kernel-native CAP_NET_RAW denial)"
+elif [ "$nt_keep_errno" -eq 0 ] && [ "$nt_keep_state" -eq 1 ] && \
+	[ "$tg_keep_errno" -eq 0 ] && [ "$tg_keep_state" -eq 1 ]; then
+	echo "RESULT keep_bind_device=PASS (physical bind preserved)"; PASS=$((PASS+1))
+else
+	echo "RESULT keep_bind_device=FAIL (nt_errno=$nt_keep_errno nt_state=$nt_keep_state tg_errno=$tg_keep_errno tg_state=$tg_keep_state)"; FAIL=$((FAIL+1))
+fi
 for vec in proc_route_v4 getifaddrs proc_route_v6 siocgifconf dev_ioctl netlink_route4 hostroute4 netlink_route6 hostroute6 policy_rule gai_getifaddrs; do
 	# The gai_getifaddrs vector only exists when the bionic probe is available
 	# (baked VPNHIDE_GAI_BIN, or built from an NDK on this host). If neither is

--- a/kmod/test/run-kpm.sh
+++ b/kmod/test/run-kpm.sh
@@ -190,7 +190,7 @@ keep_mode() {
 
 echo "------------------------- KPM test output -------------------------"
 for log in "$NT_LOG" "$TG_LOG"; do
-	grep -E 'KREL|KPMLOAD|KVER|IPROUTE2|VEC |BIND_|PANIC' "$log" 2>/dev/null | sed "s|^|[$(basename "$log")] |" || true
+	grep -E 'KREL|KPMLOAD|KVER|KPMLOG|IPROUTE2|VEC |BIND_|PANIC' "$log" 2>/dev/null | sed "s|^|[$(basename "$log")] |" || true
 done
 echo "-------------------------------------------------------------------"
 

--- a/kmod/test/run.sh
+++ b/kmod/test/run.sh
@@ -6,7 +6,7 @@
 # RESULT/SUMMARY lines.
 #
 # Usage:  kmod/test/run.sh [kmi]      (default: android12-5.10)
-# Exit:   0 = all vectors PASS, no panic; non-zero otherwise.
+# Exit:   0 = all emitted vectors PASS, no panic; non-zero otherwise.
 set -euo pipefail
 
 KMI="${1:-android12-5.10}"

--- a/kmod/test/run.sh
+++ b/kmod/test/run.sh
@@ -21,6 +21,7 @@ KDIR="$CACHE/$KMI"
 #   VPNHIDE_QEMU_KO     - module .ko   (from the kmod build artifact)
 #   VPNHIDE_QEMU_ROOTFS - Alpine minirootfs tarball (baked in the image)
 #   VPNHIDE_GAI_BIN     - optional prebuilt bionic getifaddrs probe
+#   VPNHIDE_BIND_BIN    - optional prebuilt raw-syscall socket bind probe
 IMAGE="${VPNHIDE_QEMU_IMAGE:-$KDIR/Image}"
 KO="${VPNHIDE_QEMU_KO:-$KDIR/vpnhide_kmod.ko}"
 
@@ -82,8 +83,35 @@ if [ -z "$IFC" ] && [ -n "${VPNHIDE_IFC_REQUIRED:-}" ]; then
 	exit 2
 fi
 
+# --- state-aware socket binding probe ----------------------------------------
+# This must be a native arm64 binary because it issues setsockopt with an inline
+# svc and shares the resulting socket across target/non-target child processes.
+BIND=""
+if [ -n "${VPNHIDE_BIND_BIN:-}" ] && [ -x "${VPNHIDE_BIND_BIN:-}" ]; then
+	BIND="$VPNHIDE_BIND_BIN"
+	echo "[run] socket bind probe: prebuilt ($BIND)"
+else
+	BIND_CC="${VPNHIDE_BIND_CC:-$(find "$HOME/Android/Sdk/ndk" -type f -path '*/toolchains/llvm/prebuilt/*/bin/aarch64-linux-android*-clang' 2>/dev/null | sort | tail -1 || true)}"
+	if [ -n "$BIND_CC" ] && [ -x "$BIND_CC" ]; then
+		BIND="$CACHE/bind-probe"
+		"$BIND_CC" -static -O2 -Wall -Wextra -Werror \
+			-o "$BIND" "$HERE/bind-probe.c" 2>/dev/null || BIND=""
+	fi
+	[ -n "$BIND" ] && echo "[run] socket bind probe built ($(basename "$BIND_CC"))" || \
+		echo "[run] no bionic toolchain/binary — skipping socket bind vectors"
+fi
+
+if [ -z "$BIND" ] && [ -n "${VPNHIDE_BIND_REQUIRED:-}" ]; then
+	echo "ERROR: socket bind probe is required here (VPNHIDE_BIND_REQUIRED set) but unavailable."
+	exit 2
+fi
+
 WORK="$(mktemp -d)"
-trap 'rm -rf "$WORK"' EXIT
+if [ -n "${VPNHIDE_QEMU_KEEP_WORK:-}" ]; then
+	echo "[run] preserving QEMU work directory: $WORK"
+else
+	trap 'rm -rf "$WORK"' EXIT
+fi
 RFS="$WORK/rootfs"
 mkdir -p "$RFS"
 tar xzf "$ALPINE_TAR" -C "$RFS"
@@ -92,6 +120,7 @@ cp "$HERE/init.sh" "$RFS/init"
 chmod +x "$RFS/init"
 [ -n "$GAI" ] && { cp "$GAI" "$RFS/gai"; chmod +x "$RFS/gai"; }
 [ -n "$IFC" ] && { cp "$IFC" "$RFS/ifconf"; chmod +x "$RFS/ifconf"; }
+[ -n "$BIND" ] && { cp "$BIND" "$RFS/bind-probe"; chmod +x "$RFS/bind-probe"; }
 ( cd "$RFS" && find . | cpio -o -H newc 2>/dev/null | gzip > "$WORK/initramfs.cpio.gz" )
 
 LOG="$WORK/serial.log"

--- a/kmod/vpnhide_kmod.c
+++ b/kmod/vpnhide_kmod.c
@@ -756,8 +756,8 @@ static int sock_ioctl_entry(struct kretprobe_instance *ri, struct pt_regs *regs)
 	if (!hook_active(VPNHIDE_HOOK_SOCK_IOCTL))
 		return 0;
 
-	/* sock_ioctl only runs for socket files, so file->private_data is the
-	 * struct socket (same thing sock_from_file() returns). Stable uapi. */
+	/* sock_ioctl is the socket file_operations callback, so private_data is
+	 * the struct socket, matching sock_from_file()'s internal invariant. */
 	file = (struct file *)regs->regs[0];
 	sock = file ? file->private_data : NULL;
 	data->net = (sock && sock->sk) ? sock_net(sock->sk) : NULL;

--- a/kmod/vpnhide_kmod.c
+++ b/kmod/vpnhide_kmod.c
@@ -1,11 +1,12 @@
 // SPDX-License-Identifier: MIT
 /*
  * vpnhide_kmod — kernel module that hides VPN network interfaces from
- * selected Android apps by filtering ioctl, netlink, and procfs
- * responses based on the calling process's UID.
+ * selected Android apps by filtering ioctl, netlink, and procfs responses and
+ * refusing VPN-interface socket binds based on the calling process's UID.
  *
- * Uses kretprobes so no modification of the running kernel is needed;
- * works on stock Android GKI kernels with CONFIG_KPROBES=y.
+ * Uses kretprobes for return-value/data filtering and ordinary entry kprobes
+ * for pre-mutation socket-bind replacement, so no modification of the running
+ * kernel is needed; works on stock Android GKI kernels with CONFIG_KPROBES=y.
  *
  * Hooks:
  *   - dev_ioctl: filters SIOCGIFFLAGS / SIOCGIFNAME / SIOCGIFMTU / etc.
@@ -18,6 +19,8 @@
  *   - fib_dump_info: filters IPv4 RTM_GETROUTE dump replies
  *   - rt6_fill_node: filters IPv6 RTM_GETROUTE replies
  *   - fib_nl_fill_rule: filters policy routing rules for target UIDs
+ *   - sock_setsockopt / sk_setsockopt: denies SO_BINDTODEVICE and
+ *     SO_BINDTOIFINDEX for hidden VPN interfaces before socket state changes
  *
  * Control plane: a single folded node /proc/vpnhide_ctl carries the shared
  * control/stats protocol (docs/protocol.md). A write is a `vpnhide 1 config`
@@ -26,9 +29,10 @@
  * list) and /proc/vpnhide_debug nodes — the same wire format every backend now
  * speaks (parser shared verbatim with the KPM via shared/vpnhide_logic.h).
  *
- * Architecture: arm64 only. The handlers read syscall arguments via
- * `regs->regs[N]` (AAPCS64 calling convention). On other architectures
- * those slots have a different meaning, so the build is gated below.
+ * Architecture: arm64 only. Several handlers read function arguments via
+ * `regs->regs[N]`, and the socket-bind entry probes redirect the saved PC
+ * according to AAPCS64. On other architectures those registers have a
+ * different meaning, so the build is gated below.
  */
 
 #include <linux/module.h>
@@ -48,6 +52,7 @@
 #include <linux/rtnetlink.h>
 #include <linux/skbuff.h>
 #include <linux/inetdevice.h>
+#include <linux/rcupdate.h>
 #include <net/sock.h>
 #include <net/if_inet6.h>
 #include <net/ip_fib.h>
@@ -83,7 +88,7 @@
  *
  * 64 covers a comfortable working set (apps × threads doing
  * getifaddrs/SIOCGIFCONF/route reads at once) without burning
- * meaningful memory: 6 probes × 64 instances × ~80 B ≈ 30 KB total.
+ * meaningful memory: 10 probes × 64 instances × ~80 B ≈ 50 KB total.
  */
 #define VPNHIDE_KRETPROBE_MAXACTIVE 64
 
@@ -403,6 +408,297 @@ static struct kretprobe dev_ioctl_krp = {
 	.maxactive = VPNHIDE_KRETPROBE_MAXACTIVE,
 	.kp.symbol_name = "dev_ioctl",
 };
+
+/* ================================================================== */
+/*  Hook 11: SO_BINDTODEVICE / SO_BINDTOIFINDEX                       */
+/*                                                                    */
+/*  A return-only kretprobe would be wrong here: by return time the   */
+/*  kernel has already changed sk_bound_dev_if, so merely reporting   */
+/*  ENODEV leaves a usable bound socket behind. A kprobe entry handler */
+/*  cannot solve this safely either: it runs in atomic context, where */
+/*  a not-yet-resident userspace option page cannot be faulted in.     */
+/*                                                                    */
+/*  These functions therefore use an ordinary entry kprobe's supported */
+/*  execution-path redirection: its atomic pre_handler only changes PC */
+/*  and returns !0. The replacement wrapper then runs after exception  */
+/*  handling has finished, in the original process context, where      */
+/*  copy_from_sockptr may fault normally. It snapshots the option once */
+/*  and passes an immutable KERNEL_SOCKPTR to the original function,   */
+/*  eliminating userspace TOCTOU. A hidden interface returns ENODEV    */
+/*  without ever calling the mutation path.                            */
+/*                                                                    */
+/*  sock_setsockopt is the ordinary SOL_SOCKET path on every shipped  */
+/*  GKI. On 6.1+ MPTCP can delegate directly to sk_setsockopt, so that */
+/*  symbol is covered as a second required registration there.       */
+/* ================================================================== */
+
+union socket_bind_snapshot {
+	char name[IFNAMSIZ];
+	int ifindex;
+};
+
+enum socket_bind_action {
+	VPNHIDE_BIND_PASSTHROUGH,
+	VPNHIDE_BIND_FROZEN,
+	VPNHIDE_BIND_DENY,
+	VPNHIDE_BIND_FAULT,
+};
+
+/* 1 = VPN interface, 0 = physical/non-VPN, -1 = unknown. Unknown positive
+ * indexes fail closed: sock_bindtoindex accepts a non-existent positive index,
+ * which would otherwise leave observable state on the socket. */
+static int classify_bind_ifindex(struct sock *sk, int ifindex)
+{
+	struct net_device *dev;
+	int result = -1;
+
+	if (!sk || ifindex <= 0)
+		return ifindex == 0 ? 0 : -1;
+	rcu_read_lock();
+	dev = dev_get_by_index_rcu(sock_net(sk), ifindex);
+	if (dev)
+		result = is_vpn_ifname(dev->name) ? 1 : 0;
+	rcu_read_unlock();
+	return result;
+}
+
+static enum socket_bind_action
+prepare_socket_bind(struct sock *sk, int level, int optname, sockptr_t optval,
+		    unsigned int optlen, union socket_bind_snapshot *snapshot)
+{
+	if (level != SOL_SOCKET ||
+	    !hook_active(VPNHIDE_HOOK_SOCKET_BIND_INTERFACE))
+		return VPNHIDE_BIND_PASSTHROUGH;
+	if (optname != SO_BINDTODEVICE && optname != SO_BINDTOIFINDEX)
+		return VPNHIDE_BIND_PASSTHROUGH;
+
+	memset(snapshot, 0, sizeof(*snapshot));
+	if (optname == SO_BINDTODEVICE) {
+		size_t n;
+
+		/* sock_setbindtodevice takes an int and rejects this before
+		 * touching optval. Preserve EINVAL and avoid needless uaccess. */
+		if ((int)optlen < 0)
+			return VPNHIDE_BIND_PASSTHROUGH;
+		n = min_t(size_t, optlen, IFNAMSIZ - 1);
+
+		if (n && copy_from_sockptr(snapshot->name, optval, n))
+			return VPNHIDE_BIND_FAULT;
+		if (snapshot->name[0] && is_vpn_ifname(snapshot->name))
+			return VPNHIDE_BIND_DENY;
+		return VPNHIDE_BIND_FROZEN;
+	}
+
+	if (optlen < sizeof(snapshot->ifindex))
+		return VPNHIDE_BIND_PASSTHROUGH;
+	if (copy_from_sockptr(&snapshot->ifindex, optval,
+			      sizeof(snapshot->ifindex)))
+		return VPNHIDE_BIND_FAULT;
+	if (snapshot->ifindex > 0 &&
+	    classify_bind_ifindex(sk, snapshot->ifindex) != 0)
+		return VPNHIDE_BIND_DENY;
+	return VPNHIDE_BIND_FROZEN;
+}
+
+typedef int (*sock_setsockopt_fn)(struct socket *, int, int, sockptr_t,
+				  unsigned int);
+static sock_setsockopt_fn original_sock_setsockopt;
+
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 1, 0)
+typedef int (*sk_setsockopt_fn)(struct sock *, int, int, sockptr_t,
+				unsigned int);
+static sk_setsockopt_fn original_sk_setsockopt;
+#endif
+
+/* noinline + a post-call barrier keep the original call from becoming a tail
+ * branch: the redirect kprobe uses the module return address to distinguish it
+ * from an external call that must be redirected. __nocfi is required for the
+ * non-exported sk_setsockopt address resolved through kprobe metadata. */
+static noinline __nocfi int
+call_original_sock_setsockopt(struct socket *sock, int level, int optname,
+			      sockptr_t optval, unsigned int optlen)
+{
+	int ret =
+		original_sock_setsockopt(sock, level, optname, optval, optlen);
+
+	barrier();
+	return ret;
+}
+
+static noinline int vpnhide_sock_setsockopt(struct socket *sock, int level,
+					    int optname, sockptr_t optval,
+					    unsigned int optlen)
+{
+	union socket_bind_snapshot snapshot;
+	enum socket_bind_action action =
+		prepare_socket_bind(sock ? READ_ONCE(sock->sk) : NULL, level,
+				    optname, optval, optlen, &snapshot);
+
+	if (action == VPNHIDE_BIND_DENY) {
+		record_hook_hit(VPNHIDE_HOOK_SOCKET_BIND_INTERFACE);
+		return -ENODEV;
+	}
+	if (action == VPNHIDE_BIND_FAULT)
+		return -EFAULT;
+	if (action == VPNHIDE_BIND_FROZEN)
+		optval = KERNEL_SOCKPTR(&snapshot);
+	return call_original_sock_setsockopt(sock, level, optname, optval,
+					     optlen);
+}
+
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 1, 0)
+static noinline __nocfi int call_original_sk_setsockopt(struct sock *sk,
+							int level, int optname,
+							sockptr_t optval,
+							unsigned int optlen)
+{
+	int ret = original_sk_setsockopt(sk, level, optname, optval, optlen);
+
+	barrier();
+	return ret;
+}
+
+static noinline int vpnhide_sk_setsockopt(struct sock *sk, int level,
+					  int optname, sockptr_t optval,
+					  unsigned int optlen)
+{
+	union socket_bind_snapshot snapshot;
+	enum socket_bind_action action = prepare_socket_bind(
+		sk, level, optname, optval, optlen, &snapshot);
+
+	if (action == VPNHIDE_BIND_DENY) {
+		record_hook_hit(VPNHIDE_HOOK_SOCKET_BIND_INTERFACE);
+		return -ENODEV;
+	}
+	if (action == VPNHIDE_BIND_FAULT)
+		return -EFAULT;
+	if (action == VPNHIDE_BIND_FROZEN)
+		optval = KERNEL_SOCKPTR(&snapshot);
+	return call_original_sk_setsockopt(sk, level, optname, optval, optlen);
+}
+#endif
+
+struct socket_bind_kprobe_hook {
+	const char *name;
+	unsigned long replacement;
+	struct kprobe kp;
+	bool registered;
+};
+
+static bool socket_bind_hooks_ready;
+
+static int socket_bind_kprobe_pre(struct kprobe *kp, struct pt_regs *regs)
+{
+	struct socket_bind_kprobe_hook *hook =
+		container_of(kp, struct socket_bind_kprobe_hook, kp);
+	unsigned long parent_ip = regs->regs[30];
+
+	if (!READ_ONCE(socket_bind_hooks_ready) ||
+	    within_module(parent_ip, THIS_MODULE))
+		return 0;
+	instruction_pointer_set(regs, hook->replacement);
+	/* Per Documentation/trace/kprobes.rst, !0 tells kprobes not to
+	 * single-step the replaced first instruction and to resume at our PC. */
+	return 1;
+}
+
+/* A post_handler keeps these probes out of the optimized-kprobe detour path,
+ * where changing PC from the pre_handler is not supported. It is reached only
+ * for the module's intentional call-through to the original function. */
+static void socket_bind_kprobe_post(struct kprobe *kp, struct pt_regs *regs,
+				    unsigned long flags)
+{
+	(void)kp;
+	(void)regs;
+	(void)flags;
+}
+
+static struct socket_bind_kprobe_hook socket_bind_kprobe_hooks[] = {
+	{
+		.name = "sock_setsockopt",
+		.replacement = (unsigned long)vpnhide_sock_setsockopt,
+		.kp = {
+			.symbol_name = "sock_setsockopt",
+			.pre_handler = socket_bind_kprobe_pre,
+			.post_handler = socket_bind_kprobe_post,
+		},
+	},
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 1, 0)
+	{
+		.name = "sk_setsockopt",
+		.replacement = (unsigned long)vpnhide_sk_setsockopt,
+		.kp = {
+			.symbol_name = "sk_setsockopt",
+			.pre_handler = socket_bind_kprobe_pre,
+			.post_handler = socket_bind_kprobe_post,
+		},
+	},
+#endif
+};
+
+static bool socket_bind_hooks_registered;
+
+static void unregister_socket_bind_hooks(void)
+{
+	bool must_drain = READ_ONCE(socket_bind_hooks_ready);
+	int i;
+
+	WRITE_ONCE(socket_bind_hooks_ready, false);
+	for (i = ARRAY_SIZE(socket_bind_kprobe_hooks) - 1; i >= 0; i--) {
+		struct socket_bind_kprobe_hook *hook =
+			&socket_bind_kprobe_hooks[i];
+
+		if (!hook->registered)
+			continue;
+		unregister_kprobe(&hook->kp);
+		hook->registered = false;
+		pr_info(MODNAME ": redirect kprobe(%s) unregistered\n",
+			hook->name);
+	}
+	/* A redirected wrapper executes after the kprobe exception handler has
+	 * returned, so unregister_kprobe() alone cannot see it. Wait until every
+	 * task that could have observed hooks_ready=true passes through a Tasks-RCU
+	 * quiescent state before module text may be freed on rmmod/init failure. */
+	if (must_drain)
+		synchronize_rcu_tasks();
+	socket_bind_hooks_registered = false;
+}
+
+static int register_socket_bind_hooks(void)
+{
+	int i, ret;
+
+	WRITE_ONCE(socket_bind_hooks_ready, false);
+	for (i = 0; i < ARRAY_SIZE(socket_bind_kprobe_hooks); i++) {
+		struct socket_bind_kprobe_hook *hook =
+			&socket_bind_kprobe_hooks[i];
+
+		ret = register_kprobe(&hook->kp);
+		if (ret)
+			goto fail;
+		hook->registered = true;
+		if (i == 0)
+			original_sock_setsockopt =
+				(sock_setsockopt_fn)hook->kp.addr;
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 1, 0)
+		else
+			original_sk_setsockopt =
+				(sk_setsockopt_fn)hook->kp.addr;
+#endif
+		pr_info(MODNAME ": redirect kprobe(%s) registered\n",
+			hook->name);
+	}
+
+	WRITE_ONCE(socket_bind_hooks_ready, true);
+	socket_bind_hooks_registered = true;
+	return 0;
+
+fail:
+	pr_warn(MODNAME ": redirect kprobe(%s) failed: %d\n",
+		socket_bind_kprobe_hooks[i].name, ret);
+	unregister_socket_bind_hooks();
+	return ret;
+}
 
 /* ================================================================== */
 /*  Hook 2: sock_ioctl — SIOCGIFCONF interface enumeration            */
@@ -1437,7 +1733,7 @@ static struct kretprobe_reg probes[] = {
 	  false },
 };
 
-/* Bitset of hooks that actually registered — the `status` hooks mask (§4.3). */
+/* Bitset of logical hooks that fully registered — the `status` hooks mask. */
 static u32 installed_hook_mask(void)
 {
 	u32 mask = 0;
@@ -1446,6 +1742,8 @@ static u32 installed_hook_mask(void)
 	for (i = 0; i < ARRAY_SIZE(probes); i++)
 		if (probes[i].registered)
 			mask |= (1u << probes[i].hook_id);
+	if (socket_bind_hooks_registered)
+		mask |= (1u << VPNHIDE_HOOK_SOCKET_BIND_INTERFACE);
 	return mask;
 }
 
@@ -1474,6 +1772,7 @@ static int __init vpnhide_init(void)
 		pr_warn(MODNAME ": only %d/%zu kretprobes registered — "
 				"some detection paths are not covered\n",
 			ok, ARRAY_SIZE(probes));
+	register_socket_bind_hooks();
 
 	/* 0600: root-only read/write. The config snapshot is written here by
 	 * service.sh and the VPN Hide app (both root). Apps must not see the
@@ -1485,6 +1784,7 @@ static int __init vpnhide_init(void)
 		 * target list, so the module would silently filter nothing —
 		 * fail loudly instead of pretending to work. */
 		pr_err(MODNAME ": proc_create(vpnhide_ctl) failed; aborting\n");
+		unregister_socket_bind_hooks();
 		for (i = 0; i < ARRAY_SIZE(probes); i++)
 			if (probes[i].registered)
 				unregister_kretprobe(probes[i].krp);
@@ -1502,6 +1802,7 @@ static void __exit vpnhide_exit(void)
 
 	if (ctl_entry)
 		proc_remove(ctl_entry);
+	unregister_socket_bind_hooks();
 
 	for (i = 0; i < ARRAY_SIZE(probes); i++) {
 		if (probes[i].registered) {

--- a/kmod/vpnhide_kmod.c
+++ b/kmod/vpnhide_kmod.c
@@ -33,6 +33,11 @@
  * `regs->regs[N]`, and the socket-bind entry probes redirect the saved PC
  * according to AAPCS64. On other architectures those registers have a
  * different meaning, so the build is gated below.
+ *
+ * Lifecycle: the module is intentionally non-unloadable. Root module managers
+ * install, update, disable, and remove it across a reboot; keeping module text
+ * resident for the whole boot also makes redirected entry-kprobe targets an
+ * unconditional lifetime invariant.
  */
 
 #include <linux/module.h>
@@ -52,7 +57,6 @@
 #include <linux/rtnetlink.h>
 #include <linux/skbuff.h>
 #include <linux/inetdevice.h>
-#include <linux/rcupdate.h>
 #include <net/sock.h>
 #include <net/if_inet6.h>
 #include <net/ip_fib.h>
@@ -427,8 +431,8 @@ static struct kretprobe dev_ioctl_krp = {
 /*  eliminating userspace TOCTOU. A hidden interface returns ENODEV    */
 /*  without ever calling the mutation path.                            */
 /*                                                                    */
-/*  sock_setsockopt is the ordinary SOL_SOCKET path on every shipped  */
-/*  GKI. On 6.1+ MPTCP can delegate directly to sk_setsockopt, so that */
+/*  sock_setsockopt is the ordinary SOL_SOCKET path on supported GKI  */
+/*  kernels. On 6.1+ MPTCP can delegate directly to sk_setsockopt, so */
 /*  symbol is covered as a second required registration there.       */
 /* ================================================================== */
 
@@ -638,12 +642,14 @@ static struct socket_bind_kprobe_hook socket_bind_kprobe_hooks[] = {
 
 static bool socket_bind_hooks_registered;
 
-static void unregister_socket_bind_hooks(void)
+/* Registration keeps redirection disabled until every required probe exists.
+ * Therefore rollback cannot race a redirected wrapper and needs no runtime
+ * drain protocol. Once ready becomes true the permanent module keeps these
+ * probes and their replacement text resident until reboot. */
+static void rollback_socket_bind_hooks(void)
 {
-	bool must_drain = READ_ONCE(socket_bind_hooks_ready);
 	int i;
 
-	WRITE_ONCE(socket_bind_hooks_ready, false);
 	for (i = ARRAY_SIZE(socket_bind_kprobe_hooks) - 1; i >= 0; i--) {
 		struct socket_bind_kprobe_hook *hook =
 			&socket_bind_kprobe_hooks[i];
@@ -655,12 +661,6 @@ static void unregister_socket_bind_hooks(void)
 		pr_info(MODNAME ": redirect kprobe(%s) unregistered\n",
 			hook->name);
 	}
-	/* A redirected wrapper executes after the kprobe exception handler has
-	 * returned, so unregister_kprobe() alone cannot see it. Wait until every
-	 * task that could have observed hooks_ready=true passes through a Tasks-RCU
-	 * quiescent state before module text may be freed on rmmod/init failure. */
-	if (must_drain)
-		synchronize_rcu_tasks();
 	socket_bind_hooks_registered = false;
 }
 
@@ -696,7 +696,7 @@ static int register_socket_bind_hooks(void)
 fail:
 	pr_warn(MODNAME ": redirect kprobe(%s) failed: %d\n",
 		socket_bind_kprobe_hooks[i].name, ret);
-	unregister_socket_bind_hooks();
+	rollback_socket_bind_hooks();
 	return ret;
 }
 
@@ -705,12 +705,12 @@ fail:
 /*                                                                    */
 /*  Why sock_ioctl instead of dev_ifconf?                             */
 /*                                                                    */
-/*  On GKI 5.10 kernels built with Clang LTO (all stock Android       */
-/*  devices), the linker inlines dev_ifconf() into sock_do_ioctl().   */
+/*  On GKI 5.10 kernels built with Clang LTO, the linker can inline   */
+/*  dev_ifconf() into sock_do_ioctl().                                */
 /*  The symbol "dev_ifconf" stays in kallsyms as a dead stub, so      */
 /*  kretprobe registration succeeds but the probe never fires.        */
-/*  Confirmed by disassembly on Xiaomi 13 Lite (5.10.136) and Lenovo  */
-/*  Legion 2 Pro (5.10.101): no `bl dev_ifconf` in sock_do_ioctl.    */
+/*  The unused dev_ifconf symbol then has no live call from           */
+/*  sock_do_ioctl, despite successful kretprobe registration.         */
 /*                                                                    */
 /*  On 6.1+, SIOCGIFCONF was moved out of sock_do_ioctl() into       */
 /*  sock_ioctl() directly (handled in the switch statement), so       */
@@ -719,8 +719,7 @@ fail:
 /*  sock_ioctl is the correct hook point because:                     */
 /*  1. It is the file_operations->unlocked_ioctl callback for socket  */
 /*     fds — used as a function pointer, so LTO cannot inline it.     */
-/*  2. ALL socket ioctls, including SIOCGIFCONF, pass through it on   */
-/*     every kernel version (5.10 through 6.12+).                     */
+/*  2. Supported GKI paths dispatch socket ioctls through it.         */
 /*  3. After sock_ioctl returns, the ifconf data (ifreq array +       */
 /*     ifc_len) is already in userspace — we filter it uniformly via  */
 /*     copy_from_user/copy_to_user regardless of kernel version.      */
@@ -1702,10 +1701,8 @@ static struct kretprobe fib_rule_fill_krp = {
 };
 
 /* ================================================================== */
-/*  Module init / exit                                                */
+/*  Module init                                                       */
 /* ================================================================== */
-
-static struct proc_dir_entry *ctl_entry;
 
 struct kretprobe_reg {
 	struct kretprobe *krp;
@@ -1772,52 +1769,33 @@ static int __init vpnhide_init(void)
 		pr_warn(MODNAME ": only %d/%zu kretprobes registered — "
 				"some detection paths are not covered\n",
 			ok, ARRAY_SIZE(probes));
-	register_socket_bind_hooks();
-
 	/* 0600: root-only read/write. The config snapshot is written here by
 	 * service.sh and the VPN Hide app (both root). Apps must not see the
 	 * control channel. (Renamed from vpnhide_targets for semantic accuracy
 	 * — it is now control+stats, not just targets, §OPEN-4.) */
-	ctl_entry = proc_create("vpnhide_ctl", 0600, NULL, &ctl_proc_ops);
-	if (!ctl_entry) {
+	if (!proc_create("vpnhide_ctl", 0600, NULL, &ctl_proc_ops)) {
 		/* Without /proc/vpnhide_ctl userspace cannot configure the
 		 * target list, so the module would silently filter nothing —
 		 * fail loudly instead of pretending to work. */
 		pr_err(MODNAME ": proc_create(vpnhide_ctl) failed; aborting\n");
-		unregister_socket_bind_hooks();
 		for (i = 0; i < ARRAY_SIZE(probes); i++)
 			if (probes[i].registered)
 				unregister_kretprobe(probes[i].krp);
 		return -ENOMEM;
 	}
 
+	/* Activate execution redirection last. No fallible initialization may run
+	 * after module text becomes reachable outside the kprobe handler. The module
+	 * has no exit function and remains resident until reboot. */
+	register_socket_bind_hooks();
+
 	pr_info(MODNAME
 		": loaded — write a config snapshot to /proc/vpnhide_ctl\n");
 	return 0;
 }
 
-static void __exit vpnhide_exit(void)
-{
-	int i;
-
-	if (ctl_entry)
-		proc_remove(ctl_entry);
-	unregister_socket_bind_hooks();
-
-	for (i = 0; i < ARRAY_SIZE(probes); i++) {
-		if (probes[i].registered) {
-			unregister_kretprobe(probes[i].krp);
-			pr_info(MODNAME ": kretprobe(%s) unregistered "
-					"(missed %d)\n",
-				probes[i].name, probes[i].krp->nmissed);
-		}
-	}
-
-	pr_info(MODNAME ": unloaded\n");
-}
-
 module_init(vpnhide_init);
-module_exit(vpnhide_exit);
+/* Deliberately no module_exit(): vpnhide_kmod stays loaded until reboot. */
 
 /* The source is MIT-licensed (see SPDX header), but MODULE_LICENSE("GPL")
  * is required to resolve EXPORT_SYMBOL_GPL symbols (kretprobes, etc.)

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/ProbeStats.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/ProbeStats.kt
@@ -49,7 +49,9 @@ internal enum class DetectionMethod(
 
                 HookIds.Hook.FIB_NL_FILL_RULE -> PolicyRules
 
-                HookIds.Hook.SOCKET_BIND_INTERFACE -> SocketBinding
+                HookIds.Hook.SOCKET_BIND_INTERFACE,
+                HookIds.Hook.ZYGISK_SETSOCKOPT,
+                -> SocketBinding
 
                 HookIds.Hook.LSPOSED_NETWORK_CAPABILITIES -> NetworkCapabilities
 

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/ProbeStats.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/ProbeStats.kt
@@ -7,7 +7,7 @@ import dev.okhsunrog.vpnhide.generated.HookIds
 // glance. "Native" covers both the kernel backends and Zygisk's libc hooks.
 internal enum class MethodSurface { Java, Native, Package }
 
-// User-facing detection method: a small taxonomy over the 18 raw hooks so the
+// User-facing detection method: a small taxonomy over the raw hook registry so the
 // Statistics screen reads as "what the app tried" instead of kernel symbol
 // names. Several hooks fold into one method (e.g. the four route hooks).
 internal enum class DetectionMethod(
@@ -19,6 +19,7 @@ internal enum class DetectionMethod(
     Routes(MethodSurface.Native, R.string.method_routes, R.string.method_desc_routes),
     Interfaces(MethodSurface.Native, R.string.method_interfaces, R.string.method_desc_interfaces),
     InterfaceIoctl(MethodSurface.Native, R.string.method_interface_ioctl, R.string.method_desc_interface_ioctl),
+    SocketBinding(MethodSurface.Native, R.string.method_socket_binding, R.string.method_desc_socket_binding),
     PolicyRules(MethodSurface.Native, R.string.method_policy_rules, R.string.method_desc_policy_rules),
     NetworkCapabilities(MethodSurface.Java, R.string.method_network_capabilities, R.string.method_desc_network_capabilities),
     LinkProperties(MethodSurface.Java, R.string.method_link_properties, R.string.method_desc_link_properties),
@@ -47,6 +48,8 @@ internal enum class DetectionMethod(
                 -> InterfaceIoctl
 
                 HookIds.Hook.FIB_NL_FILL_RULE -> PolicyRules
+
+                HookIds.Hook.SOCKET_BIND_INTERFACE -> SocketBinding
 
                 HookIds.Hook.LSPOSED_NETWORK_CAPABILITIES -> NetworkCapabilities
 

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/generated/HookIds.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/generated/HookIds.kt
@@ -86,11 +86,14 @@ internal object HookIds {
 
         // SO_BINDTODEVICE / SO_BINDTOIFINDEX pre-mutation denial
         SOCKET_BIND_INTERFACE(25, "socket_bind_interface", "SO_BINDTODEVICE / SO_BINDTOIFINDEX pre-mutation denial"),
+
+        // libc setsockopt() best-effort socket-interface bind denial
+        ZYGISK_SETSOCKOPT(26, "zygisk_setsockopt", "libc setsockopt() best-effort socket-interface bind denial"),
     }
 
     // Hooks owned by each backend: apply `mask and own`.
     const val KERNEL_HOOK_MASK = 0x20003ff
-    const val ZYGISK_HOOK_MASK = 0x1fc0000
+    const val ZYGISK_HOOK_MASK = 0x5fc0000
     const val LSPOSED_HOOK_MASK = 0x3fc00
 
     /** status error codes (protocol §5.1). */

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/generated/HookIds.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/generated/HookIds.kt
@@ -83,10 +83,13 @@ internal object HookIds {
 
         // __recvfrom_chk() fortified netlink dump filtering
         ZYGISK_RECVFROM_CHK(24, "zygisk_recvfrom_chk", "__recvfrom_chk() fortified netlink dump filtering"),
+
+        // SO_BINDTODEVICE / SO_BINDTOIFINDEX pre-mutation denial
+        SOCKET_BIND_INTERFACE(25, "socket_bind_interface", "SO_BINDTODEVICE / SO_BINDTOIFINDEX pre-mutation denial"),
     }
 
     // Hooks owned by each backend: apply `mask and own`.
-    const val KERNEL_HOOK_MASK = 0x3ff
+    const val KERNEL_HOOK_MASK = 0x20003ff
     const val ZYGISK_HOOK_MASK = 0x1fc0000
     const val LSPOSED_HOOK_MASK = 0x3fc00
 

--- a/lsposed/app/src/main/res/values-ru/strings.xml
+++ b/lsposed/app/src/main/res/values-ru/strings.xml
@@ -182,6 +182,7 @@
     <string name="method_routes">Таблица маршрутов</string>
     <string name="method_interfaces">Сетевые интерфейсы</string>
     <string name="method_interface_ioctl">Запрос интерфейсов (ioctl)</string>
+    <string name="method_socket_binding">Привязка сокета к интерфейсу</string>
     <string name="method_policy_rules">Правила маршрутизации</string>
     <string name="method_network_capabilities">NetworkCapabilities</string>
     <string name="method_link_properties">LinkProperties</string>
@@ -193,6 +194,7 @@
     <string name="method_desc_routes">Приложение читает таблицу маршрутов (/proc/net/route или netlink). VPN добавляет маршрут по умолчанию через свой туннельный интерфейс — его наличие выдаёт VPN.</string>
     <string name="method_desc_interfaces">Приложение перечисляет сетевые интерфейсы и их адреса (getifaddrs / netlink). VPN виден как лишний интерфейс tunNN с адресом, не совпадающим с Wi-Fi или мобильной сетью.</string>
     <string name="method_desc_interface_ioctl">Приложение запрашивает интерфейсы напрямую через ioctl (SIOCGIFCONF / SIOCGIFFLAGS). Туннельный интерфейс VPN появляется в списке или отмечается как активный.</string>
+    <string name="method_desc_socket_binding">Приложение привязывает сокет по имени или индексу интерфейса (SO_BINDTODEVICE / SO_BINDTOIFINDEX). Успех привязки может выдать скрытый VPN-интерфейс или направить через него трафик.</string>
     <string name="method_desc_policy_rules">Приложение читает правила маршрутизации (RTM_GETRULE). VPN добавляет правила, направляющие трафик в туннель, — они его выдают.</string>
     <string name="method_desc_network_capabilities">Приложение запрашивает NetworkCapabilities. Активный VPN выставляет флаг VPN-транспорта — прямой признак включённого VPN.</string>
     <string name="method_desc_link_properties">Приложение читает LinkProperties. VPN раскрывает имя своего интерфейса tunNN, VPN-маршруты и DNS-серверы.</string>

--- a/lsposed/app/src/main/res/values/strings.xml
+++ b/lsposed/app/src/main/res/values/strings.xml
@@ -212,6 +212,7 @@
     <string name="method_routes">Routing table</string>
     <string name="method_interfaces">Network interfaces</string>
     <string name="method_interface_ioctl">Interface query (ioctl)</string>
+    <string name="method_socket_binding">Socket interface binding</string>
     <string name="method_policy_rules">Routing policy rules</string>
     <string name="method_network_capabilities">NetworkCapabilities</string>
     <string name="method_link_properties">LinkProperties</string>
@@ -223,6 +224,7 @@
     <string name="method_desc_routes">An app reads the routing table (/proc/net/route or netlink). A VPN installs a catch-all default route through its tunnel interface — its presence gives the VPN away.</string>
     <string name="method_desc_interfaces">An app enumerates network interfaces and their addresses (getifaddrs / netlink). A VPN appears as an extra tunNN interface with an address that doesn\'t match Wi-Fi or cellular.</string>
     <string name="method_desc_interface_ioctl">An app queries interfaces directly via ioctl (SIOCGIFCONF / SIOCGIFFLAGS). The VPN tunnel interface shows up in the list or reports as up.</string>
+    <string name="method_desc_socket_binding">An app binds a socket by interface name or index (SO_BINDTODEVICE / SO_BINDTOIFINDEX). Whether the bind succeeds can reveal a hidden VPN interface or route traffic through it.</string>
     <string name="method_desc_policy_rules">An app reads policy routing rules (RTM_GETRULE). A VPN adds rules that steer traffic into the tunnel, which betray its presence.</string>
     <string name="method_desc_network_capabilities">An app queries NetworkCapabilities. An active VPN sets the VPN transport flag — a direct signal that a VPN is up.</string>
     <string name="method_desc_link_properties">An app reads LinkProperties. A VPN exposes its tunNN interface name, VPN routes and DNS servers.</string>

--- a/lsposed/app/src/test/kotlin/dev/okhsunrog/vpnhide/ConfigChannelsTest.kt
+++ b/lsposed/app/src/test/kotlin/dev/okhsunrog/vpnhide/ConfigChannelsTest.kt
@@ -13,13 +13,13 @@ class ConfigChannelsTest {
             """
             vpnhide 1 config
             debug 0
-            target 0x2711 0x3ff
-            target 0x27fa 0x3ff
+            target 0x2711 0x20003ff
+            target 0x27fa 0x20003ff
             """.trimIndent() + "\n",
             wire,
         )
         // The mask is exactly the generated kernel hook mask.
-        assertEquals("0x${HookIds.KERNEL_HOOK_MASK.toString(16)}", "0x3ff")
+        assertEquals("0x${HookIds.KERNEL_HOOK_MASK.toString(16)}", "0x20003ff")
     }
 
     @Test

--- a/lsposed/app/src/test/kotlin/dev/okhsunrog/vpnhide/ProbeStatsTest.kt
+++ b/lsposed/app/src/test/kotlin/dev/okhsunrog/vpnhide/ProbeStatsTest.kt
@@ -29,6 +29,7 @@ class ProbeStatsTest {
         // Hooks fold into a shared method.
         assertEquals(DetectionMethod.Routes, DetectionMethod.of(HookIds.Hook.FIB_ROUTE_SEQ_SHOW))
         assertEquals(DetectionMethod.Routes, DetectionMethod.of(HookIds.Hook.FIB_DUMP_INFO))
+        assertEquals(DetectionMethod.SocketBinding, DetectionMethod.of(HookIds.Hook.SOCKET_BIND_INTERFACE))
     }
 
     @Test

--- a/lsposed/app/src/test/kotlin/dev/okhsunrog/vpnhide/ProbeStatsTest.kt
+++ b/lsposed/app/src/test/kotlin/dev/okhsunrog/vpnhide/ProbeStatsTest.kt
@@ -30,6 +30,7 @@ class ProbeStatsTest {
         assertEquals(DetectionMethod.Routes, DetectionMethod.of(HookIds.Hook.FIB_ROUTE_SEQ_SHOW))
         assertEquals(DetectionMethod.Routes, DetectionMethod.of(HookIds.Hook.FIB_DUMP_INFO))
         assertEquals(DetectionMethod.SocketBinding, DetectionMethod.of(HookIds.Hook.SOCKET_BIND_INTERFACE))
+        assertEquals(DetectionMethod.SocketBinding, DetectionMethod.of(HookIds.Hook.ZYGISK_SETSOCKOPT))
     }
 
     @Test

--- a/lsposed/app/src/test/kotlin/dev/okhsunrog/vpnhide/StatisticsDataTest.kt
+++ b/lsposed/app/src/test/kotlin/dev/okhsunrog/vpnhide/StatisticsDataTest.kt
@@ -171,7 +171,7 @@ class StatisticsDataTest {
                     vpnhide 1 status
                     backend 0x0
                     kver 0x6019d
-                    hooks 0x3ff
+                    hooks 0x20003ff
                     error 0x0
                     vpnhide 1 stats
                     0x278b 0x6:0x2 0x63:0x1
@@ -181,7 +181,7 @@ class StatisticsDataTest {
                     vpnhide 1 status
                     backend 0x1
                     kver 0x6019d
-                    hooks 0x3ff
+                    hooks 0x20003ff
                     error 0x0
                     vpnhide 1 stats
                     0x27fa 0x0:0x5

--- a/lsposed/app/src/test/kotlin/dev/okhsunrog/vpnhide/StorageConfigTest.kt
+++ b/lsposed/app/src/test/kotlin/dev/okhsunrog/vpnhide/StorageConfigTest.kt
@@ -33,6 +33,7 @@ class StorageConfigTest {
                 "zygisk_recv",
                 "zygisk_recvfrom",
                 "zygisk_recvfrom_chk",
+                "zygisk_setsockopt",
             ),
             ZygiskNativeHookEntries.map { it.hookName },
         )

--- a/lsposed/app/src/test/kotlin/dev/okhsunrog/vpnhide/StorageConfigTest.kt
+++ b/lsposed/app/src/test/kotlin/dev/okhsunrog/vpnhide/StorageConfigTest.kt
@@ -20,6 +20,7 @@ class StorageConfigTest {
                 "fib_dump_info",
                 "rt6_fill_node",
                 "fib_nl_fill_rule",
+                "socket_bind_interface",
             ),
             NativeKernelHookEntries.map { it.hookName },
         )

--- a/zygisk/README.md
+++ b/zygisk/README.md
@@ -12,9 +12,11 @@ All hooks are inline on `libc.so` via ByteDance shadowhook:
 | `ioctl` | `SIOCGIFNAME` | Calls through; rewrites result to `ENODEV` if returned name is VPN. |
 | `ioctl` | `SIOCGIFCONF` | Calls through; compacts VPN entries out of the returned `ifreq` array. |
 | `getifaddrs` | `NetworkInterface.getNetworkInterfaces()`, Dart VM, direct C/C++ | Unlinks VPN entries from the returned linked list. |
+| `setsockopt` | `SO_BINDTODEVICE`, `SO_BINDTOIFINDEX` | Best-effort fallback: returns `ENODEV` before the syscall for VPN names/indices. |
 | `openat` | `/proc/net/{route,ipv6_route,if_inet6,tcp,tcp6}` | Returns a memfd with VPN entries stripped out. |
 | `recvmsg` | Netlink `RTM_NEWADDR` / `RTM_NEWLINK` dump responses | Removes VPN interface entries from netlink messages. |
 | `recv` | Netlink `RTM_NEWADDR` / `RTM_NEWLINK` dump responses | Same as `recvmsg`; hooked separately because bionic's `recv()` tail-calls `recvfrom`. |
+| `recvfrom`, `__recvfrom_chk` | Direct/FORTIFY'd netlink reads | Same filtering for callers that bypass the plain `recv` symbol. |
 
 ## Architecture
 
@@ -25,7 +27,7 @@ PLT hooks patch the caller library's procedure linkage table. At `post_app_speci
 ### Flow
 
 1. **`pre_app_specialize`** -- runs in the already-forked child, before the kernel drops it to the app's UID and SELinux context (still has zygote privileges at this point). Reads `args.nice_name`, checks against the module-dir `targets.txt` runtime wire generated from `/data/system/vpnhide_config.json` by the activator. Non-targeted apps get `DlCloseModuleLibrary` (zero cost after unload). See `src/lib.rs`'s top-level doc block for the full Zygisk lifecycle and why every Rust `static` is fresh per app launch.
-2. **`post_app_specialize`** -- on targeted processes only: `shadowhook_init`, install five inline hooks (`ioctl`, `getifaddrs`, `openat`, `recvmsg`, `recv`), then scrub maps. `recv` is hooked separately because bionic's `recv()` is `b recvfrom` (tail-call) — patching `recvfrom`'s prologue would break `recv`.
+2. **`post_app_specialize`** -- on targeted processes only: `shadowhook_init`, install the selected inline hooks (`ioctl`, `getifaddrs`, `setsockopt`, `openat`, `recvmsg`, `recv`, `recvfrom`, `__recvfrom_chk`), then scrub maps. `recv` is hooked separately because bionic's `recv()` is `b recvfrom` (tail-call) — patching `recvfrom`'s prologue would break `recv`.
 
 ### Thread-local guard
 
@@ -118,7 +120,8 @@ VPN interface prefixes: `tun`, `ppp`, `tap`, `wg`, `ipsec`, `xfrm`, `utun`, `l2t
 
 ## Known limitations
 
-- **Direct `svc #0` syscalls bypass the hook.** Apps issuing raw syscalls skip libc entirely. Use a kernel-level backend, [vpnhide-kmod](../kmod/) or [KPM](../kmod/kpm/), for these apps.
+- **Direct `svc #0` syscalls bypass the hook.** Apps issuing raw syscalls skip libc entirely, including the best-effort `setsockopt` protection. Use a kernel-level backend, [vpnhide-kmod](../kmod/) or [KPM](../kmod/kpm/), for these apps.
+- **Socket binding is left native before Linux 5.7.** Those kernels reject an unprivileged `SO_BINDTODEVICE` before reading the name, and `SO_BINDTOIFINDEX` does not exist; filtering would introduce a distinguishable error instead of closing an oracle.
 - **arm64 only.** No 32-bit arm, no x86.
 - **`getifaddrs` hook leaks a few bytes per call.** Unlinked VPN entries in the ifaddrs linked list are intentionally leaked rather than tracked with a shadow allocator. Acceptable tradeoff -- `getifaddrs` is called infrequently.
 - **Tested on Android 16 (API 36).** Should work back to API 24 in principle, but nothing older has been exercised.
@@ -126,7 +129,7 @@ VPN interface prefixes: `tun`, `ppp`, `tap`, `wg`, `ipsec`, `xfrm`, `utun`, `l2t
 ## Files
 
 - `src/lib.rs` -- module entry point, target gating, hook installer, maps scrubbing
-- `src/hooks.rs` -- hook replacements for ioctl, getifaddrs, openat, recvmsg, recv
+- `src/hooks.rs` -- hook replacements for ioctl, getifaddrs, setsockopt, openat, and the recv family
 - `src/filter.rs` -- VPN interface name matching and proc/net content filters (unit tested)
 - `src/shadowhook.rs` -- minimal FFI to shadowhook
 - `build.rs` -- drives CMake on the shadowhook submodule

--- a/zygisk/src/generated/hook_ids.rs
+++ b/zygisk/src/generated/hook_ids.rs
@@ -58,13 +58,15 @@ pub enum Hook {
     ZygiskRecvfromChk = 24,
     /// SO_BINDTODEVICE / SO_BINDTOIFINDEX pre-mutation denial
     SocketBindInterface = 25,
+    /// libc setsockopt() best-effort socket-interface bind denial
+    ZygiskSetsockopt = 26,
 }
 
-pub const HOOK_COUNT: u32 = 26;
+pub const HOOK_COUNT: u32 = 27;
 
 /// Hooks owned by each backend: apply `mask & own`.
 pub const KERNEL_HOOK_MASK: u32 = 0x20003ff;
-pub const ZYGISK_HOOK_MASK: u32 = 0x1fc0000;
+pub const ZYGISK_HOOK_MASK: u32 = 0x5fc0000;
 pub const LSPOSED_HOOK_MASK: u32 = 0x3fc00;
 
 /// status error codes (protocol §5.1).
@@ -97,7 +99,7 @@ pub enum Backend {
     Lsposed = 3,
 }
 
-pub const HOOK_NAMES: [&str; 26] = [
+pub const HOOK_NAMES: [&str; 27] = [
     "fib_route_seq_show",
     "ipv6_route_seq_show",
     "rtnl_fill_ifinfo",
@@ -124,4 +126,5 @@ pub const HOOK_NAMES: [&str; 26] = [
     "zygisk_recvfrom",
     "zygisk_recvfrom_chk",
     "socket_bind_interface",
+    "zygisk_setsockopt",
 ];

--- a/zygisk/src/generated/hook_ids.rs
+++ b/zygisk/src/generated/hook_ids.rs
@@ -56,12 +56,14 @@ pub enum Hook {
     ZygiskRecvfrom = 23,
     /// __recvfrom_chk() fortified netlink dump filtering
     ZygiskRecvfromChk = 24,
+    /// SO_BINDTODEVICE / SO_BINDTOIFINDEX pre-mutation denial
+    SocketBindInterface = 25,
 }
 
-pub const HOOK_COUNT: u32 = 25;
+pub const HOOK_COUNT: u32 = 26;
 
 /// Hooks owned by each backend: apply `mask & own`.
-pub const KERNEL_HOOK_MASK: u32 = 0x3ff;
+pub const KERNEL_HOOK_MASK: u32 = 0x20003ff;
 pub const ZYGISK_HOOK_MASK: u32 = 0x1fc0000;
 pub const LSPOSED_HOOK_MASK: u32 = 0x3fc00;
 
@@ -95,7 +97,7 @@ pub enum Backend {
     Lsposed = 3,
 }
 
-pub const HOOK_NAMES: [&str; 25] = [
+pub const HOOK_NAMES: [&str; 26] = [
     "fib_route_seq_show",
     "ipv6_route_seq_show",
     "rtnl_fill_ifinfo",
@@ -121,4 +123,5 @@ pub const HOOK_NAMES: [&str; 25] = [
     "zygisk_recv",
     "zygisk_recvfrom",
     "zygisk_recvfrom_chk",
+    "socket_bind_interface",
 ];

--- a/zygisk/src/hooks.rs
+++ b/zygisk/src/hooks.rs
@@ -24,7 +24,7 @@
 
 use core::cell::{Cell, RefCell};
 use core::ffi::{c_int, c_void};
-use core::sync::atomic::{AtomicPtr, Ordering};
+use core::sync::atomic::{AtomicPtr, AtomicU8, Ordering};
 
 use libc::{SIOCGIFCONF, SIOCGIFNAME, ifreq};
 
@@ -84,15 +84,28 @@ fn is_netlink_fd(fd: c_int) -> bool {
 
 // Android bionic exposes the thread-local errno via `int *__errno()`.
 // The `libc` crate doesn't re-export this symbol for android targets,
-// so declare it ourselves. Matches bionic's prototype exactly.
+// so declare it ourselves. Matches bionic's prototype exactly. Host unit
+// tests use glibc's equivalent entry point.
+#[cfg(target_os = "android")]
 unsafe extern "C" {
     fn __errno() -> *mut c_int;
 }
 
+#[cfg(all(not(target_os = "android"), target_os = "linux"))]
+unsafe extern "C" {
+    fn __errno_location() -> *mut c_int;
+}
+
 #[inline(always)]
 fn set_errno(val: c_int) {
+    #[cfg(target_os = "android")]
     unsafe {
         *__errno() = val;
+    }
+
+    #[cfg(all(not(target_os = "android"), target_os = "linux"))]
+    unsafe {
+        *__errno_location() = val;
     }
 }
 
@@ -104,7 +117,7 @@ fn set_errno(val: c_int) {
 ///
 /// Each hook needs the same four items to call through to the function it
 /// replaced, so we generate them from one declaration instead of hand-copying
-/// the block seven times:
+/// the block eight times:
 ///   - `static $slot: AtomicPtr<c_void>` — the captured original pointer,
 ///   - `type $ty` — its function-pointer shape (doc comments carry through),
 ///   - `fn $getter() -> Option<$ty>` — None before install or if somehow null,
@@ -152,6 +165,286 @@ saved_original! {
     static REAL_IOCTL;
     fn real_ioctl;
     pub fn set_real_ioctl_ptr;
+}
+
+saved_original! {
+    /// Raw function type for `setsockopt`.
+    type SetsockoptFn = unsafe extern "C" fn(
+        c_int,
+        c_int,
+        c_int,
+        *const c_void,
+        libc::socklen_t,
+    ) -> c_int;
+    static REAL_SETSOCKOPT;
+    fn real_setsockopt;
+    pub fn set_real_setsockopt_ptr;
+}
+
+// Android's UAPI has exposed SO_BINDTOIFINDEX since Linux 5.7, but the libc
+// crate intentionally follows the portable libc surface and does not define
+// it. Keep the kernel ABI value local to this hook.
+const SO_BINDTOIFINDEX: c_int = 62;
+
+const KERNEL_BIND_POLICY_UNKNOWN: u8 = 0;
+const KERNEL_BIND_POLICY_NATIVE_ONLY: u8 = 1;
+const KERNEL_BIND_POLICY_HOOK: u8 = 2;
+static KERNEL_BIND_POLICY: AtomicU8 = AtomicU8::new(KERNEL_BIND_POLICY_UNKNOWN);
+
+fn parse_decimal_component(input: &[u8], cursor: &mut usize) -> Option<u32> {
+    let start = *cursor;
+    let mut value = 0u32;
+    while let Some(&byte) = input.get(*cursor) {
+        if !byte.is_ascii_digit() {
+            break;
+        }
+        value = value.checked_mul(10)?.checked_add(u32::from(byte - b'0'))?;
+        *cursor += 1;
+    }
+    (*cursor > start).then_some(value)
+}
+
+fn release_has_unprivileged_first_bind(release: &[u8]) -> bool {
+    let mut cursor = 0usize;
+    let Some(major) = parse_decimal_component(release, &mut cursor) else {
+        return false;
+    };
+    if release.get(cursor) != Some(&b'.') {
+        return false;
+    }
+    cursor += 1;
+    let Some(minor) = parse_decimal_component(release, &mut cursor) else {
+        return false;
+    };
+    major > 5 || (major == 5 && minor >= 7)
+}
+
+/// Linux before 5.7 rejected an unprivileged SO_BINDTODEVICE before reading the
+/// interface name. Filtering there would create a name-dependent ENODEV/EPERM
+/// difference and expose rather than hide VPN prefixes. Keep the hook inert on
+/// those kernels; SO_BINDTOIFINDEX did not exist there either.
+fn kernel_needs_socket_bind_hiding() -> bool {
+    match KERNEL_BIND_POLICY.load(Ordering::Relaxed) {
+        KERNEL_BIND_POLICY_NATIVE_ONLY => return false,
+        KERNEL_BIND_POLICY_HOOK => return true,
+        _ => {}
+    }
+
+    let mut uts = core::mem::MaybeUninit::<libc::utsname>::zeroed();
+    let hook = unsafe {
+        if libc::uname(uts.as_mut_ptr()) != 0 {
+            false
+        } else {
+            let uts = uts.assume_init();
+            let release =
+                core::slice::from_raw_parts(uts.release.as_ptr().cast::<u8>(), uts.release.len());
+            let end = release
+                .iter()
+                .position(|&byte| byte == 0)
+                .unwrap_or(release.len());
+            release_has_unprivileged_first_bind(&release[..end])
+        }
+    };
+    KERNEL_BIND_POLICY.store(
+        if hook {
+            KERNEL_BIND_POLICY_HOOK
+        } else {
+            KERNEL_BIND_POLICY_NATIVE_ONLY
+        },
+        Ordering::Relaxed,
+    );
+    hook
+}
+
+/// Copy caller memory without dereferencing its pointer in-process.
+///
+/// A libc hook receives the same untrusted pointer the kernel syscall would.
+/// Dereferencing it in Rust would turn a normal `setsockopt(..., EFAULT)` into
+/// a process crash. `process_vm_readv` against our own pid gives us the same
+/// fault-contained user-memory read primitive. Use the raw syscall so the
+/// module does not acquire a dynamic dependency on bionic's API-23 symbol.
+fn copy_from_self(src: *const c_void, dst: &mut [u8]) -> bool {
+    if dst.is_empty() {
+        return true;
+    }
+    if src.is_null() {
+        return false;
+    }
+
+    let local = libc::iovec {
+        iov_base: dst.as_mut_ptr().cast(),
+        iov_len: dst.len(),
+    };
+    let remote = libc::iovec {
+        // process_vm_readv's ABI uses mutable iovec fields even though the
+        // remote side is read-only.
+        iov_base: src as *mut c_void,
+        iov_len: dst.len(),
+    };
+    let copied = unsafe {
+        libc::syscall(
+            libc::SYS_process_vm_readv,
+            libc::getpid(),
+            &local as *const libc::iovec,
+            1usize,
+            &remote as *const libc::iovec,
+            1usize,
+            0usize,
+        )
+    };
+    copied == dst.len() as libc::c_long
+}
+
+/// Resolve an interface index without letting our own ioctl hook hide it.
+///
+/// `if_indextoname` normally issues `SIOCGIFNAME`. The thread-local guard is
+/// shared with getifaddrs' internal lookups and makes this one lookup reach the
+/// real ioctl before we classify the returned name ourselves.
+fn ifindex_is_vpn(ifindex: c_int) -> Option<bool> {
+    if ifindex <= 0 {
+        return Some(false);
+    }
+
+    let mut name = [0u8; libc::IFNAMSIZ];
+    let result = IN_GETIFADDRS.with(|guard| {
+        let previous = guard.replace(true);
+        let result = unsafe { libc::if_indextoname(ifindex as u32, name.as_mut_ptr().cast()) };
+        guard.set(previous);
+        result
+    });
+    (!result.is_null()).then(|| is_vpn_iface_bytes(&name))
+}
+
+#[inline(always)]
+fn deny_ifindex_bind(ifindex: c_int, resolved_is_vpn: Option<bool>) -> bool {
+    // Zero unbinds; negative values are left to the kernel's native EINVAL.
+    // A positive index that disappears during resolution is denied: letting an
+    // unresolved index through would re-open the oracle during interface churn.
+    ifindex > 0 && resolved_is_vpn.unwrap_or(true)
+}
+
+/// Check the syscall's first validation step without changing socket state.
+/// Returning false also covers non-socket fds, so the real call can preserve
+/// its native `EBADF`/`ENOTSOCK` ordering before we inspect the interface name.
+fn is_socket_fd(fd: c_int) -> bool {
+    let mut socket_type: c_int = 0;
+    let mut len = core::mem::size_of::<c_int>() as libc::socklen_t;
+    unsafe {
+        libc::getsockopt(
+            fd,
+            libc::SOL_SOCKET,
+            libc::SO_TYPE,
+            (&mut socket_type as *mut c_int).cast(),
+            &mut len,
+        ) == 0
+    }
+}
+
+// ============================================================================
+//  Hook: setsockopt
+// ============================================================================
+
+/// Best-effort Zygisk replacement for bionic's `setsockopt` entry point.
+///
+/// Denies successful socket binds to VPN interfaces before the real syscall,
+/// matching the kernel backends' externally visible `ENODEV` result without
+/// ever leaving `sk_bound_dev_if` mutated. Raw syscalls still bypass this hook;
+/// this exists only as a fallback for devices where kmod/KPM cannot run.
+///
+/// Invalid pointers and unsupported lengths are passed to the real function so
+/// the kernel remains the authority for `EFAULT`/`EINVAL` instead of this hook
+/// crashing or inventing a different result.
+///
+/// # Safety
+///
+/// Called from native code via an inline-hook trampoline. `optval` is untrusted
+/// caller memory and must only be inspected through [`copy_from_self`].
+pub unsafe extern "C" fn hooked_setsockopt(
+    fd: c_int,
+    level: c_int,
+    optname: c_int,
+    optval: *const c_void,
+    optlen: libc::socklen_t,
+) -> c_int {
+    let Some(real) = real_setsockopt() else {
+        set_errno(libc::EFAULT);
+        return -1;
+    };
+
+    if level != libc::SOL_SOCKET {
+        return unsafe { real(fd, level, optname, optval, optlen) };
+    }
+
+    if (optname == libc::SO_BINDTODEVICE || optname == SO_BINDTOIFINDEX)
+        && (!kernel_needs_socket_bind_hiding() || !is_socket_fd(fd))
+    {
+        return unsafe { real(fd, level, optname, optval, optlen) };
+    }
+
+    if optname == libc::SO_BINDTODEVICE {
+        // The kernel takes a signed length internally. Preserve its native
+        // handling for values that wrapped through the unsigned libc ABI.
+        if optlen == 0 || optlen > c_int::MAX as libc::socklen_t {
+            return unsafe { real(fd, level, optname, optval, optlen) };
+        }
+
+        // sock_bindtoindex() copies at most IFNAMSIZ - 1 bytes, then appends a
+        // NUL. Mirror that exact classification window.
+        let copied_len = (optlen as usize).min(libc::IFNAMSIZ - 1);
+        let mut name = [0u8; libc::IFNAMSIZ];
+        if !copy_from_self(optval, &mut name[..copied_len]) {
+            return unsafe { real(fd, level, optname, optval, optlen) };
+        }
+        if is_vpn_iface_bytes(&name) {
+            set_errno(libc::ENODEV);
+            return -1;
+        }
+
+        // Pass the validated snapshot, not the racy caller buffer. The kernel
+        // caps this option to the same copied_len, so shortening a larger
+        // optlen does not change the selected interface.
+        return unsafe {
+            real(
+                fd,
+                level,
+                optname,
+                name.as_ptr().cast(),
+                copied_len as libc::socklen_t,
+            )
+        };
+    }
+
+    if optname == SO_BINDTOIFINDEX {
+        if optlen < core::mem::size_of::<c_int>() as libc::socklen_t
+            || optlen > c_int::MAX as libc::socklen_t
+        {
+            return unsafe { real(fd, level, optname, optval, optlen) };
+        }
+
+        let mut raw = [0u8; core::mem::size_of::<c_int>()];
+        if !copy_from_self(optval, &mut raw) {
+            return unsafe { real(fd, level, optname, optval, optlen) };
+        }
+        let ifindex = c_int::from_ne_bytes(raw);
+        if deny_ifindex_bind(ifindex, ifindex_is_vpn(ifindex)) {
+            set_errno(libc::ENODEV);
+            return -1;
+        }
+
+        // The kernel reads one int and ignores any trailing bytes for this
+        // option. Passing our snapshot closes a caller-memory race.
+        return unsafe {
+            real(
+                fd,
+                level,
+                optname,
+                (&ifindex as *const c_int).cast(),
+                core::mem::size_of::<c_int>() as libc::socklen_t,
+            )
+        };
+    }
+
+    unsafe { real(fd, level, optname, optval, optlen) }
 }
 
 // ============================================================================
@@ -1178,6 +1471,183 @@ fn collect_vpn_iface_indices() -> ([u32; crate::filter::MAX_VPN_ADDRS], usize) {
     }
 
     (indices, n)
+}
+
+#[cfg(test)]
+mod setsockopt_tests {
+    use core::ffi::{c_int, c_void};
+    use core::sync::atomic::{AtomicU32, AtomicUsize, Ordering};
+
+    use super::{
+        KERNEL_BIND_POLICY, KERNEL_BIND_POLICY_HOOK, SO_BINDTOIFINDEX, copy_from_self,
+        deny_ifindex_bind, hooked_setsockopt, release_has_unprivileged_first_bind, set_errno,
+        set_real_setsockopt_ptr,
+    };
+
+    static REAL_CALLS: AtomicUsize = AtomicUsize::new(0);
+    static LAST_OPTLEN: AtomicU32 = AtomicU32::new(0);
+
+    unsafe extern "C" fn fake_setsockopt(
+        _fd: c_int,
+        _level: c_int,
+        _optname: c_int,
+        _optval: *const c_void,
+        optlen: libc::socklen_t,
+    ) -> c_int {
+        REAL_CALLS.fetch_add(1, Ordering::Relaxed);
+        LAST_OPTLEN.store(optlen, Ordering::Relaxed);
+        73
+    }
+
+    #[test]
+    fn self_copy_contains_bad_caller_pointers() {
+        let source = *b"tun0";
+        let mut destination = [0u8; 4];
+        assert!(copy_from_self(source.as_ptr().cast(), &mut destination));
+        assert_eq!(destination, source);
+
+        assert!(!copy_from_self(
+            core::ptr::dangling::<c_void>(),
+            &mut destination
+        ));
+    }
+
+    #[test]
+    fn ifindex_decision_denies_vpn_and_resolution_races_only() {
+        assert!(deny_ifindex_bind(42, Some(true)));
+        assert!(deny_ifindex_bind(42, None));
+        assert!(!deny_ifindex_bind(42, Some(false)));
+        assert!(!deny_ifindex_bind(0, Some(true)));
+        assert!(!deny_ifindex_bind(-1, Some(true)));
+    }
+
+    #[test]
+    fn socket_bind_oracle_starts_at_linux_5_7() {
+        assert!(!release_has_unprivileged_first_bind(b"4.19.325-android"));
+        assert!(!release_has_unprivileged_first_bind(b"5.6.19"));
+        assert!(release_has_unprivileged_first_bind(b"5.7.0"));
+        assert!(release_has_unprivileged_first_bind(b"6.1.134-gki"));
+        assert!(!release_has_unprivileged_first_bind(b"not-a-release"));
+    }
+
+    #[test]
+    fn libc_hook_denies_vpn_names_before_calling_the_real_function() {
+        set_real_setsockopt_ptr(fake_setsockopt as *const ());
+        KERNEL_BIND_POLICY.store(KERNEL_BIND_POLICY_HOOK, Ordering::Relaxed);
+        REAL_CALLS.store(0, Ordering::Relaxed);
+        LAST_OPTLEN.store(u32::MAX, Ordering::Relaxed);
+        let fd = unsafe { libc::socket(libc::AF_INET, libc::SOCK_STREAM | libc::SOCK_CLOEXEC, 0) };
+        assert!(fd >= 0);
+
+        let vpn = *b"tun0";
+        set_errno(0);
+        let rc = unsafe {
+            hooked_setsockopt(
+                fd,
+                libc::SOL_SOCKET,
+                libc::SO_BINDTODEVICE,
+                vpn.as_ptr().cast(),
+                vpn.len() as libc::socklen_t,
+            )
+        };
+        assert_eq!(rc, -1);
+        assert_eq!(
+            std::io::Error::last_os_error().raw_os_error(),
+            Some(libc::ENODEV)
+        );
+        assert_eq!(REAL_CALLS.load(Ordering::Relaxed), 0);
+
+        let physical = *b"eth0";
+        let rc = unsafe {
+            hooked_setsockopt(
+                fd,
+                libc::SOL_SOCKET,
+                libc::SO_BINDTODEVICE,
+                physical.as_ptr().cast(),
+                physical.len() as libc::socklen_t,
+            )
+        };
+        assert_eq!(rc, 73);
+        assert_eq!(REAL_CALLS.load(Ordering::Relaxed), 1);
+        assert_eq!(LAST_OPTLEN.load(Ordering::Relaxed), 4);
+
+        // Empty names unbind and must retain the kernel's native behavior.
+        let rc = unsafe {
+            hooked_setsockopt(
+                fd,
+                libc::SOL_SOCKET,
+                libc::SO_BINDTODEVICE,
+                core::ptr::null(),
+                0,
+            )
+        };
+        assert_eq!(rc, 73);
+        assert_eq!(REAL_CALLS.load(Ordering::Relaxed), 2);
+
+        // A bad pointer is handed to the real syscall, which remains the
+        // authority for EFAULT; the hook itself must not dereference it.
+        let rc = unsafe {
+            hooked_setsockopt(
+                fd,
+                libc::SOL_SOCKET,
+                libc::SO_BINDTODEVICE,
+                core::ptr::dangling::<c_void>(),
+                4,
+            )
+        };
+        assert_eq!(rc, 73);
+        assert_eq!(REAL_CALLS.load(Ordering::Relaxed), 3);
+
+        // Wrapped signed lengths likewise stay on the native path.
+        let rc = unsafe {
+            hooked_setsockopt(
+                fd,
+                libc::SOL_SOCKET,
+                libc::SO_BINDTODEVICE,
+                core::ptr::dangling::<c_void>(),
+                c_int::MAX as libc::socklen_t + 1,
+            )
+        };
+        assert_eq!(rc, 73);
+        assert_eq!(REAL_CALLS.load(Ordering::Relaxed), 4);
+
+        // Index zero is an unbind and the real function receives one validated
+        // int rather than a potentially mutable caller buffer.
+        let ifindex = 0i32;
+        let rc = unsafe {
+            hooked_setsockopt(
+                fd,
+                libc::SOL_SOCKET,
+                SO_BINDTOIFINDEX,
+                (&ifindex as *const c_int).cast(),
+                core::mem::size_of::<c_int>() as libc::socklen_t,
+            )
+        };
+        assert_eq!(rc, 73);
+        assert_eq!(REAL_CALLS.load(Ordering::Relaxed), 5);
+        assert_eq!(
+            LAST_OPTLEN.load(Ordering::Relaxed),
+            core::mem::size_of::<c_int>() as u32
+        );
+
+        // Validation ordering matters: even a VPN-looking value on an invalid
+        // fd belongs to the real syscall's EBADF path, not our ENODEV path.
+        let rc = unsafe {
+            hooked_setsockopt(
+                -1,
+                libc::SOL_SOCKET,
+                libc::SO_BINDTODEVICE,
+                vpn.as_ptr().cast(),
+                vpn.len() as libc::socklen_t,
+            )
+        };
+        assert_eq!(rc, 73);
+        assert_eq!(REAL_CALLS.load(Ordering::Relaxed), 6);
+
+        unsafe {
+            libc::close(fd);
+        }
+    }
 }
 
 #[cfg(test)]

--- a/zygisk/src/lib.rs
+++ b/zygisk/src/lib.rs
@@ -91,9 +91,9 @@ use zygisk_api::jni::JNIEnv;
 
 use crate::hooks::{
     hooked_getifaddrs, hooked_ioctl, hooked_openat, hooked_recv, hooked_recvfrom,
-    hooked_recvfrom_chk, hooked_recvmsg, set_real_getifaddrs_ptr, set_real_ioctl_ptr,
-    set_real_openat_ptr, set_real_recv_ptr, set_real_recvfrom_chk_ptr, set_real_recvfrom_ptr,
-    set_real_recvmsg_ptr,
+    hooked_recvfrom_chk, hooked_recvmsg, hooked_setsockopt, set_real_getifaddrs_ptr,
+    set_real_ioctl_ptr, set_real_openat_ptr, set_real_recv_ptr, set_real_recvfrom_chk_ptr,
+    set_real_recvfrom_ptr, set_real_recvmsg_ptr, set_real_setsockopt_ptr,
 };
 
 const LOG_TAG: &str = "vpnhide-zygisk";
@@ -360,6 +360,8 @@ fn mark_cleanup(api: &mut ZygiskApi<'_, V2>) {
 ///     inside libcore, by the Dart VM's
 ///     `NetworkInterface.list()`, and by anything in C/C++
 ///     that calls `getifaddrs()` directly.
+///   * `setsockopt` — denies libc-routed `SO_BINDTODEVICE` /
+///     `SO_BINDTOIFINDEX` attempts for VPN interfaces before the syscall.
 ///   * `openat` — intercepts opens of `/proc/net/{route,ipv6_route,
 ///     if_inet6,tcp,tcp6}`; returns a `memfd` with VPN
 ///     entries stripped out.
@@ -403,6 +405,12 @@ fn install_hooks(hookmask: u32) -> Result<(), String> {
             hook_id: Hook::ZygiskGetifaddrs,
             replacement: hooked_getifaddrs as *mut _,
             store_orig: set_real_getifaddrs_ptr,
+        },
+        HookDesc {
+            sym: c"setsockopt",
+            hook_id: Hook::ZygiskSetsockopt,
+            replacement: hooked_setsockopt as *mut _,
+            store_orig: set_real_setsockopt_ptr,
         },
         HookDesc {
             sym: c"openat",


### PR DESCRIPTION
## Summary

- deny `SO_BINDTODEVICE` and `SO_BINDTOIFINDEX` for selected apps before socket state changes
- cover direct raw syscalls in both kernel backends and add a best-effort bionic `setsockopt` fallback for Zygisk-only installs
- register separate kernel and Zygisk hook IDs in config, status, diagnostics, and statistics contracts
- add mandatory state-aware QEMU probes built from the PR checkout and wire them into the GKI and legacy jobs
- keep the GKI `.ko` resident until reboot, matching the lifecycle of Magisk, KernelSU, and APatch modules
- make KPM fail closed outside its supported kernel range or without safe user-copy wrappers
- remove stale KPM scaffolding and rewrite comments around the actual QEMU/DDK validation boundary

## Root cause

The existing native filters hid VPN interfaces from enumeration, but an app could still call `setsockopt` and use bind success as an oracle or route a socket through the hidden interface. A return-only kretprobe is too late: changing only the reported errno leaves `sk_bound_dev_if` mutated and the socket usable.

## Backend behavior

- The `.ko` backend uses entry-kprobe execution redirection to typed `sock_setsockopt` / `sk_setsockopt` wrappers. Hidden names and indices return `ENODEV` before the original mutation path. The module is intentionally non-unloadable: redirection is activated only after all other initialization succeeds, and module text remains resident until reboot.
- KPM uses a pre-hook with `skip_origin`. Linux 5.9+ inputs are frozen into a kernel `sockptr_t` snapshot to close userspace TOCTOU. Linux 5.7-5.8 uses the resolved-ifindex helper, while older kernels preserve their native `CAP_NET_RAW` denial.
- The Zygisk fallback inline-hooks bionic `setsockopt`. It fault-safely reads untrusted option pointers, preserves invalid-fd and malformed-input behavior, and denies VPN names or indices before calling the real function. It stays inert before Linux 5.7, where native permission checks already precede name lookup.
- Unknown positive indices fail closed. A direct `svc #0` syscall still bypasses Zygisk, so only `.ko` and KPM provide the bypass-proof guarantee.

## KPM maintenance and safety

- Remove the unused procfs resolver/layout scaffold; KPM control, status, and statistics remain exclusively on the KernelPatch `ctl0` channel.
- Build KPM metadata from the project version instead of the old WIP literal and compile it with strict warnings.
- Reject kernels below 4.14 or above 6.12 instead of selecting an unverified boundary offset table.
- Prefer the PAN-aware `_copy_from_user` and `_copy_to_user` wrappers. If a build exposes only raw architecture routines, use them only on 4.14/4.19, where the routines bracket user access themselves, or when the kernel reports hardware PAN support.
- Restrict fuzzy symbol lookup to numbered GCC `.isra` and `.constprop` clones instead of accepting any dotted suffix.
- Document that offsets come from matching upstream, AOSP, or DDK sources and are exercised on reference QEMU images; this is not certification of every vendor kernel or physical device.

## Validation

- CI builds the raw arm64 bind probe once from the exact PR checkout and supplies it to every `.ko`, GKI KPM, and legacy KPM QEMU job with `VPNHIDE_BIND_REQUIRED=1`, so stale Docker-image probes cannot silently reduce coverage.
- The probe checks actual post-call socket state from a second UID, plus name/index binds, missing NUL, invalid pointers, invalid lengths, and physical-interface pass-through.
- The `.ko` harness verifies that ordinary `rmmod` is refused and that the module and `/proc/vpnhide_ctl` remain active.
- CI retains the DDK GKI build matrix and the booted QEMU reference matrix for the `.ko` and KPM backends. The QEMU Docker images also carry the bind probe as a fallback for local/manual runs and are rebuilt after relevant changes merge to `main`.
- Local focused checks passed: representative DDK `.ko` build; KPM package and strict relocatable build; C protocol/shared-logic tests; codegen; Ruff; clang-format; and shellcheck. Focused KPM QEMU runs also passed on android14-6.1 with the hardware-PAN raw fallback, android11-5.4 with software PAN and the normal wrappers, and 4.14 with software PAN and the legacy self-bracketing raw routines. The full matrix is left to CI.

Fixes #244

