### PR TITLE
fix: clear stale SIOCGIFCONF buffer entries

### DIFF
--- a/.github/docker/ddk-qemu/Dockerfile
+++ b/.github/docker/ddk-qemu/Dockerfile
@@ -95,7 +95,7 @@ COPY --from=gai /opt/bind-probe /opt/qemu/bind-probe
 # cache. VPNHIDE_QEMU_KSRC is the kernel tree to build the test module against;
 # VPNHIDE_KP_BIN is the baked KernelPatch tool/runtime dir (KPM only);
 # VPNHIDE_GAI_BIN is the prebuilt bionic getifaddrs probe;
-# VPNHIDE_IFC_BIN is the prebuilt SIOCGIFCONF size-query probe;
+# VPNHIDE_IFC_BIN is the prebuilt SIOCGIFCONF size/tail probe;
 # VPNHIDE_BIND_BIN is the state-aware raw-syscall socket bind probe.
 ENV VPNHIDE_QEMU_IMAGE=/opt/qemu/Image
 ENV VPNHIDE_QEMU_ROOTFS=/opt/qemu/alpine-minirootfs.tar.gz

--- a/.github/docker/kpm-qemu-legacy/Dockerfile
+++ b/.github/docker/kpm-qemu-legacy/Dockerfile
@@ -28,12 +28,14 @@ RUN curl -fsSL "https://dl.google.com/android/repository/android-ndk-${NDK_VER}-
     unzip -q /tmp/ndk.zip "android-ndk-${NDK_VER}/toolchains/llvm/prebuilt/linux-x86_64/*" \
         -d /opt && rm /tmp/ndk.zip
 COPY kmod/test/gai-probe.c /tmp/gai-probe.c
+COPY kmod/test/ifconf-probe.c /tmp/ifconf-probe.c
 COPY kmod/test/bind-probe.c /tmp/bind-probe.c
 RUN TC="/opt/android-ndk-${NDK_VER}/toolchains/llvm/prebuilt/linux-x86_64/bin" && \
     "$TC/aarch64-linux-android24-clang" -static -O2 -o /opt/gai /tmp/gai-probe.c && \
+    "$TC/aarch64-linux-android24-clang" -static -O2 -o /opt/ifconf /tmp/ifconf-probe.c && \
     "$TC/aarch64-linux-android24-clang" -static -O2 -Wall -Wextra -Werror \
         -o /opt/bind-probe /tmp/bind-probe.c && \
-    "$TC/llvm-strip" /opt/gai /opt/bind-probe
+    "$TC/llvm-strip" /opt/gai /opt/ifconf /opt/bind-probe
 
 FROM debian:trixie-slim
 
@@ -65,10 +67,11 @@ RUN mkdir -p /opt/qemu/kp && \
             -o "/opt/qemu/kp/$a"; \
     done && chmod +x /opt/qemu/kp/kptools-linux
 
-# Prebuilt bionic getifaddrs and raw-syscall socket bind probes. Old kernels
-# normally deny the first bind natively; running the probe still guards that
-# assumption and makes any future behavior change visible.
+# Prebuilt bionic getifaddrs, SIOCGIFCONF, and raw-syscall socket bind probes.
+# Old kernels normally deny the first bind natively; running the probe still
+# guards that assumption and makes any future behavior change visible.
 COPY --from=gai /opt/gai /opt/qemu/gai
+COPY --from=gai /opt/ifconf /opt/qemu/ifconf
 COPY --from=gai /opt/bind-probe /opt/qemu/bind-probe
 
 # run-kpm.sh reads these. The per-version Image lives at
@@ -77,4 +80,5 @@ COPY --from=gai /opt/bind-probe /opt/qemu/bind-probe
 ENV VPNHIDE_QEMU_ROOTFS=/opt/qemu/alpine-minirootfs.tar.gz
 ENV VPNHIDE_KP_BIN=/opt/qemu/kp
 ENV VPNHIDE_GAI_BIN=/opt/qemu/gai
+ENV VPNHIDE_IFC_BIN=/opt/qemu/ifconf
 ENV VPNHIDE_BIND_BIN=/opt/qemu/bind-probe

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,9 +34,9 @@ jobs:
           echo "ddkqemu=ghcr.io/${REPO,,}/ddk-qemu" >> "$GITHUB_OUTPUT"
           echo "kpmlegacy=ghcr.io/${REPO,,}/kpm-qemu-legacy:latest" >> "$GITHUB_OUTPUT"
 
-  # Build the raw-syscall probe from the PR checkout once, then feed that exact
-  # binary to every QEMU job. The long-lived QEMU images also carry a fallback
-  # copy, but relying on it makes a PR that adds/changes a probe fail until the
+  # Build native probes from the PR checkout once, then feed those exact
+  # binaries to every QEMU job. The long-lived QEMU images also carry fallback
+  # copies, but relying on them makes a PR that changes a probe fail until the
   # post-merge image rebuild catches up.
   qemu-native-probes:
     needs: setup
@@ -50,13 +50,16 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      - name: Build state-aware socket bind probe
+      - name: Build native QEMU probes
         run: |
           TC="$ANDROID_NDK_HOME/toolchains/llvm/prebuilt/linux-x86_64/bin"
           mkdir -p .artifacts/qemu-native-probes
           "$TC/aarch64-linux-android24-clang" -static -O2 -Wall -Wextra -Werror \
+            -o .artifacts/qemu-native-probes/ifconf kmod/test/ifconf-probe.c
+          "$TC/aarch64-linux-android24-clang" -static -O2 -Wall -Wextra -Werror \
             -o .artifacts/qemu-native-probes/bind-probe kmod/test/bind-probe.c
-          "$TC/llvm-strip" .artifacts/qemu-native-probes/bind-probe
+          "$TC/llvm-strip" .artifacts/qemu-native-probes/ifconf \
+            .artifacts/qemu-native-probes/bind-probe
 
       - name: Upload QEMU native probes
         uses: actions/upload-artifact@v7
@@ -327,6 +330,8 @@ jobs:
         password: ${{ secrets.GITHUB_TOKEN }}
     env:
       KMI: ${{ matrix.kmi }}
+      VPNHIDE_IFC_REQUIRED: "1"
+      VPNHIDE_IFC_BIN: ${{ github.workspace }}/.artifacts/qemu-native-probes/ifconf
       VPNHIDE_BIND_REQUIRED: "1"
       VPNHIDE_BIND_BIN: ${{ github.workspace }}/.artifacts/qemu-native-probes/bind-probe
 
@@ -343,7 +348,7 @@ jobs:
           path: .artifacts/qemu-native-probes
 
       - name: Mark QEMU native probes executable
-        run: chmod +x "$VPNHIDE_BIND_BIN"
+        run: chmod +x "$VPNHIDE_IFC_BIN" "$VPNHIDE_BIND_BIN"
 
       - name: Build module + QEMU runtime test
         # Build the module against the BAKED kernel tree (VPNHIDE_QEMU_KSRC) so
@@ -380,6 +385,7 @@ jobs:
         password: ${{ secrets.GITHUB_TOKEN }}
     env:
       KMI: ${{ matrix.kmi }}
+      VPNHIDE_IFC_BIN: ${{ github.workspace }}/.artifacts/qemu-native-probes/ifconf
       VPNHIDE_BIND_BIN: ${{ github.workspace }}/.artifacts/qemu-native-probes/bind-probe
 
     steps:
@@ -397,7 +403,7 @@ jobs:
           path: .artifacts/qemu-native-probes
 
       - name: Mark QEMU native probes executable
-        run: chmod +x "$VPNHIDE_BIND_BIN"
+        run: chmod +x "$VPNHIDE_IFC_BIN" "$VPNHIDE_BIND_BIN"
 
       - name: Build .kpm + KPM QEMU runtime test
         # `make kpm` builds the relocatable .kpm against the KernelPatch
@@ -407,6 +413,7 @@ jobs:
         # image, so a skip means it's missing — fail rather than drop coverage.
         env:
           VPNHIDE_GAI_REQUIRED: "1"
+          VPNHIDE_IFC_REQUIRED: "1"
           VPNHIDE_BIND_REQUIRED: "1"
         run: |
           CLANG_BIN="$(ls -d /opt/ddk/clang/*/bin | head -1)"
@@ -431,6 +438,7 @@ jobs:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
     env:
+      VPNHIDE_IFC_BIN: ${{ github.workspace }}/.artifacts/qemu-native-probes/ifconf
       VPNHIDE_BIND_BIN: ${{ github.workspace }}/.artifacts/qemu-native-probes/bind-probe
 
     steps:
@@ -448,7 +456,7 @@ jobs:
           path: .artifacts/qemu-native-probes
 
       - name: Mark QEMU native probes executable
-        run: chmod +x "$VPNHIDE_BIND_BIN"
+        run: chmod +x "$VPNHIDE_IFC_BIN" "$VPNHIDE_BIND_BIN"
 
       - name: Build .kpm + legacy KPM QEMU test
         # plain clang from the legacy image; the baked Image + rootfs + KP tools
@@ -458,6 +466,7 @@ jobs:
         # image, so a skip means it's missing — fail rather than drop coverage.
         env:
           VPNHIDE_GAI_REQUIRED: "1"
+          VPNHIDE_IFC_REQUIRED: "1"
           VPNHIDE_BIND_REQUIRED: "1"
         run: |
           make -C kmod kpm

--- a/changelog.d/fixed-cleared-stale-siocgifconf-buffer-entries-so-6f06.md
+++ b/changelog.d/fixed-cleared-stale-siocgifconf-buffer-entries-so-6f06.md
@@ -1,0 +1,9 @@
+_2026-08-10_
+
+## English
+
+Cleared stale SIOCGIFCONF buffer entries so apps cannot recover hidden VPN interface names past the returned length.
+
+## Русский
+
+Удалены остаточные записи из буфера SIOCGIFCONF, чтобы приложения не могли найти скрытые VPN-интерфейсы за пределами возвращённой длины.

--- a/docs/detection-vectors.md
+++ b/docs/detection-vectors.md
@@ -133,7 +133,15 @@ saw a one-interface discrepancy. `sock_ioctl_ret` now also handles the
 `ifc_req == NULL` path — it rcu-enumerates the socket's netns netdevs and subtracts
 `sizeof(struct ifreq)` per *IPv4-addressed* VPN iface (matched by `ifa_label`, the
 exact set/naming `inet_gifconf` would have emitted), so the size query agrees with
-the filtered fill. Validated by the harness `ifconf_size_probe` vector.
+the filtered fill. Validated by the harness `ifconf_probe` vector.
+
+All three native implementations also clear the compacted part of the
+kernel-written buffer before shortening `ifc_len`. Without that cleanup, a
+caller could scan its oversized buffer past the reported length and recover a
+removed VPN name (or detect duplicated entries left by compaction). The QEMU
+probe starts with a zeroed oversized buffer and verifies that no interface
+names remain in this tail; it does not require or assume that bytes beyond the
+kernel's original result are overwritten.
 
 **One narrow `SIOCGIFCONF` gap still open:**
 

--- a/kmod/kpm/vpnhide_kpm.c
+++ b/kmod/kpm/vpnhide_kpm.c
@@ -722,6 +722,7 @@ static int filter_ifconf(void *uifc)
 {
 	char ifc[16]; /* struct ifconf snapshot: len@0 (int), req@8 (ptr) */
 	char e[VPNHIDE_IFREQ_SZ];
+	char zero[VPNHIDE_IFREQ_SZ] = { 0 };
 	char *req;
 	int len, n, i, dst = 0;
 
@@ -750,6 +751,16 @@ static int filter_ifconf(void *uifc)
 	}
 	if (dst != n) {
 		int newlen = dst * VPNHIDE_IFREQ_SZ;
+		int tail;
+
+		/* The shortened length does not make the old entries disappear from
+		 * the caller-owned buffer. Clear only the kernel-written slots removed
+		 * by compaction, leaving unused caller capacity untouched. */
+		for (tail = dst; tail < n; tail++) {
+			if (_copy_to_user(req + (long)tail * VPNHIDE_IFREQ_SZ,
+					  zero, VPNHIDE_IFREQ_SZ))
+				return 0;
+		}
 
 		if (_copy_to_user(uifc, &newlen, sizeof(newlen)))
 			return 0; /* failed to shrink ifc_len */

--- a/kmod/kpm/vpnhide_kpm.c
+++ b/kmod/kpm/vpnhide_kpm.c
@@ -720,18 +720,25 @@ static void dev_ioctl_after(hook_fargs5_t *fargs, void *udata)
 
 static int filter_ifconf(void *uifc)
 {
-	char ifc[16]; /* struct ifconf snapshot: len@0 (int), req@8 (ptr) */
 	char e[VPNHIDE_IFREQ_SZ];
 	char zero[VPNHIDE_IFREQ_SZ] = { 0 };
 	char *req;
 	int len, n, i, dst = 0;
 
-	if (!_copy_from_user || !_copy_to_user)
+	uint32_t req_lo = 0, req_hi = 0;
+	long rc_len, rc_lo, rc_hi;
+
+	if (!uifc || !_copy_from_user || !_copy_to_user)
 		return 0;
-	if (_copy_from_user(ifc, uifc, sizeof(ifc)))
+	/* Read the UAPI pointer as two fixed-width words. The 5.10/5.15 KPM QEMU
+	 * targets preserved only its low word when it was copied directly into a
+	 * pointer-typed local; reconstructing both halves keeps the arm64 address. */
+	rc_len = _copy_from_user(&len, uifc, sizeof(len));
+	rc_lo = _copy_from_user(&req_lo, (char *)uifc + 8, sizeof(req_lo));
+	rc_hi = _copy_from_user(&req_hi, (char *)uifc + 12, sizeof(req_hi));
+	req = (char *)(unsigned long)(((uint64_t)req_hi << 32) | req_lo);
+	if (rc_len || rc_lo || rc_hi)
 		return 0;
-	len = *(int *)ifc;
-	req = *(char **)(ifc + 8);
 	if (!req || len <= 0)
 		return 0;
 
@@ -770,14 +777,21 @@ static int filter_ifconf(void *uifc)
 	return 0;
 }
 
-static void sock_ioctl_after(hook_fargs3_t *fargs, void *udata)
+static void sock_ioctl_before(hook_fargs3_t *fargs, void *udata)
 {
 	unsigned long cmd = (unsigned long)fargs->arg1;
-	void *argp = (void *)fargs->arg2;
+
+	fargs->local.data0 = 0;
+	if (cmd != VPNHIDE_SIOCGIFCONF || !hook_active(VPNHIDE_HOOK_SOCK_IOCTL))
+		return;
+	fargs->local.data0 = fargs->arg2;
+}
+
+static void sock_ioctl_after(hook_fargs3_t *fargs, void *udata)
+{
+	void *argp = (void *)fargs->local.data0;
 
 	if ((long)fargs->ret != 0 || !argp)
-		return;
-	if (cmd != VPNHIDE_SIOCGIFCONF || !hook_active(VPNHIDE_HOOK_SOCK_IOCTL))
 		return;
 	if (filter_ifconf(argp))
 		record_hook_hit(VPNHIDE_HOOK_SOCK_IOCTL);
@@ -1354,8 +1368,8 @@ static long vpnhide_kpm_init(const char *args, const char *event,
 	}
 	install_hook("dev_ioctl", 5, 0, (void *)dev_ioctl_after,
 		     VPNHIDE_HOOK_DEV_IOCTL);
-	install_hook("sock_ioctl", 3, 0, (void *)sock_ioctl_after,
-		     VPNHIDE_HOOK_SOCK_IOCTL);
+	install_hook("sock_ioctl", 3, (void *)sock_ioctl_before,
+		     (void *)sock_ioctl_after, VPNHIDE_HOOK_SOCK_IOCTL);
 	if (off->skb_len)
 		install_hook("rtnl_fill_ifinfo", 12, (void *)rtnl_fill_before,
 			     (void *)rtnl_fill_after,
@@ -1549,7 +1563,8 @@ static long vpnhide_kpm_exit(void *__user reserved)
 		hook_unwrap((void *)fn, 0, (void *)dev_ioctl_after);
 	fn = lookup_fn("sock_ioctl");
 	if (fn)
-		hook_unwrap((void *)fn, 0, (void *)sock_ioctl_after);
+		hook_unwrap((void *)fn, (void *)sock_ioctl_before,
+			    (void *)sock_ioctl_after);
 	fn = lookup_fn("fib_dump_info");
 	if (fn)
 		hook_unwrap((void *)fn, (void *)fib_dump_before,

--- a/kmod/test/README.md
+++ b/kmod/test/README.md
@@ -42,7 +42,7 @@ Vectors exercised (`init.sh`):
 |---|---|---|
 | getifaddrs | `ip addr show` | `rtnl_fill_ifinfo` + `inet*_fill_ifaddr` |
 | bionic getifaddrs | `/gai` static NDK probe | `rtnl_fill_ifinfo` + `inet*_fill_ifaddr` |
-| SIOCGIFCONF | `ifconfig -a` | `sock_ioctl` |
+| SIOCGIFCONF | `ifconfig -a` + `/ifconf` oversized-buffer probe | `sock_ioctl` |
 | dev ioctl by name | `ifconfig vpn0` | `dev_ioctl` |
 | /proc/net/route | `cat /proc/net/route` | `fib_route_seq_show` |
 | /proc/net/ipv6_route | `cat /proc/net/ipv6_route` | `ipv6_route_seq_show` |
@@ -78,8 +78,9 @@ to use prebuilt artifacts (CI) instead of the local cache. It also honors
 `VPNHIDE_GAI_BIN` for a prebuilt static bionic `getifaddrs()` probe and
 `VPNHIDE_GAI_REQUIRED=1` to fail instead of silently skipping that native probe.
 `VPNHIDE_IFC_BIN` / `VPNHIDE_IFC_REQUIRED=1` control the `SIOCGIFCONF`
-size-query probe, and `VPNHIDE_BIND_BIN` / `VPNHIDE_BIND_REQUIRED=1` provide the
-equivalent control for the state-aware socket-bind probe.
+size-query and stale-tail probe, and `VPNHIDE_BIND_BIN` /
+`VPNHIDE_BIND_REQUIRED=1` provide the equivalent control for the state-aware
+socket-bind probe.
 
 Requirements: `docker` (for build-kernel.sh), `qemu-system-aarch64`, `cpio`,
 `curl`.

--- a/kmod/test/ifconf-probe.c
+++ b/kmod/test/ifconf-probe.c
@@ -1,14 +1,16 @@
 /*
  * SIOCGIFCONF probe for the kmod harness — exercises the legacy ioctl
- * enumeration path, specifically the two-step "size query then fill" sequence
- * the `ip addr`/`ifconfig` shell vectors don't isolate.
+ * enumeration path, including the two-step "size query then fill" sequence
+ * and bytes left in the caller-owned buffer past the returned length.
  *
  * The classic caller first issues SIOCGIFCONF with ifc_req == NULL to learn how
  * big a buffer it needs (the kernel returns ifc_len = N * sizeof(struct ifreq)
  * without copying anything), then issues a sized call to fill it. If the kmod
  * filters the fill but leaves the size query unfiltered, the two disagree by
  * one interface for a hidden VPN — a detectable tell. This probe reports both
- * so the harness can assert they stay consistent.
+ * so the harness can assert they stay consistent. The fill buffer starts
+ * zeroed and is deliberately oversized, so any non-empty name after the
+ * returned entries is stale output left behind by in-place filtering.
  *
  * Build (static, runs on the Alpine VM regardless of its libc):
  *   <ndk>/aarch64-linux-android35-clang -static -O2 -o ifconf ifconf-probe.c
@@ -16,6 +18,8 @@
  *   IFCONF_SIZE=<n>      ifreqs reported by the NULL size-query
  *   IFCONF_FILL=<n>      ifreqs returned by a real fill
  *   IFCONF_FILL_VPN=<n>  of the fill entries, how many name "vpn0"
+ *   IFCONF_TAIL=<n>      non-empty names after the returned entries
+ *   IFCONF_TAIL_VPN=<n>  of those stale names, how many name "vpn0"
  */
 #include <net/if.h>
 #include <stdio.h>
@@ -28,11 +32,12 @@ int main(void)
 {
 	struct ifconf ifc;
 	struct ifreq buf[64];
-	int fd, i, size_n, fill_n, vpn = 0;
+	int fd, i, size_n, fill_n, vpn = 0, tail = 0, tail_vpn = 0;
 
 	fd = socket(AF_INET, SOCK_DGRAM, 0);
 	if (fd < 0) {
-		printf("IFCONF_SIZE=-1\nIFCONF_FILL=-1\nIFCONF_FILL_VPN=-1\n");
+		printf("IFCONF_SIZE=-1\nIFCONF_FILL=-1\nIFCONF_FILL_VPN=-1\n"
+		       "IFCONF_TAIL=-1\nIFCONF_TAIL_VPN=-1\n");
 		return 2;
 	}
 
@@ -47,21 +52,30 @@ int main(void)
 	size_n = ifc.ifc_len / (int)sizeof(struct ifreq);
 
 	/* Step 2: real fill into a fixed buffer. */
+	memset(buf, 0, sizeof(buf));
 	ifc.ifc_len = (int)sizeof(buf);
 	ifc.ifc_req = buf;
 	if (ioctl(fd, SIOCGIFCONF, &ifc) < 0) {
-		printf("IFCONF_SIZE=%d\nIFCONF_FILL=-1\nIFCONF_FILL_VPN=-1\n",
+		printf("IFCONF_SIZE=%d\nIFCONF_FILL=-1\nIFCONF_FILL_VPN=-1\n"
+		       "IFCONF_TAIL=-1\nIFCONF_TAIL_VPN=-1\n",
 		       size_n);
 		close(fd);
 		return 2;
 	}
 	fill_n = ifc.ifc_len / (int)sizeof(struct ifreq);
 	for (i = 0; i < fill_n; i++)
-		if (strcmp(buf[i].ifr_name, "vpn0") == 0)
+		if (strncmp(buf[i].ifr_name, "vpn0", IFNAMSIZ) == 0)
 			vpn++;
+	for (i = fill_n; i < (int)(sizeof(buf) / sizeof(buf[0])); i++) {
+		if (buf[i].ifr_name[0] != '\0')
+			tail++;
+		if (strncmp(buf[i].ifr_name, "vpn0", IFNAMSIZ) == 0)
+			tail_vpn++;
+	}
 
 	close(fd);
-	printf("IFCONF_SIZE=%d\nIFCONF_FILL=%d\nIFCONF_FILL_VPN=%d\n", size_n,
-	       fill_n, vpn);
+	printf("IFCONF_SIZE=%d\nIFCONF_FILL=%d\nIFCONF_FILL_VPN=%d\n"
+	       "IFCONF_TAIL=%d\nIFCONF_TAIL_VPN=%d\n",
+	       size_n, fill_n, vpn, tail, tail_vpn);
 	return 0;
 }

--- a/kmod/test/init-kpm.sh
+++ b/kmod/test/init-kpm.sh
@@ -84,6 +84,9 @@ if [ -x /gai ]; then
 	echo "VEC gai_getifaddrs=$(printf '%s\n' "$GAI_OUT" | sed -n 's/^GAI_VPN0=//p' | head -1)"
 	echo "VEC keep_gai_getifaddrs=$(printf '%s\n' "$GAI_OUT" | sed -n 's/^GAI_OTHER=//p' | head -1)"
 fi
+if [ -x /ifconf ]; then
+	/ifconf 2>/dev/null
+fi
 
 PANIC=$(dmesg | grep -ci 'Unable to handle\|Internal error\|Oops\|BUG:\|Kernel panic')
 echo "PANIC=$PANIC"

--- a/kmod/test/init.sh
+++ b/kmod/test/init.sh
@@ -158,35 +158,38 @@ ifc_field() {
 	/ifconf 2>/dev/null | sed -n "s/^$1=//p" | head -1
 }
 
-# SIOCGIFCONF size-query path: the legacy two-step probe (NULL ifc_req to learn
-# the size, then a sized fill). A target's size query must (a) agree with its
-# own filtered fill and (b) drop below the non-target size query — i.e. vpn0's
-# address was subtracted from the count, not just from the buffer.
-check_ifconf_size() {
+# SIOCGIFCONF probe: the target's size query must agree with its filtered fill,
+# drop below the non-target size, and leave no stale names past ifc_len.
+check_ifconf() {
 	if [ ! -x /ifconf ]; then
-		echo "RESULT ifconf_size_probe=SKIP (no ifconf probe available)"
+		echo "RESULT ifconf_probe=SKIP (no ifconf probe available)"
 		return
 	fi
 
 	set_target 5555
 	_nt_size=$(ifc_field IFCONF_SIZE)
+	_nt_tail=$(ifc_field IFCONF_TAIL)
 	set_target 0
 	_tg_size=$(ifc_field IFCONF_SIZE)
 	_tg_fill=$(ifc_field IFCONF_FILL)
 	_tg_vpn=$(ifc_field IFCONF_FILL_VPN)
+	_tg_tail=$(ifc_field IFCONF_TAIL)
 	[ -n "$_nt_size" ] || _nt_size=-1
 	[ -n "$_tg_size" ] || _tg_size=-1
 	[ -n "$_tg_fill" ] || _tg_fill=-1
 	[ -n "$_tg_vpn" ] || _tg_vpn=-1
+	[ -n "$_nt_tail" ] || _nt_tail=-1
+	[ -n "$_tg_tail" ] || _tg_tail=-1
 
 	# tg_vpn==0 guards against matching two equally-broken numbers: the fill
 	# must actually be vpn-free for the size==fill agreement to mean anything.
-	if [ "$_tg_vpn" -eq 0 ] && [ "$_tg_size" -eq "$_tg_fill" ] &&
+	if [ "$_tg_vpn" -eq 0 ] && [ "$_nt_tail" -eq 0 ] &&
+		[ "$_tg_tail" -eq 0 ] && [ "$_tg_size" -eq "$_tg_fill" ] &&
 		[ "$_nt_size" -gt "$_tg_size" ]; then
-		echo "RESULT ifconf_size_probe=PASS (nt_size=$_nt_size tg_size=$_tg_size tg_fill=$_tg_fill)"
+		echo "RESULT ifconf_probe=PASS (nt_size=$_nt_size tg_size=$_tg_size tg_fill=$_tg_fill nt_tail=$_nt_tail tg_tail=$_tg_tail)"
 		PASS=$((PASS + 1))
 	else
-		echo "RESULT ifconf_size_probe=FAIL (nt_size=$_nt_size tg_size=$_tg_size tg_fill=$_tg_fill tg_vpn=$_tg_vpn)"
+		echo "RESULT ifconf_probe=FAIL (nt_size=$_nt_size tg_size=$_tg_size tg_fill=$_tg_fill tg_vpn=$_tg_vpn nt_tail=$_nt_tail tg_tail=$_tg_tail)"
 		FAIL=$((FAIL + 1))
 	fi
 }
@@ -312,7 +315,7 @@ check_hide netlink_route6  "ip -6 route show table all"   "vpn0"   # rt6_fill_no
 check_hide hostroute6      "ip -6 route show table all"   "2001:4860" # rt6_fill_node public host-route
 check_hide policy_rule     "ip rule show"                 "199"    # fib_nl_fill_rule
 check_gai
-check_ifconf_size                                                  # sock_ioctl size-query
+check_ifconf                                                       # sock_ioctl size/tail
 check_socket_bind                                                  # interface socket binding
 
 # Non-VPN entries must survive target filtering. This catches over-trimming

--- a/kmod/test/run-kpm.sh
+++ b/kmod/test/run-kpm.sh
@@ -116,6 +116,27 @@ if [ -z "$GAI" ] && [ -n "${VPNHIDE_GAI_REQUIRED:-}" ]; then
 	exit 2
 fi
 
+# --- static SIOCGIFCONF probe (visible entries + stale tail) ----------------
+IFC=""
+if [ -n "${VPNHIDE_IFC_BIN:-}" ] && [ -x "${VPNHIDE_IFC_BIN:-}" ]; then
+	IFC="$VPNHIDE_IFC_BIN"
+	echo "[run-kpm] ifconf probe: prebuilt ($IFC)"
+else
+	IFC_CC="${VPNHIDE_IFC_CC:-$(find "$HOME/Android/Sdk/ndk" -type f -path '*/toolchains/llvm/prebuilt/*/bin/aarch64-linux-android*-clang' 2>/dev/null | sort | tail -1 || true)}"
+	if [ -n "$IFC_CC" ] && [ -x "$IFC_CC" ]; then
+		IFC="$CACHE/ifconf"
+		"$IFC_CC" -static -O2 -Wall -Wextra -Werror \
+			-o "$IFC" "$HERE/ifconf-probe.c" 2>/dev/null || IFC=""
+	fi
+	[ -n "$IFC" ] && echo "[run-kpm] ifconf probe built ($(basename "$IFC_CC"))" || \
+		echo "[run-kpm] no bionic toolchain/binary — skipping SIOCGIFCONF tail probe"
+fi
+
+if [ -z "$IFC" ] && [ -n "${VPNHIDE_IFC_REQUIRED:-}" ]; then
+	echo "ERROR: ifconf probe is required here (VPNHIDE_IFC_REQUIRED set) but unavailable."
+	exit 2
+fi
+
 # --- state-aware socket binding probe ----------------------------------------
 BIND=""
 if [ -n "${VPNHIDE_BIND_BIN:-}" ] && [ -x "${VPNHIDE_BIND_BIN:-}" ]; then
@@ -154,6 +175,7 @@ boot_phase() {
 	cp "$HERE/init-kpm.sh" "$rfs/init"
 	chmod +x "$rfs/init"
 	[ -n "$GAI" ] && { cp "$GAI" "$rfs/gai"; chmod +x "$rfs/gai"; }
+	[ -n "$IFC" ] && { cp "$IFC" "$rfs/ifconf"; chmod +x "$rfs/ifconf"; }
 	[ -n "$BIND" ] && { cp "$BIND" "$rfs/bind-probe"; chmod +x "$rfs/bind-probe"; }
 	( cd "$rfs" && find . | cpio -o -H newc 2>/dev/null | gzip > "$WORK/initramfs.$tag.gz" )
 
@@ -175,6 +197,7 @@ NT_LOG="$(boot_phase "" notarget)"
 TG_LOG="$(boot_phase $'0\n5555' target)"
 
 vec_count() { grep -oE "VEC $1=[0-9]+" "$2" | head -1 | grep -oE '[0-9]+$' || echo "-1"; }
+ifc_count() { grep -oE "$1=[0-9]+" "$2" | head -1 | grep -oE '[0-9]+$' || echo "-1"; }
 panic_count() { grep -oE 'PANIC=[0-9]+' "$1" | head -1 | grep -oE '[0-9]+$' || echo "1"; }
 kpmload() { grep -q 'KPMLOAD=ok' "$1" && echo ok || echo FAIL; }
 keep_mode() {
@@ -286,6 +309,22 @@ elif [ "$nt_keep_errno" -eq 0 ] && [ "$nt_keep_state" -eq 1 ] && \
 else
 	echo "RESULT keep_bind_device=FAIL (nt_errno=$nt_keep_errno nt_state=$nt_keep_state tg_errno=$tg_keep_errno tg_state=$tg_keep_state)"; FAIL=$((FAIL+1))
 fi
+
+if [ -z "$IFC" ]; then
+	echo "RESULT ifconf_tail=SKIP (no ifconf probe available)"
+else
+	nt_ifc_vpn="$(ifc_count IFCONF_FILL_VPN "$NT_LOG")"
+	tg_ifc_vpn="$(ifc_count IFCONF_FILL_VPN "$TG_LOG")"
+	nt_ifc_tail="$(ifc_count IFCONF_TAIL "$NT_LOG")"
+	tg_ifc_tail="$(ifc_count IFCONF_TAIL "$TG_LOG")"
+	if [ "$nt_ifc_vpn" -gt 0 ] && [ "$tg_ifc_vpn" -eq 0 ] && \
+		[ "$nt_ifc_tail" -eq 0 ] && [ "$tg_ifc_tail" -eq 0 ]; then
+		echo "RESULT ifconf_tail=PASS (nt_vpn=$nt_ifc_vpn tg_vpn=$tg_ifc_vpn nt_tail=$nt_ifc_tail tg_tail=$tg_ifc_tail)"; PASS=$((PASS+1))
+	else
+		echo "RESULT ifconf_tail=FAIL (nt_vpn=$nt_ifc_vpn tg_vpn=$tg_ifc_vpn nt_tail=$nt_ifc_tail tg_tail=$tg_ifc_tail)"; FAIL=$((FAIL+1))
+	fi
+fi
+
 for vec in proc_route_v4 getifaddrs proc_route_v6 siocgifconf dev_ioctl netlink_route4 hostroute4 netlink_route6 hostroute6 policy_rule gai_getifaddrs; do
 	# The gai_getifaddrs vector only exists when the bionic probe is available
 	# (baked VPNHIDE_GAI_BIN, or built from an NDK on this host). If neither is

--- a/kmod/test/run.sh
+++ b/kmod/test/run.sh
@@ -59,10 +59,10 @@ if [ -z "$GAI" ] && [ -n "${VPNHIDE_GAI_REQUIRED:-}" ]; then
 	exit 2
 fi
 
-# --- static SIOCGIFCONF probe (validates the ifconf size-query path) ---------
+# --- static SIOCGIFCONF probe (validates size query + stale tail) ------------
 # Reuses the same bionic toolchain as the getifaddrs probe (any libc would do
 # for this one, but keep it consistent). Built only if a toolchain is around;
-# the harness SKIPs the size-probe vectors when it's missing.
+# the harness SKIPs the probe when it's missing.
 IFC=""
 if [ -n "${VPNHIDE_IFC_BIN:-}" ] && [ -x "${VPNHIDE_IFC_BIN:-}" ]; then
 	IFC="$VPNHIDE_IFC_BIN"
@@ -74,12 +74,12 @@ else
 		"$IFC_CC" -static -O2 -o "$IFC" "$HERE/ifconf-probe.c" 2>/dev/null || IFC=""
 	fi
 	[ -n "$IFC" ] && echo "[run] ifconf probe built ($(basename "$IFC_CC"))" || \
-		echo "[run] no bionic toolchain/binary — skipping SIOCGIFCONF size-probe vector"
+		echo "[run] no bionic toolchain/binary — skipping SIOCGIFCONF probe"
 fi
 
 if [ -z "$IFC" ] && [ -n "${VPNHIDE_IFC_REQUIRED:-}" ]; then
 	echo "ERROR: ifconf probe is required here (VPNHIDE_IFC_REQUIRED set) but" \
-	     "unavailable. Refusing to pass with the SIOCGIFCONF size-query path unchecked."
+	     "unavailable. Refusing to pass with SIOCGIFCONF size/tail behavior unchecked."
 	exit 2
 fi
 

--- a/kmod/vpnhide_kmod.c
+++ b/kmod/vpnhide_kmod.c
@@ -778,10 +778,10 @@ static int sock_ioctl_entry(struct kretprobe_instance *ri, struct pt_regs *regs)
  * are safe in this context (it's the same userspace the original
  * sock_ioctl handler accessed). PAN/uaccess primitives are honoured.
  *
- * Faults are handled cleanly: if the user buffer was unmapped or
- * raced, the copy fails with -EFAULT and we report COPY_FAULT to the
- * caller, who skips the ifc_len rewrite to avoid a half-filtered
- * array (`buffer compacted, length unchanged`) escaping to userspace.
+ * If the caller races by unmapping its buffer, uaccess reports a fault and
+ * filtering stops. The buffer may already be partly rewritten, so the caller
+ * keeps the original ifc_len rather than receiving a shortened length that
+ * claims the incomplete transformation succeeded.
  */
 enum filter_ifconf_result {
 	FILTER_IFCONF_NO_CHANGE,
@@ -789,8 +789,9 @@ enum filter_ifconf_result {
 	FILTER_IFCONF_COPY_FAULT,
 };
 
-/* Compact VPN entries out of the userspace ifreq array. The caller is
- * responsible for updating `ifc_len` only on FILTER_IFCONF_CHANGED. */
+/* Compact VPN entries out of the userspace ifreq array and clear the slots
+ * removed from the kernel-written range. The caller is responsible for
+ * updating `ifc_len` only on FILTER_IFCONF_CHANGED. */
 static enum filter_ifconf_result filter_ifconf_buf(struct ifreq __user *usr_ifr,
 						   int n, int *out_len)
 {
@@ -812,6 +813,13 @@ static enum filter_ifconf_result filter_ifconf_buf(struct ifreq __user *usr_ifr,
 
 	if (dst == n)
 		return FILTER_IFCONF_NO_CHANGE;
+
+	/* Shortening ifc_len alone leaves the removed kernel output readable in
+	 * the caller-owned tail. Clear only slots the kernel returned, never the
+	 * unused remainder of the caller's buffer. */
+	if (clear_user(&usr_ifr[dst], (n - dst) * sizeof(struct ifreq)))
+		return FILTER_IFCONF_COPY_FAULT;
+
 	*out_len = dst * (int)sizeof(struct ifreq);
 	return FILTER_IFCONF_CHANGED;
 }

--- a/zygisk/src/hooks.rs
+++ b/zygisk/src/hooks.rs
@@ -540,8 +540,8 @@ fn is_siocgif(request: libc::c_ulong) -> bool {
     (0x8910..=0x8970).contains(&(request as u32))
 }
 
-/// Walk the `ifreq[]` array inside an `ifconf` and remove VPN entries
-/// by shifting non-VPN entries forward, then adjusting `ifc_len`.
+/// Walk the `ifreq[]` array inside an `ifconf`, shift non-VPN entries forward,
+/// clear the removed part of the kernel-written range, and adjust `ifc_len`.
 ///
 /// # Safety
 ///
@@ -577,7 +577,72 @@ unsafe fn filter_ifconf(ifc: *mut ifconf) {
         dst += 1;
     }
 
+    if dst != n {
+        // A caller can inspect its buffer past the shortened ifc_len. Erase
+        // only slots returned by the kernel and removed by compaction.
+        unsafe {
+            core::ptr::write_bytes(ifc.ifc_req.offset(dst as isize), 0, (n - dst) as usize);
+        }
+    }
+
     ifc.ifc_len = dst * entry_size;
+}
+
+#[cfg(test)]
+mod ifconf_tests {
+    use super::{filter_ifconf, ifconf};
+
+    fn named_ifreq(name: &[u8]) -> libc::ifreq {
+        assert!(name.len() < libc::IFNAMSIZ);
+        let mut entry = unsafe { core::mem::zeroed::<libc::ifreq>() };
+        unsafe {
+            core::ptr::copy_nonoverlapping(
+                name.as_ptr(),
+                entry.ifr_name.as_mut_ptr().cast::<u8>(),
+                name.len(),
+            );
+        }
+        entry
+    }
+
+    fn name(entry: &libc::ifreq) -> &[u8] {
+        let bytes = unsafe {
+            core::slice::from_raw_parts(entry.ifr_name.as_ptr().cast::<u8>(), entry.ifr_name.len())
+        };
+        &bytes[..bytes.iter().position(|b| *b == 0).unwrap_or(bytes.len())]
+    }
+
+    #[test]
+    fn compaction_clears_only_the_removed_kernel_output() {
+        let mut entries = [
+            named_ifreq(b"eth0"),
+            named_ifreq(b"tun0"),
+            named_ifreq(b"wlan0"),
+            named_ifreq(b"caller-owned"),
+        ];
+        let entry_size = core::mem::size_of::<libc::ifreq>();
+        let mut conf = ifconf {
+            ifc_len: (3 * entry_size) as libc::c_int,
+            ifc_req: entries.as_mut_ptr(),
+        };
+
+        unsafe { filter_ifconf(&mut conf) };
+
+        assert_eq!(conf.ifc_len, (2 * entry_size) as libc::c_int);
+        assert_eq!(name(&entries[0]), b"eth0");
+        assert_eq!(name(&entries[1]), b"wlan0");
+        assert!(
+            unsafe {
+                core::slice::from_raw_parts(
+                    (&entries[2] as *const libc::ifreq).cast::<u8>(),
+                    entry_size,
+                )
+            }
+            .iter()
+            .all(|b| *b == 0)
+        );
+        assert_eq!(name(&entries[3]), b"caller-owned");
+    }
 }
 
 // ============================================================================


### PR DESCRIPTION
## Why

After compacting filtered `SIOCGIFCONF` results, the backends shortened `ifc_len` but left removed entries in the caller-owned buffer. A detector using an oversized zeroed buffer could scan past the returned length and recover a hidden VPN name or observe duplicated entries left by compaction.

## What changed

- clear only the removed part of the kernel-written `ifreq` range in the `.ko`, KPM, and Zygisk backends
- preserve caller-owned capacity beyond the kernel result
- extend the native ifconf probe to detect stale tail entries
- run the probe for both `.ko` and KPM QEMU jobs, including legacy KPM images
- add a Zygisk unit test covering compaction, tail clearing, and the untouched caller-owned suffix

## Testing

- `cargo test --manifest-path zygisk/Cargo.toml`
- `cargo clippy --manifest-path zygisk/Cargo.toml --tests -- -D warnings`
- `scripts/clang-format-c.sh --check kmod/vpnhide_kmod.c kmod/kpm/vpnhide_kpm.c kmod/test/ifconf-probe.c`
- `shellcheck kmod/test/run.sh kmod/test/run-kpm.sh kmod/test/init.sh kmod/test/init-kpm.sh`
- host compilation of `kmod/test/ifconf-probe.c` with `-Wall -Wextra -Werror`
- `.ko` DDK build for `android14-6.1`
- KPM build

The full QEMU kernel matrix is left to CI.