### PR TITLE
ci: stabilize QEMU kernel image builds

### DIFF
--- a/.github/docker/ddk-qemu/Dockerfile
+++ b/.github/docker/ddk-qemu/Dockerfile
@@ -6,12 +6,14 @@
 #   + the Alpine minirootfs tarball (so the test needs no download at run time)
 #
 # Stock GKI boot images can't boot in plain QEMU (no virtio/console drivers),
-# so we build kernel/common@<kmi> with kmod/test/qemu.config merged onto
-# gki_defconfig, using the DDK container's matching clang. The module itself is
-# NOT baked — it's built per-PR by the kmod CI job and passed in via
+# so we build the matrix-pinned kernel/common commit for each KMI with
+# kmod/test/qemu.config merged onto gki_defconfig, using the DDK container's
+# matching clang. The module itself is NOT baked — it's built per-PR by the
+# kmod CI job and passed in via
 # VPNHIDE_QEMU_KO (a kdir-built module loads fine here: same source, same
-# vermagic). Built rarely by qemu-image.yml since kernels change seldom.
-ARG KMI
+# vermagic). Built rarely by qemu-image.yml; source updates are explicit matrix
+# pin changes rather than ambient movement of the KMI branches.
+ARG KMI=android14-6.1
 
 # --- builder: the bionic getifaddrs probe ----------------------------------
 # The gai_getifaddrs vector must run a *bionic* binary (it validates how
@@ -40,11 +42,12 @@ RUN TC="/opt/android-ndk-${NDK_VER}/toolchains/llvm/prebuilt/linux-x86_64/bin" &
 
 FROM ghcr.io/ylarod/ddk-min:${KMI}-20260313
 ARG KMI
+ARG KERNEL_COMMIT
 
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && apt-get install -y --no-install-recommends \
         qemu-system-arm cpio gzip curl ca-certificates git \
-        bc bison flex libelf-dev libssl-dev \
+        bc bison flex libelf-dev libssl-dev patch \
         gcc-aarch64-linux-gnu && \
     rm -rf /var/lib/apt/lists/*
 
@@ -55,10 +58,19 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 # (incremental-rebuild artifacts, ~half the tree, not needed for external
 # modules) to keep the image smaller.
 COPY kmod/test/qemu.config /tmp/qemu.config
+COPY .github/docker/ddk-qemu/extract-cert-key-pass.patch /tmp/extract-cert-key-pass.patch
 RUN CLANG_BIN="$(ls -d /opt/ddk/clang/*/bin | head -1)" && export PATH="$CLANG_BIN:$PATH" && \
     mkdir -p /opt/qemu && \
-    git clone --depth=1 -b "${KMI}" \
-        https://android.googlesource.com/kernel/common /opt/qemu/linux && \
+    git init /opt/qemu/linux && \
+    git -C /opt/qemu/linux remote add origin \
+        https://android.googlesource.com/kernel/common && \
+    git -C /opt/qemu/linux fetch --depth=1 origin "${KERNEL_COMMIT}" && \
+    git -C /opt/qemu/linux checkout --detach FETCH_HEAD && \
+    test "$(git -C /opt/qemu/linux rev-parse HEAD)" = "${KERNEL_COMMIT}" && \
+    case "${KMI}" in \
+        android14-6.1|android15-6.6) \
+            patch -d /opt/qemu/linux -p1 < /tmp/extract-cert-key-pass.patch ;; \
+    esac && \
     cd /opt/qemu/linux && \
     make ARCH=arm64 LLVM=1 gki_defconfig && \
     ./scripts/kconfig/merge_config.sh -m .config /tmp/qemu.config && \
@@ -67,7 +79,7 @@ RUN CLANG_BIN="$(ls -d /opt/ddk/clang/*/bin | head -1)" && export PATH="$CLANG_B
     make ARCH=arm64 LLVM=1 modules_prepare && \
     cp arch/arm64/boot/Image /opt/qemu/Image && \
     cp vmlinux.symvers Module.symvers && \
-    rm -f /tmp/qemu.config && \
+    rm -f /tmp/qemu.config /tmp/extract-cert-key-pass.patch && \
     find /opt/qemu/linux -name '*.cmd' -delete
 
 RUN curl -fsSL \

--- a/.github/docker/ddk-qemu/extract-cert-key-pass.patch
+++ b/.github/docker/ddk-qemu/extract-cert-key-pass.patch
@@ -1,0 +1,10 @@
+--- a/certs/extract-cert.c
++++ b/certs/extract-cert.c
+@@ -80,3 +80,1 @@
+-#ifdef USE_PKCS11_ENGINE
+ static const char *key_pass;
+-#endif
+@@ -111,3 +109,1 @@
+-#ifdef USE_PKCS11_ENGINE
+ 	key_pass = getenv("KBUILD_SIGN_PIN");
+-#endif

--- a/.github/workflows/qemu-image.yml
+++ b/.github/workflows/qemu-image.yml
@@ -1,8 +1,9 @@
 name: QEMU Test Images
 
 # Bakes the per-KMI kmod test images (ddk-min + qemu + a virtio GKI kernel)
-# used by the kmod QEMU runtime gate. Kernels change seldom, so this runs only
-# when the recipe changes, monthly, or on demand — not per PR.
+# used by the kmod QEMU runtime gate. Kernel commits are pinned in the matrix;
+# this runs when the recipe changes, monthly to refresh image dependencies, or
+# on demand — not per PR.
 
 on:
   push:
@@ -34,14 +35,21 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        kmi:
-          - android12-5.10
-          - android13-5.10
-          - android13-5.15
-          - android14-5.15
-          - android14-6.1
-          - android15-6.6
-          - android16-6.12
+        include:
+          - kmi: android12-5.10
+            kernel_commit: 1290154c48656bd1012a837076a0fbe379330eb3
+          - kmi: android13-5.10
+            kernel_commit: 0e7b22b8ec1e944e03b3ab937657aff77f67822e
+          - kmi: android13-5.15
+            kernel_commit: fe59c182e7da104c649b661eac72fb2a2da0bb01
+          - kmi: android14-5.15
+            kernel_commit: f9b6dcd0cc376e7e90e86d06ec344202425d6878
+          - kmi: android14-6.1
+            kernel_commit: 3f3ca1c40482a51cc007a86606ea1516fd4c5077
+          - kmi: android15-6.6
+            kernel_commit: cf8ba5678385b2b8832ed2e87c035925eb12bc4a
+          - kmi: android16-6.12
+            kernel_commit: 309759bcbe6d85ba8c702d8e1c83be556304722d
     steps:
       - uses: actions/checkout@v7
 
@@ -83,7 +91,9 @@ jobs:
         with:
           context: .
           file: .github/docker/ddk-qemu/Dockerfile
-          build-args: KMI=${{ matrix.kmi }}
+          build-args: |
+            KMI=${{ matrix.kmi }}
+            KERNEL_COMMIT=${{ matrix.kernel_commit }}
           push: true
           tags: ${{ steps.img.outputs.image }}
           # Keep reading any existing per-KMI GHA cache entries while they


### PR DESCRIPTION
## Why

The QEMU Test Images workflow repeatedly failed while compiling the Android 14 6.1 and Android 15 6.6 kernel sources. Their current `certs/extract-cert.c` guards `key_pass` inconsistently when built against the image host OpenSSL headers.

The image recipe also cloned moving KMI branch heads, so identical vpnhide commits could build different kernel sources over time.

## Changes

- pin the kernel/common commit used by every GKI image
- fetch the exact commit rather than a moving KMI branch head
- apply a narrow `extract-cert.c` backport only to the affected 6.1 and 6.6 sources
- make Dockerfile validation pass without the previous empty-ARG warning

## Testing

- `docker buildx build --check`
- workflow YAML and matrix validation
- patch dry-run against both pinned affected sources
- exact-SHA shallow fetch from android.googlesource.com
- full QEMU Test Images workflow: https://github.com/okhsunrog/vpnhide/actions/runs/31391785060 — all eight jobs passed