### PR TITLE
fix(lsposed): name profiles the system leaves nameless

### DIFF
--- a/changelog.d/fixed-apps-living-in-a-user-profile-e4c8.md
+++ b/changelog.d/fixed-apps-living-in-a-user-profile-e4c8.md
@@ -1,0 +1,9 @@
+_2026-08-11_
+
+## English
+
+Apps living in a user profile that the system leaves nameless (cloned apps, private space) are now labelled by profile type in the Hiding list instead of a bare user ID. Rows like "Beeline (10)" looked like leftovers from an app that had already been uninstalled.
+
+## Русский
+
+Приложения из профилей, у которых система не задаёт имя (клоны приложений, приватное пространство), теперь подписываются типом профиля, а не голым номером пользователя. Раньше строки вида «билайн (10)» в списке «Скрытие» выглядели как остатки уже удалённого приложения.

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/AppListCache.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/AppListCache.kt
@@ -48,10 +48,11 @@ internal fun looksLikeVpnAppName(label: String): Boolean = label.uppercase(Local
  * otherwise every row in the list reads "Cromite (0)", "Chrome (0)",
  * ... for users who don't even have a secondary profile.
  *
- * When [userNames] contains an entry for a user ID, its friendly name
- * ("Work", "Second Space") is used; otherwise we fall back to the raw
+ * When [userNames] contains an entry for a user ID, its display name
+ * ("Work", "Cloned app") is used; otherwise we fall back to the raw
  * numeric ID. This keeps the helper usable even before the user-name
- * map is loaded (no root / parse failure).
+ * map is loaded (no root / parse failure) — see
+ * [AppListCache.userNames] for how nameless profiles get a name.
  */
 internal fun labelWithUsers(
     label: String,
@@ -80,10 +81,13 @@ internal object AppListCache : StateCache<List<AppSummary>>(
 ) {
     val apps: StateFlow<List<AppSummary>?> get() = value
 
-    /** user_id → friendly profile name (e.g. 10 → "Work"). Populated
-     * from `pm list users` alongside the package scan. Empty map if
-     * root isn't available or parsing failed — `labelWithUsers` falls
-     * back to numeric IDs in that case.
+    /** user_id → display profile name (e.g. 10 → "Work"). Populated
+     * from `pm list users` alongside the package scan. Profiles the OS
+     * reports without a name — clone profiles are routinely nameless —
+     * get a name derived from their type ("Cloned app", "Private
+     * space") instead of leaking a bare user ID into the UI. Empty map
+     * if root isn't available or parsing failed — `labelWithUsers`
+     * falls back to numeric IDs in that case.
      */
     private val _userNames = MutableStateFlow<Map<Int, String>>(emptyMap())
     val userNames: StateFlow<Map<Int, String>> = _userNames.asStateFlow()
@@ -126,7 +130,7 @@ internal object AppListCache : StateCache<List<AppSummary>>(
             val pm = appContext.packageManager
             val vpnServicePkgs = queryVpnServiceProviders(pm)
             val (packages, users) = loadPackagesAndUsersViaRoot()
-            _userNames.value = users
+            _userNames.value = users.mapValues { (_, profile) -> profileDisplayName(appContext, profile) }
             if (packages.isNotEmpty()) {
                 packages.entries
                     .map { (pkg, meta) ->
@@ -211,30 +215,59 @@ internal object AppListCache : StateCache<List<AppSummary>>(
      * Enumerate every installed package and every user profile in a
      * single `su` invocation. `pm list packages -U -f --user all` gives
      * APK path + UID per (pkg, user) tuple; `pm list users` gives the
-     * friendly profile names ("Work", "Second Space") that the UI
-     * renders instead of raw user IDs. Two commands, one `su` spawn —
-     * separated by a sentinel the parser splits on.
+     * profile names ("Work", "Second Space") and types that the UI
+     * renders instead of raw user IDs. One `su` spawn — the packages
+     * section is separated from the users section by a sentinel the
+     * parser splits on.
+     *
+     * Both `pm list users` forms are emitted. `-v` is what carries the
+     * profile *type* (`profile.CLONE`, `profile.MANAGED`, …), which is
+     * the only way to name a profile the OS left nameless; it exists
+     * since Android 11 but prints "Invalid option" on anything older,
+     * so the plain form follows as the naming fallback. AOSP pins the
+     * plain format, which also makes it a safety net if an OEM reworks
+     * the verbose printf.
      *
      * Packages output is one of:
      *   package:<apk_path>=<pkg> uid:<uid>            (single-user)
      *   package:<apk_path>=<pkg> uid:<uid>,<uid>,...  (AOSP --user all)
      *   package:<apk_path>=<pkg> uid:<uid>            (repeated per user
      *                                                  on some ROMs)
-     * Users output is:
-     *   UserInfo{<id>:<name>:<flags>} [running ...]
+     * Users output is parsed by [parseUserProfiles].
      */
-    private fun loadPackagesAndUsersViaRoot(): Pair<Map<String, PkgMeta>, Map<Int, String>> {
+    private fun loadPackagesAndUsersViaRoot(): Pair<Map<String, PkgMeta>, Map<Int, UserProfileInfo>> {
         val (exitCode, raw) =
             suExec(
                 "pm list packages -U -f --user all 2>/dev/null; " +
                     "echo '$USERS_SENTINEL'; " +
+                    "pm list users -v 2>/dev/null; " +
                     "pm list users 2>/dev/null",
             )
         if (exitCode != 0) return emptyMap<String, PkgMeta>() to emptyMap()
         val parts = raw.split(USERS_SENTINEL, limit = 2)
         val packages = parsePackages(parts[0])
-        val users = if (parts.size > 1) parseUsers(parts[1]) else emptyMap()
+        val users = if (parts.size > 1) parseUserProfiles(parts[1]) else emptyMap()
         return packages to users
+    }
+
+    /**
+     * A profile's own name wins — it is what the system UI shows. Only
+     * when the OS reports none do we synthesize one from the profile
+     * type, so the Hiding list never shows a bare `(10)` the user can't
+     * place against anything on their device.
+     */
+    private fun profileDisplayName(
+        context: Context,
+        profile: UserProfileInfo,
+    ): String {
+        profile.name?.let { return it }
+        return when (profile.kind) {
+            UserProfileKind.WORK -> context.getString(R.string.profile_kind_work)
+            UserProfileKind.CLONE -> context.getString(R.string.profile_kind_clone)
+            UserProfileKind.PRIVATE -> context.getString(R.string.profile_kind_private)
+            UserProfileKind.SECONDARY -> context.getString(R.string.profile_kind_secondary, profile.id)
+            UserProfileKind.UNKNOWN -> context.getString(R.string.profile_kind_unknown, profile.id)
+        }
     }
 
     private fun parsePackages(raw: String): Map<String, PkgMeta> {
@@ -271,23 +304,6 @@ internal object AppListCache : StateCache<List<AppSummary>>(
                         )
                     }
             }
-        return out
-    }
-
-    // `UserInfo{10:Work:1030}` — flags are trailing hex, name is
-    // everything between the first `:` and the last `:`. The lazy
-    // name-group (.*?) combined with a greedy flags-group anchored to
-    // `}` handles names that contain `:` (rare, but Android allows it).
-    private val userLine = Regex("""UserInfo\{(\d+):(.*?):[0-9a-fA-F]+\}""")
-
-    private fun parseUsers(raw: String): Map<Int, String> {
-        val out = LinkedHashMap<Int, String>()
-        raw.lineSequence().forEach { line ->
-            val m = userLine.find(line) ?: return@forEach
-            val id = m.groupValues[1].toIntOrNull() ?: return@forEach
-            val name = m.groupValues[2].trim()
-            if (name.isNotEmpty()) out[id] = name
-        }
         return out
     }
 

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/UserProfileData.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/UserProfileData.kt
@@ -1,0 +1,98 @@
+package dev.okhsunrog.vpnhide
+
+import java.util.Locale
+
+/**
+ * What kind of Android user a secondary profile is. Derived from
+ * `pm list users -v`, which is the only place the type is exposed to a
+ * shell — the plain `pm list users` output carries the name only.
+ */
+internal enum class UserProfileKind {
+    WORK,
+    CLONE,
+    PRIVATE,
+    SECONDARY,
+    UNKNOWN,
+}
+
+/**
+ * One row of `pm list users`. [name] is null when the OS reports no name
+ * for the profile — clone profiles in particular are commonly created
+ * nameless, which is what used to leave the Hiding list showing a bare
+ * `(10)` next to an app the user could not place.
+ */
+internal data class UserProfileInfo(
+    val id: Int,
+    val name: String?,
+    val kind: UserProfileKind,
+)
+
+// Verbose row, Android 13+:
+//   1: id=10, name=null, type=profile.CLONE, flags=PROFILE|... (parentId=0)
+// Android 11/12 print the same row without the `type=` field, so that
+// group is optional and the kind falls back to the flags.
+private val verboseUserLine =
+    Regex("""^\s*\d+:\s*id=(\d+),\s*name=(.*?),\s*(?:type=([^,]+),\s*)?flags=(\S*)""")
+
+// `UserInfo{10:Work:1030}` — flags are trailing hex, name is everything
+// between the first `:` and the last `:`. The lazy name-group (.*?)
+// combined with a greedy flags-group anchored to `}` handles names that
+// contain `:` (rare, but Android allows it). AOSP pins this format, so it
+// stays the fallback when the verbose form is unavailable or unparsable.
+private val legacyUserLine = Regex("""UserInfo\{(\d+):(.*?):[0-9a-fA-F]+\}""")
+
+/** `name=null` is what the verbose printf emits for a nameless profile. */
+private fun normalizeName(raw: String): String? = raw.trim().takeIf { it.isNotEmpty() && it != "null" }
+
+internal fun classifyUserProfile(
+    type: String?,
+    flags: String?,
+): UserProfileKind {
+    val t = type?.uppercase(Locale.ROOT).orEmpty()
+    val f = flags?.uppercase(Locale.ROOT).orEmpty()
+    return when {
+        t.contains("MANAGED") || f.contains("MANAGED_PROFILE") -> UserProfileKind.WORK
+        t.contains("CLONE") -> UserProfileKind.CLONE
+        t.contains("PRIVATE") -> UserProfileKind.PRIVATE
+        t.startsWith("FULL") -> UserProfileKind.SECONDARY
+        t.startsWith("PROFILE") -> UserProfileKind.UNKNOWN
+        f.contains("FULL") -> UserProfileKind.SECONDARY
+        else -> UserProfileKind.UNKNOWN
+    }
+}
+
+/**
+ * Parse the users section of the package/user scan. The section holds the
+ * output of `pm list users -v` followed by plain `pm list users`, so both
+ * formats are accepted: the verbose rows carry the profile type, the plain
+ * rows are the naming fallback for ROMs where `-v` isn't supported.
+ */
+internal fun parseUserProfiles(raw: String): Map<Int, UserProfileInfo> {
+    val out = LinkedHashMap<Int, UserProfileInfo>()
+    raw.lineSequence().forEach { line ->
+        val verbose = verboseUserLine.find(line)
+        if (verbose != null) {
+            val id = verbose.groupValues[1].toIntOrNull() ?: return@forEach
+            out[id] =
+                UserProfileInfo(
+                    id = id,
+                    name = normalizeName(verbose.groupValues[2]),
+                    kind = classifyUserProfile(verbose.groupValues[3], verbose.groupValues[4]),
+                )
+            return@forEach
+        }
+        val legacy = legacyUserLine.find(line) ?: return@forEach
+        val id = legacy.groupValues[1].toIntOrNull() ?: return@forEach
+        val name = normalizeName(legacy.groupValues[2])
+        val existing = out[id]
+        out[id] =
+            if (existing == null) {
+                UserProfileInfo(id = id, name = name, kind = UserProfileKind.UNKNOWN)
+            } else {
+                // The verbose row already classified this profile; the plain
+                // row can still supply a name the verbose row printed as null.
+                existing.copy(name = existing.name ?: name)
+            }
+    }
+    return out
+}

--- a/lsposed/app/src/main/res/values-ru/strings.xml
+++ b/lsposed/app/src/main/res/values-ru/strings.xml
@@ -19,6 +19,14 @@
     <string name="target_group_configured">Настроенные</string>
     <string name="target_group_other_apps">Остальные приложения</string>
     <string name="target_group_header">%1$s · %2$d</string>
+
+    <!-- Fallback names for user profiles the system reports without a name -->
+    <string name="profile_kind_work">Рабочий профиль</string>
+    <string name="profile_kind_clone">Клон приложения</string>
+    <string name="profile_kind_private">Приватное пространство</string>
+    <string name="profile_kind_secondary">Пользователь %d</string>
+    <string name="profile_kind_unknown">Профиль %d</string>
+
     <string name="apps_help_title">Как это работает</string>
     <string name="java_hooks_title">Java-хуки</string>
     <string name="native_hooks_title">Нативные хуки</string>

--- a/lsposed/app/src/main/res/values/strings.xml
+++ b/lsposed/app/src/main/res/values/strings.xml
@@ -19,6 +19,13 @@
     <string name="target_group_configured">Configured</string>
     <string name="target_group_other_apps">Other apps</string>
     <string name="target_group_header">%1$s · %2$d</string>
+
+    <!-- Fallback names for user profiles the system reports without a name -->
+    <string name="profile_kind_work">Work profile</string>
+    <string name="profile_kind_clone">Cloned app</string>
+    <string name="profile_kind_private">Private space</string>
+    <string name="profile_kind_secondary">User %d</string>
+    <string name="profile_kind_unknown">Profile %d</string>
     <string name="apps_help_title">How it works</string>
     <string name="chip_java" translatable="false">J</string>
     <string name="chip_native" translatable="false">N</string>

--- a/lsposed/app/src/test/kotlin/dev/okhsunrog/vpnhide/UserProfileDataTest.kt
+++ b/lsposed/app/src/test/kotlin/dev/okhsunrog/vpnhide/UserProfileDataTest.kt
@@ -1,0 +1,118 @@
+package dev.okhsunrog.vpnhide
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class UserProfileDataTest {
+    @Test
+    fun `parses verbose rows with profile types`() {
+        val raw =
+            """
+            3 users:
+
+            0: id=0, name=Owner, type=full.SYSTEM, flags=ADMIN|FULL|INITIALIZED|PRIMARY|SYSTEM (running) (current)
+            1: id=10, name=null, type=profile.CLONE, flags=INITIALIZED|PROFILE (parentId=0) (running)
+            2: id=11, name=Рабочий профиль, type=profile.MANAGED, flags=INITIALIZED|MANAGED_PROFILE|PROFILE (parentId=0)
+            """.trimIndent()
+
+        val profiles = parseUserProfiles(raw)
+
+        assertEquals(setOf(0, 10, 11), profiles.keys)
+        assertEquals("Owner", profiles[0]?.name)
+        assertEquals(UserProfileKind.SECONDARY, profiles[0]?.kind)
+        assertNull(profiles[10]?.name)
+        assertEquals(UserProfileKind.CLONE, profiles[10]?.kind)
+        assertEquals("Рабочий профиль", profiles[11]?.name)
+        assertEquals(UserProfileKind.WORK, profiles[11]?.kind)
+    }
+
+    @Test
+    fun `parses android 11 verbose rows that carry no type field`() {
+        val raw =
+            """
+            2 users:
+
+            0: id=0, name=Owner, flags=ADMIN|FULL|INITIALIZED|PRIMARY|SYSTEM (running) (current)
+            1: id=10, name=Work profile, flags=INITIALIZED|MANAGED_PROFILE|PROFILE (running)
+            """.trimIndent()
+
+        val profiles = parseUserProfiles(raw)
+
+        assertEquals("Work profile", profiles[10]?.name)
+        assertEquals(UserProfileKind.WORK, profiles[10]?.kind)
+        assertEquals(UserProfileKind.SECONDARY, profiles[0]?.kind)
+    }
+
+    @Test
+    fun `falls back to the plain UserInfo format when verbose is unsupported`() {
+        val raw =
+            """
+            Invalid option: -v
+            Users:
+            	UserInfo{0:Owner:c13} running
+            	UserInfo{10:Second Space:10} running
+            """.trimIndent()
+
+        val profiles = parseUserProfiles(raw)
+
+        assertEquals(setOf(0, 10), profiles.keys)
+        assertEquals("Second Space", profiles[10]?.name)
+        assertEquals(UserProfileKind.UNKNOWN, profiles[10]?.kind)
+    }
+
+    @Test
+    fun `plain rows supply a name the verbose row printed as null`() {
+        val raw =
+            """
+            1: id=10, name=null, type=profile.CLONE, flags=INITIALIZED|PROFILE (parentId=0)
+            Users:
+            	UserInfo{10:Клон:1030} running
+            """.trimIndent()
+
+        val profiles = parseUserProfiles(raw)
+
+        assertEquals("Клон", profiles[10]?.name)
+        // The verbose classification survives the merge.
+        assertEquals(UserProfileKind.CLONE, profiles[10]?.kind)
+    }
+
+    @Test
+    fun `plain rows do not overwrite a name the verbose row already had`() {
+        val raw =
+            """
+            1: id=10, name=Verbose name, type=profile.MANAGED, flags=MANAGED_PROFILE|PROFILE
+            	UserInfo{10:Legacy name:1030} running
+            """.trimIndent()
+
+        assertEquals("Verbose name", parseUserProfiles(raw)[10]?.name)
+    }
+
+    @Test
+    fun `nameless profiles stay nameless instead of being dropped`() {
+        // The old parser skipped empty names outright, which is what left a
+        // bare user ID in the Hiding list for nameless clone profiles.
+        val profiles = parseUserProfiles("\tUserInfo{10::1030} running")
+
+        assertEquals(setOf(10), profiles.keys)
+        assertNull(profiles[10]?.name)
+    }
+
+    @Test
+    fun `classifies by type first and by flags when the type is absent`() {
+        assertEquals(UserProfileKind.WORK, classifyUserProfile("profile.MANAGED", "PROFILE"))
+        assertEquals(UserProfileKind.WORK, classifyUserProfile(null, "INITIALIZED|MANAGED_PROFILE"))
+        assertEquals(UserProfileKind.CLONE, classifyUserProfile("profile.CLONE", "PROFILE"))
+        assertEquals(UserProfileKind.PRIVATE, classifyUserProfile("profile.PRIVATE", "PROFILE"))
+        assertEquals(UserProfileKind.SECONDARY, classifyUserProfile("full.SECONDARY", "FULL"))
+        assertEquals(UserProfileKind.SECONDARY, classifyUserProfile(null, "FULL|INITIALIZED"))
+        // An unrecognised profile type must not be mislabelled as a full user.
+        assertEquals(UserProfileKind.UNKNOWN, classifyUserProfile("profile.SUPERVISING", "PROFILE"))
+        assertEquals(UserProfileKind.UNKNOWN, classifyUserProfile(null, null))
+    }
+
+    @Test
+    fun `ignores unrelated output lines`() {
+        assertEquals(emptyMap<Int, UserProfileInfo>(), parseUserProfiles("Users:\npackage:/data/app/x=y uid:1010"))
+    }
+}


### PR DESCRIPTION
The Hiding list showed a bare user ID for apps living in a profile that `pm list users` reports without a name — clone profiles are routinely nameless — so a row read "Beeline (10)" and was reasonably mistaken for a leftover from an already-uninstalled app (reported in #252). The list itself is correct: it comes from a live `pm list packages -U -f --user all` on every launch with no disk cache, and uninstalled packages don't appear there since `MATCH_UNINSTALLED_PACKAGES` is never passed. Only the label was unreadable. The old parser made it worse by dropping `pm list users` entries with an empty name outright, so those profiles had no name to fall back to at all.

- Add `UserProfileData.kt` with `parseUserProfiles` / `classifyUserProfile`: pure parsing of both `pm list users` formats and a `WORK / CLONE / PRIVATE / SECONDARY / UNKNOWN` classification.
- Ask for `pm list users -v` in the existing package/user `su` spawn — it is the only shell-visible source of the profile type — keeping the plain form after it as the fallback for pre-Android-11 ROMs and as a safety net if an OEM reworks the verbose printf.
- Classify by `type=` when present and by `flags=` when it isn't; Android 11/12 print the verbose row without a type field.
- Keep nameless profiles in the map instead of discarding them, and derive a display name from the kind. A profile's own name still wins, since that is what the system UI shows.
- Add EN/RU strings: Work profile, Cloned app, Private space, User %d, Profile %d.
- Cover the parser with `UserProfileDataTest`: verbose rows with types, Android 11 rows without them, the plain-format fallback, verbose/plain merging in both directions, nameless profiles surviving, and the classification table.

This changes the label only. An app that is genuinely still installed in another profile stays in the list — as it should — but now reads "Beeline (Cloned app)" instead of "Beeline (10)".
