### PR TITLE
Refactor diagnostics into one canonical report and carry it into the debug bundle

### DIFF
--- a/changelog.d/changed-diagnostics-debug-export-now-records-each-9c22.md
+++ b/changelog.d/changed-diagnostics-debug-export-now-records-each-9c22.md
@@ -1,0 +1,9 @@
+_2026-08-11_
+
+## English
+
+Diagnostics debug export now records each check's full outcome (leak / hidden by backend / hidden by SELinux) and the root ground-truth behind it, plus each layer's verdict and a machine-readable diagnostics.json — instead of a plain pass/fail list.
+
+## Русский
+
+Экспорт диагностики теперь фиксирует по каждой проверке полный исход (утечка / скрыто бэкендом / скрыто SELinux) и данные от root, на которых он основан, а также вердикт каждого слоя и машиночитаемый diagnostics.json — вместо простого списка pass/fail.

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/AgentControl.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/AgentControl.kt
@@ -657,13 +657,12 @@ private fun LayerStatus.toAgentStatus(): String =
 
 private fun CheckResults.toAgentDiagnosticsReport(): AgentDiagnosticsReport {
     val score = all.score()
-    // Native checks (in NATIVE_CHECKS order) carry the root-differential outcome;
-    // Java checks carry the gate-derived outcome on the result itself. nativeExtra
-    // (Java-implemented native-level probes) has no outcome.
+    // Every check carries its own root-differential/gate outcome now, so no join
+    // back to NATIVE_CHECKS by index. nativeExtra (Java-implemented native-level
+    // probes) has no root differential and reports on the tri-state only.
     val nativeWithOutcomes =
-        native.mapIndexed { i, cr ->
-            cr.toAgentCheckResult(nativeOutcomes[NATIVE_CHECKS.getOrNull(i)?.id]?.token())
-        } + nativeExtra.map { it.toAgentCheckResult(null) }
+        native.map { it.toAgentCheckResult(it.outcome?.token()) } +
+            nativeExtra.map { it.toAgentCheckResult(null) }
     return AgentDiagnosticsReport(
         state = "ready",
         score = AgentCheckScore(score.passed, score.total),

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DashboardData.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DashboardData.kt
@@ -1282,12 +1282,7 @@ internal suspend fun loadDashboardState(
     val hookProps = parseLsposedStateMetadata(lsposedStateRaw)
     val hookVersion = hookProps["version"]
     val hookBootId = hookProps["boot_id"]
-    val hooksActiveThisBoot =
-        lsposedStatus?.backend ==
-            HookIds.Backend.LSPOSED.id
-                .toLong() &&
-            hookBootId != null &&
-            hookBootId == currentBootId.trim()
+    val hooksActiveThisBoot = lsposedHooksActiveThisBoot(lsposedStateRaw, currentBootId)
     val lsposedTargetCount = countPackages(targetsSnapshot.lsposedTargets)
     val lsposedFramework = detectLsposedFramework(shellSnapshot)
     val lsposedConfig =

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DashboardData.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DashboardData.kt
@@ -1648,18 +1648,20 @@ internal suspend fun loadDashboardState(
                         ProtectionCheck.NoVpn
                     }
                 } else {
-                    // Tiles judge each backend on the vectors it owns; unowned leaks
-                    // (out of scope for the tile) are surfaced via the hero warning below.
-                    val native = summarizeNativeLayer(nativeBackend, checks.nativeOutcomes)
-                    val java = summarizeJavaLayer(lsposed is LsposedState.Active, checks.java)
-                    // Rust-probe leaks the tile doesn't own, plus any Java-native
-                    // probe (nativeExtra) that saw the VPN — the latter has no
-                    // outcome, so fold its raw fails in here so they still warn.
-                    unownedNativeLeakCount =
-                        unownedNativeLeaks(nativeBackend, checks.nativeOutcomes) +
-                        checks.nativeExtra.count { it.passed == false }
-                    VpnHideLog.i(TAG, "nativeLayer=$native javaLayer=$java unownedLeaks=$unownedNativeLeakCount")
-                    ProtectionCheck.Checked(native, java)
+                    // Derive tiles from the one canonical report (the same object the
+                    // debug bundle renders), so the on-screen verdict and the exported
+                    // one can never diverge. Tiles judge each backend on the vectors it
+                    // owns; unowned leaks are surfaced via the hero warning below.
+                    val report =
+                        buildDiagnosticReport(
+                            gate = DiagnosticGate.ROUTED,
+                            results = checks,
+                            backend = nativeBackend,
+                            lsposedActive = lsposed is LsposedState.Active,
+                            complete = true,
+                        )
+                    unownedNativeLeakCount = report.native.unownedLeaks
+                    ProtectionCheck.Checked(report.native.status, report.java.status)
                 }
             }
         }

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DebugExport.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DebugExport.kt
@@ -77,7 +77,7 @@ internal suspend fun exportDebugZip(
                     context = context,
                     shellSnapshot = shellSnapshot,
                     counterBaseline = counterBaseline,
-                    results = checkResults,
+                    report = report,
                 )
             files["dmesg_vpnhide.txt"] = filterVpnHideDmesg(dmesg)
             files["dmesg_full.txt"] = dmesg.ifBlank { "(no dmesg entries)" }

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DebugExport.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DebugExport.kt
@@ -54,29 +54,24 @@ internal suspend fun exportDebugZip(
             restoreAttempted = true
             val completedLoggingSession = loggingSession.withRestore(restore)
 
-            // 4. Collect everything into named files — each section is its own
-            //    builder below.
+            // 4. Fold the run into the one canonical report (the same object the
+            //    dashboard renders), then collect everything into named files.
+            val report = buildExportDiagnosticReport(context, checkResults, shellSnapshot, selfNeedsRestart)
             val files =
                 linkedMapOf(
                     "summary.txt" to
                         buildDiagnosticSummaryText(
                             context = context,
                             selfNeedsRestart = selfNeedsRestart,
-                            results = checkResults,
+                            report = report,
                             shellSnapshot = shellSnapshot,
                             loggingSession = completedLoggingSession,
                             captureKind = "debug_zip",
                         ),
-                    "diagnostics.txt" to buildDiagnosticsText(checkResults),
+                    "diagnostics.txt" to report.toDiagnosticsText(),
+                    "diagnostics.json" to report.toJson(),
                 )
-            files.putAll(
-                buildCommonDiagnosticTextFiles(
-                    context = context,
-                    selfNeedsRestart = selfNeedsRestart,
-                    shellSnapshot = shellSnapshot,
-                    loggingSession = completedLoggingSession,
-                ),
-            )
+            files.putAll(buildCommonDiagnosticTextFiles(context, selfNeedsRestart, shellSnapshot, completedLoggingSession))
             files["hook_report.txt"] =
                 buildHookDiagnosticsText(
                     context = context,
@@ -108,34 +103,58 @@ internal suspend fun exportDebugZip(
         }
     }
 
-// ── Debug-zip section builders (each produces one file in the export) ─────
+/**
+ * Fold the forced capture run into the canonical [DiagnosticReport]. Derives the
+ * gate (VPN presence + self-in-tunnel + pending restart), the active native backend,
+ * and the Java-layer liveness from the same helpers the dashboard uses, so the
+ * bundle's verdict is identical to the on-screen one.
+ */
+private suspend fun buildExportDiagnosticReport(
+    context: Context,
+    checkResults: CheckResults,
+    shellSnapshot: DebugShellSnapshot,
+    selfNeedsRestart: Boolean,
+): DiagnosticReport =
+    buildDiagnosticReport(
+        gate =
+            resolveDiagnosticGate(
+                vpnActive = isVpnActive(),
+                selfRouted = GroundTruthProbe.selfRoutedThroughVpn(context),
+                selfNeedsRestart = selfNeedsRestart,
+            ),
+        results = checkResults,
+        backend = displayNativeBackend(detectNativeBackendStates(shellSnapshot.sections)),
+        lsposedActive =
+            lsposedHooksActiveThisBoot(
+                shellSnapshot.sections["lsposed_state"].orEmpty(),
+                shellSnapshot.sections["current_boot_id"].orEmpty(),
+            ),
+        complete = true,
+    )
 
-private fun badge(passed: Boolean?): String =
-    when (passed) {
-        true -> "PASS"
-        false -> "FAIL"
-        null -> "INFO"
-    }
+// ── Debug-zip section builders (each produces one file in the export) ─────
 
 internal fun buildDiagnosticSummaryText(
     context: Context,
     selfNeedsRestart: Boolean,
-    results: CheckResults?,
+    report: DiagnosticReport?,
     shellSnapshot: DebugShellSnapshot,
     loggingSession: DebugCaptureLoggingSession,
     captureKind: String,
 ): String =
     buildString {
-        appendLine("Diagnostic bundle schema: 3")
+        appendLine("Diagnostic bundle schema: 4")
         appendLine("Capture type: $captureKind")
         appendLine("Generated: ${SimpleDateFormat("yyyy-MM-dd HH:mm:ss Z", Locale.US).format(Date())}")
         appendLine("App package: ${context.packageName}")
         appendLine("App version: ${appVersionText(context)}")
-        if (results == null) {
+        if (report == null) {
             appendLine("Diagnostics: not run")
         } else {
-            val score = results.all.score()
-            appendLine("Diagnostics: ${score.passed}/${score.total} passed")
+            appendLine("Diagnostics gate: ${report.gate.name.lowercase()}")
+            appendLine("Native verdict: ${report.native.verdictLabel()}")
+            appendLine("Java verdict: ${report.java.verdictLabel()}")
+            appendLine("Outcomes: ${report.outcomeTally()}")
         }
         appendLine("selfNeedsRestart: $selfNeedsRestart")
         appendLine("debugCaptureForced: ${loggingSession.forced}")
@@ -187,24 +206,6 @@ internal fun writeDiagnosticZip(
         }
     }
 }
-
-private fun buildDiagnosticsText(results: CheckResults): String =
-    buildString {
-        val score = results.all.score()
-        appendLine("=== Diagnostics: ${score.passed}/${score.total} passed ===")
-        appendLine()
-        appendLine("--- Native level ---")
-        for (c in results.nativeAll) {
-            appendLine("[${badge(c.passed)}] ${c.name}")
-            appendLine("  ${c.detail}")
-        }
-        appendLine()
-        appendLine("--- Java API level ---")
-        for (c in results.java) {
-            appendLine("[${badge(c.passed)}] ${c.name}")
-            appendLine("  ${c.detail}")
-        }
-    }
 
 private fun buildDeviceInfoText(
     context: Context,

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DiagnosticReport.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DiagnosticReport.kt
@@ -1,0 +1,172 @@
+package dev.okhsunrog.vpnhide
+
+import dev.okhsunrog.vpnhide.generated.HookIds
+
+/**
+ * Schema version for the serialized report (the debug bundle's `diagnostics.json`
+ * and the summary header). Bump when the wire shape changes.
+ */
+internal const val DIAGNOSTIC_REPORT_SCHEMA: Int = 1
+
+internal enum class CheckLayer { NATIVE, JAVA }
+
+/**
+ * Why the check suite did or did not run this session — the terminal gate from
+ * [DiagnosticsCache]. Only [ROUTED] yields measured per-layer verdicts; the other
+ * states mean "we deliberately did not measure" (VPN off, this app split-tunnelled
+ * out of the VPN, or a pending self-restart), which a consumer must surface
+ * instead of a misleading clean/Ok result.
+ */
+internal enum class DiagnosticGate { VPN_OFF, SELF_NOT_ROUTED, NEEDS_RESTART, ROUTED }
+
+/**
+ * One fully-classified check: the root-differential [outcome] plus the evidence
+ * behind it — the app-view [appDetail], the root [groundTruthDetail] (native
+ * probes run as root), and, for native probes, the hooks that should cover the
+ * vector and whether the active backend [owned] it.
+ */
+internal data class DiagnosticCheck(
+    val id: String,
+    val label: String,
+    val layer: CheckLayer,
+    val outcome: CheckOutcome,
+    val appDetail: String,
+    val groundTruthDetail: String?,
+    val expectedHooks: List<HookIds.Hook>,
+    val owned: Boolean,
+)
+
+/** Per-layer rollup: presence/verdict plus the classified checks that produced it. */
+internal data class LayerReport(
+    val layer: CheckLayer,
+    val backend: NativeBackendId?,
+    val status: LayerStatus,
+    // Leaks on vectors the active backend does NOT own (native only) — surfaced as
+    // a warning, never counted against the tile verdict. Always 0 for the Java layer.
+    val unownedLeaks: Int,
+    val checks: List<DiagnosticCheck>,
+) {
+    /** Ok/Partial/Broken when the layer is [LayerStatus.Active]; null otherwise.
+     * Only meaningful when the report's [DiagnosticReport.gate] is
+     * [DiagnosticGate.ROUTED] — a gated report carries presence only. */
+    val verdict: Verdict? get() = (status as? LayerStatus.Active)?.verdict
+}
+
+/**
+ * The single canonical diagnostic snapshot.
+ *
+ * The app used to re-derive the diagnostic verdict independently in four places
+ * (dashboard tiles, the Diagnostics screen, the agent bridge, and the debug-ZIP
+ * text renderers), each flattening the rich per-check attribution back down to a
+ * PASS/FAIL badge. [buildDiagnosticReport] computes the whole thing **once**;
+ * every consumer is a pure render of this object, so no two views can disagree
+ * and the debug bundle carries exactly what the UI shows.
+ */
+internal data class DiagnosticReport(
+    val gate: DiagnosticGate,
+    val native: LayerReport,
+    val java: LayerReport,
+    // False after the fast core phase, true once the slow Java probes have filled in.
+    val complete: Boolean,
+    val schema: Int = DIAGNOSTIC_REPORT_SCHEMA,
+)
+
+/**
+ * Fold the raw check run into the canonical [DiagnosticReport]. Pure: same inputs
+ * → same report, no Android or IO dependency, so it is unit-tested directly.
+ *
+ * [results] is null when the gate blocked the run ([DiagnosticGate.ROUTED] is the
+ * only gate that carries measurements); the layers then report presence only and
+ * their [LayerReport.verdict] must not be consulted.
+ */
+internal fun buildDiagnosticReport(
+    gate: DiagnosticGate,
+    results: CheckResults?,
+    backend: DisplayNativeBackend,
+    lsposedActive: Boolean,
+    complete: Boolean,
+): DiagnosticReport {
+    val nativeOutcomes = results?.nativeOutcomes ?: emptyMap()
+    val unowned =
+        if (results == null) {
+            0
+        } else {
+            unownedNativeLeaks(backend, nativeOutcomes) + results.nativeExtra.count { it.passed == false }
+        }
+    return DiagnosticReport(
+        gate = gate,
+        native =
+            LayerReport(
+                layer = CheckLayer.NATIVE,
+                backend = backend.id,
+                status = summarizeNativeLayer(backend, nativeOutcomes),
+                unownedLeaks = unowned,
+                checks = nativeDiagnosticChecks(results, backend),
+            ),
+        java =
+            LayerReport(
+                layer = CheckLayer.JAVA,
+                backend = null,
+                status = summarizeJavaLayer(lsposedActive, results?.java ?: emptyList()),
+                unownedLeaks = 0,
+                checks = javaDiagnosticChecks(results),
+            ),
+        complete = complete,
+    )
+}
+
+private fun nativeDiagnosticChecks(
+    results: CheckResults?,
+    backend: DisplayNativeBackend,
+): List<DiagnosticCheck> {
+    if (results == null) return emptyList()
+    val ownMask = nativeOwnMask(backend.id)
+    // native and nativeExtra are built in NATIVE_CHECKS order, so a positional zip
+    // is stable by construction — the spec carries the stable id + hook coverage,
+    // the result carries the localized label, outcome, and root ground-truth detail.
+    val owned =
+        NATIVE_CHECKS.zip(results.native) { spec, cr ->
+            DiagnosticCheck(
+                id = spec.id,
+                label = cr.name,
+                layer = CheckLayer.NATIVE,
+                outcome = cr.outcome ?: CheckOutcome.NotMeasured(NotMeasuredReason.NoGroundTruth),
+                appDetail = cr.detail,
+                groundTruthDetail = cr.groundTruthDetail,
+                expectedHooks = spec.expectedHooks.toList(),
+                owned = spec.hasHookIn(ownMask),
+            )
+        }
+    // Java-implemented native-level probes (NetworkInterface enum): no hook
+    // ownership and no root differential, so the outcome comes off the tri-state.
+    val extra =
+        results.nativeExtra.map { cr ->
+            DiagnosticCheck(
+                id = "",
+                label = cr.name,
+                layer = CheckLayer.NATIVE,
+                outcome = cr.outcome ?: classifyJavaOutcome(cr.passed),
+                appDetail = cr.detail,
+                groundTruthDetail = null,
+                expectedHooks = emptyList(),
+                owned = false,
+            )
+        }
+    return owned + extra
+}
+
+private fun javaDiagnosticChecks(results: CheckResults?): List<DiagnosticCheck> =
+    results
+        ?.java
+        ?.map { cr ->
+            DiagnosticCheck(
+                id = "",
+                label = cr.name,
+                layer = CheckLayer.JAVA,
+                outcome = cr.outcome ?: classifyJavaOutcome(cr.passed),
+                appDetail = cr.detail,
+                groundTruthDetail = cr.groundTruthDetail,
+                expectedHooks = emptyList(),
+                owned = true,
+            )
+        }.orEmpty()

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DiagnosticReport.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DiagnosticReport.kt
@@ -20,6 +20,24 @@ internal enum class CheckLayer { NATIVE, JAVA }
 internal enum class DiagnosticGate { VPN_OFF, SELF_NOT_ROUTED, NEEDS_RESTART, ROUTED }
 
 /**
+ * Fold the three independent gate signals — VPN presence, this app's self-in-tunnel
+ * routing, and a pending self-restart — into one [DiagnosticGate], worst-first, so
+ * the dashboard, the live cache, and the debug export classify the run the same way.
+ * Only [DiagnosticGate.ROUTED] means "measured; verdicts are meaningful".
+ */
+internal fun resolveDiagnosticGate(
+    vpnActive: Boolean,
+    selfRouted: Boolean?,
+    selfNeedsRestart: Boolean,
+): DiagnosticGate =
+    when {
+        !vpnActive -> DiagnosticGate.VPN_OFF
+        selfNeedsRestart -> DiagnosticGate.NEEDS_RESTART
+        selfRouted == false -> DiagnosticGate.SELF_NOT_ROUTED
+        else -> DiagnosticGate.ROUTED
+    }
+
+/**
  * One fully-classified check: the root-differential [outcome] plus the evidence
  * behind it — the app-view [appDetail], the root [groundTruthDetail] (native
  * probes run as root), and, for native probes, the hooks that should cover the

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DiagnosticReport.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DiagnosticReport.kt
@@ -104,7 +104,11 @@ internal fun buildDiagnosticReport(
     lsposedActive: Boolean,
     complete: Boolean,
 ): DiagnosticReport {
-    val nativeOutcomes = results?.nativeOutcomes ?: emptyMap()
+    val nativeChecks = nativeDiagnosticChecks(results, backend)
+    // The per-check outcome is the single source of truth; the by-id map the layer
+    // summary needs is derived here (owned spec checks only), not stored a second
+    // time on CheckResults.
+    val nativeOutcomes = nativeChecks.filter { it.id.isNotEmpty() }.associate { it.id to it.outcome }
     val unowned =
         if (results == null) {
             0
@@ -119,7 +123,7 @@ internal fun buildDiagnosticReport(
                 backend = backend.id,
                 status = summarizeNativeLayer(backend, nativeOutcomes),
                 unownedLeaks = unowned,
-                checks = nativeDiagnosticChecks(results, backend),
+                checks = nativeChecks,
             ),
         java =
             LayerReport(

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DiagnosticReportRender.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DiagnosticReportRender.kt
@@ -1,0 +1,143 @@
+package dev.okhsunrog.vpnhide
+
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+
+/**
+ * The debug-bundle renderers for the canonical [DiagnosticReport]. Both outputs
+ * are pure functions of the report, so the bundle carries exactly what the UI
+ * computes — the root-differential outcome and its ground-truth basis, the
+ * per-layer verdict, and the gate — instead of the old flattened PASS/FAIL badge.
+ */
+
+private fun LayerStatus.presenceToken(): String =
+    when (this) {
+        LayerStatus.Absent -> "absent"
+        LayerStatus.Inactive -> "inactive"
+        is LayerStatus.Active -> "active"
+    }
+
+/** One-line verdict/presence summary for a layer, e.g. `broken (hidden 0, leaks 2, unowned 1)`. */
+internal fun LayerReport.verdictLabel(): String {
+    val active = status as? LayerStatus.Active ?: return status.presenceToken()
+    return "${active.verdict.name.lowercase()} (hidden ${active.hidden}, leaks ${active.leaks}, unowned $unownedLeaks)"
+}
+
+/** Count of every check by outcome token across both layers — the honest headline
+ * that replaces the misleading "N/total passed" score. */
+internal fun DiagnosticReport.outcomeTally(): String =
+    (native.checks + java.checks)
+        .groupingBy { it.outcome.token() }
+        .eachCount()
+        .entries
+        .sortedBy { it.key }
+        .joinToString(", ") { "${it.key}=${it.value}" }
+        .ifEmpty { "(no checks run)" }
+
+// ── human-readable diagnostics.txt ─────────────────────────────────────────
+
+internal fun DiagnosticReport.toDiagnosticsText(): String =
+    buildString {
+        appendLine("=== Diagnostics report (schema $schema) ===")
+        appendLine("gate: ${gate.name.lowercase()}")
+        appendLine("complete: $complete")
+        appendLine("outcomes: ${outcomeTally()}")
+        appendLine()
+        appendLayer(native, "Native", native.backend?.name?.lowercase() ?: "none")
+        appendLine()
+        appendLayer(java, "Java", "lsposed")
+    }.trimEnd()
+
+private fun StringBuilder.appendLayer(
+    layer: LayerReport,
+    title: String,
+    backendLabel: String,
+) {
+    appendLine("--- $title layer ($backendLabel) ---")
+    appendLine(layer.verdictLabel())
+    if (layer.checks.isEmpty()) {
+        appendLine("(no checks — gated run)")
+        return
+    }
+    for (c in layer.checks) {
+        val ownedMark = if (c.layer == CheckLayer.NATIVE && !c.owned) "  (unowned)" else ""
+        appendLine("[${c.outcome.token()}] ${c.label}$ownedMark")
+        appendLine("  app:  ${c.appDetail}")
+        c.groundTruthDetail?.let { appendLine("  root: $it") }
+        if (c.expectedHooks.isNotEmpty()) {
+            appendLine("  hooks: ${c.expectedHooks.joinToString { it.hookName }}")
+        }
+    }
+}
+
+// ── machine-readable diagnostics.json ──────────────────────────────────────
+
+private val reportJson = Json { prettyPrint = true }
+
+internal fun DiagnosticReport.toJson(): String = reportJson.encodeToString(ReportJson.serializer(), toReportJson())
+
+@Serializable
+private data class ReportJson(
+    val schema: Int,
+    val gate: String,
+    val complete: Boolean,
+    val native: LayerJson,
+    val java: LayerJson,
+)
+
+@Serializable
+private data class LayerJson(
+    val layer: String,
+    val backend: String?,
+    val presence: String,
+    val verdict: String?,
+    val hidden: Int?,
+    val leaks: Int?,
+    val unownedLeaks: Int,
+    val checks: List<CheckJson>,
+)
+
+@Serializable
+private data class CheckJson(
+    val id: String,
+    val label: String,
+    val outcome: String,
+    val appDetail: String,
+    val groundTruthDetail: String?,
+    val expectedHooks: List<String>,
+    val owned: Boolean,
+)
+
+private fun DiagnosticReport.toReportJson(): ReportJson =
+    ReportJson(
+        schema = schema,
+        gate = gate.name.lowercase(),
+        complete = complete,
+        native = native.toLayerJson(),
+        java = java.toLayerJson(),
+    )
+
+private fun LayerReport.toLayerJson(): LayerJson {
+    val active = status as? LayerStatus.Active
+    return LayerJson(
+        layer = layer.name.lowercase(),
+        backend = backend?.name?.lowercase(),
+        presence = status.presenceToken(),
+        verdict = active?.verdict?.name?.lowercase(),
+        hidden = active?.hidden,
+        leaks = active?.leaks,
+        unownedLeaks = unownedLeaks,
+        checks = checks.map { it.toCheckJson() },
+    )
+}
+
+private fun DiagnosticCheck.toCheckJson(): CheckJson =
+    CheckJson(
+        id = id,
+        label = label,
+        outcome = outcome.token(),
+        appDetail = appDetail,
+        groundTruthDetail = groundTruthDetail,
+        expectedHooks = expectedHooks.map { it.hookName },
+        owned = owned,
+    )

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/HookDiagnostics.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/HookDiagnostics.kt
@@ -23,7 +23,7 @@ internal fun buildHookDiagnosticsText(
     context: Context,
     shellSnapshot: DebugShellSnapshot,
     counterBaseline: DebugShellSnapshot? = null,
-    results: CheckResults? = null,
+    report: DiagnosticReport? = null,
 ): String {
     val rootSnapshot = RootSnapshot(shellSnapshot.sections)
     val currentState = buildStatisticsState(rootSnapshot)
@@ -36,6 +36,12 @@ internal fun buildHookDiagnosticsText(
     // every delta as n/a, defeating the before/after report.
     val hasBaseline = counterBaseline != null
     val statusByBackend = statusByBackend(shellSnapshot)
+    val nativeChecksById =
+        report
+            ?.native
+            ?.checks
+            ?.associateBy { it.id }
+            .orEmpty()
 
     return buildString {
         appendLine("Hook diagnostics")
@@ -57,7 +63,7 @@ internal fun buildHookDiagnosticsText(
         appendLine("=== Native diagnostic checks and expected hooks ===")
         appendNativeChecks(
             context = context,
-            results = results,
+            checksById = nativeChecksById,
             statusByBackend = statusByBackend,
             counters = currentCounters,
             baselineCounters = baselineCounters,
@@ -149,25 +155,18 @@ private fun StringBuilder.appendCounterDelta(
 
 private fun StringBuilder.appendNativeChecks(
     context: Context,
-    results: CheckResults?,
+    checksById: Map<String, DiagnosticCheck>,
     statusByBackend: Map<HookIds.Backend, Protocol.Status?>,
     counters: Map<CounterKey, Long>,
     baselineCounters: Map<CounterKey, Long>,
     hasBaseline: Boolean,
 ) {
-    val byName =
-        results
-            ?.native
-            ?.mapIndexedNotNull { index, result ->
-                NATIVE_CHECKS.getOrNull(index)?.id?.let { it to result }
-            }.orEmpty()
-            .toMap()
-
     for (spec in NATIVE_CHECKS) {
-        val result = byName[spec.id]
-        appendLine("${spec.id}: ${result?.name ?: context.getString(spec.labelRes)}")
-        appendLine("  result=${result?.passed?.let(::badge) ?: "(not run)"}")
-        result?.detail?.takeIf { it.isNotBlank() }?.let { appendLine("  detail=$it") }
+        val check = checksById[spec.id]
+        appendLine("${spec.id}: ${check?.label ?: context.getString(spec.labelRes)}")
+        appendLine("  result=${check?.outcome?.token() ?: "(not run)"}")
+        check?.appDetail?.takeIf { it.isNotBlank() }?.let { appendLine("  detail=$it") }
+        check?.groundTruthDetail?.let { appendLine("  root=$it") }
         if (spec.expectedHooks.isEmpty()) {
             appendLine("  expected hooks: none registered; this probe is covered outside the hook registry")
         } else {
@@ -178,8 +177,6 @@ private fun StringBuilder.appendNativeChecks(
         }
     }
 }
-
-private fun badge(passed: Boolean): String = if (passed) "PASS" else "FAIL"
 
 private fun formatHookWithOwners(
     hook: HookIds.Hook,

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/JavaChecks.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/JavaChecks.kt
@@ -77,10 +77,6 @@ internal data class CheckResults(
     // Remaining Java probes (active-network, push callback, routes, proxy) —
     // the slow push-callback check lives here, so it runs in a second phase.
     val extraJava: List<CheckResult> = emptyList(),
-    // Honest per-check outcome for the Rust native checks, keyed by spec id —
-    // the who-hid-it differential (app view vs root ground truth). Empty when the
-    // ground-truth probe couldn't run.
-    val nativeOutcomes: Map<String, CheckOutcome> = emptyMap(),
 ) {
     val nativeAll get() = native + nativeExtra
     val java get() = coreJava + extraJava
@@ -130,11 +126,9 @@ internal fun runCoreChecks(
     // differential. Join both back to the specs by stable id.
     val nativeAppView = NativeProbe.runAll()
     val nativeGroundTruth = GroundTruthProbe.run(context)
-    // One pass builds both the per-check UI results and the outcome map (keyed by
-    // spec id for the agent bridge / dashboard). The outcome — the root-differential
-    // attribution — rides along on each CheckResult so the UI is a pure function of
-    // the list.
-    val nativeOutcomes = LinkedHashMap<String, CheckOutcome>()
+    // The root-differential outcome rides along on each CheckResult, so the UI and
+    // the report are a pure function of the list — no parallel outcome map to keep
+    // in sync (buildDiagnosticReport derives the by-id map when it needs one).
     val native =
         NATIVE_CHECKS.map { spec ->
             val out =
@@ -143,7 +137,6 @@ internal fun runCoreChecks(
             val groundTruth = nativeGroundTruth[spec.id]
             val outcome = classifyNativeOutcome(out, groundTruth)
             VpnHideLog.i(TAG, "[outcome] ${spec.id}: ${outcome.token()}")
-            nativeOutcomes[spec.id] = outcome
             nativeCheckResult(res.getString(spec.labelRes), out, outcome, groundTruth?.detail)
         }
 
@@ -170,7 +163,6 @@ internal fun runCoreChecks(
         native = native,
         nativeExtra = nativeExtra,
         coreJava = coreJava,
-        nativeOutcomes = nativeOutcomes,
     )
 }
 

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/LayerStatus.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/LayerStatus.kt
@@ -39,7 +39,16 @@ val LayerStatus.Active.verdict: Verdict
             else -> Verdict.Broken
         }
 
-private fun NativeCheckSpec.hasHookIn(mask: Int): Boolean = expectedHooks.any { (1 shl it.id) and mask != 0 }
+internal fun NativeCheckSpec.hasHookIn(mask: Int): Boolean = expectedHooks.any { (1 shl it.id) and mask != 0 }
+
+/**
+ * The hook mask the given native backend owns: Zygisk owns the zygisk hooks;
+ * every kernel backend — and the null/none case — owns the kernel hooks. Single
+ * source so the tile verdict, the unowned-leak count, and [buildDiagnosticReport]
+ * all scope "owned vectors" the same way.
+ */
+internal fun nativeOwnMask(id: NativeBackendId?): Int =
+    if (id == NativeBackendId.Zygisk) HookIds.ZYGISK_HOOK_MASK else HookIds.KERNEL_HOOK_MASK
 
 /**
  * Native tile = health of the active backend, judged **only on vectors it owns**
@@ -54,12 +63,7 @@ internal fun summarizeNativeLayer(
 ): LayerStatus {
     if (backend.state is ModuleState.NotInstalled) return LayerStatus.Absent
     if (!moduleActive(backend.state)) return LayerStatus.Inactive
-    val ownMask =
-        when (backend.id) {
-            NativeBackendId.Kmod, NativeBackendId.Kpm -> HookIds.KERNEL_HOOK_MASK
-            NativeBackendId.Zygisk -> HookIds.ZYGISK_HOOK_MASK
-            null -> HookIds.KERNEL_HOOK_MASK
-        }
+    val ownMask = nativeOwnMask(backend.id)
     val ownedIds = NATIVE_CHECKS.filter { it.hasHookIn(ownMask) }.map { it.id }.toSet()
     // Both counts are scoped to vectors this backend owns, so hidden and leaks
     // describe the same vector set — a cross-backend hidden (only possible if the
@@ -96,11 +100,7 @@ internal fun unownedNativeLeaks(
     outcomes: Map<String, CheckOutcome>,
 ): Int {
     if (backend.state !is ModuleState.Installed || !moduleActive(backend.state)) return 0
-    val ownMask =
-        when (backend.id) {
-            NativeBackendId.Zygisk -> HookIds.ZYGISK_HOOK_MASK
-            else -> HookIds.KERNEL_HOOK_MASK
-        }
+    val ownMask = nativeOwnMask(backend.id)
     val ownedIds = NATIVE_CHECKS.filter { it.hasHookIn(ownMask) }.map { it.id }.toSet()
     return outcomes.count { (id, outcome) -> outcome is CheckOutcome.Leak && id !in ownedIds }
 }

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/LogcatRecorder.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/LogcatRecorder.kt
@@ -240,7 +240,7 @@ internal object LogcatRecorder {
                     buildDiagnosticSummaryText(
                         context = context,
                         selfNeedsRestart = recording.selfNeedsRestart,
-                        results = null,
+                        report = null,
                         shellSnapshot = shellSnapshot,
                         loggingSession = loggingSession,
                         captureKind = "full_system_logcat",

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/LsposedState.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/LsposedState.kt
@@ -34,6 +34,24 @@ internal fun parseLsposedStateMetadata(raw: String): Map<String, String> =
             key to value
         }.toMap()
 
+/**
+ * Are the LSPosed hooks live *this boot*? True when the state file reports the
+ * LSPosed backend and its stamped boot_id matches the current one — the same test
+ * [resolveLsposedState] applies for [LsposedState.Active]. Extracted so the
+ * dashboard and the debug export derive "Java layer active" from one place.
+ */
+internal fun lsposedHooksActiveThisBoot(
+    stateRaw: String,
+    currentBootId: String,
+): Boolean {
+    val hookBootId = parseLsposedStateMetadata(stateRaw)[LsposedStateMetadata.BOOT_ID]
+    return Protocol.parseStatus(stateRaw)?.backend ==
+        HookIds.Backend.LSPOSED.id
+            .toLong() &&
+        hookBootId != null &&
+        hookBootId == currentBootId.trim()
+}
+
 internal fun formatLsposedState(
     status: Protocol.Status,
     metadata: Map<String, String>,

--- a/lsposed/app/src/test/kotlin/dev/okhsunrog/vpnhide/DiagnosticReportTest.kt
+++ b/lsposed/app/src/test/kotlin/dev/okhsunrog/vpnhide/DiagnosticReportTest.kt
@@ -1,0 +1,117 @@
+package dev.okhsunrog.vpnhide
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * The canonical report is the single computed diagnostic snapshot: one build,
+ * every consumer a pure render. These tests pin the folding — verdicts, the
+ * owned/unowned split, per-check attribution carry-through, and the gate — so no
+ * renderer has to re-derive (and risk disagreeing with) any of it.
+ */
+class DiagnosticReportTest {
+    private fun installed(active: Boolean) = ModuleState.Installed(version = "1.0", active = active, targetCount = 1)
+
+    private fun zygisk(state: ModuleState = installed(active = true)) =
+        displayNativeBackend(
+            NativeBackendStates(kmod = ModuleState.NotInstalled, kpm = ModuleState.NotInstalled, zygisk = state),
+        )
+
+    private fun report(
+        gate: DiagnosticGate = DiagnosticGate.ROUTED,
+        results: CheckResults?,
+        backend: DisplayNativeBackend = zygisk(),
+        lsposedActive: Boolean = true,
+        complete: Boolean = true,
+    ) = buildDiagnosticReport(gate, results, backend, lsposedActive, complete)
+
+    // ── native verdict folds off the owned outcomes ────────────────────────
+
+    @Test
+    fun `native verdict is Broken when an owned vector leaks and nothing hid`() {
+        val r = report(results = CheckResults(native = emptyList(), nativeOutcomes = mapOf("ioctl_flags" to CheckOutcome.Leak)))
+        assertEquals(Verdict.Broken, r.native.verdict)
+    }
+
+    @Test
+    fun `native verdict is Partial when it hides some but an owned vector leaks`() {
+        val outcomes = mapOf("ioctl_flags" to CheckOutcome.Leak, "getifaddrs" to CheckOutcome.HiddenByBackend)
+        assertEquals(Verdict.Partial, report(results = CheckResults(native = emptyList(), nativeOutcomes = outcomes)).native.verdict)
+    }
+
+    @Test
+    fun `native verdict is Ok when nothing owned leaks`() {
+        val outcomes = mapOf("ioctl_flags" to CheckOutcome.HiddenByBackend)
+        assertEquals(Verdict.Ok, report(results = CheckResults(native = emptyList(), nativeOutcomes = outcomes)).native.verdict)
+    }
+
+    // ── unowned leaks are surfaced separately, never against the verdict ────
+
+    @Test
+    fun `a kernel-only leak under zygisk is unowned, not a verdict leak`() {
+        // netlink_getrule (fib_nl_fill_rule) has no zygisk hook → out of scope for
+        // the zygisk tile, so the verdict stays Ok and the leak is counted as unowned.
+        val r = report(results = CheckResults(native = emptyList(), nativeOutcomes = mapOf("netlink_getrule" to CheckOutcome.Leak)))
+        assertEquals(Verdict.Ok, r.native.verdict)
+        assertEquals(1, r.native.unownedLeaks)
+    }
+
+    @Test
+    fun `a leaking java-implemented native probe folds into the unowned count`() {
+        val results =
+            CheckResults(
+                native = emptyList(),
+                nativeExtra = listOf(CheckResult("NetworkInterface enum", passed = false, detail = "tun0 in list")),
+            )
+        assertEquals(1, report(results = results).native.unownedLeaks)
+    }
+
+    // ── per-check attribution carries through verbatim ─────────────────────
+
+    @Test
+    fun `native check carries id, outcome, ground truth and owned flag`() {
+        val results =
+            CheckResults(
+                native =
+                    listOf(
+                        CheckResult(
+                            name = "ioctl SIOCGIFFLAGS tun0",
+                            passed = false,
+                            detail = "tun0 is visible!",
+                            outcome = CheckOutcome.Leak,
+                            groundTruthDetail = "root: tun0 up",
+                        ),
+                    ),
+                nativeOutcomes = mapOf("ioctl_flags" to CheckOutcome.Leak),
+            )
+        val check = report(results = results).native.checks.single { it.layer == CheckLayer.NATIVE }
+        assertEquals("ioctl_flags", check.id) // stable id joined from NATIVE_CHECKS, not an index
+        assertEquals(CheckOutcome.Leak, check.outcome)
+        assertEquals("root: tun0 up", check.groundTruthDetail)
+        assertTrue("ioctl_flags is zygisk-owned via zygisk_ioctl", check.owned)
+    }
+
+    @Test
+    fun `java check carries its gate-derived outcome`() {
+        val results =
+            CheckResults(
+                native = emptyList(),
+                coreJava = listOf(CheckResult("hasTransport(VPN)", passed = false, detail = "VPN!", outcome = CheckOutcome.Leak)),
+            )
+        val r = report(results = results)
+        val javaCheck = r.java.checks.single()
+        assertEquals(CheckOutcome.Leak, javaCheck.outcome)
+        assertEquals(Verdict.Broken, r.java.verdict)
+    }
+
+    // ── gate ───────────────────────────────────────────────────────────────
+
+    @Test
+    fun `a blocked gate carries no checks and no measured verdict`() {
+        val r = report(gate = DiagnosticGate.VPN_OFF, results = null)
+        assertEquals(DiagnosticGate.VPN_OFF, r.gate)
+        assertTrue(r.native.checks.isEmpty())
+        assertTrue(r.java.checks.isEmpty())
+    }
+}

--- a/lsposed/app/src/test/kotlin/dev/okhsunrog/vpnhide/DiagnosticReportTest.kt
+++ b/lsposed/app/src/test/kotlin/dev/okhsunrog/vpnhide/DiagnosticReportTest.kt
@@ -26,24 +26,32 @@ class DiagnosticReportTest {
         complete: Boolean = true,
     ) = buildDiagnosticReport(gate, results, backend, lsposedActive, complete)
 
+    /** Native results in the real NATIVE_CHECKS order, carrying the given per-id
+     * outcomes; every other probe is left unmeasured. The builder derives the
+     * by-id outcome map from this list — there is no separate map to pass. */
+    private fun nativeResults(vararg outcomes: Pair<String, CheckOutcome>): List<CheckResult> {
+        val byId = outcomes.toMap()
+        return NATIVE_CHECKS.map { spec -> CheckResult(spec.id, passed = null, detail = "", outcome = byId[spec.id]) }
+    }
+
     // ── native verdict folds off the owned outcomes ────────────────────────
 
     @Test
     fun `native verdict is Broken when an owned vector leaks and nothing hid`() {
-        val r = report(results = CheckResults(native = emptyList(), nativeOutcomes = mapOf("ioctl_flags" to CheckOutcome.Leak)))
+        val r = report(results = CheckResults(native = nativeResults("ioctl_flags" to CheckOutcome.Leak)))
         assertEquals(Verdict.Broken, r.native.verdict)
     }
 
     @Test
     fun `native verdict is Partial when it hides some but an owned vector leaks`() {
-        val outcomes = mapOf("ioctl_flags" to CheckOutcome.Leak, "getifaddrs" to CheckOutcome.HiddenByBackend)
-        assertEquals(Verdict.Partial, report(results = CheckResults(native = emptyList(), nativeOutcomes = outcomes)).native.verdict)
+        val native = nativeResults("ioctl_flags" to CheckOutcome.Leak, "getifaddrs" to CheckOutcome.HiddenByBackend)
+        assertEquals(Verdict.Partial, report(results = CheckResults(native = native)).native.verdict)
     }
 
     @Test
     fun `native verdict is Ok when nothing owned leaks`() {
-        val outcomes = mapOf("ioctl_flags" to CheckOutcome.HiddenByBackend)
-        assertEquals(Verdict.Ok, report(results = CheckResults(native = emptyList(), nativeOutcomes = outcomes)).native.verdict)
+        val native = nativeResults("ioctl_flags" to CheckOutcome.HiddenByBackend)
+        assertEquals(Verdict.Ok, report(results = CheckResults(native = native)).native.verdict)
     }
 
     // ── unowned leaks are surfaced separately, never against the verdict ────
@@ -52,7 +60,7 @@ class DiagnosticReportTest {
     fun `a kernel-only leak under zygisk is unowned, not a verdict leak`() {
         // netlink_getrule (fib_nl_fill_rule) has no zygisk hook → out of scope for
         // the zygisk tile, so the verdict stays Ok and the leak is counted as unowned.
-        val r = report(results = CheckResults(native = emptyList(), nativeOutcomes = mapOf("netlink_getrule" to CheckOutcome.Leak)))
+        val r = report(results = CheckResults(native = nativeResults("netlink_getrule" to CheckOutcome.Leak)))
         assertEquals(Verdict.Ok, r.native.verdict)
         assertEquals(1, r.native.unownedLeaks)
     }
@@ -69,24 +77,28 @@ class DiagnosticReportTest {
 
     // ── per-check attribution carries through verbatim ─────────────────────
 
+    /** Full native list with the first probe (ioctl_flags) carrying a rich leak +
+     * root ground-truth, the rest unmeasured — the shape a real leaking run has. */
+    private fun ioctlFlagsLeakNative(): List<CheckResult> =
+        NATIVE_CHECKS.map { spec ->
+            if (spec.id == "ioctl_flags") {
+                CheckResult(
+                    name = "ioctl SIOCGIFFLAGS tun0",
+                    passed = false,
+                    detail = "tun0 is visible!",
+                    outcome = CheckOutcome.Leak,
+                    groundTruthDetail = "root: tun0 up",
+                )
+            } else {
+                CheckResult(spec.id, passed = null, detail = "", outcome = null)
+            }
+        }
+
     @Test
     fun `native check carries id, outcome, ground truth and owned flag`() {
-        val results =
-            CheckResults(
-                native =
-                    listOf(
-                        CheckResult(
-                            name = "ioctl SIOCGIFFLAGS tun0",
-                            passed = false,
-                            detail = "tun0 is visible!",
-                            outcome = CheckOutcome.Leak,
-                            groundTruthDetail = "root: tun0 up",
-                        ),
-                    ),
-                nativeOutcomes = mapOf("ioctl_flags" to CheckOutcome.Leak),
-            )
-        val check = report(results = results).native.checks.single { it.layer == CheckLayer.NATIVE }
-        assertEquals("ioctl_flags", check.id) // stable id joined from NATIVE_CHECKS, not an index
+        val checks = report(results = CheckResults(native = ioctlFlagsLeakNative())).native.checks
+        val check = checks.first { it.id == "ioctl_flags" }
+        assertEquals("ioctl SIOCGIFFLAGS tun0", check.label) // localized label off the result
         assertEquals(CheckOutcome.Leak, check.outcome)
         assertEquals("root: tun0 up", check.groundTruthDetail)
         assertTrue("ioctl_flags is zygisk-owned via zygisk_ioctl", check.owned)
@@ -130,23 +142,7 @@ class DiagnosticReportTest {
 
     // ── renderers carry the attribution the old bundle dropped ─────────────
 
-    private fun leakReport() =
-        report(
-            results =
-                CheckResults(
-                    native =
-                        listOf(
-                            CheckResult(
-                                name = "ioctl SIOCGIFFLAGS tun0",
-                                passed = false,
-                                detail = "tun0 is visible!",
-                                outcome = CheckOutcome.Leak,
-                                groundTruthDetail = "root: tun0 up",
-                            ),
-                        ),
-                    nativeOutcomes = mapOf("ioctl_flags" to CheckOutcome.Leak),
-                ),
-        )
+    private fun leakReport() = report(results = CheckResults(native = ioctlFlagsLeakNative()))
 
     @Test
     fun `diagnostics text carries the outcome, the ground truth and the verdict`() {

--- a/lsposed/app/src/test/kotlin/dev/okhsunrog/vpnhide/DiagnosticReportTest.kt
+++ b/lsposed/app/src/test/kotlin/dev/okhsunrog/vpnhide/DiagnosticReportTest.kt
@@ -114,4 +114,55 @@ class DiagnosticReportTest {
         assertTrue(r.native.checks.isEmpty())
         assertTrue(r.java.checks.isEmpty())
     }
+
+    @Test
+    fun `gate folds the three signals worst-first`() {
+        assertEquals(DiagnosticGate.VPN_OFF, resolveDiagnosticGate(vpnActive = false, selfRouted = true, selfNeedsRestart = false))
+        assertEquals(DiagnosticGate.NEEDS_RESTART, resolveDiagnosticGate(vpnActive = true, selfRouted = true, selfNeedsRestart = true))
+        assertEquals(
+            DiagnosticGate.SELF_NOT_ROUTED,
+            resolveDiagnosticGate(vpnActive = true, selfRouted = false, selfNeedsRestart = false),
+        )
+        assertEquals(DiagnosticGate.ROUTED, resolveDiagnosticGate(vpnActive = true, selfRouted = true, selfNeedsRestart = false))
+        // A null self-routed answer (no root) does not block.
+        assertEquals(DiagnosticGate.ROUTED, resolveDiagnosticGate(vpnActive = true, selfRouted = null, selfNeedsRestart = false))
+    }
+
+    // ── renderers carry the attribution the old bundle dropped ─────────────
+
+    private fun leakReport() =
+        report(
+            results =
+                CheckResults(
+                    native =
+                        listOf(
+                            CheckResult(
+                                name = "ioctl SIOCGIFFLAGS tun0",
+                                passed = false,
+                                detail = "tun0 is visible!",
+                                outcome = CheckOutcome.Leak,
+                                groundTruthDetail = "root: tun0 up",
+                            ),
+                        ),
+                    nativeOutcomes = mapOf("ioctl_flags" to CheckOutcome.Leak),
+                ),
+        )
+
+    @Test
+    fun `diagnostics text carries the outcome, the ground truth and the verdict`() {
+        val text = leakReport().toDiagnosticsText()
+        assertTrue("gate is recorded", text.contains("gate: routed"))
+        assertTrue("outcome token, not a PASS/FAIL badge", text.contains("[leak] ioctl SIOCGIFFLAGS tun0"))
+        assertTrue("the root ground truth is included", text.contains("root: tun0 up"))
+        assertTrue("the native verdict is Broken", text.contains("broken"))
+    }
+
+    @Test
+    fun `diagnostics json serializes outcome and verdict`() {
+        val json = leakReport().toJson()
+        assertTrue(json.contains("\"outcome\": \"leak\""))
+        assertTrue(json.contains("\"verdict\": \"broken\""))
+        assertTrue(json.contains("\"groundTruthDetail\": \"root: tun0 up\""))
+        assertTrue(json.contains("\"id\": \"ioctl_flags\""))
+    }
 }


### PR DESCRIPTION
The diagnostic verdict was re-derived independently in four places — the dashboard tiles, the Diagnostics screen, the agent bridge, and the debug-ZIP text — each flattening the rich per-check attribution back to a PASS/FAIL badge. The debug bundle was the worst hit: it dropped the root-differential outcome, the root ground-truth behind it, every layer verdict, and the gate, and led with an "N/total passed" score that counts SELinux-blocked and nothing-to-leak as passes. On a device whose native hooks load but never intercept (issue #241: GrapheneOS/ReZygisk on Android 17), the bundle showed only a green heartbeat and a list of FAILs, with no way to read "native = Broken" — even though the app already computes exactly that.

This introduces one immutable `DiagnosticReport`, built once by a pure `buildDiagnosticReport`, that every consumer now renders instead of recomputing. The debug bundle carries the full attribution again, so a report is diagnosable without the live UI (and without reaching for logcat).

- Add `DiagnosticReport` (gate + per-layer verdict + per-check outcome/ground-truth), computed by one pure, unit-tested function.
- Render it into the bundle: `diagnostics.txt` now shows each check's outcome + root ground-truth + owned flag and the per-layer verdict; a new machine-readable `diagnostics.json` carries the same; `summary.txt` leads with the gate, verdicts and an outcome tally instead of the misleading pass score. Bundle schema 3 → 4.
- Fold VPN-off / self-not-routed / needs-restart into one `resolveDiagnosticGate`, and extract `lsposedHooksActiveThisBoot` and `nativeOwnMask` so the dashboard and the export derive gate, Java-layer liveness, and owned-vector scope from one place.
- Point the dashboard tiles at the report instead of calling the layer-summary helpers by hand.
- Drop the two index-joins (agent bridge, hook report) that re-matched probe results to `NATIVE_CHECKS` by list position; the hook report now looks checks up by id and prints the outcome token.
- Remove the duplicate `nativeOutcomes` map from `CheckResults` — the per-check `outcome` is the single source of truth.

Note: `CheckResult.passed` is intentionally kept — it still backs the diagnostics score and the Diagnostics screen's tri-state fallback for the Java-implemented native probes, which have no root differential.