### PR TITLE
Merge the three parallel diagnostics gate types onto one DiagnosticGate

### DIFF
--- a/changelog.d/fixed-dashboard-no-longer-says-the-vpn-6266.md
+++ b/changelog.d/fixed-dashboard-no-longer-says-the-vpn-6266.md
@@ -1,0 +1,9 @@
+_2026-08-11_
+
+## English
+
+Dashboard no longer says the VPN is off when a diagnostics run actually failed (root dropped); it shows a distinct retry prompt.
+
+## Русский
+
+Дашборд больше не пишет, что VPN выключен, когда прогон диагностики на самом деле не удался (пропал root) — показывается отдельная подсказка с повтором.

--- a/changelog.d/fixed-the-dashboard-and-diagnostics-screen-now-5779.md
+++ b/changelog.d/fixed-the-dashboard-and-diagnostics-screen-now-5779.md
@@ -1,0 +1,9 @@
+_2026-08-11_
+
+## English
+
+The dashboard and diagnostics screen now agree on why a check is blocked, and a pending self-restart is shown ahead of a VPN-off prompt.
+
+## Русский
+
+Дашборд и экран диагностики теперь согласованно объясняют, почему проверка заблокирована, а необходимость перезагрузки показывается раньше подсказки о выключенном VPN.

--- a/lsposed/app/build.gradle.kts
+++ b/lsposed/app/build.gradle.kts
@@ -65,7 +65,7 @@ detekt {
 // default ceiling. Remove an entry once a file drops below the default.
 val kotlinSourceLineBudgets =
     mapOf(
-        "DashboardData.kt" to 1716,
+        "DashboardData.kt" to 1730,
         "DashboardScreen.kt" to 1335,
         "HookEntry.kt" to 1276,
         "SettingsScreen.kt" to 1201,

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/AgentControl.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/AgentControl.kt
@@ -39,7 +39,7 @@ internal object AgentControl {
             val results = DiagnosticsCache.awaitFullResults(context)
             if (results == null) {
                 val gatedState =
-                    if (DiagnosticsCache.state.value is DiagnosticsCache.State.SelfNotRouted) {
+                    if ((DiagnosticsCache.state.value as? DiagnosticsCache.State.Blocked)?.gate == DiagnosticGate.SELF_NOT_ROUTED) {
                         "self_not_routed"
                     } else {
                         "vpn_off"

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/AgentControl.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/AgentControl.kt
@@ -38,7 +38,9 @@ internal object AgentControl {
         withAppContext(context) { context ->
             // awaitTerminal carries the reason (blocked gate / failed) instead of
             // re-reading state.value after a null (a race) — same fix as the dashboard.
-            when (val terminal = DiagnosticsCache.awaitTerminal(context)) {
+            // The agent doesn't know selfNeedsRestart; false is safe because the cache's
+            // sticky flag keeps a UI-set NEEDS_RESTART from being cleared here.
+            when (val terminal = DiagnosticsCache.awaitTerminal(context, selfNeedsRestart = false)) {
                 is DiagnosticsCache.State.Ready -> {
                     terminal.results.toAgentDiagnosticsReport()
                 }

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/AgentControl.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/AgentControl.kt
@@ -36,22 +36,26 @@ internal object AgentControl {
      */
     suspend fun runFullDiagnostics(context: Context): AgentDiagnosticsReport =
         withAppContext(context) { context ->
-            val results = DiagnosticsCache.awaitFullResults(context)
-            if (results == null) {
-                val gatedState =
-                    if ((DiagnosticsCache.state.value as? DiagnosticsCache.State.Blocked)?.gate == DiagnosticGate.SELF_NOT_ROUTED) {
-                        "self_not_routed"
-                    } else {
-                        "vpn_off"
-                    }
-                AgentDiagnosticsReport(
-                    state = gatedState,
-                    score = AgentCheckScore(0, 0),
-                    nativeChecks = emptyList(),
-                    javaChecks = emptyList(),
-                )
-            } else {
-                results.toAgentDiagnosticsReport()
+            // awaitTerminal carries the reason (blocked gate / failed) instead of
+            // re-reading state.value after a null (a race) — same fix as the dashboard.
+            when (val terminal = DiagnosticsCache.awaitTerminal(context)) {
+                is DiagnosticsCache.State.Ready -> {
+                    terminal.results.toAgentDiagnosticsReport()
+                }
+
+                else -> {
+                    val state =
+                        when (terminal) {
+                            is DiagnosticsCache.State.Blocked -> terminal.gate.agentStateToken()
+                            else -> "failed"
+                        }
+                    AgentDiagnosticsReport(
+                        state = state,
+                        score = AgentCheckScore(0, 0),
+                        nativeChecks = emptyList(),
+                        javaChecks = emptyList(),
+                    )
+                }
             }
         }
 
@@ -635,6 +639,10 @@ private fun ProtectionCheck.toAgentProtectionSummary(): AgentProtectionSummary =
     when (this) {
         is ProtectionCheck.Blocked -> {
             AgentProtectionSummary(state = gate.agentStateToken())
+        }
+
+        ProtectionCheck.Failed -> {
+            AgentProtectionSummary(state = "failed")
         }
 
         is ProtectionCheck.Checked -> {

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/AgentControl.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/AgentControl.kt
@@ -622,18 +622,19 @@ private fun ModuleState.toAgentModuleState(
         }
     }
 
+/** Agent-bridge wire token for a blocked gate (protocol-facing — keep stable). */
+private fun DiagnosticGate.agentStateToken(): String =
+    when (this) {
+        DiagnosticGate.VPN_OFF -> "vpn_off"
+        DiagnosticGate.NEEDS_RESTART -> "needs_restart"
+        DiagnosticGate.SELF_NOT_ROUTED -> "self_not_routed"
+        DiagnosticGate.ROUTED -> "routed" // unreachable: a Blocked gate is never ROUTED
+    }
+
 private fun ProtectionCheck.toAgentProtectionSummary(): AgentProtectionSummary =
     when (this) {
-        ProtectionCheck.NoVpn -> {
-            AgentProtectionSummary(state = "vpn_off")
-        }
-
-        ProtectionCheck.NeedsRestart -> {
-            AgentProtectionSummary(state = "needs_restart")
-        }
-
-        ProtectionCheck.SelfNotRouted -> {
-            AgentProtectionSummary(state = "self_not_routed")
+        is ProtectionCheck.Blocked -> {
+            AgentProtectionSummary(state = gate.agentStateToken())
         }
 
         is ProtectionCheck.Checked -> {

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DashboardData.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DashboardData.kt
@@ -1642,7 +1642,7 @@ internal suspend fun loadDashboardState(
                     // (VPN up but this app split-tunnelled out) from a genuine
                     // no-VPN / failed run, so the hero can guide "add to tunnel"
                     // instead of the wrong "turn on VPN".
-                    if (DiagnosticsCache.state.value is DiagnosticsCache.State.SelfNotRouted) {
+                    if ((DiagnosticsCache.state.value as? DiagnosticsCache.State.Blocked)?.gate == DiagnosticGate.SELF_NOT_ROUTED) {
                         ProtectionCheck.SelfNotRouted
                     } else {
                         ProtectionCheck.NoVpn

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DashboardData.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DashboardData.kt
@@ -76,14 +76,18 @@ sealed interface LsposedState {
     ) : LsposedState
 }
 
-sealed interface ProtectionCheck {
-    data object NoVpn : ProtectionCheck
-
-    data object NeedsRestart : ProtectionCheck
-
-    // A VPN is up, but this app is not routed through it (split-tunnelled out) —
-    // hiding is moot for us, so we ask the user to add VPN Hide to the tunnel.
-    data object SelfNotRouted : ProtectionCheck
+internal sealed interface ProtectionCheck {
+    // The gate stopped the run before anything could be measured — VPN off, this app
+    // split-tunnelled out (hiding is moot for us → "add to tunnel"), or a pending
+    // self-restart. Carries the shared [DiagnosticGate] so the hero/agent explain
+    // which without a second enum. Never [DiagnosticGate.ROUTED] — that is [Checked].
+    data class Blocked(
+        val gate: DiagnosticGate,
+    ) : ProtectionCheck {
+        init {
+            require(gate != DiagnosticGate.ROUTED) { "Blocked gate must not be ROUTED" }
+        }
+    }
 
     data class Checked(
         val native: LayerStatus,
@@ -305,11 +309,12 @@ internal fun computeHeroStatus(
     warningCount: Int,
 ): HeroStatus {
     val p = state.protection
-    if (p is ProtectionCheck.NoVpn) return HeroStatus.VpnOff
+    if (p is ProtectionCheck.Blocked && p.gate == DiagnosticGate.VPN_OFF) return HeroStatus.VpnOff
     // 0 = protected, 1 = attention, 2 = unprotected — keep the worst signal.
     var rank = 0
     when (p) {
-        ProtectionCheck.NeedsRestart, ProtectionCheck.SelfNotRouted -> {
+        // A non-VPN-off block (self-not-routed / needs-restart) is attention, not off.
+        is ProtectionCheck.Blocked -> {
             rank = maxOf(rank, 1)
         }
 
@@ -1625,11 +1630,11 @@ internal suspend fun loadDashboardState(
     val protection: ProtectionCheck =
         when {
             !vpnActive -> {
-                ProtectionCheck.NoVpn
+                ProtectionCheck.Blocked(DiagnosticGate.VPN_OFF)
             }
 
             selfNeedsRestart -> {
-                ProtectionCheck.NeedsRestart
+                ProtectionCheck.Blocked(DiagnosticGate.NEEDS_RESTART)
             }
 
             else -> {
@@ -1638,15 +1643,13 @@ internal suspend fun loadDashboardState(
                 // result so its "OK" state means every protection probe passed.
                 val checks = DiagnosticsCache.awaitFullResults(context)
                 if (checks == null) {
-                    // No results to summarize. Distinguish the self-not-routed gate
-                    // (VPN up but this app split-tunnelled out) from a genuine
-                    // no-VPN / failed run, so the hero can guide "add to tunnel"
-                    // instead of the wrong "turn on VPN".
-                    if ((DiagnosticsCache.state.value as? DiagnosticsCache.State.Blocked)?.gate == DiagnosticGate.SELF_NOT_ROUTED) {
-                        ProtectionCheck.SelfNotRouted
-                    } else {
-                        ProtectionCheck.NoVpn
-                    }
+                    // No results to summarize. Carry the self-not-routed gate (VPN up
+                    // but this app split-tunnelled out) through so the hero can guide
+                    // "add to tunnel" instead of the wrong "turn on VPN". A Failed run
+                    // still folds to VPN_OFF here — the next commit gives it its own state.
+                    val gate = (DiagnosticsCache.state.value as? DiagnosticsCache.State.Blocked)?.gate
+                    val shown = if (gate == DiagnosticGate.SELF_NOT_ROUTED) DiagnosticGate.SELF_NOT_ROUTED else DiagnosticGate.VPN_OFF
+                    ProtectionCheck.Blocked(shown)
                 } else {
                     // Derive tiles from the one canonical report (the same object the
                     // debug bundle renders), so the on-screen verdict and the exported

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DashboardData.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DashboardData.kt
@@ -1637,49 +1637,37 @@ internal suspend fun loadDashboardState(
     // differential and so aren't in nativeOutcomes. Set during the protection
     // computation, surfaced via the hero warning so a leak there is never invisible.
     var unownedNativeLeakCount = 0
+    // Single source of truth: the cache does all the gating (VPN off / needs-restart /
+    // self-not-routed) through the one fold. awaitTerminal returns the terminal state
+    // itself, so the reason for "no results" (blocked gate vs a failed run) is carried
+    // through instead of re-derived from a second VPN sensor or a raced state.value read.
     val protection: ProtectionCheck =
-        when {
-            !vpnActive -> {
-                ProtectionCheck.Blocked(DiagnosticGate.VPN_OFF)
+        when (val terminal = DiagnosticsCache.awaitTerminal(context, selfNeedsRestart)) {
+            is DiagnosticsCache.State.Blocked -> {
+                ProtectionCheck.Blocked(terminal.gate)
             }
 
-            selfNeedsRestart -> {
-                ProtectionCheck.Blocked(DiagnosticGate.NEEDS_RESTART)
+            is DiagnosticsCache.State.Ready -> {
+                // Derive tiles from the one canonical report (the same object the
+                // debug bundle renders), so the on-screen verdict and the exported
+                // one can never diverge. Tiles judge each backend on the vectors it
+                // owns; unowned leaks are surfaced via the hero warning below.
+                val report =
+                    buildDiagnosticReport(
+                        gate = DiagnosticGate.ROUTED,
+                        results = terminal.results,
+                        backend = nativeBackend,
+                        lsposedActive = lsposed is LsposedState.Active,
+                        complete = true,
+                    )
+                unownedNativeLeakCount = report.native.unownedLeaks
+                ProtectionCheck.Checked(report.native.status, report.java.status)
             }
 
+            // State.Failed, and defensively the never-terminal NotRun/Running:
+            // the run couldn't measure — distinct from a VPN-off gate.
             else -> {
-                // Single source of truth: reuse the cached run. awaitTerminal returns
-                // the terminal state itself, so the reason for "no results" (blocked
-                // gate vs a failed run) is carried through instead of reconstructed by
-                // re-reading state.value (which would race a subsequent run).
-                when (val terminal = DiagnosticsCache.awaitTerminal(context)) {
-                    is DiagnosticsCache.State.Blocked -> {
-                        ProtectionCheck.Blocked(terminal.gate)
-                    }
-
-                    is DiagnosticsCache.State.Ready -> {
-                        // Derive tiles from the one canonical report (the same object the
-                        // debug bundle renders), so the on-screen verdict and the exported
-                        // one can never diverge. Tiles judge each backend on the vectors it
-                        // owns; unowned leaks are surfaced via the hero warning below.
-                        val report =
-                            buildDiagnosticReport(
-                                gate = DiagnosticGate.ROUTED,
-                                results = terminal.results,
-                                backend = nativeBackend,
-                                lsposedActive = lsposed is LsposedState.Active,
-                                complete = true,
-                            )
-                        unownedNativeLeakCount = report.native.unownedLeaks
-                        ProtectionCheck.Checked(report.native.status, report.java.status)
-                    }
-
-                    // State.Failed, and defensively the never-terminal NotRun/Running:
-                    // the run couldn't measure — distinct from a VPN-off gate.
-                    else -> {
-                        ProtectionCheck.Failed
-                    }
-                }
+                ProtectionCheck.Failed
             }
         }
 

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DashboardData.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DashboardData.kt
@@ -89,6 +89,11 @@ internal sealed interface ProtectionCheck {
         }
     }
 
+    // The run threw (root dropped, shell exec failure) — the VPN may well be up, we
+    // just couldn't measure. Distinct from a VPN-off gate so the hero doesn't tell an
+    // active-VPN user to turn their VPN on.
+    data object Failed : ProtectionCheck
+
     data class Checked(
         val native: LayerStatus,
         val java: LayerStatus,
@@ -315,6 +320,11 @@ internal fun computeHeroStatus(
     when (p) {
         // A non-VPN-off block (self-not-routed / needs-restart) is attention, not off.
         is ProtectionCheck.Blocked -> {
+            rank = maxOf(rank, 1)
+        }
+
+        // Couldn't measure — attention, not "off" (we don't know protection is broken).
+        ProtectionCheck.Failed -> {
             rank = maxOf(rank, 1)
         }
 
@@ -1638,33 +1648,37 @@ internal suspend fun loadDashboardState(
             }
 
             else -> {
-                // Single source of truth: reuse the cached check run instead of
-                // probing again here. Dashboard waits for the full Diagnostics
-                // result so its "OK" state means every protection probe passed.
-                val checks = DiagnosticsCache.awaitFullResults(context)
-                if (checks == null) {
-                    // No results to summarize. Carry the self-not-routed gate (VPN up
-                    // but this app split-tunnelled out) through so the hero can guide
-                    // "add to tunnel" instead of the wrong "turn on VPN". A Failed run
-                    // still folds to VPN_OFF here — the next commit gives it its own state.
-                    val gate = (DiagnosticsCache.state.value as? DiagnosticsCache.State.Blocked)?.gate
-                    val shown = if (gate == DiagnosticGate.SELF_NOT_ROUTED) DiagnosticGate.SELF_NOT_ROUTED else DiagnosticGate.VPN_OFF
-                    ProtectionCheck.Blocked(shown)
-                } else {
-                    // Derive tiles from the one canonical report (the same object the
-                    // debug bundle renders), so the on-screen verdict and the exported
-                    // one can never diverge. Tiles judge each backend on the vectors it
-                    // owns; unowned leaks are surfaced via the hero warning below.
-                    val report =
-                        buildDiagnosticReport(
-                            gate = DiagnosticGate.ROUTED,
-                            results = checks,
-                            backend = nativeBackend,
-                            lsposedActive = lsposed is LsposedState.Active,
-                            complete = true,
-                        )
-                    unownedNativeLeakCount = report.native.unownedLeaks
-                    ProtectionCheck.Checked(report.native.status, report.java.status)
+                // Single source of truth: reuse the cached run. awaitTerminal returns
+                // the terminal state itself, so the reason for "no results" (blocked
+                // gate vs a failed run) is carried through instead of reconstructed by
+                // re-reading state.value (which would race a subsequent run).
+                when (val terminal = DiagnosticsCache.awaitTerminal(context)) {
+                    is DiagnosticsCache.State.Blocked -> {
+                        ProtectionCheck.Blocked(terminal.gate)
+                    }
+
+                    is DiagnosticsCache.State.Ready -> {
+                        // Derive tiles from the one canonical report (the same object the
+                        // debug bundle renders), so the on-screen verdict and the exported
+                        // one can never diverge. Tiles judge each backend on the vectors it
+                        // owns; unowned leaks are surfaced via the hero warning below.
+                        val report =
+                            buildDiagnosticReport(
+                                gate = DiagnosticGate.ROUTED,
+                                results = terminal.results,
+                                backend = nativeBackend,
+                                lsposedActive = lsposed is LsposedState.Active,
+                                complete = true,
+                            )
+                        unownedNativeLeakCount = report.native.unownedLeaks
+                        ProtectionCheck.Checked(report.native.status, report.java.status)
+                    }
+
+                    // State.Failed, and defensively the never-terminal NotRun/Running:
+                    // the run couldn't measure — distinct from a VPN-off gate.
+                    else -> {
+                        ProtectionCheck.Failed
+                    }
                 }
             }
         }

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DashboardScreen.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DashboardScreen.kt
@@ -176,21 +176,20 @@ fun DashboardScreen(
         // pending. The all-good "Checked" state renders nothing here — the hero's
         // per-level tiles already carry that status, so the old duplicate per-level
         // cards (Native / Java «OK», which just restated those tiles) are gone.
-        when (loadedState.protection) {
-            is ProtectionCheck.NoVpn -> {
+        // Per-layer verdict (Checked) renders in the cards below; only a blocked gate
+        // shows a hero banner. Retry re-reads dashboard state (re-runs its own VPN +
+        // protection probes) and re-runs the diag cache so both screens recover together.
+        val onRetry = {
+            DashboardCache.refresh(scope, context, selfNeedsRestart)
+            DiagnosticsCache.retry(scope, context)
+        }
+        when ((loadedState.protection as? ProtectionCheck.Blocked)?.gate) {
+            DiagnosticGate.VPN_OFF -> {
                 Spacer(Modifier.height(12.dp))
-                VpnOffPrompt(
-                    onRetry = {
-                        // Re-read dashboard state (re-runs its own VPN + protection
-                        // probes) and re-run the diag cache so both screens move to
-                        // "Ready" when VPN is back.
-                        DashboardCache.refresh(scope, context, selfNeedsRestart)
-                        DiagnosticsCache.retry(scope, context)
-                    },
-                )
+                VpnOffPrompt(onRetry = onRetry)
             }
 
-            is ProtectionCheck.NeedsRestart -> {
+            DiagnosticGate.NEEDS_RESTART -> {
                 Spacer(Modifier.height(12.dp))
                 StatusBanner(
                     text = stringResource(R.string.dashboard_needs_restart),
@@ -199,18 +198,12 @@ fun DashboardScreen(
                 )
             }
 
-            is ProtectionCheck.SelfNotRouted -> {
+            DiagnosticGate.SELF_NOT_ROUTED -> {
                 Spacer(Modifier.height(12.dp))
-                SelfNotRoutedPrompt(
-                    onRetry = {
-                        DashboardCache.refresh(scope, context, selfNeedsRestart)
-                        DiagnosticsCache.retry(scope, context)
-                    },
-                )
+                SelfNotRoutedPrompt(onRetry = onRetry)
             }
 
-            // Per-layer verdict renders in the cards below; no hero banner here.
-            is ProtectionCheck.Checked -> {}
+            else -> {} // Checked (null gate) or the unreachable ROUTED: no hero banner
         }
         Spacer(Modifier.height(20.dp))
 
@@ -693,7 +686,7 @@ private fun nativeSummaryText(protection: ProtectionCheck): String =
     when (protection) {
         // VPN off / app not in the tunnel / needs restart: the layer wasn't measured, so the
         // tile just reads "not checked" — the hero and banner carry the actual reason.
-        ProtectionCheck.NoVpn, ProtectionCheck.NeedsRestart, ProtectionCheck.SelfNotRouted -> {
+        is ProtectionCheck.Blocked -> {
             stringResource(R.string.dashboard_protection_unknown)
         }
 
@@ -705,14 +698,14 @@ private fun nativeSummaryText(protection: ProtectionCheck): String =
 @Composable
 private fun nativeSummaryAccent(protection: ProtectionCheck): Color =
     when (protection) {
-        ProtectionCheck.NoVpn, ProtectionCheck.NeedsRestart, ProtectionCheck.SelfNotRouted -> MaterialTheme.colorScheme.onSurfaceVariant
+        is ProtectionCheck.Blocked -> MaterialTheme.colorScheme.onSurfaceVariant
         is ProtectionCheck.Checked -> layerSummaryAccent(protection.native)
     }
 
 @Composable
 private fun javaSummaryText(protection: ProtectionCheck): String =
     when (protection) {
-        ProtectionCheck.NoVpn, ProtectionCheck.NeedsRestart, ProtectionCheck.SelfNotRouted -> {
+        is ProtectionCheck.Blocked -> {
             stringResource(R.string.dashboard_protection_unknown)
         }
 
@@ -724,7 +717,7 @@ private fun javaSummaryText(protection: ProtectionCheck): String =
 @Composable
 private fun javaSummaryAccent(protection: ProtectionCheck): Color =
     when (protection) {
-        ProtectionCheck.NoVpn, ProtectionCheck.NeedsRestart, ProtectionCheck.SelfNotRouted -> MaterialTheme.colorScheme.onSurfaceVariant
+        is ProtectionCheck.Blocked -> MaterialTheme.colorScheme.onSurfaceVariant
         is ProtectionCheck.Checked -> layerSummaryAccent(protection.java)
     }
 

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DashboardScreen.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DashboardScreen.kt
@@ -181,7 +181,7 @@ fun DashboardScreen(
         // protection probes) and re-runs the diag cache so both screens recover together.
         val onRetry = {
             DashboardCache.refresh(scope, context, selfNeedsRestart)
-            DiagnosticsCache.retry(scope, context)
+            DiagnosticsCache.retry(scope, context, selfNeedsRestart)
         }
         val protection = loadedState.protection
         when {

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DashboardScreen.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DashboardScreen.kt
@@ -183,13 +183,14 @@ fun DashboardScreen(
             DashboardCache.refresh(scope, context, selfNeedsRestart)
             DiagnosticsCache.retry(scope, context)
         }
-        when ((loadedState.protection as? ProtectionCheck.Blocked)?.gate) {
-            DiagnosticGate.VPN_OFF -> {
+        val protection = loadedState.protection
+        when {
+            (protection as? ProtectionCheck.Blocked)?.gate == DiagnosticGate.VPN_OFF -> {
                 Spacer(Modifier.height(12.dp))
                 VpnOffPrompt(onRetry = onRetry)
             }
 
-            DiagnosticGate.NEEDS_RESTART -> {
+            (protection as? ProtectionCheck.Blocked)?.gate == DiagnosticGate.NEEDS_RESTART -> {
                 Spacer(Modifier.height(12.dp))
                 StatusBanner(
                     text = stringResource(R.string.dashboard_needs_restart),
@@ -198,12 +199,17 @@ fun DashboardScreen(
                 )
             }
 
-            DiagnosticGate.SELF_NOT_ROUTED -> {
+            (protection as? ProtectionCheck.Blocked)?.gate == DiagnosticGate.SELF_NOT_ROUTED -> {
                 Spacer(Modifier.height(12.dp))
                 SelfNotRoutedPrompt(onRetry = onRetry)
             }
 
-            else -> {} // Checked (null gate) or the unreachable ROUTED: no hero banner
+            protection is ProtectionCheck.Failed -> {
+                Spacer(Modifier.height(12.dp))
+                DiagnosticsFailedPrompt(onRetry = onRetry)
+            }
+
+            else -> {} // Checked: the per-layer tiles carry the status; no hero banner
         }
         Spacer(Modifier.height(20.dp))
 
@@ -686,7 +692,7 @@ private fun nativeSummaryText(protection: ProtectionCheck): String =
     when (protection) {
         // VPN off / app not in the tunnel / needs restart: the layer wasn't measured, so the
         // tile just reads "not checked" — the hero and banner carry the actual reason.
-        is ProtectionCheck.Blocked -> {
+        is ProtectionCheck.Blocked, ProtectionCheck.Failed -> {
             stringResource(R.string.dashboard_protection_unknown)
         }
 
@@ -698,14 +704,14 @@ private fun nativeSummaryText(protection: ProtectionCheck): String =
 @Composable
 private fun nativeSummaryAccent(protection: ProtectionCheck): Color =
     when (protection) {
-        is ProtectionCheck.Blocked -> MaterialTheme.colorScheme.onSurfaceVariant
+        is ProtectionCheck.Blocked, ProtectionCheck.Failed -> MaterialTheme.colorScheme.onSurfaceVariant
         is ProtectionCheck.Checked -> layerSummaryAccent(protection.native)
     }
 
 @Composable
 private fun javaSummaryText(protection: ProtectionCheck): String =
     when (protection) {
-        is ProtectionCheck.Blocked -> {
+        is ProtectionCheck.Blocked, ProtectionCheck.Failed -> {
             stringResource(R.string.dashboard_protection_unknown)
         }
 
@@ -717,7 +723,7 @@ private fun javaSummaryText(protection: ProtectionCheck): String =
 @Composable
 private fun javaSummaryAccent(protection: ProtectionCheck): Color =
     when (protection) {
-        is ProtectionCheck.Blocked -> MaterialTheme.colorScheme.onSurfaceVariant
+        is ProtectionCheck.Blocked, ProtectionCheck.Failed -> MaterialTheme.colorScheme.onSurfaceVariant
         is ProtectionCheck.Checked -> layerSummaryAccent(protection.java)
     }
 

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DiagnosticReport.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DiagnosticReport.kt
@@ -20,10 +20,14 @@ internal enum class CheckLayer { NATIVE, JAVA }
 internal enum class DiagnosticGate { VPN_OFF, SELF_NOT_ROUTED, NEEDS_RESTART, ROUTED }
 
 /**
- * Fold the three independent gate signals — VPN presence, this app's self-in-tunnel
- * routing, and a pending self-restart — into one [DiagnosticGate], worst-first, so
- * the dashboard, the live cache, and the debug export classify the run the same way.
- * Only [DiagnosticGate.ROUTED] means "measured; verdicts are meaningful".
+ * Fold the three independent gate signals — a pending self-restart, VPN presence,
+ * and this app's self-in-tunnel routing — into one [DiagnosticGate], most-blocking
+ * first, so the dashboard, the live cache, and the debug export classify the run the
+ * same way. Only [DiagnosticGate.ROUTED] means "measured; verdicts are meaningful".
+ *
+ * [NEEDS_RESTART] outranks [VPN_OFF]: when this app was just added as a target its
+ * own hooks aren't applied to this process yet, so a run would measure nothing no
+ * matter the VPN state — "reboot to apply" is the actionable step, not "turn on VPN".
  */
 internal fun resolveDiagnosticGate(
     vpnActive: Boolean,
@@ -31,8 +35,8 @@ internal fun resolveDiagnosticGate(
     selfNeedsRestart: Boolean,
 ): DiagnosticGate =
     when {
-        !vpnActive -> DiagnosticGate.VPN_OFF
         selfNeedsRestart -> DiagnosticGate.NEEDS_RESTART
+        !vpnActive -> DiagnosticGate.VPN_OFF
         selfRouted == false -> DiagnosticGate.SELF_NOT_ROUTED
         else -> DiagnosticGate.ROUTED
     }

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DiagnosticsCache.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DiagnosticsCache.kt
@@ -80,15 +80,35 @@ internal object DiagnosticsCache {
     // summary), so they survive even if no screen scope is active.
     private val cacheScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
 
+    // Whether this app's own hooks need a reboot to apply (it was just added as a
+    // target). Process-constant, so it is sticky-OR: the first run() call sets it and
+    // no later caller can clear it. When set, a run measures nothing (the hooks aren't
+    // in this process), so the cache parks at Blocked(NEEDS_RESTART) and never probes.
+    @Volatile private var restartPending = false
+
     /** Start a run if one isn't already in flight and we don't have a
      * completed result yet. Idempotent — safe to call from both
      * Dashboard and Diagnostics screens on every composition.
+     *
+     * [selfNeedsRestart] is the shared gate signal: once any caller reports true the
+     * cache stays at Blocked(NEEDS_RESTART) (a run would be meaningless), so a caller
+     * that doesn't know it — the agent bridge — can safely pass false.
      */
     @Synchronized
     fun run(
         scope: CoroutineScope,
         context: Context,
+        selfNeedsRestart: Boolean,
     ) {
+        restartPending = restartPending || selfNeedsRestart
+        if (restartPending) {
+            // Publish the gate synchronously and never launch doRun — this keeps the
+            // Job/cancellation machinery reserved for the real run. selfNeedsRestart is
+            // process-constant, so this is decided on the first run() and never flips
+            // out from under an in-flight run.
+            _state.value = State.Blocked(DiagnosticGate.NEEDS_RESTART)
+            return
+        }
         val current = _state.value
         when (current) {
             is State.Ready -> {
@@ -116,7 +136,8 @@ internal object DiagnosticsCache {
     fun retry(
         scope: CoroutineScope,
         context: Context,
-    ) = run(scope, context)
+        selfNeedsRestart: Boolean,
+    ) = run(scope, context, selfNeedsRestart)
 
     /**
      * Suspend until the full Diagnostics result is available. Dashboard uses
@@ -124,8 +145,11 @@ internal object DiagnosticsCache {
      * probe shown in Settings → Detailed diagnostics, including the slow push-callback
      * and route/NetworkInfo Java checks.
      */
-    suspend fun awaitTerminal(context: Context): State {
-        run(cacheScope, context)
+    suspend fun awaitTerminal(
+        context: Context,
+        selfNeedsRestart: Boolean,
+    ): State {
+        run(cacheScope, context, selfNeedsRestart)
         return state.first {
             it is State.Blocked || it is State.Failed || (it is State.Ready && it.complete)
         }
@@ -135,7 +159,10 @@ internal object DiagnosticsCache {
      * measurement (blocked or failed). Callers that need to distinguish *why*
      * there are no results should use [awaitTerminal] — reading [state] again
      * after a null here would race a subsequent run. */
-    suspend fun awaitFullResults(context: Context): CheckResults? = (awaitTerminal(context) as? State.Ready)?.results
+    suspend fun awaitFullResults(
+        context: Context,
+        selfNeedsRestart: Boolean,
+    ): CheckResults? = (awaitTerminal(context, selfNeedsRestart) as? State.Ready)?.results
 
     private suspend fun doRun(appContext: Context) {
         _state.value = State.Running

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DiagnosticsCache.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DiagnosticsCache.kt
@@ -29,11 +29,11 @@ import kotlin.coroutines.coroutineContext
  * State machine:
  * - [State.NotRun] — fresh, nothing attempted yet.
  * - [State.Running] — a run is in flight.
- * - [State.VpnOff] — last run aborted because no active VPN was
- *   detected. User gets a "turn on VPN, then retry" banner.
+ * - [State.Blocked] — the gate stopped the run (VPN off, or this app split-tunnelled
+ *   out); carries the [DiagnosticGate] so the banner explains which.
  * - [State.Failed] — last run threw (root dropped, shell exec failure). VPN may
  *   well be on; the user gets a "diagnostics failed, retry" banner — distinct
- *   from [State.VpnOff] so an active-VPN user isn't told their VPN is off.
+ *   from a [State.Blocked] VPN-off gate so an active-VPN user isn't told their VPN is off.
  * - [State.Ready] — at least the fast phase is captured; [State.Ready.complete]
  *   flips to true when the slow Java probes have filled in too. Dashboard waits
  *   for the complete result, while Diagnostics can show the fast result first.
@@ -48,13 +48,17 @@ internal object DiagnosticsCache {
 
         data object Running : State
 
-        data object VpnOff : State
-
-        // A VPN is up on the device, but this app's own uid is not routed through
-        // it (excluded by split tunnelling). The checks would be meaningless —
-        // nothing to hide from us — so we ask the user to add VPN Hide to the
-        // tunnel instead of showing misleadingly-clean results.
-        data object SelfNotRouted : State
+        // The gate blocked the run: no active VPN, or a VPN is up but this app is
+        // split-tunnelled out of it (nothing to hide from us). Carries the shared
+        // [DiagnosticGate] so every consumer speaks one vocabulary and no one
+        // re-folds the reason. Never [DiagnosticGate.ROUTED] — that becomes [Ready].
+        data class Blocked(
+            val gate: DiagnosticGate,
+        ) : State {
+            init {
+                require(gate != DiagnosticGate.ROUTED) { "Blocked gate must not be ROUTED" }
+            }
+        }
 
         data object Failed : State
 
@@ -99,7 +103,7 @@ internal object DiagnosticsCache {
                 if (inflight?.isActive == true) return
             }
 
-            State.NotRun, State.VpnOff, State.SelfNotRouted, State.Failed -> { /* proceed */ }
+            State.NotRun, is State.Blocked, State.Failed -> { /* proceed */ }
         }
         if (inflight?.isActive == true) return
         inflight = scope.launch { doRun(context.applicationContext) }
@@ -107,7 +111,7 @@ internal object DiagnosticsCache {
 
     /** Used by the retry button in the "VPN off" / "failed" banners — a readable
      * alias for [run] at the call site (the [run] guard already permits a re-run
-     * from NotRun, VpnOff, and Failed).
+     * from NotRun, Blocked, and Failed).
      */
     fun retry(
         scope: CoroutineScope,
@@ -120,34 +124,40 @@ internal object DiagnosticsCache {
      * probe shown in Settings → Detailed diagnostics, including the slow push-callback
      * and route/NetworkInfo Java checks.
      */
-    suspend fun awaitFullResults(context: Context): CheckResults? {
+    suspend fun awaitTerminal(context: Context): State {
         run(cacheScope, context)
-        val terminal =
-            state.first {
-                it is State.VpnOff || it is State.SelfNotRouted || it is State.Failed ||
-                    (it is State.Ready && it.complete)
-            }
-        return (terminal as? State.Ready)?.results
+        return state.first {
+            it is State.Blocked || it is State.Failed || (it is State.Ready && it.complete)
+        }
     }
+
+    /** The complete check results, or null when the terminal state carried no
+     * measurement (blocked or failed). Callers that need to distinguish *why*
+     * there are no results should use [awaitTerminal] — reading [state] again
+     * after a null here would race a subsequent run. */
+    suspend fun awaitFullResults(context: Context): CheckResults? = (awaitTerminal(context) as? State.Ready)?.results
 
     private suspend fun doRun(appContext: Context) {
         _state.value = State.Running
         try {
             StartupTrace.mark("diagnostics_cache_start")
+            // Probe lazily and fold each decision through the one shared classifier
+            // ([resolveDiagnosticGate]) so the live path, the debug export, and the
+            // dashboard all order the gate identically. selfNeedsRestart is false
+            // here — callers pre-gate on it, so this path is only reached when it is.
             val vpnActive = withContext(Dispatchers.IO) { isVpnActive() }
             if (!vpnActive) {
-                _state.value = State.VpnOff
+                _state.value = State.Blocked(resolveDiagnosticGate(vpnActive = false, selfRouted = null, selfNeedsRestart = false))
                 StartupTrace.mark("diagnostics_cache_vpn_off")
                 return
             }
-            // Self-in-tunnel gate: a VPN is up, but is *this* app routed through
-            // it? If it is provably not (excluded by split tunnelling), the checks
-            // have nothing to hide from us — block with a "add to tunnel" prompt.
+            // Self-in-tunnel gate: a VPN is up, but is *this* app routed through it?
             // A null answer (no root to tell) does not block — a no-root device is
             // already handled as VPN-off above.
             val selfRouted = withContext(Dispatchers.IO) { GroundTruthProbe.selfRoutedThroughVpn(appContext) }
-            if (selfRouted == false) {
-                _state.value = State.SelfNotRouted
+            val gate = resolveDiagnosticGate(vpnActive = true, selfRouted = selfRouted, selfNeedsRestart = false)
+            if (gate != DiagnosticGate.ROUTED) {
+                _state.value = State.Blocked(gate)
                 StartupTrace.mark("diagnostics_cache_self_not_routed")
                 return
             }
@@ -166,13 +176,13 @@ internal object DiagnosticsCache {
         } catch (e: CancellationException) {
             // A cancelled job (e.g. the screen left) must propagate so
             // structured concurrency unwinds — never get reinterpreted as a
-            // VpnOff result. If we were cancelled before publishing a result,
-            // reset Running back to NotRun so a later run() can relaunch.
+            // Blocked/Failed result. If we were cancelled before publishing a
+            // result, reset Running back to NotRun so a later run() can relaunch.
             resetRunningIfStillOurs(coroutineContext.job)
             throw e
         } catch (e: Exception) {
-            // A real failure (root dropped, shell exec failure) — distinct from
-            // VpnOff so an active-VPN user isn't wrongly told their VPN is off.
+            // A real failure (root dropped, shell exec failure) — distinct from a
+            // VPN-off gate so an active-VPN user isn't wrongly told their VPN is off.
             // Both states offer a retry; these causes are usually transient.
             _state.value = State.Failed
             StartupTrace.mark("diagnostics_cache_failed")

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DiagnosticsScreen.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DiagnosticsScreen.kt
@@ -78,6 +78,7 @@ fun DiagnosticsScreen(
     }
 
     val results = (diagState as? DiagnosticsCache.State.Ready)?.results
+    val blockedGate = (diagState as? DiagnosticsCache.State.Blocked)?.gate
     // Native probes that couldn't run (ECONNREFUSED from socket()) classify as
     // NotMeasured(NoNetworkPermission). Java-level checks never produce that state,
     // so this isolates the "app has no network permission" banner from everything else.
@@ -108,7 +109,7 @@ fun DiagnosticsScreen(
                 )
             }
 
-            diagState is DiagnosticsCache.State.VpnOff -> {
+            blockedGate == DiagnosticGate.VPN_OFF -> {
                 VpnOffPrompt(
                     onRetry = {
                         DiagnosticsCache.retry(scope, context)
@@ -117,7 +118,7 @@ fun DiagnosticsScreen(
                 )
             }
 
-            diagState is DiagnosticsCache.State.SelfNotRouted -> {
+            blockedGate == DiagnosticGate.SELF_NOT_ROUTED -> {
                 SelfNotRoutedPrompt(
                     onRetry = {
                         DiagnosticsCache.retry(scope, context)

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DiagnosticsScreen.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DiagnosticsScreen.kt
@@ -67,14 +67,11 @@ fun DiagnosticsScreen(
     val diagState by DiagnosticsCache.state.collectAsState()
     val tallyFmt = stringResource(R.string.diag_summary_tally)
 
-    // Kick off the diagnostics run once per process. If selfNeedsRestart
-    // is true we skip — hooks aren't applied to this app yet, results
-    // would be meaningless. DiagnosticsCache.run is idempotent: no-op
-    // when Ready/Running.
+    // Kick off the diagnostics run once per process. The cache parks at
+    // Blocked(NEEDS_RESTART) itself when selfNeedsRestart (hooks aren't applied to this
+    // app yet, so a run would be meaningless); run is idempotent otherwise.
     LaunchedEffect(selfNeedsRestart) {
-        if (!selfNeedsRestart) {
-            DiagnosticsCache.run(scope, context)
-        }
+        DiagnosticsCache.run(scope, context, selfNeedsRestart)
     }
 
     val results = (diagState as? DiagnosticsCache.State.Ready)?.results
@@ -100,8 +97,12 @@ fun DiagnosticsScreen(
     ) {
         Spacer(Modifier.height(8.dp))
 
+        val onRetry = {
+            DiagnosticsCache.retry(scope, context, selfNeedsRestart)
+            DashboardCache.refresh(scope, context, selfNeedsRestart)
+        }
         when {
-            selfNeedsRestart -> {
+            blockedGate == DiagnosticGate.NEEDS_RESTART -> {
                 StatusBanner(
                     text = stringResource(R.string.banner_added_self),
                     containerColor = MaterialTheme.colorScheme.tertiaryContainer,
@@ -110,30 +111,15 @@ fun DiagnosticsScreen(
             }
 
             blockedGate == DiagnosticGate.VPN_OFF -> {
-                VpnOffPrompt(
-                    onRetry = {
-                        DiagnosticsCache.retry(scope, context)
-                        DashboardCache.refresh(scope, context, selfNeedsRestart)
-                    },
-                )
+                VpnOffPrompt(onRetry = onRetry)
             }
 
             blockedGate == DiagnosticGate.SELF_NOT_ROUTED -> {
-                SelfNotRoutedPrompt(
-                    onRetry = {
-                        DiagnosticsCache.retry(scope, context)
-                        DashboardCache.refresh(scope, context, selfNeedsRestart)
-                    },
-                )
+                SelfNotRoutedPrompt(onRetry = onRetry)
             }
 
             diagState is DiagnosticsCache.State.Failed -> {
-                DiagnosticsFailedPrompt(
-                    onRetry = {
-                        DiagnosticsCache.retry(scope, context)
-                        DashboardCache.refresh(scope, context, selfNeedsRestart)
-                    },
-                )
+                DiagnosticsFailedPrompt(onRetry = onRetry)
             }
 
             diagState is DiagnosticsCache.State.Running ||

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/StartupCoordinator.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/StartupCoordinator.kt
@@ -87,7 +87,9 @@ internal class StartupCoordinator(
     ) {
         AppListCache.ensureLoaded(scope, appContext)
         DashboardCache.ensureLoaded(scope, appContext, selfNeedsRestart)
-        if (!selfNeedsRestart) DiagnosticsCache.run(scope, appContext)
+        // The cache parks at Blocked(NEEDS_RESTART) itself when selfNeedsRestart — this
+        // is also the first run() call, so it stamps the process-constant flag.
+        DiagnosticsCache.run(scope, appContext, selfNeedsRestart)
         startAutoHideReconcile(scope)
     }
 

--- a/lsposed/app/src/test/kotlin/dev/okhsunrog/vpnhide/DashboardUiStateTest.kt
+++ b/lsposed/app/src/test/kotlin/dev/okhsunrog/vpnhide/DashboardUiStateTest.kt
@@ -46,9 +46,9 @@ class DashboardUiStateTest {
     @Test
     fun `protectionFullyPassed is true only when native and java layers are ok`() {
         assertTrue(protectionFullyPassed(ProtectionCheck.Checked(ok, ok)))
-        assertFalse(protectionFullyPassed(ProtectionCheck.NoVpn))
-        assertFalse(protectionFullyPassed(ProtectionCheck.NeedsRestart))
-        assertFalse(protectionFullyPassed(ProtectionCheck.SelfNotRouted))
+        assertFalse(protectionFullyPassed(ProtectionCheck.Blocked(DiagnosticGate.VPN_OFF)))
+        assertFalse(protectionFullyPassed(ProtectionCheck.Blocked(DiagnosticGate.NEEDS_RESTART)))
+        assertFalse(protectionFullyPassed(ProtectionCheck.Blocked(DiagnosticGate.SELF_NOT_ROUTED)))
         assertFalse(protectionFullyPassed(ProtectionCheck.Checked(LayerStatus.Absent, ok)))
         assertFalse(protectionFullyPassed(ProtectionCheck.Checked(partial, ok)))
         assertFalse(protectionFullyPassed(ProtectionCheck.Checked(ok, partial)))
@@ -60,7 +60,7 @@ class DashboardUiStateTest {
         assertEquals(
             HeroStatus.VpnOff,
             computeHeroStatus(
-                state = dashboardState(protection = ProtectionCheck.NoVpn),
+                state = dashboardState(protection = ProtectionCheck.Blocked(DiagnosticGate.VPN_OFF)),
                 errorCount = 1,
                 warningCount = 1,
             ),
@@ -72,7 +72,7 @@ class DashboardUiStateTest {
         assertEquals(
             HeroStatus.Attention,
             computeHeroStatus(
-                state = dashboardState(protection = ProtectionCheck.NeedsRestart),
+                state = dashboardState(protection = ProtectionCheck.Blocked(DiagnosticGate.NEEDS_RESTART)),
                 errorCount = 0,
                 warningCount = 0,
             ),
@@ -82,7 +82,7 @@ class DashboardUiStateTest {
         assertEquals(
             HeroStatus.Attention,
             computeHeroStatus(
-                state = dashboardState(protection = ProtectionCheck.SelfNotRouted),
+                state = dashboardState(protection = ProtectionCheck.Blocked(DiagnosticGate.SELF_NOT_ROUTED)),
                 errorCount = 0,
                 warningCount = 0,
             ),

--- a/lsposed/app/src/test/kotlin/dev/okhsunrog/vpnhide/DashboardUiStateTest.kt
+++ b/lsposed/app/src/test/kotlin/dev/okhsunrog/vpnhide/DashboardUiStateTest.kt
@@ -87,6 +87,15 @@ class DashboardUiStateTest {
                 warningCount = 0,
             ),
         )
+        // A failed run couldn't measure — attention, never "VPN off" (the VPN may be up).
+        assertEquals(
+            HeroStatus.Attention,
+            computeHeroStatus(
+                state = dashboardState(protection = ProtectionCheck.Failed),
+                errorCount = 0,
+                warningCount = 0,
+            ),
+        )
         assertEquals(
             HeroStatus.Attention,
             computeHeroStatus(

--- a/lsposed/app/src/test/kotlin/dev/okhsunrog/vpnhide/DiagnosticReportTest.kt
+++ b/lsposed/app/src/test/kotlin/dev/okhsunrog/vpnhide/DiagnosticReportTest.kt
@@ -136,6 +136,9 @@ class DiagnosticReportTest {
     fun `gate folds the three signals worst-first`() {
         assertEquals(DiagnosticGate.VPN_OFF, resolveDiagnosticGate(vpnActive = false, selfRouted = true, selfNeedsRestart = false))
         assertEquals(DiagnosticGate.NEEDS_RESTART, resolveDiagnosticGate(vpnActive = true, selfRouted = true, selfNeedsRestart = true))
+        // needs-restart outranks vpn-off: the app's own hooks aren't applied yet, so a
+        // run measures nothing regardless of the VPN — reboot is the actionable step.
+        assertEquals(DiagnosticGate.NEEDS_RESTART, resolveDiagnosticGate(vpnActive = false, selfRouted = null, selfNeedsRestart = true))
         assertEquals(
             DiagnosticGate.SELF_NOT_ROUTED,
             resolveDiagnosticGate(vpnActive = true, selfRouted = false, selfNeedsRestart = false),


### PR DESCRIPTION
The "did we measure, and what blocked it" axis was spelled out three times — DiagnosticsCache.State, DiagnosticGate, and ProtectionCheck — with the worst-first fold re-implemented four times (the pure resolveDiagnosticGate, the cache's doRun, the dashboard build, and the agent bridge), and resolveDiagnosticGate itself wired only into the debug export. This makes DiagnosticGate the single shared vocabulary: the cache and the dashboard keep their own axes (lifecycle, measured payload) but stop re-enumerating the gate, and the one fold classifies every path. Along the way it fixes two latent inconsistencies the duplication was hiding.

- Collapse DiagnosticsCache.State.VpnOff + SelfNotRouted into Blocked(gate) and route doRun through resolveDiagnosticGate; add awaitTerminal() returning the terminal state so the dashboard and agent bridge stop re-reading state.value after a null (a race)
- Collapse ProtectionCheck.NoVpn / NeedsRestart / SelfNotRouted into Blocked(gate); every consumer matches the gate once, and the agent wire tokens move to one stable gate→token helper
- Give a failed run its own state: a run that threw (root dropped) no longer shows as "VPN is off" on the dashboard — it gets a distinct retry prompt and ranks Attention, and the agent bridge reports state=failed
- Make the cache the single gate authority: push selfNeedsRestart into run() as a sticky process-constant flag, drop the dashboard's second VPN sensor and its pre-fold, and reorder resolveDiagnosticGate so needs-restart outranks VPN-off — so the dashboard and diagnostics screen finally agree on which prompt to show

Behaviour-preserving except the two fixes above (both changelogged). No new tests were needed beyond pinning the gate priority and the failed-run hero rank; the pure folds stay unit-tested and the Compose banners are thin renders of them.