### PR TITLE
Expand native targets and stream complete statistics

### DIFF
--- a/changelog.d/changed-native-backend-statistics-now-stream-complete-0444.md
+++ b/changelog.d/changed-native-backend-statistics-now-stream-complete-0444.md
@@ -1,0 +1,9 @@
+_2026-08-11_
+
+## English
+
+Native backend statistics now stream complete results instead of stopping at fixed KPM or kernel-module output buffers.
+
+## Русский
+
+Статистика нативных бэкендов теперь передаётся полностью и больше не обрывается из-за фиксированных буферов KPM или модуля ядра.

--- a/changelog.d/changed-raised-the-native-backend-target-limit-2fd9.md
+++ b/changelog.d/changed-raised-the-native-backend-target-limit-2fd9.md
@@ -1,0 +1,9 @@
+_2026-08-11_
+
+## English
+
+Raised the native backend target limit from 64 to 160 UIDs while keeping oversized KPM control payloads fail-safe.
+
+## Русский
+
+Лимит целей нативных бэкендов увеличен с 64 до 160 UID, при этом слишком большие управляющие сообщения KPM по-прежнему безопасно отклоняются.

--- a/changelog.d/changed-the-app-now-blocks-native-selections-08bf.md
+++ b/changelog.d/changed-the-app-now-blocks-native-selections-08bf.md
@@ -1,0 +1,9 @@
+_2026-08-11_
+
+## English
+
+The app now blocks Native selections beyond 159 resolved app UIDs, reserves one backend slot for VPN Hide, and prevents secondary-profile copies from changing the shared configuration.
+
+## Русский
+
+Приложение теперь не позволяет выбрать для Native больше 159 UID приложений, резервирует одно место бэкенда для VPN Hide и запрещает копиям в дополнительных профилях изменять общую конфигурацию.

--- a/crates/activator/src/kpm.rs
+++ b/crates/activator/src/kpm.rs
@@ -194,9 +194,9 @@ impl KpmClient {
                 Err(_) if attempt + 1 < ATTEMPTS => {
                     // A concurrent boot/app ctl0 config gets the KPM's short
                     // busy return instead of spinning inside the kernel. The
-                    // critical section is only a 64-entry copy, so a brief
-                    // retry also covers runtimes that flatten negative return
-                    // codes to a generic CLI failure.
+                    // critical section is only a bounded target-array copy,
+                    // so a brief retry also covers runtimes that flatten
+                    // negative return codes to a generic CLI failure.
                     thread::sleep(Duration::from_millis(20));
                 }
                 Err(error) => return Err(error),

--- a/crates/activator/src/kpm.rs
+++ b/crates/activator/src/kpm.rs
@@ -207,9 +207,18 @@ impl KpmClient {
 
     pub(crate) fn ctl0_read(&self, wire: &str) -> Result<String> {
         let _lock = KpmCtlLock::acquire()?;
+        normalize_kpm_reply(wire, self.ctl0_read_raw(wire)?)
+    }
+
+    pub(crate) fn ctl0_stats(&self) -> Result<String> {
+        let _lock = KpmCtlLock::acquire()?;
+        collect_kpm_stats_pages(|wire| self.ctl0_read_raw(wire))
+    }
+
+    fn ctl0_read_raw(&self, wire: &str) -> Result<String> {
         match self {
-            Self::KpatchCli { path } => run_kpatch_kpm_ctl0_read(path, wire),
-            Self::ApatchSupercall { key, style } => apatch_kpm_ctl0_read(key, *style, wire),
+            Self::KpatchCli { path } => run_kpatch_kpm_ctl0_read_raw(path, wire),
+            Self::ApatchSupercall { key, style } => apatch_kpm_ctl0_read_raw(key, *style, wire),
         }
     }
 }
@@ -267,7 +276,7 @@ fn run_kpatch_kpm_ctl0_config(kpatch: &Path, wire: &str) -> Result<()> {
     }
 }
 
-fn run_kpatch_kpm_ctl0_read(kpatch: &Path, wire: &str) -> Result<String> {
+fn run_kpatch_kpm_ctl0_read_raw(kpatch: &Path, wire: &str) -> Result<String> {
     let mut cmd = Command::new(kpatch);
     cmd.args(["kpm", "ctl0", KPM_NAME, wire]);
     let out = cmd.output()?;
@@ -279,7 +288,12 @@ fn run_kpatch_kpm_ctl0_read(kpatch: &Path, wire: &str) -> Result<String> {
     // error the supercall returns a negative rc and never fills the buffer, so
     // stdout is empty. Trust stdout: the reply text is authoritative, the exit
     // code is not (it can't even round-trip a reply longer than 255 bytes).
-    normalize_kpm_reply(wire, String::from_utf8_lossy(&out.stdout).into_owned())
+    let reply = String::from_utf8_lossy(&out.stdout).into_owned();
+    if reply.is_empty() {
+        Err("KPM ctl0 returned an empty reply".into())
+    } else {
+        Ok(reply)
+    }
 }
 
 /// Validate a KPM readback and preserve the protocol's missing-newline
@@ -302,6 +316,156 @@ pub(crate) fn normalize_kpm_reply(wire: &str, mut reply: String) -> Result<Strin
         reply.push('\n');
     }
     Ok(reply)
+}
+
+const MAX_KPM_STATS_PAGES: usize = 512;
+
+#[derive(Debug, PartialEq, Eq)]
+enum StatsPageNext {
+    Cursor(u32),
+    Done,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+struct StatsPage {
+    rows: Vec<String>,
+    next: StatsPageNext,
+}
+
+fn parse_prefixed_hex_u64(token: &str) -> Option<u64> {
+    let digits = token
+        .strip_prefix("0x")
+        .or_else(|| token.strip_prefix("0X"))?;
+    (!digits.is_empty())
+        .then(|| u64::from_str_radix(digits, 16).ok())
+        .flatten()
+}
+
+fn parse_prefixed_hex_u32(token: &str) -> Option<u32> {
+    parse_prefixed_hex_u64(token).and_then(|value| u32::try_from(value).ok())
+}
+
+/// Parse and validate the additive KPM `page` trailer. `None` is a complete
+/// legacy reply from an older backend; a present trailer is strict so a broken
+/// cursor cannot silently duplicate or omit cumulative counters.
+fn parse_kpm_stats_page(reply: &str, requested: u32) -> Result<Option<StatsPage>> {
+    if peek_kind(reply.as_bytes()) != Some(Kind::Stats) {
+        return Err("invalid KPM stats reply header".into());
+    }
+    let lines = reply.lines().map(str::trim).collect::<Vec<_>>();
+    let page_positions = lines
+        .iter()
+        .enumerate()
+        .filter(|(_, line)| line.split_whitespace().next() == Some("page"))
+        .map(|(index, _)| index)
+        .collect::<Vec<_>>();
+    if page_positions.is_empty() {
+        return Ok(None);
+    }
+    if page_positions.len() != 1 || page_positions[0] + 1 != lines.len() {
+        return Err("KPM stats reply has a misplaced or repeated page trailer".into());
+    }
+
+    let trailer = lines[page_positions[0]]
+        .split_whitespace()
+        .collect::<Vec<_>>();
+    if trailer.len() != 4 {
+        return Err("malformed KPM stats page trailer".into());
+    }
+    let echoed = parse_prefixed_hex_u32(trailer[1]).ok_or("invalid echoed stats cursor")?;
+    if echoed != requested {
+        return Err(
+            format!("KPM stats page echoed cursor 0x{echoed:x}, expected 0x{requested:x}").into(),
+        );
+    }
+    let declared_rows =
+        parse_prefixed_hex_u32(trailer[3]).ok_or("invalid stats page row count")? as usize;
+
+    let mut rows = Vec::new();
+    let mut previous_uid = requested;
+    for line in &lines[1..page_positions[0]] {
+        if line.is_empty() || line.starts_with('#') {
+            continue;
+        }
+        let fields = line.split_whitespace().collect::<Vec<_>>();
+        let uid = fields
+            .first()
+            .and_then(|token| parse_prefixed_hex_u32(token))
+            .ok_or("invalid UID in KPM stats page")?;
+        if uid <= previous_uid || fields.len() < 2 {
+            return Err("KPM stats page UIDs are not strictly increasing".into());
+        }
+        for field in &fields[1..] {
+            let (hook, count) = field
+                .split_once(':')
+                .ok_or("invalid hook counter in KPM stats page")?;
+            parse_prefixed_hex_u32(hook).ok_or("invalid hook id in KPM stats page")?;
+            let count = parse_prefixed_hex_u64(count).ok_or("invalid count in KPM stats page")?;
+            if count == 0 {
+                return Err("zero count in sparse KPM stats page".into());
+            }
+        }
+        previous_uid = uid;
+        rows.push((*line).to_owned());
+    }
+    if rows.len() != declared_rows {
+        return Err(format!(
+            "KPM stats page declared {declared_rows} rows but carried {}",
+            rows.len()
+        )
+        .into());
+    }
+
+    let next = if trailer[2] == "done" {
+        if !reply.ends_with('\n') {
+            return Err("final KPM stats page is missing its newline".into());
+        }
+        StatsPageNext::Done
+    } else {
+        let next = parse_prefixed_hex_u32(trailer[2]).ok_or("invalid next stats cursor")?;
+        if next <= requested || next < previous_uid {
+            return Err("KPM stats page cursor did not advance".into());
+        }
+        if reply.ends_with('\n') {
+            return Err("non-final KPM stats page unexpectedly ends with a newline".into());
+        }
+        StatsPageNext::Cursor(next)
+    };
+    Ok(Some(StatsPage { rows, next }))
+}
+
+pub(crate) fn collect_kpm_stats_pages(
+    mut read: impl FnMut(&str) -> Result<String>,
+) -> Result<String> {
+    let mut cursor = 0u32;
+    let mut aggregate = format!("vpnhide {} stats\n", vpnhide_protocol::TELEMETRY_VERSION);
+
+    for page_index in 0..MAX_KPM_STATS_PAGES {
+        let request = if page_index == 0 {
+            aggregate.trim_end().to_owned()
+        } else {
+            format!(
+                "vpnhide {} stats\nafter 0x{cursor:x}\n",
+                vpnhide_protocol::TELEMETRY_VERSION
+            )
+        };
+        let reply = read(&request)?;
+        let Some(page) = parse_kpm_stats_page(&reply, cursor)? else {
+            if page_index != 0 {
+                return Err("KPM stopped paginating stats mid-read".into());
+            }
+            return normalize_kpm_reply(&request, reply);
+        };
+        for row in page.rows {
+            aggregate.push_str(&row);
+            aggregate.push('\n');
+        }
+        match page.next {
+            StatsPageNext::Done => return Ok(aggregate),
+            StatsPageNext::Cursor(next) => cursor = next,
+        }
+    }
+    Err(format!("KPM stats exceeded {MAX_KPM_STATS_PAGES} pages").into())
 }
 
 pub(crate) fn kpatch_ctl0_config_status_ok(status: std::process::ExitStatus, wire: &str) -> bool {
@@ -367,11 +531,15 @@ fn apatch_kpm_ctl0_config(key: &str, style: ApatchCommandStyle, wire: &str) -> R
     supercall_ok(rc, "kpm ctl0")
 }
 
-fn apatch_kpm_ctl0_read(key: &str, style: ApatchCommandStyle, wire: &str) -> Result<String> {
+fn apatch_kpm_ctl0_read_raw(key: &str, style: ApatchCommandStyle, wire: &str) -> Result<String> {
     let (rc, out) = apatch_kpm_ctl0_raw(key, style, wire)?;
     supercall_ok(rc, "kpm ctl0")?;
     let len = apatch_output_len(rc, &out);
-    normalize_kpm_reply(wire, String::from_utf8_lossy(&out[..len]).into_owned())
+    if len == 0 {
+        Err("KPM ctl0 returned an empty reply".into())
+    } else {
+        Ok(String::from_utf8_lossy(&out[..len]).into_owned())
+    }
 }
 
 fn apatch_kpm_ctl0_raw(

--- a/crates/activator/src/lib.rs
+++ b/crates/activator/src/lib.rs
@@ -230,13 +230,14 @@ pub fn read_kpm_status() -> Result<String> {
 }
 
 pub fn read_kpm_stats() -> Result<String> {
-    read_kpm_payload("vpnhide 1 stats")
+    let client = KpmClient::detect()?;
+    client.ctl0_stats()
 }
 
 pub fn read_kpm_state() -> Result<String> {
     let client = KpmClient::detect()?;
     let mut out = client.ctl0_read("vpnhide 1 status")?;
-    out.push_str(&client.ctl0_read("vpnhide 1 stats")?);
+    out.push_str(&client.ctl0_stats()?);
     Ok(out)
 }
 

--- a/crates/activator/src/lib.rs
+++ b/crates/activator/src/lib.rs
@@ -63,7 +63,7 @@ const KPM_SUPPORTED_KERNEL_PAIRS: &[(u32, u32)] = &[
 ];
 // The native-target cap is owned by the shared protocol crate (and mirrored by
 // the C backends' `#define MAX_TARGET_UIDS`); alias it here so all three stay in
-// lock-step instead of restating the literal 64.
+// lock-step instead of restating the literal capacity.
 const MAX_NATIVE_TARGETS: usize = MAX_TARGET_UIDS;
 // The control protocol carries a default hookmask for every uid NOT listed as a
 // target, which is the mechanism a whitelist mode would ride on: non-zero flips

--- a/crates/activator/src/model.rs
+++ b/crates/activator/src/model.rs
@@ -316,6 +316,24 @@ pub(crate) fn project_native_with_resolver_for_family(
         let Some(mask) = app.native.hookmask(family) else {
             continue;
         };
+        // The APK is intentionally single-owner: only its main-profile copy
+        // may manage the shared config. Keep its mandatory self target just as
+        // singular here. An accidentally installed work/clone-profile copy is
+        // blocked at startup and must not consume another backend slot.
+        if pkg == APP_PACKAGE {
+            if let Some(uid) = resolver
+                .uids_for(pkg)
+                .iter()
+                .copied()
+                .find(|uid| *uid < PER_USER_RANGE && is_app_uid(*uid))
+            {
+                by_uid
+                    .entry(uid)
+                    .and_modify(|existing| *existing |= mask)
+                    .or_insert(mask);
+            }
+            continue;
+        }
         for uid in resolver.uids_for(pkg) {
             // Below the app range a uid is not an app but a platform identity
             // shared by many components — a package declaring sharedUserId

--- a/crates/activator/src/tests.rs
+++ b/crates/activator/src/tests.rs
@@ -674,3 +674,56 @@ fn kpm_readback_rejects_empty_or_wrong_kind_replies() {
         .is_err(),
     );
 }
+
+#[test]
+fn kpm_stats_pages_are_validated_and_folded_into_legacy_telemetry() {
+    let replies = [
+        "vpnhide 1 stats\n0x2800 0x0:0x12 0x19:0x5\npage 0x0 0x2800 0x1",
+        "vpnhide 1 stats\n0x2801 0x2:0x7\npage 0x2800 done 0x1\n",
+    ];
+    let mut replies = replies.into_iter();
+    let mut requests = Vec::new();
+    let stats = collect_kpm_stats_pages(|request| {
+        requests.push(request.to_owned());
+        Ok(replies.next().unwrap().to_owned())
+    })
+    .unwrap();
+
+    assert_eq!(
+        requests,
+        ["vpnhide 1 stats", "vpnhide 1 stats\nafter 0x2800\n",]
+    );
+    assert_eq!(
+        stats,
+        "vpnhide 1 stats\n0x2800 0x0:0x12 0x19:0x5\n0x2801 0x2:0x7\n"
+    );
+}
+
+#[test]
+fn kpm_stats_reader_accepts_a_complete_legacy_reply() {
+    let legacy = "vpnhide 1 stats\n0x2800 0x0:0x12\n";
+    assert_eq!(
+        collect_kpm_stats_pages(|_| Ok(legacy.to_owned())).unwrap(),
+        legacy
+    );
+}
+
+#[test]
+fn kpm_stats_pages_reject_broken_integrity_signals() {
+    let cases = [
+        // Echoed cursor mismatch.
+        "vpnhide 1 stats\n0x2800 0x0:0x1\npage 0x1 0x2800 0x1",
+        // Declared row count mismatch.
+        "vpnhide 1 stats\n0x2800 0x0:0x1\npage 0x0 0x2800 0x2",
+        // A non-final page must retain the old-reader truncation signal.
+        "vpnhide 1 stats\n0x2800 0x0:0x1\npage 0x0 0x2800 0x1\n",
+        // A final page must be conventionally newline-terminated.
+        "vpnhide 1 stats\n0x2800 0x0:0x1\npage 0x0 done 0x1",
+    ];
+    for reply in cases {
+        assert!(
+            collect_kpm_stats_pages(|_| Ok(reply.to_owned())).is_err(),
+            "{reply:?}"
+        );
+    }
+}

--- a/crates/activator/src/tests.rs
+++ b/crates/activator/src/tests.rs
@@ -82,6 +82,32 @@ fn projects_native_roles_to_wire() {
 }
 
 #[test]
+fn native_projection_targets_only_the_main_profile_copy_of_vpnhide() {
+    let cfg = parse_canonical(
+        r#"{
+          "version": 1,
+          "apps": {
+            "dev.okhsunrog.vpnhide": { "native": true },
+            "com.example.profiled": { "native": true }
+          }
+        }"#,
+    )
+    .unwrap();
+    let resolver = parse_pm_packages(
+        "package:dev.okhsunrog.vpnhide uid:10123,1010123\n\
+         package:com.example.profiled uid:10234,1010234\n",
+    );
+
+    assert_eq!(
+        project_native_with_resolver(&cfg, &resolver),
+        "vpnhide 2 config\n\
+         debug 0\n\
+         targets 20003ff 278b 27fa f6a3a\n\
+         end 3\n",
+    );
+}
+
+#[test]
 fn native_projection_drops_platform_aids_but_keeps_preinstalled_apps() {
     // A package sharing "android.uid.system" resolves to 1000 — the same uid as
     // system_server — so listing it would mean "hide from everything running as

--- a/crates/activator/src/tests.rs
+++ b/crates/activator/src/tests.rs
@@ -543,7 +543,8 @@ fn apatch_kernel_version_hint_parses_dmesg() {
 
 #[test]
 fn projection_is_bounded_to_backend_target_capacity() {
-    let apps = (0..70)
+    let projected = MAX_NATIVE_TARGETS + 10;
+    let apps = (0..projected)
         .map(|i| {
             (
                 format!("com.example.{i:02}"),
@@ -560,15 +561,15 @@ fn projection_is_bounded_to_backend_target_capacity() {
         apps,
         settings: Settings::default(),
     };
-    let pm = (0..70)
+    let pm = (0..projected)
         .map(|i| format!("package:com.example.{i:02} uid:{}", 10_000 + i))
         .collect::<Vec<_>>()
         .join("\n");
     let wire = project_native_with_resolver(&cfg, &parse_pm_packages(&pm));
 
-    // All 70 share one mask, so the whole set rides one `targets` record and the
-    // count lives in the `end` fuse — which the backend checks, so the producer
-    // has to cap itself here rather than let the backend reject the payload.
+    // Every app shares one mask, so the whole set rides one `targets` record
+    // and the count lives in the `end` fuse — which the backend checks, so the
+    // producer has to cap itself here rather than let the backend reject it.
     assert_eq!(
         wire.lines().filter(|l| l.starts_with("targets ")).count(),
         1
@@ -587,8 +588,8 @@ fn projection_is_bounded_to_backend_target_capacity() {
     // payload carrying more uids than a backend can hold.
     assert!(vpnhide_protocol::parse_config(wire.as_bytes()).is_some());
     assert_eq!(
-        native_target_capacity_warning(70),
-        "vpnhide-warning native_target_cap total=70 cap=64 dropped=6",
+        native_target_capacity_warning(projected),
+        "vpnhide-warning native_target_cap total=170 cap=160 dropped=10",
     );
 }
 

--- a/crates/protocol/src/lib.rs
+++ b/crates/protocol/src/lib.rs
@@ -51,7 +51,7 @@ fn current_version(kind: Kind) -> u32 {
 /// source of truth for the cap on the wire boundary; the C backends mirror it as
 /// `#define MAX_TARGET_UIDS` in kmod/vpnhide_kmod.c and kmod/kpm/vpnhide_kpm.c —
 /// keep all three in sync.
-pub const MAX_TARGET_UIDS: usize = 64;
+pub const MAX_TARGET_UIDS: usize = 160;
 
 #[derive(Copy, Clone, PartialEq, Eq, Debug)]
 pub enum Kind {
@@ -621,22 +621,30 @@ mod tests {
     }
 
     #[test]
-    fn full_shared_mask_target_set_fits_the_kpm_transport() {
-        // Use maximum-width u32 values rather than today's usual five-digit
-        // Android UIDs. This guards the dense/common case promised by the v2
-        // grammar: every available target slot sharing one full hookmask must
-        // still leave room for KernelPatch's trailing NUL.
+    fn representative_full_target_set_fits_the_kpm_transport() {
+        // Ordinary Android app UIDs use four or five hexadecimal digits across
+        // owner/work-profile sets. The activator separately checks the actual
+        // wire length because unusual maximum-width UIDs or many distinct
+        // masks can still exceed the fixed KernelPatch transport independently
+        // of the target count.
         let targets: Vec<Target> = (0..MAX_TARGET_UIDS as u32)
-            .map(|offset| Target {
-                uid: u32::MAX - offset,
-                hookmask: u32::MAX,
+            .map(|offset| {
+                let half = MAX_TARGET_UIDS as u32 / 2;
+                Target {
+                    uid: if offset < half {
+                        10_000 + offset
+                    } else {
+                        1_010_000 + offset - half
+                    },
+                    hookmask: u32::MAX,
+                }
             })
             .collect();
         let wire = format_config(true, u32::MAX, &targets);
 
         assert!(
             wire.len() < KPM_ARGS_LEN,
-            "{MAX_TARGET_UIDS} maximum-width targets need {} bytes plus NUL, KPM_ARGS_LEN is {KPM_ARGS_LEN}",
+            "{MAX_TARGET_UIDS} representative Android targets need {} bytes plus NUL, KPM_ARGS_LEN is {KPM_ARGS_LEN}",
             wire.len(),
         );
     }

--- a/docs/limits.md
+++ b/docs/limits.md
@@ -56,7 +56,9 @@ whole-payload rejection. See [protocol.md §4.3](protocol.md).
 
 **The cap counts UIDs, not apps.** `resolver.uids_for()` returns every UID a
 package has across profiles, so an app present in a work profile spends two
-slots. A user with a work profile reaches 160 UIDs at around 80 apps.
+slots. The picker allows 159 selected-app UIDs and reserves the final slot for
+VPN Hide's main-profile UID. A user selecting apps present in both the main and
+work profiles therefore reaches the picker limit at around 79 apps.
 
 ## Telemetry — how many apps report counters
 

--- a/docs/limits.md
+++ b/docs/limits.md
@@ -27,10 +27,10 @@ can't raise the app count because stats won't fit" conflates the two.
 
 | constraint | where | value | binds at |
 |---|---|---|---|
-| `MAX_TARGET_UIDS` | `crates/protocol/src/lib.rs`, mirrored in both backends | 64 | **64 targets — currently binding** |
+| `MAX_TARGET_UIDS` | `crates/protocol/src/lib.rs`, mirrored in both backends | 160 | **160 targets — currently binding** |
 | `KPM_ARGS_LEN` | `kmod/third_party/KernelPatch/kernel/include/kpmodule.h` | 1024 B | ~190 targets sharing one mask; fewer with many distinct masks |
 | `ctl_write` payload cap | `kmod/vpnhide_kmod.c` (`count > PAGE_SIZE`) | 4096 B | ~800 targets |
-| parse scratch on the kernel stack | `ctl_write`, `vpnhide_kpm_ctl0` | 8 B/target | thousands (16 KiB arm64 stack, shared with a 4 KiB reply buffer in the KPM) |
+| config parse snapshot | `.ko` heap; KPM serialized static scratch | 8 B/target | does not grow either kernel stack |
 
 Measured control payloads under the v2 grammar (one shared full kernel
 hookmask, five-digit UIDs):
@@ -56,7 +56,7 @@ whole-payload rejection. See [protocol.md §4.3](protocol.md).
 
 **The cap counts UIDs, not apps.** `resolver.uids_for()` returns every UID a
 package has across profiles, so an app present in a work profile spends two
-slots. A user with a work profile reaches 64 UIDs at around 32 apps.
+slots. A user with a work profile reaches 160 UIDs at around 80 apps.
 
 ## Telemetry — how many apps report counters
 
@@ -82,8 +82,9 @@ The two backends are not in the same position:
 KPM keeps no serialisation snapshot. Its live table stores only the 11
 kernel-owned hook counters rather than the 27-id global registry, and a zero UID
 is the hash-table empty sentinel, so no separate `stats_used` array is needed.
-At the current 64-target cap the resulting `.bss` is **6480 B**, down from
-23120 B before compact storage and cursor output.
+At the current 160-target cap, including the static config parse scratch, the
+resulting `.bss` is **18004 B**. That is still below the **23120 B** used by the
+old 64-target layout before compact storage and cursor output.
 
 ## Raising a ceiling — options and cost
 
@@ -91,13 +92,13 @@ Ordered by cost. None of these are scheduled; this is the menu.
 
 ### Control
 
-1. **Do not raise `MAX_TARGET_UIDS` to ~160 by itself.** A typical one-mask,
-   five-digit-UID wire fits the KPM transport (848 B), and the kmod payload cap
-   has room, but KPM `.bss` rises from 23120 B to 45392 B because the live stats
-   table still follows the target cap. That returns it to the static-size range
-   already known to break KernelPatch boot on 6.12. First decouple or redesign
-   live stats storage, move the parse scratch off the kernel stack (8 B/target),
-   then re-run the 6.12 KPM boot harness. The hard cap therefore remains 64.
+1. **The shipped cap is 160.** Compact 11-hook stats storage and cursor output
+   keep KPM `.bss` at 18004 B, and config parsing uses serialized static scratch
+   rather than growing the KPM stack. A typical one-mask, five-digit-UID wire is
+   848 B and fits the KPM transport; maximum-width UIDs or many distinct masks
+   may hit the independent byte limit sooner. The activator validates the exact
+   formatted size and rejects the whole KPM update rather than sending a
+   truncated target set.
 2. **Past ~190 targets on the KPM**, the 1024-byte transport is the wall. The
    only way through is chunking — `config-begin` / `config-chunk` /
    `config-commit` across several ctl0 calls — which is a control-protocol
@@ -138,12 +139,12 @@ projection.
 
 ## Re-measuring
 
-Nothing here should be trusted because it is written down. The control-side
-figure is guarded by a test — `crates/protocol` asserts that all
-`MAX_TARGET_UIDS` targets, using maximum-width UIDs and one shared full mask,
-fit in `KPM_ARGS_LEN` with room for its trailing NUL. Arbitrary per-app masks
-can cost more group headers, so the activator also checks the formatted wire's
-actual byte length before KPM delivery.
+Nothing here should be trusted because it is written down. The representative
+control-side figure is guarded by a test — `crates/protocol` asserts that all
+`MAX_TARGET_UIDS` ordinary Android app UIDs, using one shared full mask, fit in
+`KPM_ARGS_LEN` with room for its trailing NUL. Maximum-width UIDs and arbitrary
+per-app masks can cost more bytes, so the activator also checks the formatted
+wire's actual length before KPM delivery.
 
 The telemetry table is not guarded, because its input is a usage profile rather
 than a constant. To redo it, format `n` uids × `k` hooks with

--- a/docs/limits.md
+++ b/docs/limits.md
@@ -60,38 +60,30 @@ slots. A user with a work profile reaches 64 UIDs at around 32 apps.
 
 ## Telemetry — how many apps report counters
 
-There is no fixed app count. A uid's cost depends on how many hooks fired for it
-and how large its counters grew, and counters are cumulative since the backend
-loaded — so the same device fits fewer uids after a week of uptime than after a
-reboot. Measured with the real formatter, 5-digit uids:
+There is no fixed output app count. A uid's text cost depends on how many hooks
+fired for it and how large its cumulative counters grew. Representative
+single-record sizes from the real formatter, for 5-digit uids:
 
-| profile | bytes/uid | fits in 4096 (KPM) | fits in 32768 (kmod) |
-|---|---|---|---|
-| 2 hooks, counts < 256 | 25 | 163 | 1310 |
-| 4 hooks, counts < 65k | 51 | 80 | 642 |
-| 8 hooks, counts ~1e6 | 103 | 39 | 317 |
-| 27 hooks, saturated u64 | 639 | 6 | 51 |
+| profile | bytes/uid | approximate rows in one 4096-byte KPM page |
+|---|---|---|
+| 2 hooks, counts < 256 | 25 | 160 |
+| 4 hooks, counts < 65k | 51 | 79 |
+| 8 hooks, counts ~1e6 | 103 | 39 |
+| all 11 kernel hooks, saturated u64 | 261 | 15 |
 
 The two backends are not in the same position:
 
-- **KPM** — 4096 B hard: `VPNHIDE_OUT_MAX` in `kmod/kpm/vpnhide_kpm.c`, and the
-  KPatch and APatch clients cap their side at the same figure, so a larger
-  userspace buffer does not help. On overflow it clamps to a whole record, the
-  activator marks the reply `# vpnhide truncated`, and the app drops that
-  backend's stats rather than showing partial totals
-  (`StatisticsData.kt`). Blunt, but it never reports a wrong number.
-- **kmod** — 32 KiB (`CTL_READ_BUF_SIZE`), and its entry array is already
-  heap-allocated. Eight times the room.
+- **KPM** — each ctl0 reply remains capped at 4096 B by the module and both
+  clients. The backend pages by ascending UID; the activator validates and
+  aggregates every page before exposing one normal telemetry block to the app.
+- **kmod** — `/proc/vpnhide_ctl` is a real `seq_operations` stream with one UID
+  per record. There is no whole-output buffer or formatter ceiling.
 
-The KPM's serialisation scratch is deliberately sized by the transport
-(`VPNHIDE_STATS_SNAPSHOT_MAX = VPNHIDE_OUT_MAX / 8`), not by
-`MAX_TARGET_UIDS * VPNHIDE_HOOK_COUNT`. The product would reserve 1728 entries
-when no reply can carry more than ~510. This removed one source of target-cap
-growth, but not all of it: the live `stats_used`, `stats_uids`, and
-`stats_counts[MAX_TARGET_UIDS][VPNHIDE_HOOK_COUNT]` arrays still scale with the
-cap. Static growth is what broke KernelPatch boot on the 6.12 image. At 64
-targets `.bss` is 23120 B (down from 42576 B); a source-only build with the cap
-changed to 160 measured **45392 B**, before any boot test.
+KPM keeps no serialisation snapshot. Its live table stores only the 11
+kernel-owned hook counters rather than the 27-id global registry, and a zero UID
+is the hash-table empty sentinel, so no separate `stats_used` array is needed.
+At the current 64-target cap the resulting `.bss` is **6480 B**, down from
+23120 B before compact storage and cursor output.
 
 ## Raising a ceiling — options and cost
 
@@ -121,16 +113,12 @@ Ordered by cost. None of these are scheduled; this is the menu.
 
 ### Telemetry
 
-1. **Bare hex in a telemetry v2** — the same trick control v2 used:
+1. **Bare hex in a future telemetry v2** — the same trick control v2 used:
    ` 0x3:0xf4240` → ` 3:f4240`, four bytes per cell, roughly +45% uids per read
    at the heavy profile. Cheap in code, expensive in delivery: telemetry's
    reader is the app, so bumping it means shipping the APK in step with every
    module. Only worth bundling with some other telemetry change.
-2. **A cursor** — `stats <after-uid>`, read in a loop. [protocol.md §7.2](protocol.md)
-   currently says "no pagination" for the KPM; that was a decision, not a law.
-   This is the only option that actually scales, and it is confined to the KPM
-   transport.
-3. **Cap by policy, not by configuration** — emit the top-N uids by total and
+2. **Cap by policy, not by configuration** — emit the top-N uids by total and
    mark that it happened. The user gets numbers for the apps that did something
    and configures nothing.
 
@@ -147,14 +135,6 @@ captures activator stderr, and the picker shows a localized long-duration
 warning instead of the normal success message. The canonical package selection
 is still saved in full; the warning describes the capped native runtime
 projection.
-
-## Known gaps
-
-- The app does not act on the truncation signal for the **kmod** stats channel.
-  It reads `/proc/vpnhide_ctl` directly and only looks for the activator's
-  `# vpnhide truncated` marker, which exists on the KPM path. After the clamp
-  fix a truncated kmod read ends on a whole record, so the numbers shown are
-  correct — there are just silently fewer of them.
 
 ## Re-measuring
 

--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -534,8 +534,9 @@ static long vpnhide_kpm_ctl0(const char *args, char *__user out_msg, int outlen)
         return nr_target_uids;           /* short code only (NOT surfaced as text) */
     }
     if (kind_is_stats(args) || kind_is_status(args)) {
-        char buf[OUT_MAX];               /* "vpnhide 1 stats" / "...status" */
-        int n = kind_is_stats(args) ? format_stats(buf, sizeof buf)
+        char buf[OUT_MAX];               /* one stats page, or all of status */
+        int n = kind_is_stats(args) ? format_stats_page(buf, sizeof buf,
+                                                        parse_after(args))
                                     : format_status(buf, sizeof buf);
         if (n > outlen)
             n = clamp_to_line(buf, outlen);        /* never mid-record */
@@ -547,19 +548,43 @@ static long vpnhide_kpm_ctl0(const char *args, char *__user out_msg, int outlen)
 }
 ```
 
-### 7.2 The one KPM-specific rule: no pagination
+### 7.2 KPM stats cursor
 
-`out_msg`/`outlen` is a single fixed buffer per call — unlike seq_file, which
-paginates. Therefore:
+`out_msg`/`outlen` is a single fixed 4096-byte buffer per call. Stats therefore
+uses an additive UID cursor while keeping telemetry v1 and the ordinary §4.3 UID
+records. The first request is the legacy request; later pages add one record:
 
-1. The reader passes a generously large `outlen` (stats for tens of uids is a few
-   KiB).
-2. The module truncates **only on a line boundary** (`clamp_to_line`), never
-   mid-record — otherwise the app parses a garbage tail.
-3. Truncation is signalled by the **absence of a trailing `\n`**. The app, seeing
-   no trailing `\n`, knows the snapshot is incomplete and either re-reads with a
-   bigger buffer or accepts the partial. (This is exactly the §4.1 rule that a
-   trailing `\n` is optional on read but meaningful here.)
+```text
+vpnhide 1 stats
+after 0x27ff
+```
+
+Every new-backend response ends in an integrity trailer:
+
+```text
+vpnhide 1 stats
+0x2800 0x0:0x12 0x19:0x5
+0x2801 0x2:0x7
+page 0x27ff 0x2801 0x2
+```
+
+The fields are the requested cursor, the next cursor (or literal `done`), and
+the number of UID rows carried by this page. UID rows are strictly increasing
+and contain only UIDs greater than `after`. The activator validates the echoed
+cursor, monotonic next cursor, row count, and every numeric field while holding
+the cross-process ctl0 lock across the full loop. It then folds all pages into
+one ordinary `vpnhide 1 stats` block, so the APK parser is unchanged.
+
+A non-final page deliberately omits the trailing `\n`; the `page` record itself
+is complete. An old activator therefore applies its existing truncation rule and
+drops the incomplete stats instead of presenting a partial total. A final page
+uses `page <requested> done <count>\n`. Conversely, a new activator accepts a
+newline-terminated legacy response with no `page` trailer as a complete
+single-page snapshot from an older backend.
+
+The `.ko` transport needs no cursor: `/proc/vpnhide_ctl` uses `seq_operations`
+with one UID per record, so the kernel streams arbitrarily many complete rows to
+the reader without constructing a fixed-size snapshot.
 
 On write, the whole snapshot must fit in `args`, including its trailing NUL.
 Bound it by `MAX_TARGET_UIDS`, check the formatted byte length before the

--- a/docs/storage.md
+++ b/docs/storage.md
@@ -46,6 +46,11 @@ The number-keying difference is deliberate and bridged by the activator:
 | Canonical JSON | **package name** | survives reinstall (UID rotates, package doesn't) |
 | Runtime protocol | **UID** | the kernel has no PackageManager |
 
+VPN Hide itself is the one package with a deliberately narrower projection:
+the activator emits only its main-profile (user 0) UID. The APK blocks its UI in
+secondary/work/clone profiles, so accidental extra copies neither write the
+shared canonical file nor consume extra native target slots.
+
 ---
 
 ## 2. The canonical config (the only file you manage)

--- a/kmod/generated/hook_ids.h
+++ b/kmod/generated/hook_ids.h
@@ -37,6 +37,45 @@
 #define VPNHIDE_ZYGISK_HOOK_MASK 0x5fc0000u
 #define VPNHIDE_LSPOSED_HOOK_MASK 0x3fc00u
 
+/* Dense storage slots for kernel-owned stats counters. The wire keeps
+   global hook ids; native backends use these helpers only in memory. */
+#define VPNHIDE_KERNEL_HOOK_COUNT 11
+static inline int vpnhide_kernel_hook_slot(unsigned int id)
+{
+	switch (id) {
+	case 0: return 0;
+	case 1: return 1;
+	case 2: return 2;
+	case 3: return 3;
+	case 4: return 4;
+	case 5: return 5;
+	case 6: return 6;
+	case 7: return 7;
+	case 8: return 8;
+	case 9: return 9;
+	case 25: return 10;
+	default: return -1;
+	}
+}
+
+static inline unsigned int vpnhide_kernel_hook_id(unsigned int slot)
+{
+	switch (slot) {
+	case 0: return 0;
+	case 1: return 1;
+	case 2: return 2;
+	case 3: return 3;
+	case 4: return 4;
+	case 5: return 5;
+	case 6: return 6;
+	case 7: return 7;
+	case 8: return 8;
+	case 9: return 9;
+	case 10: return 25;
+	default: return VPNHIDE_HOOK_COUNT;
+	}
+}
+
 /* status error codes (protocol §5.1). */
 #define VPNHIDE_ERR_OK                       0
 #define VPNHIDE_ERR_UNSUPPORTED_KVER         1

--- a/kmod/kpm/vpnhide_kpm.c
+++ b/kmod/kpm/vpnhide_kpm.c
@@ -110,12 +110,14 @@ static bool debug_enabled;
 static uint32_t installed_hooks;
 static uint32_t last_error;
 
-/* Native interception stats, cumulative since KPM load. The KernelPatch build
- * does not use the target kernel's spinlock headers, so slots are reserved with
- * atomic builtins: used=0 empty, 2 initializing, 1 ready. */
-static uint32_t stats_used[MAX_TARGET_UIDS];
+/* Native interception stats, cumulative since KPM load. Only the 11
+ * kernel-owned hooks need storage; the global 27-id space also contains
+ * LSPosed/Zygisk hooks that can never fire here. A zero UID is the empty-slot
+ * sentinel (system AIDs are unconditionally excluded), claimed atomically by
+ * open addressing so concurrent first hits for one UID converge on one slot. */
 static uint32_t stats_uids[MAX_TARGET_UIDS];
-static unsigned long long stats_counts[MAX_TARGET_UIDS][VPNHIDE_HOOK_COUNT];
+static unsigned long long stats_counts[MAX_TARGET_UIDS]
+				      [VPNHIDE_KERNEL_HOOK_COUNT];
 /* Single fixed reply buffer for stats/status (§7.2 — no pagination). A few KiB
  * holds stats for tens of uids; the reader passes a generous outlen and we
  * truncate on a line boundary (clamp_to_line) if it ever overflows. */
@@ -254,45 +256,28 @@ static int hook_active(uint32_t hook_id)
 
 static int stats_slot_for_uid(uint32_t uid)
 {
-	int i;
+	uint32_t first;
+	int probe;
 
-	for (i = 0; i < MAX_TARGET_UIDS; i++) {
-		if (__atomic_load_n(&stats_used[i], __ATOMIC_ACQUIRE) == 1 &&
-		    stats_uids[i] == uid)
+	if (!uid)
+		return -1;
+	first = (uid * 2654435761u) % MAX_TARGET_UIDS;
+	for (probe = 0; probe < MAX_TARGET_UIDS; probe++) {
+		int i = (int)((first + (uint32_t)probe) % MAX_TARGET_UIDS);
+		uint32_t owner =
+			__atomic_load_n(&stats_uids[i], __ATOMIC_ACQUIRE);
+
+		if (owner == uid)
 			return i;
-	}
-
-	for (i = 0; i < MAX_TARGET_UIDS; i++) {
-		uint32_t st;
-
-		/* Wait out a concurrent claimer that is mid-init (state 2):
-		 * until it settles to state 1 we can't read its uid, and just
-		 * skipping it (the old code's `continue`) would let us allocate a
-		 * SECOND slot for the SAME uid. The init window is a few
-		 * instructions (CAS -> store uid -> store state 1), so this
-		 * settles immediately. */
-		while ((st = __atomic_load_n(&stats_used[i],
-					     __ATOMIC_ACQUIRE)) == 2)
-			;
-		if (st == 1) {
-			if (stats_uids[i] == uid)
-				return i; /* already ours */
-			continue; /* another uid owns this slot */
-		}
-		/* st == 0: free — try to claim it. */
-		if (__sync_bool_compare_and_swap(&stats_used[i], 0, 2)) {
-			stats_uids[i] = uid;
-			__sync_synchronize();
-			__atomic_store_n(&stats_used[i], 1, __ATOMIC_RELEASE);
+		if (owner != 0)
+			continue;
+		if (__sync_bool_compare_and_swap(&stats_uids[i], 0, uid))
 			return i;
-		}
-		/* Lost the CAS to a concurrent claimer — re-examine THIS slot (it
-		 * may be settling to our uid) instead of moving on and allocating
-		 * a duplicate. (A residual window remains only if two first-hits
-		 * for one uid claim two different free slots simultaneously; that
-		 * just splits a counter across two stats lines, never a crash —
-		 * a perfect lock-free find-or-insert needs a lock KP lacks.) */
-		i--;
+		/* A competing first hit claimed this deterministic probe position.
+		 * Re-read it before advancing: if it was the same UID, returning this
+		 * slot prevents the duplicate-row race of the old two-pass scan. */
+		if (__atomic_load_n(&stats_uids[i], __ATOMIC_ACQUIRE) == uid)
+			return i;
 	}
 
 	return -1;
@@ -300,13 +285,14 @@ static int stats_slot_for_uid(uint32_t uid)
 
 static void record_hook_hit(uint32_t hook_id)
 {
-	int slot;
+	int hook_slot, uid_slot;
 
-	if (hook_id >= VPNHIDE_HOOK_COUNT)
+	hook_slot = vpnhide_kernel_hook_slot(hook_id);
+	if (hook_slot < 0)
 		return;
-	slot = stats_slot_for_uid((uint32_t)current_uid());
-	if (slot >= 0)
-		__sync_fetch_and_add(&stats_counts[slot][hook_id], 1ULL);
+	uid_slot = stats_slot_for_uid((uint32_t)current_uid());
+	if (uid_slot >= 0)
+		__sync_fetch_and_add(&stats_counts[uid_slot][hook_slot], 1ULL);
 }
 
 static int snapshot_stats(struct vpnhide_stat_entry *out, int max)
@@ -314,16 +300,20 @@ static int snapshot_stats(struct vpnhide_stat_entry *out, int max)
 	int i, hook, n = 0;
 
 	for (i = 0; i < MAX_TARGET_UIDS && n < max; i++) {
-		if (__atomic_load_n(&stats_used[i], __ATOMIC_ACQUIRE) != 1)
+		uint32_t uid =
+			__atomic_load_n(&stats_uids[i], __ATOMIC_ACQUIRE);
+
+		if (!uid)
 			continue;
-		for (hook = 0; hook < VPNHIDE_HOOK_COUNT && n < max; hook++) {
+		for (hook = 0; hook < VPNHIDE_KERNEL_HOOK_COUNT && n < max;
+		     hook++) {
 			unsigned long long count = __atomic_load_n(
 				&stats_counts[i][hook], __ATOMIC_RELAXED);
 
 			if (count == 0)
 				continue;
-			out[n].uid = stats_uids[i];
-			out[n].hook_id = (unsigned int)hook;
+			out[n].uid = uid;
+			out[n].hook_id = vpnhide_kernel_hook_id(hook);
 			out[n].count = count;
 			n++;
 		}

--- a/kmod/kpm/vpnhide_kpm.c
+++ b/kmod/kpm/vpnhide_kpm.c
@@ -56,7 +56,7 @@ KPM_DESCRIPTION("Hide VPN interfaces from selected UIDs (KPM backend, beta)");
 /* Mirror of vpnhide_protocol::MAX_TARGET_UIDS (crates/protocol/src/lib.rs); the
  * activator truncates the projected config to this many targets, so keep both in
  * sync. */
-#define MAX_TARGET_UIDS 64
+#define MAX_TARGET_UIDS 160
 
 /* ------------------------------------------------------------------ */
 /*  Resolved state                                                    */
@@ -81,10 +81,16 @@ static const struct vpnhide_offsets *off; /* selected per running kver */
  * context; the userspace activator retries the rare collision. */
 /* Parallel arrays, not an array of structs: the hot-path lookup touches only
  * the uids, so keeping them contiguous halves the cache lines a search walks
- * (a full 64-uid set is one 256-byte run). The parser hands them over sorted
+ * (a full 160-uid set is one 640-byte run). The parser hands them over sorted
  * ascending (protocol §4.3), which is what lets the search be a bisection. */
 static uint32_t target_uids[MAX_TARGET_UIDS];
 static uint32_t target_masks[MAX_TARGET_UIDS];
+/* KPM has no allocator API suitable for ctl0 parsing. Keep the enlarged
+ * snapshot in static storage, serialized independently from the live-config
+ * seqlock so hook readers never spin while userspace text is being parsed. */
+static struct vpnhide_target config_staging[MAX_TARGET_UIDS];
+static unsigned int load_uid_staging[MAX_TARGET_UIDS];
+static volatile uint32_t config_staging_writer;
 static int nr_targets;
 /* Hookmask for any uid NOT in target_uids (protocol §4.3 `default`). Zero — the
  * shipped blacklist — makes the array the set to act on; non-zero inverts that
@@ -178,6 +184,24 @@ static void cfg_write_end(void)
 {
 	__atomic_fetch_add(&cfg_seq, 1, __ATOMIC_RELEASE);
 	__atomic_store_n(&cfg_writer, 0, __ATOMIC_RELEASE);
+}
+
+/* The parser needs a full target snapshot, but putting 160 entries on the KPM
+ * stack would consume 1280 bytes before ctl0's other locals. Serialize use of
+ * the static scratch without making cfg_seq odd: readers keep running while
+ * parsing, and only the short copy into live arrays takes the seqlock. */
+static int config_staging_try_claim(void)
+{
+	uint32_t expected = 0;
+
+	return __atomic_compare_exchange_n(&config_staging_writer, &expected, 1,
+					   false, __ATOMIC_ACQUIRE,
+					   __ATOMIC_RELAXED);
+}
+
+static void config_staging_release(void)
+{
+	__atomic_store_n(&config_staging_writer, 0, __ATOMIC_RELEASE);
 }
 
 /* True if `hook_id` is enabled for the calling uid (per-hook gate, §4.3).
@@ -1389,8 +1413,6 @@ static int resolve_symbols(void)
  */
 static void apply_targets(const char *s)
 {
-	unsigned int uids[MAX_TARGET_UIDS];
-	struct vpnhide_target sorted[MAX_TARGET_UIDS];
 	unsigned long n = 0;
 	int cnt, i, nsorted = 0;
 
@@ -1398,19 +1420,21 @@ static void apply_targets(const char *s)
 		return;
 	while (s[n])
 		n++;
-	cnt = vpnhide_parse_target_uids(s, n, uids, MAX_TARGET_UIDS);
+	cnt = vpnhide_parse_target_uids(s, n, load_uid_staging,
+					MAX_TARGET_UIDS);
 	/* The load-args list arrives in whatever order the caller wrote it, but
 	 * the hot-path lookup bisects, so it has to be ordered here. Reuse the
 	 * protocol's sorted insert rather than a second ordering rule (it dedups
 	 * too). This runs once at init, off the hot path. */
 	for (i = 0; i < cnt; i++)
-		vpnhide_target_set(sorted, &nsorted, MAX_TARGET_UIDS, uids[i],
+		vpnhide_target_set(config_staging, &nsorted, MAX_TARGET_UIDS,
+				   load_uid_staging[i],
 				   VPNHIDE_KERNEL_HOOK_MASK);
 	if (!cfg_try_write_begin())
 		return; /* init path has no concurrent writer; defensive only */
 	for (i = 0; i < nsorted; i++) {
-		target_uids[i] = sorted[i].uid;
-		target_masks[i] = sorted[i].hookmask;
+		target_uids[i] = config_staging[i].uid;
+		target_masks[i] = config_staging[i].hookmask;
 	}
 	nr_targets = nsorted;
 	default_hookmask = 0;
@@ -1579,23 +1603,28 @@ static long vpnhide_kpm_ctl0(const char *args, char *__user out_msg, int outlen)
 	kind = vpnhide_peek_kind(args, n_args);
 
 	if (kind == VPNHIDE_KIND_CONFIG) {
-		/* Parse into a private stack snapshot before claiming the very short
-		 * writer gate. A bad header/version never touches live state; a
+		/* Parse into serialized static scratch before claiming the very short
+		 * live writer gate. A bad header/version never touches live state; a
 		 * concurrent ctl0 writer gets -2 (busy) and userspace retries. */
-		struct vpnhide_target new_targets[MAX_TARGET_UIDS];
 		unsigned int default_mask = 0;
 		int dbg = -1; /* absent debug record preserves live value */
 		int i, n;
 
-		n = vpnhide_parse_config(args, n_args, new_targets,
+		if (!config_staging_try_claim())
+			return -2;
+		n = vpnhide_parse_config(args, n_args, config_staging,
 					 MAX_TARGET_UIDS, &dbg, &default_mask);
-		if (n < 0)
+		if (n < 0) {
+			config_staging_release();
 			return -1; /* rejected whole (bad header / end fuse) */
-		if (!cfg_try_write_begin())
+		}
+		if (!cfg_try_write_begin()) {
+			config_staging_release();
 			return -2; /* concurrent config writer; retry from userspace */
+		}
 		for (i = 0; i < n; i++) {
-			target_uids[i] = new_targets[i].uid;
-			target_masks[i] = new_targets[i].hookmask &
+			target_uids[i] = config_staging[i].uid;
+			target_masks[i] = config_staging[i].hookmask &
 					  VPNHIDE_KERNEL_HOOK_MASK;
 		}
 		nr_targets = n;
@@ -1604,6 +1633,7 @@ static long vpnhide_kpm_ctl0(const char *args, char *__user out_msg, int outlen)
 		if (dbg >= 0)
 			debug_enabled = dbg ? true : false;
 		cfg_write_end();
+		config_staging_release();
 		vpnhide_dbg("ctl0 config: %d targets, debug=%d\n", n,
 			    debug_enabled ? 1 : 0);
 		return 0;

--- a/kmod/kpm/vpnhide_kpm.c
+++ b/kmod/kpm/vpnhide_kpm.c
@@ -118,27 +118,11 @@ static uint32_t last_error;
 static uint32_t stats_uids[MAX_TARGET_UIDS];
 static unsigned long long stats_counts[MAX_TARGET_UIDS]
 				      [VPNHIDE_KERNEL_HOOK_COUNT];
-/* Single fixed reply buffer for stats/status (§7.2 — no pagination). A few KiB
- * holds stats for tens of uids; the reader passes a generous outlen and we
- * truncate on a line boundary (clamp_to_line) if it ever overflows. */
+/* KernelPatch and both userspace clients cap one ctl0 reply at 4096 bytes.
+ * Stats are cursor-paged by UID; status remains a small single reply. */
 #define VPNHIDE_OUT_MAX 4096
-
-/*
- * Serialisation scratch for a `stats` reply. Sized by what the reply can carry,
- * NOT by MAX_TARGET_UIDS * VPNHIDE_HOOK_COUNT: an entry costs at least
- * " 0x0:0x0" (8 bytes) once formatted, and the reply is capped at
- * VPNHIDE_OUT_MAX by this module and by both KPatch and APatch clients, so no
- * reply can ever deliver more than VPNHIDE_OUT_MAX/8 of them. The product would
- * be 1728 entries — three quarters of which are unreachable — and would add
- * still more growth when the target ceiling moves. Static growth is what broke
- * KP boot on the 6.12 image (see the seqlock note above). The live stats tables
- * above still scale with MAX_TARGET_UIDS, so they must be redesigned before the
- * target ceiling can safely rise; this keeps serialisation scratch from making
- * that coupling worse.
- */
-#define VPNHIDE_STATS_SNAPSHOT_MAX (VPNHIDE_OUT_MAX / 8)
-
-static struct vpnhide_stat_entry stats_snapshot[VPNHIDE_STATS_SNAPSHOT_MAX];
+#define VPNHIDE_STATS_ROW_MAX 512
+#define VPNHIDE_STATS_TRAILER_RESERVE 64
 
 /* Kernel functions resolved at init via kallsyms. */
 static unsigned long (*_copy_from_user)(void *, const void *, unsigned long);
@@ -295,30 +279,97 @@ static void record_hook_hit(uint32_t hook_id)
 		__sync_fetch_and_add(&stats_counts[uid_slot][hook_slot], 1ULL);
 }
 
-static int snapshot_stats(struct vpnhide_stat_entry *out, int max)
+static int next_stats_uid(uint32_t after, uint32_t *uid_out, int *slot_out)
 {
-	int i, hook, n = 0;
+	uint32_t best = 0xffffffffu;
+	int best_slot = -1, i;
 
-	for (i = 0; i < MAX_TARGET_UIDS && n < max; i++) {
+	for (i = 0; i < MAX_TARGET_UIDS; i++) {
 		uint32_t uid =
 			__atomic_load_n(&stats_uids[i], __ATOMIC_ACQUIRE);
 
-		if (!uid)
-			continue;
-		for (hook = 0; hook < VPNHIDE_KERNEL_HOOK_COUNT && n < max;
-		     hook++) {
-			unsigned long long count = __atomic_load_n(
-				&stats_counts[i][hook], __ATOMIC_RELAXED);
-
-			if (count == 0)
-				continue;
-			out[n].uid = uid;
-			out[n].hook_id = vpnhide_kernel_hook_id(hook);
-			out[n].count = count;
-			n++;
+		if (uid > after && (best_slot < 0 || uid < best)) {
+			best = uid;
+			best_slot = i;
 		}
 	}
-	return n;
+	if (best_slot < 0)
+		return 0;
+	*uid_out = best;
+	*slot_out = best_slot;
+	return 1;
+}
+
+static unsigned long format_stats_row(char *buf, unsigned long cap,
+				      uint32_t uid, int uid_slot)
+{
+	struct vpnhide_buf b = { .p = buf, .cap = cap, .len = 0 };
+	int hook, have_count = 0;
+
+	vpnhide_put_hex(&b, uid);
+	for (hook = 0; hook < VPNHIDE_KERNEL_HOOK_COUNT; hook++) {
+		unsigned long long count = __atomic_load_n(
+			&stats_counts[uid_slot][hook], __ATOMIC_RELAXED);
+
+		if (!count)
+			continue;
+		have_count = 1;
+		vpnhide_putc(&b, ' ');
+		vpnhide_put_hex(&b, vpnhide_kernel_hook_id(hook));
+		vpnhide_putc(&b, ':');
+		vpnhide_put_hex(&b, count);
+	}
+	if (!have_count)
+		return 0;
+	vpnhide_putc(&b, '\n');
+	return b.len;
+}
+
+/* A page is ordered by UID, independent of the hash-table layout. `page`
+ * carries the requested cursor, the next cursor (or `done`), and emitted UID
+ * row count. A non-final page deliberately omits its final newline: an old
+ * activator therefore treats it as truncated and refuses partial totals, while
+ * a pagination-aware activator validates the complete trailer and continues. */
+static unsigned long format_stats_page(char *buf, unsigned long cap,
+				       uint32_t requested)
+{
+	struct vpnhide_buf b = { .p = buf, .cap = cap, .len = 0 };
+	char row[VPNHIDE_STATS_ROW_MAX];
+	uint32_t cursor = requested, uid;
+	unsigned int rows = 0;
+	int slot, more;
+
+	if (cap < VPNHIDE_STATS_ROW_MAX + VPNHIDE_STATS_TRAILER_RESERVE)
+		return 0;
+	vpnhide_put_header(&b, "stats", VPNHIDE_TELEMETRY_VERSION);
+	while (next_stats_uid(cursor, &uid, &slot)) {
+		unsigned long row_len =
+			format_stats_row(row, sizeof(row), uid, slot);
+
+		if (!row_len) {
+			cursor = uid;
+			continue;
+		}
+		if (b.len + row_len + VPNHIDE_STATS_TRAILER_RESERVE > cap)
+			break;
+		for (unsigned long i = 0; i < row_len; i++)
+			vpnhide_putc(&b, row[i]);
+		cursor = uid;
+		rows++;
+	}
+	more = next_stats_uid(cursor, &uid, &slot);
+	vpnhide_puts(&b, "page ");
+	vpnhide_put_hex(&b, requested);
+	vpnhide_putc(&b, ' ');
+	if (more)
+		vpnhide_put_hex(&b, cursor);
+	else
+		vpnhide_puts(&b, "done");
+	vpnhide_putc(&b, ' ');
+	vpnhide_put_hex(&b, rows);
+	if (!more)
+		vpnhide_putc(&b, '\n');
+	return b.len;
 }
 
 /* NUL-safe copy of a kernel iface name, then match via the generated rules. */
@@ -1563,11 +1614,17 @@ static long vpnhide_kpm_ctl0(const char *args, char *__user out_msg, int outlen)
 		unsigned long available, full, n;
 
 		if (kind == VPNHIDE_KIND_STATS) {
-			int count = snapshot_stats(stats_snapshot,
-						   VPNHIDE_STATS_SNAPSHOT_MAX);
+			unsigned int after;
 
-			full = vpnhide_format_stats(buf, sizeof(buf),
-						    stats_snapshot, count);
+			if (!vpnhide_parse_stats_after(args, n_args, &after))
+				return -1;
+			available = outlen > 0 ? (unsigned long)outlen : 0;
+			if (available > sizeof(buf))
+				available = sizeof(buf);
+			n = format_stats_page(buf, available, after);
+			if (_copy_to_user && out_msg && n)
+				_copy_to_user(out_msg, buf, n);
+			return (long)n;
 		} else {
 			struct vpnhide_status st;
 

--- a/kmod/shared/test_protocol.c
+++ b/kmod/shared/test_protocol.c
@@ -17,7 +17,7 @@
 /* Config capacity must equal vpnhide_protocol::MAX_TARGET_UIDS: the shared
  * vectors pin over-ceiling payloads as REJECT, so C and Rust have to be
  * rejecting at the same count. */
-#define CFG_MAX_TARGETS 64
+#define CFG_MAX_TARGETS 160
 #define MAX_FIELDS 8
 
 static int failures;

--- a/kmod/shared/test_protocol.c
+++ b/kmod/shared/test_protocol.c
@@ -246,6 +246,42 @@ static void run_fixed_buffer_overflow_clamp(void)
 		     "aaa\\nbbb");
 }
 
+static void run_stats_after_parse(void)
+{
+	static const struct {
+		const char *wire;
+		int valid;
+		unsigned int after;
+	} cases[] = {
+		{ "vpnhide 1 stats", 1, 0 },
+		{ "vpnhide 1 stats\nafter 0x27ff\n", 1, 0x27ff },
+		{ "vpnhide 1 stats\nfuture value\nafter 0XFFFFFFFF", 1,
+		  0xffffffffu },
+		{ "vpnhide 1 status\nafter 0x1", 0, 0 },
+		{ "vpnhide 1 stats\nafter 27ff", 0, 0 },
+		{ "vpnhide 1 stats\nafter 0x1 extra", 0, 0 },
+		{ "vpnhide 1 stats\nafter 0x1\nafter 0x2", 0, 0 },
+	};
+	unsigned int i;
+
+	for (i = 0; i < sizeof(cases) / sizeof(cases[0]); i++) {
+		unsigned int after = 123;
+		int valid = vpnhide_parse_stats_after(
+			cases[i].wire, strlen(cases[i].wire), &after);
+
+		checks++;
+		if (valid != cases[i].valid ||
+		    (valid && after != cases[i].after)) {
+			char got[64], want[64];
+
+			snprintf(got, sizeof(got), "%d,0x%x", valid, after);
+			snprintf(want, sizeof(want), "%d,0x%x", cases[i].valid,
+				 cases[i].after);
+			fail("stats after parse", got, want);
+		}
+	}
+}
+
 int main(int argc, char **argv)
 {
 	const char *path = argc > 1 ? argv[1] : "protocol_vectors.tsv";
@@ -290,6 +326,7 @@ int main(int argc, char **argv)
 	free(line);
 	fclose(f);
 	run_fixed_buffer_overflow_clamp();
+	run_stats_after_parse();
 
 	if (failures) {
 		fprintf(stderr, "%d/%d protocol vector(s) failed\n", failures,

--- a/kmod/shared/vpnhide_logic.h
+++ b/kmod/shared/vpnhide_logic.h
@@ -619,6 +619,36 @@ static inline enum vpnhide_kind vpnhide_peek_kind(const char *b,
 	return vpnhide_parse_header(b, len, 0);
 }
 
+/* Parse the optional KPM stats-page cursor (§7.2). Unknown records retain the
+ * normal extensibility rule; a present `after` record is strict and unique so
+ * a malformed/repeated cursor can never silently select the wrong page. */
+static inline int vpnhide_parse_stats_after(const char *b, unsigned long len,
+					    unsigned int *after)
+{
+	unsigned long i, ls, le, cs, p, ts, te;
+	unsigned long long value;
+	int ascii, seen = 0;
+
+	if (vpnhide_parse_header(b, len, &i) != VPNHIDE_KIND_STATS)
+		return 0;
+	*after = 0;
+	while (vpnhide_next_line(b, len, &i, &ls, &le)) {
+		if (!vpnhide_line_significant(b, ls, le, &cs, &ascii) || !ascii)
+			continue;
+		p = cs;
+		if (!vpnhide_next_token(b, &p, le, &ts, &te) ||
+		    !vpnhide_tok_eq(b, ts, te, "after"))
+			continue;
+		if (seen || !vpnhide_next_token(b, &p, le, &ts, &te) ||
+		    !vpnhide_tok_hex(b, ts, te, 32, &value) ||
+		    vpnhide_next_token(b, &p, le, &ts, &te))
+			return 0;
+		*after = (unsigned int)value;
+		seen = 1;
+	}
+	return 1;
+}
+
 /* --- config parse (§4.3) --------------------------------------------- */
 
 /*

--- a/kmod/vpnhide_kmod.c
+++ b/kmod/vpnhide_kmod.c
@@ -79,8 +79,6 @@
  * activator truncates the projected config to this many targets, so keep both in
  * sync. */
 #define MAX_TARGET_UIDS 64
-#define MAX_STATS_ENTRIES (MAX_TARGET_UIDS * VPNHIDE_KERNEL_HOOK_COUNT)
-#define CTL_READ_BUF_SIZE 32768
 
 /*
  * Pre-allocated kretprobe instance pool size, applied to every probe.
@@ -256,27 +254,6 @@ static void record_hook_hit(u32 hook_id)
 	spin_unlock_irqrestore(&stats_lock, flags);
 }
 
-static int snapshot_stats(struct vpnhide_stat_entry *out, int max)
-{
-	unsigned long flags;
-	int i, hook, n = 0;
-
-	spin_lock_irqsave(&stats_lock, flags);
-	for (i = 0; i < nr_stats_rows && n < max; i++) {
-		for (hook = 0; hook < VPNHIDE_KERNEL_HOOK_COUNT && n < max;
-		     hook++) {
-			if (stats_rows[i].counts[hook] == 0)
-				continue;
-			out[n].uid = stats_rows[i].uid;
-			out[n].hook_id = vpnhide_kernel_hook_id(hook);
-			out[n].count = stats_rows[i].counts[hook];
-			n++;
-		}
-	}
-	spin_unlock_irqrestore(&stats_lock, flags);
-	return n;
-}
-
 /* ------------------------------------------------------------------ */
 /*  /proc/vpnhide_ctl — the folded control + stats channel            */
 /* ------------------------------------------------------------------ */
@@ -342,65 +319,81 @@ static ssize_t ctl_write(struct file *file, const char __user *ubuf,
 	return count;
 }
 
-/*
- * Read side: a self-documenting banner + `status` + `stats` (§4.3/§7.1).
- * The shared formatters render into a temporary buffer which we hand to
- * seq_file. Stats are cumulative since module load and sparse per uid/hook.
- */
-static int ctl_show(struct seq_file *m, void *v)
+/* Read side: banner, status, stats header, then one UID per seq_file record.
+ * seq_file may replay a record when its current userspace read buffer fills,
+ * so the output streams without a whole-snapshot allocation or byte ceiling. */
+static void *ctl_seq_start(struct seq_file *m, loff_t *pos)
 {
-	char *buf;
-	struct vpnhide_stat_entry *stats;
-	struct vpnhide_status st;
-	unsigned long len;
-	int n;
+	if (*pos >= 3 + MAX_TARGET_UIDS)
+		return NULL;
+	return (void *)(unsigned long)(*pos + 1);
+}
 
-	seq_puts(m, VPNHIDE_READ_BANNER);
+static void *ctl_seq_next(struct seq_file *m, void *v, loff_t *pos)
+{
+	(*pos)++;
+	return ctl_seq_start(m, pos);
+}
 
-	buf = kmalloc(CTL_READ_BUF_SIZE, GFP_KERNEL);
-	stats = kcalloc(MAX_STATS_ENTRIES, sizeof(*stats), GFP_KERNEL);
-	if (!buf || !stats) {
-		kfree(stats);
-		kfree(buf);
-		return -ENOMEM;
+static void ctl_seq_stop(struct seq_file *m, void *v)
+{
+}
+
+static int ctl_seq_show(struct seq_file *m, void *v)
+{
+	unsigned long item = (unsigned long)v - 1;
+
+	if (item == 0) {
+		seq_puts(m, VPNHIDE_READ_BANNER);
+	} else if (item == 1) {
+		u32 hooks = installed_hook_mask();
+		u32 error = hooks == VPNHIDE_KERNEL_HOOK_MASK ?
+				    VPNHIDE_ERR_OK :
+				    VPNHIDE_ERR_PARTIAL_HOOKS;
+
+		seq_printf(m,
+			   "vpnhide %u status\nbackend 0x%x\nkver 0x%x\n"
+			   "hooks 0x%x\nerror 0x%x\n",
+			   VPNHIDE_TELEMETRY_VERSION, VPNHIDE_BACKEND_KMOD,
+			   LINUX_VERSION_CODE, hooks, error);
+	} else if (item == 2) {
+		seq_printf(m, "vpnhide %u stats\n", VPNHIDE_TELEMETRY_VERSION);
+	} else {
+		struct stats_row row;
+		unsigned long flags;
+		int hook, index = (int)item - 3;
+
+		spin_lock_irqsave(&stats_lock, flags);
+		if (index >= nr_stats_rows) {
+			spin_unlock_irqrestore(&stats_lock, flags);
+			return 0;
+		}
+		row = stats_rows[index];
+		spin_unlock_irqrestore(&stats_lock, flags);
+
+		seq_printf(m, "0x%x", row.uid);
+		for (hook = 0; hook < VPNHIDE_KERNEL_HOOK_COUNT; hook++) {
+			if (!row.counts[hook])
+				continue;
+			seq_printf(m, " 0x%x:0x%llx",
+				   vpnhide_kernel_hook_id(hook),
+				   row.counts[hook]);
+		}
+		seq_putc(m, '\n');
 	}
-
-	st.backend = VPNHIDE_BACKEND_KMOD;
-	st.kver = LINUX_VERSION_CODE;
-	st.hooks = installed_hook_mask();
-	st.error = (st.hooks == VPNHIDE_KERNEL_HOOK_MASK) ?
-			   VPNHIDE_ERR_OK :
-			   VPNHIDE_ERR_PARTIAL_HOOKS;
-	/*
-	 * vpnhide_format_* report the FULL intended length (snprintf semantics),
-	 * which can exceed the buffer they filled. Clamping with min() would emit
-	 * the first CTL_READ_BUF_SIZE bytes cut wherever they land — a record
-	 * severed mid-line, with nothing to say the snapshot is partial, so the
-	 * reader would total a half-parsed counter as if it were whole.
-	 * vpnhide_clamp_to_line instead ends on a complete line and drops the
-	 * final newline, which is the protocol's truncation signal (§7.2) — the
-	 * same guard the KPM's ctl0 reply uses.
-	 *
-	 * Reachable: stats cost up to ~640 bytes per uid (27 hooks, saturated u64
-	 * counters), so a full target set can format past 32 KiB. Status is four
-	 * fixed records and cannot, but it goes through the same call so the rule
-	 * is one rule.
-	 */
-	len = vpnhide_format_status(buf, CTL_READ_BUF_SIZE, &st);
-	seq_write(m, buf, vpnhide_clamp_to_line(buf, len, CTL_READ_BUF_SIZE));
-
-	n = snapshot_stats(stats, MAX_STATS_ENTRIES);
-	len = vpnhide_format_stats(buf, CTL_READ_BUF_SIZE, stats, n);
-	seq_write(m, buf, vpnhide_clamp_to_line(buf, len, CTL_READ_BUF_SIZE));
-
-	kfree(stats);
-	kfree(buf);
 	return 0;
 }
 
+static const struct seq_operations ctl_seq_ops = {
+	.start = ctl_seq_start,
+	.next = ctl_seq_next,
+	.stop = ctl_seq_stop,
+	.show = ctl_seq_show,
+};
+
 static int ctl_open(struct inode *inode, struct file *file)
 {
-	return single_open(file, ctl_show, NULL);
+	return seq_open(file, &ctl_seq_ops);
 }
 
 static const struct proc_ops ctl_proc_ops = {
@@ -408,7 +401,7 @@ static const struct proc_ops ctl_proc_ops = {
 	.proc_read = seq_read,
 	.proc_write = ctl_write,
 	.proc_lseek = seq_lseek,
-	.proc_release = single_release,
+	.proc_release = seq_release,
 };
 
 /* ================================================================== */

--- a/kmod/vpnhide_kmod.c
+++ b/kmod/vpnhide_kmod.c
@@ -79,7 +79,7 @@
  * activator truncates the projected config to this many targets, so keep both in
  * sync. */
 #define MAX_TARGET_UIDS 64
-#define MAX_STATS_ENTRIES (MAX_TARGET_UIDS * VPNHIDE_HOOK_COUNT)
+#define MAX_STATS_ENTRIES (MAX_TARGET_UIDS * VPNHIDE_KERNEL_HOOK_COUNT)
 #define CTL_READ_BUF_SIZE 32768
 
 /*
@@ -221,7 +221,7 @@ static bool hook_active(u32 hook_id)
 
 struct stats_row {
 	uid_t uid;
-	u64 counts[VPNHIDE_HOOK_COUNT];
+	u64 counts[VPNHIDE_KERNEL_HOOK_COUNT];
 };
 
 static struct stats_row stats_rows[MAX_TARGET_UIDS];
@@ -232,16 +232,17 @@ static void record_hook_hit(u32 hook_id)
 {
 	uid_t uid;
 	unsigned long flags;
-	int i;
+	int hook_slot, i;
 
-	if (hook_id >= VPNHIDE_HOOK_COUNT)
+	hook_slot = vpnhide_kernel_hook_slot(hook_id);
+	if (hook_slot < 0)
 		return;
 
 	uid = from_kuid(&init_user_ns, current_uid());
 	spin_lock_irqsave(&stats_lock, flags);
 	for (i = 0; i < nr_stats_rows; i++) {
 		if (stats_rows[i].uid == uid) {
-			stats_rows[i].counts[hook_id]++;
+			stats_rows[i].counts[hook_slot]++;
 			spin_unlock_irqrestore(&stats_lock, flags);
 			return;
 		}
@@ -250,7 +251,7 @@ static void record_hook_hit(u32 hook_id)
 		i = nr_stats_rows++;
 		stats_rows[i].uid = uid;
 		memset(stats_rows[i].counts, 0, sizeof(stats_rows[i].counts));
-		stats_rows[i].counts[hook_id] = 1;
+		stats_rows[i].counts[hook_slot] = 1;
 	}
 	spin_unlock_irqrestore(&stats_lock, flags);
 }
@@ -262,11 +263,12 @@ static int snapshot_stats(struct vpnhide_stat_entry *out, int max)
 
 	spin_lock_irqsave(&stats_lock, flags);
 	for (i = 0; i < nr_stats_rows && n < max; i++) {
-		for (hook = 0; hook < VPNHIDE_HOOK_COUNT && n < max; hook++) {
+		for (hook = 0; hook < VPNHIDE_KERNEL_HOOK_COUNT && n < max;
+		     hook++) {
 			if (stats_rows[i].counts[hook] == 0)
 				continue;
 			out[n].uid = stats_rows[i].uid;
-			out[n].hook_id = hook;
+			out[n].hook_id = vpnhide_kernel_hook_id(hook);
 			out[n].count = stats_rows[i].counts[hook];
 			n++;
 		}

--- a/kmod/vpnhide_kmod.c
+++ b/kmod/vpnhide_kmod.c
@@ -78,7 +78,7 @@
 /* Mirror of vpnhide_protocol::MAX_TARGET_UIDS (crates/protocol/src/lib.rs); the
  * activator truncates the projected config to this many targets, so keep both in
  * sync. */
-#define MAX_TARGET_UIDS 64
+#define MAX_TARGET_UIDS 160
 
 /*
  * Pre-allocated kretprobe instance pool size, applied to every probe.
@@ -129,7 +129,7 @@ static bool debug_enabled;
 
 /* Parallel arrays, not an array of structs: the lookup below touches only the
  * uids, so keeping them contiguous halves the cache lines a search walks
- * (a full 64-uid set is one 256-byte run). The parser hands them over sorted
+ * (a full 160-uid set is one 640-byte run). The parser hands them over sorted
  * ascending (protocol §4.3), which is what lets the search be a bisection. */
 static u32 target_uids[MAX_TARGET_UIDS];
 static u32 target_masks[MAX_TARGET_UIDS];
@@ -265,7 +265,7 @@ static ssize_t ctl_write(struct file *file, const char __user *ubuf,
 			 size_t count, loff_t *ppos)
 {
 	char *buf;
-	struct vpnhide_target newt[MAX_TARGET_UIDS];
+	struct vpnhide_target *newt;
 	unsigned int default_mask = 0;
 	int n, dbg;
 
@@ -275,8 +275,14 @@ static ssize_t ctl_write(struct file *file, const char __user *ubuf,
 	buf = kmalloc(count + 1, GFP_KERNEL);
 	if (!buf)
 		return -ENOMEM;
+	newt = kcalloc(MAX_TARGET_UIDS, sizeof(*newt), GFP_KERNEL);
+	if (!newt) {
+		kfree(buf);
+		return -ENOMEM;
+	}
 
 	if (copy_from_user(buf, ubuf, count)) {
+		kfree(newt);
 		kfree(buf);
 		return -EFAULT;
 	}
@@ -292,8 +298,10 @@ static ssize_t ctl_write(struct file *file, const char __user *ubuf,
 	/* A payload with no valid header / the wrong version / a broken `end`
 	 * fuse is rejected whole (§3) — a loud -EINVAL, never a silent partial
 	 * wipe. */
-	if (n < 0)
+	if (n < 0) {
+		kfree(newt);
 		return -EINVAL;
+	}
 
 	spin_lock(&targets_lock);
 	{
@@ -313,6 +321,7 @@ static ssize_t ctl_write(struct file *file, const char __user *ubuf,
 		WRITE_ONCE(active_hook_mask, mask);
 	}
 	spin_unlock(&targets_lock);
+	kfree(newt);
 	WRITE_ONCE(debug_enabled, dbg ? true : false);
 
 	pr_info(MODNAME ": config applied — %d targets, debug=%d\n", n, dbg);

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/AppPickerData.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/AppPickerData.kt
@@ -39,6 +39,7 @@ internal fun resolveAutoHiddenPackages(
 
 internal data class AppRoleSelection(
     val packageName: String,
+    val uids: List<Int> = emptyList(),
     val java: Boolean = false,
     val javaHooks: List<String>? = null,
     val native: Boolean = false,
@@ -47,6 +48,70 @@ internal data class AppRoleSelection(
     val ports: Boolean = false,
     val portPolicy: PortPolicy? = null,
 )
+
+/** Mirror of `vpnhide_protocol::MAX_TARGET_UIDS` and both native backends. */
+internal const val NATIVE_TARGET_UID_CAPACITY = 160
+internal const val NATIVE_SELF_RESERVED_UID_SLOTS = 1
+internal const val NATIVE_USER_UID_CAPACITY = NATIVE_TARGET_UID_CAPACITY - NATIVE_SELF_RESERVED_UID_SLOTS
+
+private const val ANDROID_UIDS_PER_USER = 100_000
+private const val FIRST_APPLICATION_UID = 10_000
+
+internal data class NativeTargetCapacityUsage(
+    val used: Int,
+    val capacity: Int = NATIVE_TARGET_UID_CAPACITY,
+) {
+    val overflow: Int get() = (used - capacity).coerceAtLeast(0)
+}
+
+/**
+ * Count the exact UID slots a native projection needs. Visible picker rows
+ * override their saved role; configured packages missing from the current list
+ * stay preserved, matching [buildCanonicalConfigForAppPickerSave]. UID unioning
+ * handles shared identities. The app itself uses one fixed, invisible slot:
+ * secondary-profile copies are unsupported and the activator projects the
+ * self-target only for Android's main user.
+ */
+internal fun nativeTargetCapacityUsage(
+    selfPkg: String,
+    selections: Collection<AppRoleSelection>,
+    existingNativePackages: Set<String>,
+    packageUids: Map<String, List<Int>>,
+): NativeTargetCapacityUsage {
+    val visiblePackages = selections.mapTo(mutableSetOf()) { it.packageName }
+    val selectedPackages =
+        (existingNativePackages - visiblePackages) +
+            selections.filter { it.native }.map { it.packageName }
+    val userSelectedPackages = selectedPackages - selfPkg
+    val selectionUids = selections.associate { it.packageName to it.uids }
+    val resolved = mutableSetOf<Int>()
+    var unresolvedSlots = 0
+
+    userSelectedPackages.forEach { pkg ->
+        val rawUids = selectionUids[pkg].orEmpty().ifEmpty { packageUids[pkg].orEmpty() }
+        val appUids = rawUids.filterTo(mutableSetOf(), ::isApplicationUid)
+        when {
+            rawUids.isEmpty() -> {
+                unresolvedSlots++
+            }
+
+            else -> {
+                resolved += appUids
+            }
+        }
+    }
+
+    return NativeTargetCapacityUsage(
+        used = resolved.size + unresolvedSlots + NATIVE_SELF_RESERVED_UID_SLOTS,
+    )
+}
+
+internal fun nativeCapacityIncreaseViolation(
+    current: NativeTargetCapacityUsage,
+    candidate: NativeTargetCapacityUsage,
+): NativeTargetCapacityUsage? = candidate.takeIf { it.overflow > 0 && it.used > current.used }
+
+private fun isApplicationUid(uid: Int): Boolean = uid >= 0 && uid % ANDROID_UIDS_PER_USER >= FIRST_APPLICATION_UID
 
 internal fun resolveNativeHookSelection(
     hookNames: List<String>,

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/AppPickerScreen.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/AppPickerScreen.kt
@@ -72,6 +72,7 @@ internal data class AppEntry(
     override val icon: Drawable?,
     override val isSystem: Boolean,
     override val userIds: List<Int> = emptyList(),
+    val uids: List<Int> = emptyList(),
     val java: Boolean = false,
     val javaHooks: List<String>? = null,
     val native: Boolean = false,
@@ -134,6 +135,7 @@ internal fun AppPickerScreen(
                             icon = app.icon,
                             isSystem = app.isSystem,
                             userIds = app.userIds,
+                            uids = t.packageUids[app.packageName].orEmpty(),
                             java = canonicalApp?.java ?: (app.packageName in t.lsposedTargets),
                             javaHooks = canonicalApp?.takeIf { it.java }?.javaHooks?.takeIf { it.isNotEmpty() },
                             native = app.packageName in nativeTargets,
@@ -163,6 +165,8 @@ internal fun AppPickerScreen(
         successMessage = { entries, res ->
             res.getString(R.string.save_success, entries.count { it.anySelected })
         },
+        selectionChangeError = ::nativeSelectionChangeError,
+        selectionSaveError = ::nativeSelectionSaveError,
     ) { app, userNames, targets, onChange ->
         val nativeHookFamily = targets.nativeHookFamily
         AppRow(
@@ -384,18 +388,6 @@ private fun persistUnifiedSelection(
         activation = CanonicalActivation(native = true, ports = true),
     )
 }
-
-private fun AppEntry.toRoleSelection(): AppRoleSelection =
-    AppRoleSelection(
-        packageName = packageName,
-        java = java,
-        javaHooks = javaHooks,
-        native = native,
-        nativeOverrides = nativeOverrides,
-        appHiding = appHiding,
-        ports = ports,
-        portPolicy = portPolicy,
-    )
 
 private fun AppEntry.toAutoHideSignal(): AppAutoHideSignal =
     AppAutoHideSignal(

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/MainActivity.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/MainActivity.kt
@@ -2,6 +2,7 @@ package dev.okhsunrog.vpnhide
 
 import android.Manifest
 import android.os.Bundle
+import android.os.Process
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.BackHandler
 import androidx.activity.compose.rememberLauncherForActivityResult
@@ -26,7 +27,6 @@ import androidx.compose.material.icons.filled.BarChart
 import androidx.compose.material.icons.filled.Clear
 import androidx.compose.material.icons.filled.ErrorOutline
 import androidx.compose.material.icons.filled.Home
-import androidx.compose.material.icons.filled.Lock
 import androidx.compose.material.icons.filled.Refresh
 import androidx.compose.material.icons.filled.Search
 import androidx.compose.material.icons.filled.Settings
@@ -68,11 +68,14 @@ class MainActivity : ComponentActivity() {
         StartupTrace.mark("activity_on_create")
         enableEdgeToEdge()
         super.onCreate(savedInstanceState)
-        RootSnapshotCache.setRuntimeProbeSource(GroundTruthProbe.prepare(this)?.absolutePath)
-        // Load canonical debug state before runtime work so first suExec and dashboard bootstrap agree.
-        VpnHideLog.init()
+        val mainProfile = isMainAppProfile(Process.myUid())
+        if (mainProfile) {
+            RootSnapshotCache.setRuntimeProbeSource(GroundTruthProbe.prepare(this)?.absolutePath)
+            // Load canonical debug state before runtime work so first suExec and dashboard bootstrap agree.
+            VpnHideLog.init()
+        }
         setContent {
-            VpnHideApp()
+            VpnHideApp(mainProfile)
         }
     }
 }
@@ -112,7 +115,14 @@ private fun BackgroundUpdatePromptDialog(
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun VpnHideApp() {
+fun VpnHideApp(mainProfile: Boolean = isMainAppProfile(Process.myUid())) {
+    if (!mainProfile) {
+        VpnHideTheme {
+            SecondaryProfileBlockedScreen()
+        }
+        return
+    }
+
     val context = LocalContext.current
     val settingsRepository = remember(context) { SettingsRepository(context.applicationContext) }
     val loadedSettings by settingsRepository.settings.collectAsState(initial = null)
@@ -211,6 +221,14 @@ fun VpnHideApp() {
             }
         }
     }
+}
+
+@Composable
+private fun SecondaryProfileBlockedScreen() {
+    StartupBlockingScreen(
+        title = stringResource(R.string.secondary_profile_error_title),
+        body = stringResource(R.string.secondary_profile_error_message),
+    )
 }
 
 private enum class Tab { Dashboard, Protection, Statistics }
@@ -781,37 +799,12 @@ private fun RootPreparationErrorScreen(
     }
 }
 
-@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 private fun RootDeniedScreen(onRecheck: () -> Unit) {
-    Scaffold(
-        containerColor = AppColors.screenBackground,
-        topBar = {
-            TopAppBar(
-                title = { Text(stringResource(R.string.app_name)) },
-                colors =
-                    TopAppBarDefaults.topAppBarColors(
-                        containerColor = AppColors.topBarContainer,
-                        titleContentColor = MaterialTheme.colorScheme.onSurface,
-                    ),
-            )
-        },
-    ) { innerPadding ->
-        Box(
-            modifier =
-                Modifier
-                    .fillMaxSize()
-                    .padding(innerPadding)
-                    .padding(32.dp),
-            contentAlignment = Alignment.Center,
-        ) {
-            BlockingErrorCard(
-                icon = Icons.Default.Lock,
-                title = stringResource(R.string.root_error_title),
-                body = stringResource(R.string.root_error_message),
-                actionLabel = stringResource(R.string.root_error_recheck),
-                onAction = onRecheck,
-            )
-        }
-    }
+    StartupBlockingScreen(
+        title = stringResource(R.string.root_error_title),
+        body = stringResource(R.string.root_error_message),
+        actionLabel = stringResource(R.string.root_error_recheck),
+        onAction = onRecheck,
+    )
 }

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/NativeCapacityPicker.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/NativeCapacityPicker.kt
@@ -1,0 +1,65 @@
+package dev.okhsunrog.vpnhide
+
+import android.content.res.Resources
+
+internal fun nativeSelectionChangeError(
+    current: List<AppEntry>,
+    candidate: List<AppEntry>,
+    targets: TargetsSnapshot,
+    selfPkg: String,
+    resources: Resources,
+): String? {
+    val currentUsage = nativeCapacityUsage(current, targets, selfPkg)
+    val candidateUsage = nativeCapacityUsage(candidate, targets, selfPkg)
+    return nativeCapacityIncreaseViolation(currentUsage, candidateUsage)?.run {
+        nativeCapacityMessage(resources)
+    }
+}
+
+internal fun nativeSelectionSaveError(
+    entries: List<AppEntry>,
+    targets: TargetsSnapshot,
+    selfPkg: String,
+    resources: Resources,
+): String? =
+    nativeCapacityUsage(entries, targets, selfPkg)
+        .takeIf { it.overflow > 0 }
+        ?.run { nativeCapacityMessage(resources) }
+
+internal fun AppEntry.toRoleSelection(): AppRoleSelection =
+    AppRoleSelection(
+        packageName = packageName,
+        uids = uids,
+        java = java,
+        javaHooks = javaHooks,
+        native = native,
+        nativeOverrides = nativeOverrides,
+        appHiding = appHiding,
+        ports = ports,
+        portPolicy = portPolicy,
+    )
+
+private fun nativeCapacityUsage(
+    entries: Collection<AppEntry>,
+    targets: TargetsSnapshot,
+    selfPkg: String,
+): NativeTargetCapacityUsage {
+    val existingNativePackages =
+        targets.canonicalConfig
+            ?.apps
+            ?.filterValues { it.native.enabled }
+            ?.keys
+            ?: targets.nativeTargets
+    return nativeTargetCapacityUsage(
+        selfPkg = selfPkg,
+        selections = entries.map(AppEntry::toRoleSelection),
+        existingNativePackages = existingNativePackages,
+        packageUids = targets.packageUids,
+    )
+}
+
+private fun nativeCapacityMessage(resources: Resources): String =
+    resources.getString(
+        R.string.native_target_capacity_reached,
+        NATIVE_USER_UID_CAPACITY,
+    )

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/StartupBlockingScreen.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/StartupBlockingScreen.kt
@@ -1,0 +1,60 @@
+package dev.okhsunrog.vpnhide
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Lock
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import dev.okhsunrog.vpnhide.ui.components.BlockingErrorCard
+import dev.okhsunrog.vpnhide.ui.theme.AppColors
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+internal fun StartupBlockingScreen(
+    title: String,
+    body: String,
+    actionLabel: String? = null,
+    onAction: (() -> Unit)? = null,
+) {
+    Scaffold(
+        containerColor = AppColors.screenBackground,
+        topBar = {
+            TopAppBar(
+                title = { Text(stringResource(R.string.app_name)) },
+                colors =
+                    TopAppBarDefaults.topAppBarColors(
+                        containerColor = AppColors.topBarContainer,
+                        titleContentColor = MaterialTheme.colorScheme.onSurface,
+                    ),
+            )
+        },
+    ) { innerPadding ->
+        Box(
+            modifier =
+                Modifier
+                    .fillMaxSize()
+                    .padding(innerPadding)
+                    .padding(32.dp),
+            contentAlignment = Alignment.Center,
+        ) {
+            BlockingErrorCard(
+                icon = Icons.Default.Lock,
+                title = title,
+                body = body,
+                actionLabel = actionLabel,
+                onAction = onAction,
+            )
+        }
+    }
+}

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/TargetPickerScaffold.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/TargetPickerScaffold.kt
@@ -145,6 +145,11 @@ internal fun <T : TargetEntry> TargetPickerScreen(
     countText: (entries: List<T>, resources: Resources) -> String,
     persist: suspend (entries: List<T>, ctx: SaveContext) -> CanonicalWriteResult,
     successMessage: (entries: List<T>, resources: Resources) -> String,
+    selectionChangeError:
+        (current: List<T>, candidate: List<T>, targets: TargetsSnapshot, selfPkg: String, resources: Resources) -> String? =
+        { _, _, _, _, _ -> null },
+    selectionSaveError: (entries: List<T>, targets: TargetsSnapshot, selfPkg: String, resources: Resources) -> String? =
+        { _, _, _, _ -> null },
     moduleMissing: (TargetsSnapshot) -> Boolean = { false },
     moduleMissingContent: @Composable (Modifier) -> Unit = {},
     row: @Composable (entry: T, userNames: Map<Int, String>, targets: TargetsSnapshot, onChange: (T) -> Unit) -> Unit,
@@ -232,8 +237,18 @@ internal fun <T : TargetEntry> TargetPickerScreen(
     val visibleSections = remember(visibleApps, sortMode) { targetListSections(visibleApps, sortMode) }
 
     val onChange: (T) -> Unit = { updated ->
-        allApps = allApps.map { if (it.packageName == updated.packageName) updated else it }
-        dirty = true
+        val candidate = allApps.map { if (it.packageName == updated.packageName) updated else it }
+        val error =
+            targets?.let { currentTargets ->
+                selectionChangeError(allApps, candidate, currentTargets, context.packageName, resources)
+            }
+        if (error != null) {
+            snackDuration = SnackbarDuration.Long
+            snackMessage = error
+        } else {
+            allApps = candidate
+            dirty = true
+        }
     }
 
     Column(modifier = modifier.fillMaxSize()) {
@@ -319,8 +334,17 @@ internal fun <T : TargetEntry> TargetPickerScreen(
                     )
                     EnhancedButton(
                         onClick = {
-                            saving = true
-                            dirty = false
+                            val error =
+                                targets?.let { currentTargets ->
+                                    selectionSaveError(allApps, currentTargets, context.packageName, resources)
+                                }
+                            if (error != null) {
+                                snackDuration = SnackbarDuration.Long
+                                snackMessage = error
+                            } else {
+                                saving = true
+                                dirty = false
+                            }
                         },
                         enabled = dirty && !saving,
                     ) {

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/TargetsCache.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/TargetsCache.kt
@@ -37,6 +37,10 @@ internal data class TargetsSnapshot(
     val canonicalConfig: CanonicalConfig?,
     val apatchSuperkeySaved: Boolean = false,
     val activeNativeBackendId: NativeBackendId? = null,
+    /** Exact package → UID projection from the same `pm --user all` snapshot
+     * the activator consumes. The picker uses it to enforce native capacity
+     * before Save, including profiles and shared UIDs. */
+    val packageUids: Map<String, List<Int>> = emptyMap(),
 ) {
     /** True if any native backend is installed (kmod / KPM / Zygisk). The
      * picker's "N" toggle is meaningful only when at least one is present. */
@@ -160,6 +164,7 @@ internal fun parseTargetsSnapshot(rootSnapshot: RootSnapshot): TargetsSnapshot {
             canonicalConfig = canonical,
             apatchSuperkeySaved = sections["superkey_saved"]?.trim() == "1",
             activeNativeBackendId = activeNativeBackendId,
+            packageUids = pkgToUids,
         )
     }
 
@@ -181,5 +186,6 @@ internal fun parseTargetsSnapshot(rootSnapshot: RootSnapshot): TargetsSnapshot {
         canonicalConfig = null,
         apatchSuperkeySaved = sections["superkey_saved"]?.trim() == "1",
         activeNativeBackendId = activeNativeBackendId,
+        packageUids = pkgToUids,
     )
 }

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/UserProfileData.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/UserProfileData.kt
@@ -2,6 +2,11 @@ package dev.okhsunrog.vpnhide
 
 import java.util.Locale
 
+private const val ANDROID_UIDS_PER_USER = 100_000
+
+/** VPN Hide has a single supported owner: Android's main user (user 0). */
+internal fun isMainAppProfile(uid: Int): Boolean = uid >= 0 && uid / ANDROID_UIDS_PER_USER == 0
+
 /**
  * What kind of Android user a secondary profile is. Derived from
  * `pm list users -v`, which is the only place the type is exposed to a

--- a/lsposed/app/src/main/res/values-ru/strings.xml
+++ b/lsposed/app/src/main/res/values-ru/strings.xml
@@ -58,12 +58,15 @@
     <string name="apps_help_zygisk_warning_body">Zygisk-хуки работают внутри процесса выбранного приложения. Банковские и платёжные приложения могут это обнаружить, если для них включён Native; оставьте Native выключенным и по возможности используйте Java.</string>
 
     <!-- Root status -->
+    <string name="secondary_profile_error_title">Откройте VPN Hide в основном профиле</string>
+    <string name="secondary_profile_error_message">Удалите эту копию VPN Hide и используйте копию из основного профиля. Она может управлять приложениями из всех профилей.</string>
     <string name="root_error_title">Требуется root-доступ</string>
     <string name="root_error_message">VPN Hide нужен root-доступ, чтобы управлять скрытием VPN для выбранных приложений. Выдайте его в менеджере root (Magisk, KernelSU, APatch) и нажмите «Проверить снова».</string>
     <string name="root_error_recheck">Проверить снова</string>
 
     <!-- Save feedback -->
     <string name="save_success">Сохранено целей: %d</string>
+    <string name="native_target_capacity_reached">Достигнут лимит Native: можно выбрать не более %1$d UID приложений. Сначала отключите Native у другого приложения.</string>
     <string name="save_native_target_capacity">Настройки сохранены, но Native-бэкенд может защитить только %1$d из %2$d найденных UID приложений. %3$d UID с наибольшими номерами остались без Native-защиты.</string>
     <string name="save_failed_exit">Ошибка сохранения (код выхода %d)</string>
     <string name="save_failed_error">Ошибка сохранения: %s</string>

--- a/lsposed/app/src/main/res/values/strings.xml
+++ b/lsposed/app/src/main/res/values/strings.xml
@@ -65,12 +65,15 @@
     <string name="apps_help_zygisk_warning_body">Zygisk hooks run inside the selected app process. Banking and payment apps may detect that when Native is enabled for them; leave Native off for those apps and rely on Java where possible.</string>
 
     <!-- Root status -->
+    <string name="secondary_profile_error_title">Open VPN Hide in the main profile</string>
+    <string name="secondary_profile_error_message">Uninstall this copy of VPN Hide and use the copy installed in the main profile. It can manage apps from every profile.</string>
     <string name="root_error_title">Root access required</string>
     <string name="root_error_message">VPN Hide needs root access to manage VPN hiding for selected apps. Grant it in your root manager (Magisk, KernelSU, APatch), then tap Check again.</string>
     <string name="root_error_recheck">Check again</string>
 
     <!-- Save feedback -->
     <string name="save_success">Saved %d target(s)</string>
+    <string name="native_target_capacity_reached">Native limit reached: at most %1$d app UIDs can be selected. Disable Native for another app first.</string>
     <string name="save_native_target_capacity">Saved, but the Native backend can protect only %1$d of %2$d resolved app UIDs. The %3$d highest UIDs were left without Native protection.</string>
     <string name="save_failed_exit">Save failed (exit code %d)</string>
     <string name="save_failed_error">Save failed: %s</string>

--- a/lsposed/app/src/test/kotlin/dev/okhsunrog/vpnhide/NativeCapacityDataTest.kt
+++ b/lsposed/app/src/test/kotlin/dev/okhsunrog/vpnhide/NativeCapacityDataTest.kt
@@ -1,0 +1,132 @@
+package dev.okhsunrog.vpnhide
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class NativeCapacityDataTest {
+    private val self = "dev.okhsunrog.vpnhide"
+
+    @Test
+    fun `native capacity reserves one self slot before the picker reaches the limit`() {
+        val selected =
+            (0 until NATIVE_TARGET_UID_CAPACITY - 1).map { offset ->
+                AppRoleSelection(
+                    packageName = "com.example.$offset",
+                    uids = listOf(10_000 + offset),
+                    native = true,
+                )
+            }
+        val full = nativeUsage(selected)
+        val overflow =
+            nativeUsage(
+                selected +
+                    AppRoleSelection(
+                        packageName = "com.example.overflow",
+                        uids = listOf(20_000),
+                        native = true,
+                    ),
+            )
+
+        assertEquals(NATIVE_TARGET_UID_CAPACITY, full.used)
+        assertEquals(0, full.overflow)
+        assertEquals(1, overflow.overflow)
+        assertEquals(overflow, nativeCapacityIncreaseViolation(full, overflow))
+    }
+
+    @Test
+    fun `multi-profile native app consumes one slot per resolved uid`() {
+        val selected =
+            (0 until NATIVE_TARGET_UID_CAPACITY - 2).map { offset ->
+                AppRoleSelection(
+                    packageName = "com.example.$offset",
+                    uids = listOf(10_000 + offset),
+                    native = true,
+                )
+            }
+        val current = nativeUsage(selected)
+        val candidate =
+            nativeUsage(
+                selected +
+                    AppRoleSelection(
+                        packageName = "com.example.profiled",
+                        uids = listOf(30_000, 1_030_000),
+                        native = true,
+                    ),
+            )
+
+        assertEquals(NATIVE_TARGET_UID_CAPACITY - 1, current.used)
+        assertEquals(NATIVE_TARGET_UID_CAPACITY + 1, candidate.used)
+        assertEquals(candidate, nativeCapacityIncreaseViolation(current, candidate))
+    }
+
+    @Test
+    fun `shared native uid is counted once`() {
+        val usage =
+            nativeUsage(
+                listOf(
+                    AppRoleSelection("com.shared.one", uids = listOf(12_345), native = true),
+                    AppRoleSelection("com.shared.two", uids = listOf(12_345), native = true),
+                ),
+            )
+
+        assertEquals(2, usage.used)
+    }
+
+    @Test
+    fun `platform aid does not spend native capacity`() {
+        val usage =
+            nativeUsage(
+                listOf(
+                    AppRoleSelection("android.platform", uids = listOf(1_000), native = true),
+                ),
+            )
+
+        assertEquals(1, usage.used)
+    }
+
+    @Test
+    fun `native packages missing from picker remain in capacity calculation`() {
+        val usage =
+            nativeTargetCapacityUsage(
+                selfPkg = self,
+                selections = listOf(AppRoleSelection("com.visible")),
+                existingNativePackages = setOf("com.visible", "com.preserved"),
+                packageUids =
+                    mapOf(
+                        self to listOf(10_100),
+                        "com.preserved" to listOf(12_000, 1_012_000),
+                    ),
+            )
+
+        assertEquals(3, usage.used)
+    }
+
+    @Test
+    fun `self always reserves exactly one slot`() {
+        val usage =
+            nativeTargetCapacityUsage(
+                selfPkg = self,
+                selections = emptyList(),
+                existingNativePackages = emptySet(),
+                packageUids = mapOf(self to listOf(10_100, 1_010_100)),
+            )
+
+        assertEquals(1, usage.used)
+    }
+
+    @Test
+    fun `reducing an already overflowing selection remains allowed`() {
+        val current = NativeTargetCapacityUsage(used = 162)
+        val reduced = NativeTargetCapacityUsage(used = 161)
+
+        assertEquals(null, nativeCapacityIncreaseViolation(current, reduced))
+    }
+
+    private fun nativeUsage(selections: Collection<AppRoleSelection>): NativeTargetCapacityUsage =
+        nativeTargetCapacityUsage(
+            selfPkg = self,
+            selections = selections,
+            existingNativePackages = emptySet(),
+            packageUids = emptyMap(),
+        )
+}

--- a/lsposed/app/src/test/kotlin/dev/okhsunrog/vpnhide/TargetsCacheTest.kt
+++ b/lsposed/app/src/test/kotlin/dev/okhsunrog/vpnhide/TargetsCacheTest.kt
@@ -39,6 +39,7 @@ class TargetsCacheTest {
         assertEquals(setOf("com.hidden.one", "com.hidden.two"), targets.hiddenPkgs)
         assertEquals(setOf(10123, 1010123), targets.observerUids)
         assertEquals(setOf("com.observer"), targets.observerNames)
+        assertEquals(listOf(10123, 1010123), targets.packageUids["com.observer"])
         assertEquals(setOf("com.browser"), targets.portsObservers)
         assertTrue(targets.apatchSuperkeySaved)
     }

--- a/lsposed/app/src/test/kotlin/dev/okhsunrog/vpnhide/UserProfileDataTest.kt
+++ b/lsposed/app/src/test/kotlin/dev/okhsunrog/vpnhide/UserProfileDataTest.kt
@@ -6,6 +6,14 @@ import org.junit.Test
 
 class UserProfileDataTest {
     @Test
+    fun `only android main user can run the app`() {
+        assertEquals(true, isMainAppProfile(10_123))
+        assertEquals(false, isMainAppProfile(1_010_123))
+        assertEquals(false, isMainAppProfile(1_110_123))
+        assertEquals(false, isMainAppProfile(-1))
+    }
+
+    @Test
     fun `parses verbose rows with profile types`() {
         val raw =
             """

--- a/scripts/codegen-hooks.py
+++ b/scripts/codegen-hooks.py
@@ -149,6 +149,28 @@ def emit_kmod(hooks: list[Hook], errs: list[Err], backends: list[Backend]) -> st
     for b in KNOWN_BACKENDS:
         L.append(f"#define VPNHIDE_{upper(b)}_HOOK_MASK 0x{backend_mask(hooks, b):x}u")
     L.append("")
+    kernel_hooks = [h for h in hooks if h.backend == "kernel"]
+    L.append("/* Dense storage slots for kernel-owned stats counters. The wire keeps")
+    L.append("   global hook ids; native backends use these helpers only in memory. */")
+    L.append(f"#define VPNHIDE_KERNEL_HOOK_COUNT {len(kernel_hooks)}")
+    L.append("static inline int vpnhide_kernel_hook_slot(unsigned int id)")
+    L.append("{")
+    L.append("\tswitch (id) {")
+    for slot, h in enumerate(kernel_hooks):
+        L.append(f"\tcase {h.id}: return {slot};")
+    L.append("\tdefault: return -1;")
+    L.append("\t}")
+    L.append("}")
+    L.append("")
+    L.append("static inline unsigned int vpnhide_kernel_hook_id(unsigned int slot)")
+    L.append("{")
+    L.append("\tswitch (slot) {")
+    for slot, h in enumerate(kernel_hooks):
+        L.append(f"\tcase {slot}: return {h.id};")
+    L.append("\tdefault: return VPNHIDE_HOOK_COUNT;")
+    L.append("\t}")
+    L.append("}")
+    L.append("")
     L.append("/* status error codes (protocol §5.1). */")
     ewidth = max(len(f"VPNHIDE_ERR_{upper(e.name)}") for e in errs)
     for e in errs:


### PR DESCRIPTION
## Summary

- raise the native backend target capacity from 64 to 160 UIDs
- compact native statistics to the 11 kernel-owned hook slots while retaining u64 counters
- page KPM statistics by UID and validate/aggregate every page in the activator
- stream the kernel module's proc output with seq_file instead of a fixed whole-output buffer
- move enlarged config parse snapshots off the kernel stack and document the independent target-count and KPM byte limits
- enforce the limit in the app while toggling and saving Native targets, with one slot reserved for VPN Hide
- make the main-profile copy the sole config owner; secondary-profile copies stop before root/config work and show an uninstall prompt

## Why

The 64-UID ceiling was reached quickly when selected packages existed in both owner and work profiles. Statistics had a separate problem: fixed KPM and kernel-module output buffers could truncate a larger result even when the target configuration itself was valid.

The compact layout keeps the 160-target KPM .bss at 18,004 bytes, below the old 23,120-byte 64-target layout. KPM's fixed 1,024-byte control transport remains independently guarded by the activator's exact wire-size validation.

The picker now counts resolved UIDs, including multi-profile and shared-UID cases, and allows at most 159 selected-app UIDs. The remaining slot is always available for VPN Hide's main-profile UID. Preventing secondary copies from running also removes concurrent writers to the shared canonical configuration.

## Compatibility

The telemetry wire version remains v1. KPM pagination is an additive request/reply extension consumed by the activator, which folds pages back into the existing stats block expected by the app. Legacy complete KPM replies are still accepted.

VPN Hide still manages target apps from every Android profile through the main-profile copy. Only extra copies of VPN Hide itself are blocked.

## Validation

- Rust protocol, differential-parser, activator, and Zygisk tests
- Rust clippy for protocol, differential parser, and activator
- Android unit tests, ktlint, detekt, CPD, lintDebug, and assembleRelease
- 56 shared C protocol vectors and shared-logic host tests
- pinned clang-format and codegen drift checks
- KPM build; measured .bss: 18,004 bytes
- android14-6.1 kernel-module DDK build
- android16-6.12 KPM QEMU A/B harness: 25 passed, 0 failed, 0 panics
