### PR TITLE
Fix app enumeration across Android profiles

### DIFF
--- a/changelog.d/fixed-fixed-apps-from-work-private-clone-b953.md
+++ b/changelog.d/fixed-fixed-apps-from-work-private-clone-b953.md
@@ -1,0 +1,9 @@
+_2026-08-11_
+
+## English
+
+Fixed apps from work, private, clone, and secondary profiles missing from the Hiding list on ROMs with incomplete multi-user package enumeration.
+
+## Русский
+
+Исправлено отсутствие приложений из рабочего профиля, приватного пространства, профилей-клонов и дополнительных пользователей в списке «Скрытие» на прошивках с неполным перечислением пакетов.

--- a/crates/activator/src/lib.rs
+++ b/crates/activator/src/lib.rs
@@ -435,6 +435,14 @@ fn pm_list_packages(args: &[&str]) -> Result<String> {
     Ok(String::from_utf8(out.stdout)?)
 }
 
+fn pm_list_users() -> Result<String> {
+    let out = Command::new("pm").args(["list", "users"]).output()?;
+    if !out.status.success() {
+        return Err(format!("pm list users failed with status {}", out.status).into());
+    }
+    Ok(String::from_utf8(out.stdout)?)
+}
+
 fn pm_output_has_package(output: &str, package: &str) -> bool {
     let expected = format!("package:{package}");
     output

--- a/crates/activator/src/model.rs
+++ b/crates/activator/src/model.rs
@@ -218,8 +218,19 @@ impl PackageUidMap {
 
     fn from_pm_with_wait(wait: PmReadyWait) -> Result<Self> {
         wait_for_pm_ready(wait)?;
-        let stdout = pm_list_packages(&["list", "packages", "-U", "--user", "all"])?;
-        Ok(parse_pm_packages(&stdout))
+        let users_output = pm_list_users()?;
+        let user_ids = parse_pm_user_ids(&users_output);
+        if user_ids.is_empty() {
+            return Err("PackageManager returned no Android users".into());
+        }
+
+        let mut packages = BTreeMap::<String, Vec<u32>>::new();
+        for user_id in user_ids {
+            let user = user_id.to_string();
+            let stdout = pm_list_packages(&["list", "packages", "-U", "--user", user.as_str()])?;
+            merge_pm_packages(&mut packages, parse_pm_packages(&stdout));
+        }
+        Ok(Self { packages })
     }
 
     pub(crate) fn uids_for(&self, package: &str) -> &[u32] {
@@ -239,18 +250,46 @@ pub fn parse_pm_packages(output: &str) -> PackageUidMap {
                 uid_csv = Some(rest);
             }
         }
-        let (Some(pkg), Some(uid_csv)) = (pkg, uid_csv) else {
+        let (Some(pkg_token), Some(uid_csv)) = (pkg, uid_csv) else {
             continue;
         };
+        let pkg = pkg_token
+            .rsplit_once('=')
+            .map_or(pkg_token, |(_, package)| package);
         let uids = uid_csv
             .split(',')
             .filter_map(|s| s.parse::<u32>().ok())
             .collect::<Vec<_>>();
         if !uids.is_empty() {
-            packages.insert(pkg.to_owned(), uids);
+            let existing = packages.entry(pkg.to_owned()).or_default();
+            existing.extend(uids);
+            existing.sort_unstable();
+            existing.dedup();
         }
     }
     PackageUidMap { packages }
+}
+
+pub fn parse_pm_user_ids(output: &str) -> Vec<u32> {
+    let mut users = output
+        .lines()
+        .filter_map(|line| {
+            let after_prefix = line.split_once("UserInfo{")?.1;
+            after_prefix.split_once(':')?.0.trim().parse::<u32>().ok()
+        })
+        .collect::<Vec<_>>();
+    users.sort_unstable();
+    users.dedup();
+    users
+}
+
+fn merge_pm_packages(destination: &mut BTreeMap<String, Vec<u32>>, source: PackageUidMap) {
+    for (package, uids) in source.packages {
+        let existing = destination.entry(package).or_default();
+        existing.extend(uids);
+        existing.sort_unstable();
+        existing.dedup();
+    }
 }
 
 pub fn parse_canonical(json: &str) -> Result<CanonicalConfig> {

--- a/crates/activator/src/tests.rs
+++ b/crates/activator/src/tests.rs
@@ -53,6 +53,28 @@ fn parses_pm_package_uids_for_all_profiles() {
 }
 
 #[test]
+fn parses_android_user_ids_without_treating_names_as_syntax() {
+    let users = parse_pm_user_ids(
+        "Users:\n\
+         \tUserInfo{0:Owner:c13} running\n\
+         \tUserInfo{10:Work:1030} running\n\
+         \tUserInfo{11:Second:Space:10} running\n",
+    );
+
+    assert_eq!(users, vec![0, 10, 11]);
+}
+
+#[test]
+fn merges_repeated_per_user_rows_and_accepts_apk_paths() {
+    let map = parse_pm_packages(
+        "package:/data/app/example/base.apk=com.example uid:10123\n\
+         package:/data/app/example/base.apk=com.example uid:1010123\n",
+    );
+
+    assert_eq!(map.uids_for("com.example"), &[10123, 1010123]);
+}
+
+#[test]
 fn projects_native_roles_to_wire() {
     let cfg = parse_canonical(
         r#"{

--- a/docs/state.md
+++ b/docs/state.md
@@ -70,8 +70,9 @@ module reinstall. They hold binaries and boot scripts, not user-managed config.
 - `service.sh`: starts `activator --boot-wait` in the background.
 - `uninstall.sh`: removes kmod-specific persistent diagnostics and legacy
   targets under `/data/adb/vpnhide_kmod/`.
-- `activator`: Rust bin that reads canonical JSON, resolves packages via
-  `pm list packages -U --user all`, formats text wire, waits for
+- `activator`: Rust bin that reads canonical JSON, lists Android users and
+  resolves packages with `pm list packages -U --user <id>` for each user,
+  formats text wire, waits for
   `/proc/vpnhide_ctl` in boot mode, and writes `/proc/vpnhide_ctl`.
 - `vpnhide_kmod.ko`: kernel module binary.
 

--- a/docs/storage.md
+++ b/docs/storage.md
@@ -241,8 +241,11 @@ zygisk/                     # cdylib — the injected .so. deps: protocol (+ sha
 - **When it runs:** at boot from that module's `service.sh` as
   `activator --boot-wait`, and on Save from the app (`su <path>/activator`).
   Boot mode waits indefinitely for PackageManager readiness; Save mode keeps a
-  bounded wait so the UI cannot hang forever. Then it reads the canonical,
-  resolves, and writes its channel.
+  bounded wait so the UI cannot hang forever. It lists Android users first and
+  resolves every user separately instead of relying on the OEM-dependent
+  `--user all` aggregation. If any user scan fails, activation stops before
+  replacing runtime state with a partial target set. Then it reads the
+  canonical and writes its channel.
 - **KPM load preflight:** the KPM activator parses only the leading numeric
   `major.minor` from `uname -r`; patchlevels and Android/vendor suffixes do not
   affect the offset-table family. It refuses an unknown or unsupported family

--- a/kmod/README.md
+++ b/kmod/README.md
@@ -62,7 +62,7 @@ ordinary `rmmod` is not supported.
 
 On boot:
 - `post-fs-data.sh` runs `insmod` to load the kernel module
-- `service.sh` runs the Rust activator, which reads `/data/system/vpnhide_config.json`, resolves package names via `pm list packages -U --user all`, and emits a `vpnhide 2 config` snapshot (docs/protocol.md) to `/proc/vpnhide_ctl`
+- `service.sh` runs the Rust activator, which reads `/data/system/vpnhide_config.json`, enumerates Android users, resolves package names for each user separately, and emits a `vpnhide 2 config` snapshot (docs/protocol.md) to `/proc/vpnhide_ctl`
 
 ### Target management
 

--- a/lsposed/README.md
+++ b/lsposed/README.md
@@ -39,7 +39,9 @@ re-entering them.
 
 The APK includes a Compose UI for managing target apps across all vpnhide modules:
 
-- Lists all installed apps with icons, names, and package names
+- Lists installed apps from every Android user/profile with icons, names, and
+  package names. Each user is queried separately; an incomplete profile scan is
+  rejected instead of being presented as a complete app list.
 - Text search filter
 - System apps toggle (selected system apps always visible)
 - One row per app with the current roles:

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/AppListCache.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/AppListCache.kt
@@ -109,6 +109,7 @@ internal object AppListCache : StateCache<List<AppSummary>>(
         context: Context,
     ) {
         appContext = context.applicationContext
+        RootSnapshotCache.invalidate()
         forceRefresh(scope)
     }
 
@@ -120,69 +121,49 @@ internal object AppListCache : StateCache<List<AppSummary>>(
         return if (!force) {
             apps.value ?: load(force = false)
         } else {
+            RootSnapshotCache.invalidate()
             load(force = true)
         }
     }
 
-    override suspend fun load(force: Boolean): List<AppSummary> {
+    override suspend fun load(
+        @Suppress("UNUSED_PARAMETER") force: Boolean,
+    ): List<AppSummary> {
         val appContext = requireNotNull(appContext) { "AppListCache.load before ensureLoaded/refresh" }
         return withContext(Dispatchers.IO) {
             val pm = appContext.packageManager
             val vpnServicePkgs = queryVpnServiceProviders(pm)
-            val (packages, users) = loadPackagesAndUsersViaRoot()
-            _userNames.value = users.mapValues { (_, profile) -> profileDisplayName(appContext, profile) }
-            if (packages.isNotEmpty()) {
-                packages.entries
-                    .map { (pkg, meta) ->
-                        val info = runCatching { pm.getApplicationInfo(pkg, 0) }.getOrNull()
-                        val archiveInfo =
-                            if (info == null) loadArchiveApplicationInfo(pm, meta.apkPath) else null
-                        val effectiveInfo = info ?: archiveInfo
+            val inventory = requireCompletePackageInventory(RootSnapshotCache.getOrLoad().sections)
+            _userNames.value =
+                inventory.profiles.mapValues { (_, profile) -> profileDisplayName(appContext, profile) }
+            inventory.packages.entries
+                .map { (pkg, meta) ->
+                    val info = runCatching { pm.getApplicationInfo(pkg, 0) }.getOrNull()
+                    val archiveInfo =
+                        if (info == null) loadArchiveApplicationInfo(pm, meta.apkPath) else null
+                    val effectiveInfo = info ?: archiveInfo
 
-                        // Archive-parsed ApplicationInfo doesn't carry
-                        // FLAG_SYSTEM (that bit is attached by PM at
-                        // install time, not stored in the manifest), so
-                        // for secondary-only packages we'd misclassify
-                        // every system app as user-installed. Fall back
-                        // to the APK path: /data/app/... is user-
-                        // installed, everything else is baked into the
-                        // system image.
-                        val isSystem =
-                            if (info != null) {
-                                (info.flags and ApplicationInfo.FLAG_SYSTEM) != 0
-                            } else {
-                                !meta.apkPath.startsWith("/data/app/")
-                            }
-                        val label = effectiveInfo?.loadLabel(pm)?.toString() ?: pkg
+                    // Archive-parsed ApplicationInfo doesn't carry FLAG_SYSTEM
+                    // (that bit is attached by PM at install time, not stored in
+                    // the manifest), so use the APK path for secondary-only apps.
+                    val isSystem =
+                        if (info != null) {
+                            (info.flags and ApplicationInfo.FLAG_SYSTEM) != 0
+                        } else {
+                            !meta.apkPath.orEmpty().startsWith("/data/app/")
+                        }
+                    val label = effectiveInfo?.loadLabel(pm)?.toString() ?: pkg
 
-                        AppSummary(
-                            packageName = pkg,
-                            label = label,
-                            icon = effectiveInfo?.let { runCatching { pm.getApplicationIcon(it) }.getOrNull() },
-                            isSystem = isSystem,
-                            userIds = meta.userIds,
-                            declaresVpnService = pkg in vpnServicePkgs,
-                            nameContainsVpn = !isSystem && looksLikeVpnAppName(label),
-                        )
-                    }.sortedBy { it.label.lowercase() }
-            } else {
-                // Fallback: current-profile only (legacy behavior)
-                pm
-                    .getInstalledApplications(0)
-                    .map { info ->
-                        val label = info.loadLabel(pm).toString()
-                        val isSystem = (info.flags and ApplicationInfo.FLAG_SYSTEM) != 0
-                        AppSummary(
-                            packageName = info.packageName,
-                            label = label,
-                            icon = runCatching { pm.getApplicationIcon(info) }.getOrNull(),
-                            isSystem = isSystem,
-                            userIds = listOf(Process.myUid() / 100000),
-                            declaresVpnService = info.packageName in vpnServicePkgs,
-                            nameContainsVpn = !isSystem && looksLikeVpnAppName(label),
-                        )
-                    }.sortedBy { it.label.lowercase() }
-            }
+                    AppSummary(
+                        packageName = pkg,
+                        label = label,
+                        icon = effectiveInfo?.let { runCatching { pm.getApplicationIcon(it) }.getOrNull() },
+                        isSystem = isSystem,
+                        userIds = meta.userIds,
+                        declaresVpnService = pkg in vpnServicePkgs,
+                        nameContainsVpn = !isSystem && looksLikeVpnAppName(label),
+                    )
+                }.sortedBy { it.label.lowercase() }
         }
     }
 
@@ -204,52 +185,6 @@ internal object AppListCache : StateCache<List<AppSummary>>(
             }.toSet()
     }
 
-    private data class PkgMeta(
-        val apkPath: String,
-        val userIds: List<Int>,
-    )
-
-    private const val USERS_SENTINEL = "===VPNHIDE-USERS-BOUNDARY==="
-
-    /**
-     * Enumerate every installed package and every user profile in a
-     * single `su` invocation. `pm list packages -U -f --user all` gives
-     * APK path + UID per (pkg, user) tuple; `pm list users` gives the
-     * profile names ("Work", "Second Space") and types that the UI
-     * renders instead of raw user IDs. One `su` spawn — the packages
-     * section is separated from the users section by a sentinel the
-     * parser splits on.
-     *
-     * Both `pm list users` forms are emitted. `-v` is what carries the
-     * profile *type* (`profile.CLONE`, `profile.MANAGED`, …), which is
-     * the only way to name a profile the OS left nameless; it exists
-     * since Android 11 but prints "Invalid option" on anything older,
-     * so the plain form follows as the naming fallback. AOSP pins the
-     * plain format, which also makes it a safety net if an OEM reworks
-     * the verbose printf.
-     *
-     * Packages output is one of:
-     *   package:<apk_path>=<pkg> uid:<uid>            (single-user)
-     *   package:<apk_path>=<pkg> uid:<uid>,<uid>,...  (AOSP --user all)
-     *   package:<apk_path>=<pkg> uid:<uid>            (repeated per user
-     *                                                  on some ROMs)
-     * Users output is parsed by [parseUserProfiles].
-     */
-    private fun loadPackagesAndUsersViaRoot(): Pair<Map<String, PkgMeta>, Map<Int, UserProfileInfo>> {
-        val (exitCode, raw) =
-            suExec(
-                "pm list packages -U -f --user all 2>/dev/null; " +
-                    "echo '$USERS_SENTINEL'; " +
-                    "pm list users -v 2>/dev/null; " +
-                    "pm list users 2>/dev/null",
-            )
-        if (exitCode != 0) return emptyMap<String, PkgMeta>() to emptyMap()
-        val parts = raw.split(USERS_SENTINEL, limit = 2)
-        val packages = parsePackages(parts[0])
-        val users = if (parts.size > 1) parseUserProfiles(parts[1]) else emptyMap()
-        return packages to users
-    }
-
     /**
      * A profile's own name wins — it is what the system UI shows. Only
      * when the OS reports none do we synthesize one from the profile
@@ -268,43 +203,6 @@ internal object AppListCache : StateCache<List<AppSummary>>(
             UserProfileKind.SECONDARY -> context.getString(R.string.profile_kind_secondary, profile.id)
             UserProfileKind.UNKNOWN -> context.getString(R.string.profile_kind_unknown, profile.id)
         }
-    }
-
-    private fun parsePackages(raw: String): Map<String, PkgMeta> {
-        val out = LinkedHashMap<String, PkgMeta>()
-        raw
-            .lineSequence()
-            .map { it.trim() }
-            .filter { it.startsWith("package:") }
-            .forEach { line ->
-                val body = line.removePrefix("package:")
-                val uidMarker = body.lastIndexOf(" uid:")
-                if (uidMarker <= 0) return@forEach
-                val pathAndPkg = body.substring(0, uidMarker)
-                val uidPart = body.substring(uidMarker + " uid:".length).trim()
-                val eq = pathAndPkg.lastIndexOf('=')
-                if (eq <= 0 || eq >= pathAndPkg.lastIndex) return@forEach
-                val apkPath = pathAndPkg.substring(0, eq).trim()
-                val pkg = pathAndPkg.substring(eq + 1).trim()
-                if (apkPath.isEmpty() || pkg.isEmpty()) return@forEach
-
-                val userIds =
-                    uidPart
-                        .split(',')
-                        .mapNotNull { it.trim().toIntOrNull() }
-                        .map { it / 100000 }
-
-                val existing = out[pkg]
-                out[pkg] =
-                    if (existing == null) {
-                        PkgMeta(apkPath, userIds.distinct().sorted())
-                    } else {
-                        existing.copy(
-                            userIds = (existing.userIds + userIds).distinct().sorted(),
-                        )
-                    }
-            }
-        return out
     }
 
     @Suppress("DEPRECATION")

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DebugShellSnapshot.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DebugShellSnapshot.kt
@@ -8,7 +8,7 @@ internal data class DebugShellSnapshot(
 private const val DEBUG_SNAPSHOT_BEGIN_PREFIX = "__VPNHIDE_DEBUG_SECTION_BEGIN__:"
 private const val DEBUG_SNAPSHOT_END_PREFIX = "__VPNHIDE_DEBUG_SECTION_END__:"
 
-// The batch runs many heavy root commands (pm list --user all, dumpsys
+// The batch runs many heavy root commands (per-user package scans, dumpsys
 // connectivity, ip route show table all, fib_trie, several sha256sum). On a busy
 // device 20s was easy to overrun, which truncated the output mid-section and
 // silently dropped that section and every later one. Give it real headroom.
@@ -325,7 +325,13 @@ internal fun buildDebugShellSnapshotCommand(): String =
     emit_file canonical_config $CANONICAL_CONFIG_FILE
     emit_file hidden_pkgs $SS_HIDDEN_PKGS_FILE
     emit_file observer_uids $SS_OBSERVER_UIDS_FILE
-    emit_cmd pm_packages pm list packages -U --user all
+    ${
+        buildPerUserPackageInventoryShell(
+            sectionBeginPrefix = DEBUG_SNAPSHOT_BEGIN_PREFIX,
+            sectionEndPrefix = DEBUG_SNAPSHOT_END_PREFIX,
+            stderrRedirect = "2>&1",
+        )
+    }
 
     emit_cmd network_addr ip -d addr
     emit_eval network_operstate 'for IFACE in /sys/class/net/*; do echo "${'$'}(basename "${'$'}IFACE"): ${'$'}(cat "${'$'}IFACE/operstate" 2>/dev/null)"; done'

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/PackageInventoryData.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/PackageInventoryData.kt
@@ -1,0 +1,188 @@
+package dev.okhsunrog.vpnhide
+
+internal const val PM_USERS_STATUS_PREFIX = "__VPNHIDE_PM_USERS_STATUS__:"
+internal const val PM_USER_BEGIN_PREFIX = "__VPNHIDE_PM_USER_BEGIN__:"
+internal const val PM_USER_END_PREFIX = "__VPNHIDE_PM_USER_END__:"
+private const val PACKAGE_UIDS_PER_USER = 100_000
+
+internal data class PackageInventoryEntry(
+    val apkPath: String?,
+    val uidsByUser: Map<Int, List<Int>>,
+) {
+    val userIds: List<Int> get() = uidsByUser.keys.sorted()
+    val uids: List<Int> get() =
+        uidsByUser.values
+            .flatten()
+            .distinct()
+            .sorted()
+}
+
+internal data class PackageInventory(
+    val packages: Map<String, PackageInventoryEntry>,
+    val profiles: Map<Int, UserProfileInfo>,
+    val failedUserIds: Set<Int>,
+    val userListComplete: Boolean,
+) {
+    val complete: Boolean get() = userListComplete && failedUserIds.isEmpty() && packages.isNotEmpty()
+
+    fun incompleteMessage(): String {
+        if (!userListComplete) return "Android user list was incomplete"
+        if (packages.isEmpty()) return "PackageManager returned no installed packages"
+        return "package scan failed for Android user(s): ${failedUserIds.sorted().joinToString()}"
+    }
+}
+
+internal data class ParsedPackageUidLine(
+    val packageName: String,
+    val apkPath: String?,
+    val uids: List<Int>,
+)
+
+/**
+ * Parse either supported PackageManager row:
+ *
+ * - `package:com.example uid:10123`
+ * - `package:/data/app/.../base.apk=com.example uid:10123`
+ */
+internal fun parsePackageUidLine(line: String): ParsedPackageUidLine? {
+    val trimmed = line.trim()
+    if (!trimmed.startsWith("package:")) return null
+    val body = trimmed.removePrefix("package:")
+    val uidMarker = body.lastIndexOf(" uid:")
+    if (uidMarker <= 0) return null
+    val packageToken = body.substring(0, uidMarker).trim()
+    val uidToken = body.substring(uidMarker + " uid:".length).trim()
+    val separator = packageToken.lastIndexOf('=')
+    val packageName = packageToken.substring(separator + 1).trim()
+    if (packageName.isEmpty()) return null
+    val apkPath =
+        packageToken
+            .takeIf { separator > 0 }
+            ?.substring(0, separator)
+            ?.trim()
+            ?.takeIf(String::isNotEmpty)
+    val uids =
+        uidToken
+            .split(',')
+            .mapNotNull { it.trim().toIntOrNull() }
+            .distinct()
+            .sorted()
+    if (uids.isEmpty()) return null
+    return ParsedPackageUidLine(packageName, apkPath, uids)
+}
+
+internal fun parsePackageInventory(
+    packagesRaw: String,
+    usersRaw: String,
+): PackageInventory {
+    val profiles = parseUserProfiles(usersRaw)
+    val userListStatuses = parseUserListStatuses(usersRaw)
+    val packageStatuses = linkedMapOf<Int, Int>()
+    val usersWithPackages = mutableSetOf<Int>()
+    val packages = linkedMapOf<String, MutablePackageInventoryEntry>()
+    var currentUserId: Int? = null
+
+    packagesRaw.lineSequence().forEach { line ->
+        when {
+            line.startsWith(PM_USER_BEGIN_PREFIX) -> {
+                currentUserId = line.removePrefix(PM_USER_BEGIN_PREFIX).trim().toIntOrNull()
+            }
+
+            line.startsWith(PM_USER_END_PREFIX) -> {
+                val fields = line.removePrefix(PM_USER_END_PREFIX).split(':', limit = 2)
+                val userId = fields.getOrNull(0)?.toIntOrNull()
+                val status = fields.getOrNull(1)?.toIntOrNull()
+                if (userId != null && status != null) packageStatuses[userId] = status
+                currentUserId = null
+            }
+
+            else -> {
+                val parsed = parsePackageUidLine(line) ?: return@forEach
+                val entry = packages.getOrPut(parsed.packageName) { MutablePackageInventoryEntry() }
+                if (entry.apkPath == null) entry.apkPath = parsed.apkPath
+                val userIds = currentUserId?.let(::listOf) ?: parsed.uids.map { it / PACKAGE_UIDS_PER_USER }
+                userIds.forEach { userId ->
+                    usersWithPackages += userId
+                    entry.uidsByUser.getOrPut(userId) { linkedSetOf() }.addAll(parsed.uids)
+                }
+            }
+        }
+    }
+
+    val expectedUserIds = profiles.keys
+    val failedUserIds = expectedUserIds.filterTo(sortedSetOf()) { packageStatuses[it] != 0 || it !in usersWithPackages }
+    val userListComplete = userListStatuses.any { it == 0 } && expectedUserIds.isNotEmpty()
+    return PackageInventory(
+        packages = packages.mapValues { (_, entry) -> entry.freeze() },
+        profiles = profiles,
+        failedUserIds = failedUserIds,
+        userListComplete = userListComplete,
+    )
+}
+
+internal fun requireCompletePackageInventory(sections: Map<String, String>): PackageInventory {
+    val inventory =
+        parsePackageInventory(
+            packagesRaw = sections["pm_packages"].orEmpty(),
+            usersRaw = sections["pm_users"].orEmpty(),
+        )
+    if (!inventory.complete) throw RootSnapshotException(inventory.incompleteMessage())
+    return inventory
+}
+
+/**
+ * One root-shell implementation shared by the normal root snapshot and the
+ * exported debug snapshot. It enumerates users first, then queries each user
+ * explicitly; relying on `--user all` is incomplete on some OEM ROMs.
+ */
+internal fun buildPerUserPackageInventoryShell(
+    sectionBeginPrefix: String,
+    sectionEndPrefix: String,
+    stderrRedirect: String,
+): String =
+    """
+    PM_USERS_VERBOSE="${'$'}(pm list users -v $stderrRedirect)"
+    PM_USERS_VERBOSE_STATUS=${'$'}?
+    PM_USERS_PLAIN="${'$'}(pm list users $stderrRedirect)"
+    PM_USERS_PLAIN_STATUS=${'$'}?
+    echo "${sectionBeginPrefix}pm_users"
+    echo "${PM_USERS_STATUS_PREFIX}verbose:${'$'}PM_USERS_VERBOSE_STATUS"
+    echo "${PM_USERS_STATUS_PREFIX}plain:${'$'}PM_USERS_PLAIN_STATUS"
+    [ -n "${'$'}PM_USERS_VERBOSE" ] && printf '%s\n' "${'$'}PM_USERS_VERBOSE"
+    [ -n "${'$'}PM_USERS_PLAIN" ] && printf '%s\n' "${'$'}PM_USERS_PLAIN"
+    echo "${sectionEndPrefix}pm_users"
+    PM_PLAIN_USER_IDS="${'$'}(printf '%s\n' "${'$'}PM_USERS_PLAIN" | sed -n 's/.*UserInfo{\([0-9][0-9]*\):.*/\1/p')"
+    PM_VERBOSE_USER_IDS="${'$'}(printf '%s\n' "${'$'}PM_USERS_VERBOSE" | sed -n 's/^[[:space:]]*[0-9][0-9]*:[[:space:]]*id=\([0-9][0-9]*\),.*/\1/p')"
+    PM_USER_IDS="${'$'}(printf '%s\n%s\n' "${'$'}PM_PLAIN_USER_IDS" "${'$'}PM_VERBOSE_USER_IDS" | sed '/^${'$'}/d' | sort -n -u)"
+    echo "${sectionBeginPrefix}pm_packages"
+    if [ -z "${'$'}PM_USER_IDS" ]; then
+      PM_USER_IDS=0
+    fi
+    for PM_USER_ID in ${'$'}PM_USER_IDS; do
+      PM_USER_PACKAGES="${'$'}(pm list packages -U -f --user "${'$'}PM_USER_ID" $stderrRedirect)"
+      PM_USER_STATUS=${'$'}?
+      echo "$PM_USER_BEGIN_PREFIX${'$'}PM_USER_ID"
+      [ -n "${'$'}PM_USER_PACKAGES" ] && printf '%s\n' "${'$'}PM_USER_PACKAGES"
+      echo "$PM_USER_END_PREFIX${'$'}PM_USER_ID:${'$'}PM_USER_STATUS"
+    done
+    echo "${sectionEndPrefix}pm_packages"
+    """.trimIndent()
+
+private data class MutablePackageInventoryEntry(
+    var apkPath: String? = null,
+    val uidsByUser: MutableMap<Int, MutableSet<Int>> = linkedMapOf(),
+) {
+    fun freeze(): PackageInventoryEntry =
+        PackageInventoryEntry(
+            apkPath = apkPath,
+            uidsByUser = uidsByUser.mapValues { (_, uids) -> uids.sorted() },
+        )
+}
+
+private fun parseUserListStatuses(raw: String): List<Int> =
+    raw
+        .lineSequence()
+        .mapNotNull { line ->
+            if (!line.startsWith(PM_USERS_STATUS_PREFIX)) return@mapNotNull null
+            line.substringAfterLast(':').trim().toIntOrNull()
+        }.toList()

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/RootSnapshotCache.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/RootSnapshotCache.kt
@@ -12,6 +12,11 @@ internal data class RootSnapshot(
     val sections: Map<String, String>,
 )
 
+internal data class PackageInventorySeed(
+    val packages: String,
+    val users: String,
+)
+
 internal class RootSnapshotException(
     message: String,
 ) : RuntimeException(message)
@@ -19,7 +24,7 @@ internal class RootSnapshotException(
 private const val ROOT_SNAPSHOT_BEGIN_PREFIX = "__VPNHIDE_ROOT_SECTION_BEGIN__:"
 private const val ROOT_SNAPSHOT_END_PREFIX = "__VPNHIDE_ROOT_SECTION_END__:"
 private const val ROOT_TIMING_PREFIX = "__VPNHIDE_ROOT_TIMING__:"
-private const val ROOT_SNAPSHOT_TIMEOUT_SEC: Long = 5
+private const val ROOT_SNAPSHOT_TIMEOUT_SEC: Long = 10
 
 internal val REQUIRED_ROOT_SNAPSHOT_SECTIONS =
     setOf(
@@ -53,6 +58,7 @@ internal val REQUIRED_ROOT_SNAPSHOT_SECTIONS =
         "getenforce",
         "kpatch_runtime",
         "pm_packages",
+        "pm_users",
         "proc_exists",
         "ports_chain",
         "lsposed_framework",
@@ -73,7 +79,7 @@ internal object RootSnapshotCache {
     val loading: StateFlow<Boolean> = _loading.asStateFlow()
 
     private val mutex = Mutex()
-    private var preloadedPmPackages: String? = null
+    private var preloadedPackageInventory: PackageInventorySeed? = null
     private var runtimeProbeSource: String? = null
 
     fun setRuntimeProbeSource(path: String?) {
@@ -91,27 +97,27 @@ internal object RootSnapshotCache {
     suspend fun refresh(): RootSnapshot =
         withContext(Dispatchers.IO) {
             mutex.withLock {
-                preloadedPmPackages = null
+                preloadedPackageInventory = null
                 loadLocked()
             }
         }
 
     fun invalidate() {
         _snapshot.value = null
-        preloadedPmPackages = null
+        preloadedPackageInventory = null
     }
 
-    fun seedPmPackages(pmPackages: String?) {
-        preloadedPmPackages = pmPackages?.trimEnd()?.takeIf { it.isNotBlank() }
+    fun seedPackageInventory(seed: PackageInventorySeed?) {
+        preloadedPackageInventory = seed
     }
 
     private fun loadLocked(): RootSnapshot {
         _loading.value = true
         return try {
             StartupTrace.mark("root_snapshot_start")
-            val pmPackages = preloadedPmPackages
-            preloadedPmPackages = null
-            val sections = loadRootShellSnapshot(pmPackagesOverride = pmPackages, runtimeProbeSource = runtimeProbeSource)
+            val inventory = preloadedPackageInventory
+            preloadedPackageInventory = null
+            val sections = loadRootShellSnapshot(inventoryOverride = inventory, runtimeProbeSource = runtimeProbeSource)
             val snapshot = RootSnapshot(sections)
             _snapshot.value = snapshot
             StartupTrace.mark("root_snapshot_done")
@@ -126,13 +132,13 @@ internal object RootSnapshotCache {
 }
 
 private fun loadRootShellSnapshot(
-    pmPackagesOverride: String?,
+    inventoryOverride: PackageInventorySeed?,
     runtimeProbeSource: String?,
 ): Map<String, String> {
     val (exitCode, raw) =
         suExec(
             buildRootShellSnapshotCommand(
-                includePmPackages = pmPackagesOverride == null,
+                includePmPackages = inventoryOverride == null,
                 runtimeProbeSource = runtimeProbeSource,
             ),
             timeoutSec = ROOT_SNAPSHOT_TIMEOUT_SEC,
@@ -141,8 +147,9 @@ private fun loadRootShellSnapshot(
         throw RootSnapshotException("root snapshot command failed with exit=$exitCode")
     }
     val sections = parseRootShellSnapshot(raw).toMutableMap()
-    if (pmPackagesOverride != null) {
-        sections["pm_packages"] = pmPackagesOverride
+    if (inventoryOverride != null) {
+        sections["pm_packages"] = inventoryOverride.packages
+        sections["pm_users"] = inventoryOverride.users
     }
     validateRootSnapshotSections(sections)
     return sections
@@ -330,13 +337,7 @@ internal fun buildRootShellSnapshotCommand(
         .replace(
             "__VPNHIDE_PM_PACKAGES_FUNCTION__",
             if (includePmPackages) {
-                """
-                phase_pm_packages() {
-                  phase_start pm_packages
-                  emit_cmd pm_packages pm list packages -U --user all
-                  phase_end
-                }
-                """.trimIndent()
+                buildRootPackageInventoryPhase()
             } else {
                 ""
             },
@@ -344,6 +345,21 @@ internal fun buildRootShellSnapshotCommand(
             "__VPNHIDE_PM_PACKAGES_PHASE__",
             if (includePmPackages) "phase_pm_packages" else ":",
         )
+
+private fun buildRootPackageInventoryPhase(): String =
+    """
+    phase_pm_packages() {
+      phase_start pm_packages
+      ${
+        buildPerUserPackageInventoryShell(
+            sectionBeginPrefix = ROOT_SNAPSHOT_BEGIN_PREFIX,
+            sectionEndPrefix = ROOT_SNAPSHOT_END_PREFIX,
+            stderrRedirect = "2>/dev/null",
+        ).prependIndent("  ")
+    }
+      phase_end
+    }
+    """.trimIndent()
 
 internal fun parseRootShellSnapshot(
     raw: String,

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/ShellUtils.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/ShellUtils.kt
@@ -143,26 +143,18 @@ internal fun parseKeyValueLines(raw: String): Map<String, String> =
             if (parts.size == 2) parts[0] to parts[1] else null
         }.toMap()
 
-private val PM_PACKAGE_UID_LINE = Regex("^package:(\\S+) uid:(\\S+)")
-
 /**
- * Parse `pm list packages -U [--user all]` output (the form *without* `-f`,
- * so the token after `package:` is the package name, not an APK path) into
- * `package → uids`. Multi-profile packages report comma-separated UIDs
- * (`uid:10187,1010187`); repeated lines for the same package are unioned.
- * UIDs that aren't integers are dropped. The `-f` variant has a different
- * shape and is parsed separately in [AppListCache].
+ * Parse `pm list packages -U` output into `package → uids`. Both the plain
+ * and `-f` path-prefixed forms are accepted. Repeated per-user rows and
+ * comma-separated `--user all` rows are unioned.
  */
 internal fun parsePackageUidMap(raw: String): Map<String, List<Int>> {
-    val out = LinkedHashMap<String, MutableList<Int>>()
+    val out = LinkedHashMap<String, MutableSet<Int>>()
     raw.lineSequence().forEach { line ->
-        val m = PM_PACKAGE_UID_LINE.find(line) ?: return@forEach
-        val uids = out.getOrPut(m.groupValues[1]) { mutableListOf() }
-        m.groupValues[2].split(',').forEach { token ->
-            token.trim().toIntOrNull()?.let(uids::add)
-        }
+        val parsed = parsePackageUidLine(line) ?: return@forEach
+        out.getOrPut(parsed.packageName) { linkedSetOf() }.addAll(parsed.uids)
     }
-    return out
+    return out.mapValues { (_, uids) -> uids.sorted() }
 }
 
 internal fun parseVpnIfaceStates(raw: String): List<Pair<String, String>> =
@@ -239,6 +231,7 @@ internal data class SelfTargetPreparation(
     val selfNeedsRestart: Boolean,
     val currentBootId: String?,
     val pmPackages: String? = null,
+    val pmUsers: String? = null,
     val error: String? = null,
     val failureKind: SelfTargetFailureKind = SelfTargetFailureKind.Unknown,
 )
@@ -305,6 +298,7 @@ internal fun ensureSelfInTargets(
     }
     cleanupLegacyConfigInputs(timeoutSec)
     val pmPackages = sections["pm_packages"]?.trimEnd()?.takeIf { it.isNotBlank() }
+    val pmUsers = sections["pm_users"]?.trimEnd()?.takeIf { it.isNotBlank() }
     val currentBootId = sections["current_boot_id"]?.trim()?.takeIf { it.isNotBlank() }
     VpnHideLog.d(TAG, "ensureSelfInTargets: done, selfNeedsRestart=${update.selfNeedsRestart}")
     return SelfTargetPreparation(
@@ -312,6 +306,7 @@ internal fun ensureSelfInTargets(
         selfNeedsRestart = update.selfNeedsRestart,
         currentBootId = currentBootId,
         pmPackages = pmPackages,
+        pmUsers = pmUsers,
     )
 }
 

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/StartupCoordinator.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/StartupCoordinator.kt
@@ -28,7 +28,7 @@ internal class StartupCoordinator(
     private val appVersionName: String = BuildConfig.VERSION_NAME,
     private val prepareSelfTargetsCommand: (String) -> SelfTargetPreparation = ::ensureSelfInTargets,
     private val cleanupZygiskStatus: (Context, String?) -> Unit = ::cleanupStaleZygiskStatus,
-    private val seedRootSnapshotPackages: (String?) -> Unit = RootSnapshotCache::seedPmPackages,
+    private val seedRootSnapshotInventory: (PackageInventorySeed?) -> Unit = RootSnapshotCache::seedPackageInventory,
     private val markStartupEvent: (String) -> Unit = StartupTrace::mark,
     private val reconcileRuntimeConfig: () -> Unit = { runRuntimeConfigReconcile() },
     private val reconcileAutoHidden: (CanonicalConfig, List<AppAutoHideSignal>) -> Unit =
@@ -59,7 +59,13 @@ internal class StartupCoordinator(
             withContext(Dispatchers.IO) {
                 val next = prepareSelfTargetsCommand(appContext.packageName)
                 if (next.rootAvailable) {
-                    seedRootSnapshotPackages(next.pmPackages)
+                    val inventory =
+                        if (next.pmPackages != null && next.pmUsers != null) {
+                            PackageInventorySeed(next.pmPackages, next.pmUsers)
+                        } else {
+                            null
+                        }
+                    seedRootSnapshotInventory(inventory)
                     cleanupZygiskStatus(appContext, next.currentBootId)
                 }
                 next

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/TargetPickerScaffold.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/TargetPickerScaffold.kt
@@ -192,11 +192,20 @@ internal fun <T : TargetEntry> TargetPickerScreen(
     // Surface either cache's failure: a failed app-list scan used to leave
     // the picker stuck on an endless spinner (it had no error state at all).
     if ((targetsError != null && targets == null) || (appListError != null && cachedApps == null)) {
+        val packageScanFailed = appListError != null && cachedApps == null
         TargetsLoadErrorCard(
             onRetry = {
                 AppListCache.refresh(scope, context)
                 TargetsCache.refresh(scope, context)
             },
+            title =
+                stringResource(
+                    if (packageScanFailed) R.string.profile_scan_failed_title else R.string.targets_load_failed_title,
+                ),
+            message =
+                stringResource(
+                    if (packageScanFailed) R.string.profile_scan_failed_message else R.string.targets_load_failed_message,
+                ),
             modifier = modifier,
         )
         return
@@ -252,6 +261,14 @@ internal fun <T : TargetEntry> TargetPickerScreen(
     }
 
     Column(modifier = modifier.fillMaxSize()) {
+        if (appListError != null && cachedApps != null) {
+            StatusBanner(
+                text = stringResource(R.string.profile_scan_stale_message),
+                containerColor = StatusColors.warningContainer(),
+                contentColor = StatusColors.warningHeader(),
+                modifier = Modifier.padding(horizontal = 12.dp, vertical = 8.dp),
+            )
+        }
         if (loading) {
             Box(
                 modifier = Modifier.fillMaxSize(),

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/TargetsCache.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/TargetsCache.kt
@@ -37,9 +37,9 @@ internal data class TargetsSnapshot(
     val canonicalConfig: CanonicalConfig?,
     val apatchSuperkeySaved: Boolean = false,
     val activeNativeBackendId: NativeBackendId? = null,
-    /** Exact package → UID projection from the same `pm --user all` snapshot
-     * the activator consumes. The picker uses it to enforce native capacity
-     * before Save, including profiles and shared UIDs. */
+    /** Exact package → UID projection from the shared per-user package
+     * inventory. The picker uses it to enforce native capacity before Save,
+     * including profiles and shared UIDs. */
     val packageUids: Map<String, List<Int>> = emptyMap(),
 ) {
     /** True if any native backend is installed (kmod / KPM / Zygisk). The
@@ -114,9 +114,11 @@ internal object TargetsCache : StateCache<TargetsSnapshot>(
         RootSnapshotCache.invalidate()
     }
 
-    override suspend fun load(force: Boolean): TargetsSnapshot {
-        val rootSnapshot =
-            if (force) RootSnapshotCache.refresh() else RootSnapshotCache.getOrLoad()
+    override suspend fun load(
+        @Suppress("UNUSED_PARAMETER") force: Boolean,
+    ): TargetsSnapshot {
+        val rootSnapshot = RootSnapshotCache.getOrLoad()
+        requireCompletePackageInventory(rootSnapshot.sections)
         return parseTargetsSnapshot(rootSnapshot)
     }
 }
@@ -129,10 +131,9 @@ internal fun parseTargetsSnapshot(rootSnapshot: RootSnapshot): TargetsSnapshot {
     val portsInstalled = sections["ports_prop"]?.isNotBlank() == true
     val canonical = runCatching { parseCanonicalConfig(sections["canonical_config"].orEmpty()) }.getOrNull()
 
-    // With `--user all`, multi-profile packages report comma-separated
-    // UIDs: `package:com.android.chrome uid:10187,1010187`. Each UID
-    // becomes its own entry in the reverse map so observer lookups
-    // from any profile resolve back to the same package name.
+    // The inventory contains one block per Android user. Each resolved UID
+    // becomes its own reverse-map entry so observer lookups from any profile
+    // resolve back to the same package name.
     val uidToPkg = mutableMapOf<Int, String>()
     val pkgToUids = parsePackageUidMap(sections["pm_packages"].orEmpty())
     pkgToUids.forEach { (pkg, uids) ->

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/TargetsLoadErrorCard.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/TargetsLoadErrorCard.kt
@@ -22,6 +22,8 @@ import dev.okhsunrog.vpnhide.ui.components.EnhancedCard
 @Composable
 internal fun TargetsLoadErrorCard(
     onRetry: () -> Unit,
+    title: String,
+    message: String,
     modifier: Modifier = Modifier,
 ) {
     Box(
@@ -40,14 +42,14 @@ internal fun TargetsLoadErrorCard(
                 horizontalAlignment = Alignment.CenterHorizontally,
             ) {
                 Text(
-                    text = stringResource(R.string.targets_load_failed_title),
+                    text = title,
                     style = MaterialTheme.typography.titleSmall,
                     fontWeight = FontWeight.Bold,
                     textAlign = TextAlign.Center,
                 )
                 Spacer(Modifier.height(8.dp))
                 Text(
-                    text = stringResource(R.string.targets_load_failed_message),
+                    text = message,
                     style = MaterialTheme.typography.bodyMedium,
                     textAlign = TextAlign.Center,
                 )

--- a/lsposed/app/src/main/res/values-ru/strings.xml
+++ b/lsposed/app/src/main/res/values-ru/strings.xml
@@ -26,6 +26,9 @@
     <string name="profile_kind_private">Приватное пространство</string>
     <string name="profile_kind_secondary">Пользователь %d</string>
     <string name="profile_kind_unknown">Профиль %d</string>
+    <string name="profile_scan_failed_title">Не удалос прочитать все профили Android</string>
+    <string name="profile_scan_failed_message">VPN Hide не получил полный список приложений из одного или нескольких профилей. Неполный список не загружен. При необходимости разблокируйте или запустите профиль, затем нажмите «Повторить».</string>
+    <string name="profile_scan_stale_message">Не удалось обновить все профили Android. Показан прежний полный список; настройки не удалялись.</string>
 
     <string name="apps_help_title">Как это работает</string>
     <string name="java_hooks_title">Java-хуки</string>

--- a/lsposed/app/src/main/res/values/strings.xml
+++ b/lsposed/app/src/main/res/values/strings.xml
@@ -26,6 +26,9 @@
     <string name="profile_kind_private">Private space</string>
     <string name="profile_kind_secondary">User %d</string>
     <string name="profile_kind_unknown">Profile %d</string>
+    <string name="profile_scan_failed_title">Couldn’t scan every Android profile</string>
+    <string name="profile_scan_failed_message">VPN Hide did not receive a complete app list from one or more profiles. No partial list was loaded. Unlock or start the profile if needed, then tap Retry.</string>
+    <string name="profile_scan_stale_message">Couldn’t refresh every Android profile. Showing the previous complete app list; no settings were removed.</string>
     <string name="apps_help_title">How it works</string>
     <string name="chip_java" translatable="false">J</string>
     <string name="chip_native" translatable="false">N</string>

--- a/lsposed/app/src/test/kotlin/dev/okhsunrog/vpnhide/DebugShellSnapshotTest.kt
+++ b/lsposed/app/src/test/kotlin/dev/okhsunrog/vpnhide/DebugShellSnapshotTest.kt
@@ -66,7 +66,9 @@ class DebugShellSnapshotTest {
         assertTrue(command.contains("/data/adb/lspd/config/modules_config.db"))
         assertTrue(command.contains("dumpsys connectivity"))
         assertTrue(command.contains("androidboot[.]serialno"))
-        assertTrue(command.contains("pm list packages -U --user all"))
+        assertTrue(command.contains("pm list users"))
+        assertTrue(command.contains("pm list packages -U -f --user \"${'$'}PM_USER_ID\""))
+        assertFalse(command.contains("--user all"))
         assertFalse(command.contains("debug_logging"))
     }
 

--- a/lsposed/app/src/test/kotlin/dev/okhsunrog/vpnhide/PackageInventoryDataTest.kt
+++ b/lsposed/app/src/test/kotlin/dev/okhsunrog/vpnhide/PackageInventoryDataTest.kt
@@ -1,0 +1,142 @@
+package dev.okhsunrog.vpnhide
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class PackageInventoryDataTest {
+    @Test
+    fun `merges explicit per-user package rows by package`() {
+        val users =
+            """
+            ${PM_USERS_STATUS_PREFIX}verbose:0
+            ${PM_USERS_STATUS_PREFIX}plain:0
+            Users:
+            UserInfo{0:Owner:c13} running
+            UserInfo{10:Work:1030} running
+            """.trimIndent()
+        val packages =
+            """
+            $PM_USER_BEGIN_PREFIX${0}
+            package:/data/app/telegram/base.apk=org.telegram.messenger uid:10123
+            $PM_USER_END_PREFIX${0}:0
+            $PM_USER_BEGIN_PREFIX${10}
+            package:/data/app/telegram/base.apk=org.telegram.messenger uid:1010123
+            package:/data/app/ozon/base.apk=ru.ozon.app uid:1010456
+            $PM_USER_END_PREFIX${10}:0
+            """.trimIndent()
+
+        val inventory = parsePackageInventory(packages, users)
+
+        assertTrue(inventory.complete)
+        assertEquals(listOf(0, 10), inventory.packages.getValue("org.telegram.messenger").userIds)
+        assertEquals(listOf(10123, 1010123), inventory.packages.getValue("org.telegram.messenger").uids)
+        assertEquals(listOf(10), inventory.packages.getValue("ru.ozon.app").userIds)
+        assertEquals("Work", inventory.profiles[10]?.name)
+    }
+
+    @Test
+    fun `reports a failed profile instead of accepting a partial list`() {
+        val users =
+            """
+            ${PM_USERS_STATUS_PREFIX}plain:0
+            UserInfo{0:Owner:c13}
+            UserInfo{10:Work:1030}
+            """.trimIndent()
+        val packages =
+            """
+            $PM_USER_BEGIN_PREFIX${0}
+            package:/data/app/example/base.apk=com.example uid:10123
+            $PM_USER_END_PREFIX${0}:0
+            $PM_USER_BEGIN_PREFIX${10}
+            Error: user 10 is unavailable
+            $PM_USER_END_PREFIX${10}:7
+            """.trimIndent()
+
+        val inventory = parsePackageInventory(packages, users)
+
+        assertFalse(inventory.complete)
+        assertEquals(setOf(10), inventory.failedUserIds)
+        assertTrue(inventory.incompleteMessage().contains("10"))
+    }
+
+    @Test
+    fun `successful but empty profile output is incomplete`() {
+        val users =
+            """
+            ${PM_USERS_STATUS_PREFIX}plain:0
+            UserInfo{0:Owner:c13}
+            UserInfo{10:Private:1030}
+            """.trimIndent()
+        val packages =
+            """
+            $PM_USER_BEGIN_PREFIX${0}
+            package:/system/framework/framework-res.apk=android uid:1000
+            $PM_USER_END_PREFIX${0}:0
+            $PM_USER_BEGIN_PREFIX${10}
+            $PM_USER_END_PREFIX${10}:0
+            """.trimIndent()
+
+        assertEquals(setOf(10), parsePackageInventory(packages, users).failedUserIds)
+    }
+
+    @Test
+    fun `shared package uid parser accepts path rows and unions users`() {
+        val parsed =
+            parsePackageUidMap(
+                """
+                $PM_USER_BEGIN_PREFIX${0}
+                package:/data/app/example/base.apk=com.example uid:10123
+                $PM_USER_END_PREFIX${0}:0
+                $PM_USER_BEGIN_PREFIX${10}
+                package:/data/app/example/base.apk=com.example uid:1010123
+                $PM_USER_END_PREFIX${10}:0
+                """.trimIndent(),
+            )
+
+        assertEquals(listOf(10123, 1010123), parsed["com.example"])
+    }
+
+    @Test
+    fun `shell scanner queries every listed user without user all`() {
+        val shell =
+            """
+            pm() {
+              if [ "${'$'}1 ${'$'}2 ${'$'}3" = "list users -v" ]; then
+                echo '0: id=0, name=Owner, type=full.SYSTEM, flags=FULL'
+                echo '1: id=10, name=Work, type=profile.MANAGED, flags=PROFILE'
+                return 0
+              fi
+              if [ "${'$'}1 ${'$'}2" = "list users" ]; then
+                echo 'Users:'
+                echo '  UserInfo{0:Owner:c13} running'
+                echo '  UserInfo{10:Work:1030} running'
+                return 0
+              fi
+              if [ "${'$'}6" = "0" ]; then
+                echo 'package:/data/app/example/base.apk=com.example uid:10123'
+                return 0
+              fi
+              echo 'package:/data/app/work/base.apk=com.work uid:1010456'
+            }
+            ${
+                buildPerUserPackageInventoryShell(
+                    sectionBeginPrefix = "__VPNHIDE_ROOT_SECTION_BEGIN__:",
+                    sectionEndPrefix = "__VPNHIDE_ROOT_SECTION_END__:",
+                    stderrRedirect = "2>/dev/null",
+                )
+            }
+            """.trimIndent()
+        val process = ProcessBuilder("sh", "-c", shell).start()
+        val stdout = process.inputStream.bufferedReader().readText()
+        val stderr = process.errorStream.bufferedReader().readText()
+
+        assertEquals("shell stderr: $stderr", 0, process.waitFor())
+        val sections = parseRootShellSnapshot(stdout, recordMetric = { _, _ -> })
+        val inventory = requireCompletePackageInventory(sections)
+        assertTrue(inventory.complete)
+        assertEquals(listOf(10), inventory.packages.getValue("com.work").userIds)
+        assertFalse(shell.contains("--user all"))
+    }
+}

--- a/lsposed/app/src/test/kotlin/dev/okhsunrog/vpnhide/RootSnapshotCacheTest.kt
+++ b/lsposed/app/src/test/kotlin/dev/okhsunrog/vpnhide/RootSnapshotCacheTest.kt
@@ -71,7 +71,8 @@ class RootSnapshotCacheTest {
         assertTrue(command.contains("EPOCHREALTIME"))
         assertTrue(command.contains("/proc/uptime"))
         assertTrue(command.contains("cat \"${'$'}PATH_TO_READ\""))
-        assertTrue(command.contains("pm list packages -U --user all"))
+        assertTrue(command.contains("pm list users"))
+        assertTrue(command.contains("pm list packages -U -f --user \"${'$'}PM_USER_ID\""))
         assertTrue(command.contains("grep -H . /sys/class/net/*/operstate"))
         assertTrue(command.contains("[ -s $SUPERKEY_FILE ] && echo 1 || echo 0"))
         assertTrue(command.contains("cat $PROC_CTL"))
@@ -82,6 +83,7 @@ class RootSnapshotCacheTest {
         assertTrue(command.contains("probe_ok=1"))
         assertTrue(command.contains("iptables -C OUTPUT -j vpnhide_out"))
         assertTrue(command.contains("ip6tables -C OUTPUT -j vpnhide_out6"))
+        assertFalse(command.contains("--user all"))
         assertFalse(command.contains("while IFS= read"))
         assertFalse(command.contains("base64"))
         assertFalse(command.contains("date +%s%3N"))
@@ -105,7 +107,8 @@ class RootSnapshotCacheTest {
     fun `snapshot command can skip package enumeration when startup seeded it`() {
         val command = buildRootShellSnapshotCommand(includePmPackages = false)
 
-        assertFalse(command.contains("pm list packages -U --user all"))
+        assertFalse(command.contains("pm list packages"))
+        assertFalse(command.contains("pm list users"))
         assertTrue(command.contains("phase_target_files"))
         assertTrue(command.contains("phase_vpn_ifaces"))
     }

--- a/lsposed/app/src/test/kotlin/dev/okhsunrog/vpnhide/StartupCoordinatorTest.kt
+++ b/lsposed/app/src/test/kotlin/dev/okhsunrog/vpnhide/StartupCoordinatorTest.kt
@@ -11,7 +11,7 @@ class StartupCoordinatorTest {
     fun `successful self target preparation seeds package list and cleanup boot id`() =
         runBlocking {
             val markers = mutableListOf<String>()
-            var seededPackages: String? = null
+            var seededInventory: PackageInventorySeed? = null
             var cleanupBootId: String? = null
             val coordinator =
                 StartupCoordinator(
@@ -23,17 +23,24 @@ class StartupCoordinatorTest {
                             selfNeedsRestart = true,
                             currentBootId = "boot-1",
                             pmPackages = "package:dev.okhsunrog.vpnhide uid:10123",
+                            pmUsers = "UserInfo{0:Owner:c13}",
                         )
                     },
                     cleanupZygiskStatus = { _, bootId -> cleanupBootId = bootId },
-                    seedRootSnapshotPackages = { seededPackages = it },
+                    seedRootSnapshotInventory = { seededInventory = it },
                     markStartupEvent = markers::add,
                 )
 
             coordinator.prepareSelfTargets()
 
             assertEquals(StartupSelfTargetState.Ready(selfNeedsRestart = true), coordinator.selfTargetState.value)
-            assertEquals("package:dev.okhsunrog.vpnhide uid:10123", seededPackages)
+            assertEquals(
+                PackageInventorySeed(
+                    packages = "package:dev.okhsunrog.vpnhide uid:10123",
+                    users = "UserInfo{0:Owner:c13}",
+                ),
+                seededInventory,
+            )
             assertEquals("boot-1", cleanupBootId)
             assertEquals(listOf("self_targets_start", "self_targets_done"), markers)
         }
@@ -42,7 +49,7 @@ class StartupCoordinatorTest {
     fun `failed self target preparation reports error without seeding or cleanup`() =
         runBlocking {
             val markers = mutableListOf<String>()
-            var seededPackages: String? = null
+            var seededInventory: PackageInventorySeed? = null
             var cleanupBootId: String? = null
             val coordinator =
                 StartupCoordinator(
@@ -57,7 +64,7 @@ class StartupCoordinatorTest {
                         )
                     },
                     cleanupZygiskStatus = { _, bootId -> cleanupBootId = bootId },
-                    seedRootSnapshotPackages = { seededPackages = it },
+                    seedRootSnapshotInventory = { seededInventory = it },
                     markStartupEvent = markers::add,
                 )
 
@@ -67,7 +74,7 @@ class StartupCoordinatorTest {
                 StartupSelfTargetState.Failed(SelfTargetFailureKind.RootUnavailable, "exit=-1"),
                 coordinator.selfTargetState.value,
             )
-            assertNull(seededPackages)
+            assertNull(seededInventory)
             assertNull(cleanupBootId)
             assertEquals(
                 listOf("self_targets_start", "self_targets_done", "self_targets_failed"),


### PR DESCRIPTION
## What changed

- enumerate Android users first and query packages with `--user <id>` instead of relying on incomplete OEM `--user all` aggregation
- make the Hiding picker and native-capacity calculation consume the same typed package inventory from `RootSnapshotCache`
- reject incomplete profile scans, preserve the previous complete in-memory list after a failed refresh, and explain the state in the UI
- make the Rust native/ports activator abort before replacing runtime state when any user cannot be enumerated
- include per-user scan status in exported debug snapshots

## Why

Some ROMs return a successful but incomplete package list for `--user all`, usually containing only the main user. The app then silently omitted work/private/clone-profile-only packages, while separate picker and capacity scans could disagree.

The canonical policy remains package-based: selecting an app still protects every installed profile instance. This PR only makes discovery and UID projection reliable.

Fixes #242.

## Testing

- `cargo fmt --all --check`
- `cargo clippy -p vpnhide_protocol -p vpnhide_protocol_diff -p vpnhide_activator --all-targets -- -D warnings`
- `cargo test -p vpnhide_protocol -p vpnhide_protocol_diff -p vpnhide_activator -p vpnhide_zygisk`
- `cd lsposed && ./gradlew :app:detekt cpdCheck :app:lintDebug :app:testDebugUnitTest`
- `cd lsposed && ./gradlew :app:assembleDebug`
