### PR TITLE
perf: binary-search native hook UIDs

### DIFF
--- a/kmod/vpnhide_kmod.c
+++ b/kmod/vpnhide_kmod.c
@@ -225,14 +225,57 @@ struct stats_row {
 };
 
 static struct stats_row stats_rows[MAX_TARGET_UIDS];
+/* Sorted by stats_rows[index].uid for binary lookup. Rows themselves stay in
+ * insertion order so adding a UID shifts at most this compact index (640
+ * bytes), not the roughly 15 KiB stats table, while seq_file iteration remains
+ * stable when another UID records its first hit concurrently. */
+static int stats_uid_order[MAX_TARGET_UIDS];
 static int nr_stats_rows;
 static DEFINE_SPINLOCK(stats_lock);
 
+/* stats_lock must be held. */
+static struct stats_row *find_or_add_stats_row(uid_t uid)
+{
+	struct stats_row *row;
+	int lo = 0;
+	int hi = nr_stats_rows;
+	int mid, row_index;
+
+	while (lo < hi) {
+		mid = lo + (hi - lo) / 2;
+		row = &stats_rows[stats_uid_order[mid]];
+		if (row->uid < uid)
+			lo = mid + 1;
+		else
+			hi = mid;
+	}
+
+	if (lo < nr_stats_rows) {
+		row = &stats_rows[stats_uid_order[lo]];
+		if (row->uid == uid)
+			return row;
+	}
+	if (nr_stats_rows >= MAX_TARGET_UIDS)
+		return NULL;
+
+	row_index = nr_stats_rows;
+	memmove(&stats_uid_order[lo + 1], &stats_uid_order[lo],
+		(nr_stats_rows - lo) * sizeof(stats_uid_order[0]));
+	stats_uid_order[lo] = row_index;
+	nr_stats_rows++;
+
+	row = &stats_rows[row_index];
+	row->uid = uid;
+	memset(row->counts, 0, sizeof(row->counts));
+	return row;
+}
+
 static void record_hook_hit(enum vpnhide_hook_id hook_id)
 {
+	struct stats_row *row;
 	uid_t uid;
 	unsigned long flags;
-	int hook_slot, i;
+	int hook_slot;
 
 	hook_slot = vpnhide_kernel_hook_slot(hook_id);
 	if (hook_slot < 0)
@@ -240,19 +283,9 @@ static void record_hook_hit(enum vpnhide_hook_id hook_id)
 
 	uid = from_kuid(&init_user_ns, current_uid());
 	spin_lock_irqsave(&stats_lock, flags);
-	for (i = 0; i < nr_stats_rows; i++) {
-		if (stats_rows[i].uid == uid) {
-			stats_rows[i].counts[hook_slot]++;
-			spin_unlock_irqrestore(&stats_lock, flags);
-			return;
-		}
-	}
-	if (nr_stats_rows < MAX_TARGET_UIDS) {
-		i = nr_stats_rows++;
-		stats_rows[i].uid = uid;
-		memset(stats_rows[i].counts, 0, sizeof(stats_rows[i].counts));
-		stats_rows[i].counts[hook_slot] = 1;
-	}
+	row = find_or_add_stats_row(uid);
+	if (row)
+		row->counts[hook_slot]++;
 	spin_unlock_irqrestore(&stats_lock, flags);
 }
 

--- a/zygisk/src/lib.rs
+++ b/zygisk/src/lib.rs
@@ -648,8 +648,43 @@ fn scrub_shadowhook_maps() {
 fn target_hookmask(uid: u32) -> u32 {
     CACHED_CONFIG
         .get()
-        .and_then(|cfg| cfg.targets.iter().find(|target| target.uid == uid))
-        .map_or(0, |target| target.hookmask)
+        .map_or(0, |cfg| hookmask_for_uid(&cfg.targets, uid))
+}
+
+fn hookmask_for_uid(targets: &[protocol::Target], uid: u32) -> u32 {
+    targets
+        .binary_search_by_key(&uid, |target| target.uid)
+        .map_or(0, |index| targets[index].hookmask)
+}
+
+#[cfg(test)]
+mod target_lookup_tests {
+    use super::*;
+
+    #[test]
+    fn finds_hookmask_in_sorted_targets() {
+        let targets = [
+            protocol::Target {
+                uid: 10_001,
+                hookmask: 0x1,
+            },
+            protocol::Target {
+                uid: 10_100,
+                hookmask: 0x2,
+            },
+            protocol::Target {
+                uid: 19_999,
+                hookmask: 0x4,
+            },
+        ];
+
+        assert_eq!(hookmask_for_uid(&targets, 10_001), 0x1);
+        assert_eq!(hookmask_for_uid(&targets, 10_100), 0x2);
+        assert_eq!(hookmask_for_uid(&targets, 19_999), 0x4);
+        assert_eq!(hookmask_for_uid(&targets, 10_000), 0);
+        assert_eq!(hookmask_for_uid(&targets, 10_101), 0);
+        assert_eq!(hookmask_for_uid(&[], 10_001), 0);
+    }
 }
 
 fn zygisk_hook_enabled(hookmask: u32, hook: Hook) -> bool {


### PR DESCRIPTION
## What changed

- replace the Zygisk target Vec linear scan with slice::binary_search_by_key over the parser-guaranteed UID ordering
- cover first, middle, last, missing, and empty target lookups with a focused Rust test
- replace the kmod per-hit linear stats-row scan with a binary-searched sorted UID index
- keep stats rows in insertion order, so adding a UID shifts at most the 640-byte index and seq_file iteration stays stable

## Why

The AArch64 release output for Iterator::find is a scalar load/compare loop; LLVM cannot infer the protocol parser sorting invariant. The native hook paths should use that invariant explicitly instead of scaling linearly up to the 160-target backend limit.

LSPosed Map/Set lookups, the existing kmod/KPM target bisections, and the KPM open-addressed stats table are already efficient and remain unchanged.

## Impact

- Zygisk target selection: O(log n) instead of O(n)
- kmod stats UID accounting: O(log n) instead of O(n) per recorded hook hit
- no wire-format, storage, or user-visible behavior changes

## Validation

- cargo fmt -p vpnhide_zygisk --check
- cargo test -p vpnhide_zygisk (35 passed)
- Android arm64 cargo-ndk clippy with warnings denied
- AArch64 release assembly inspection before and after
- scripts/clang-format-c.sh --check kmod/vpnhide_kmod.c
- kmod iface-list host test (48 vectors)
- shared logic host tests
- C protocol host tests (56 vectors)
- ./kmod/build.py --kmi android16-6.12