### PR TITLE
feat(kpm): add optional filesystem path hiding

### DIFF
--- a/changelog.d/added-added-optional-reboot-gated-filesystem-path-167b.md
+++ b/changelog.d/added-added-optional-reboot-gated-filesystem-path-167b.md
@@ -1,0 +1,9 @@
+_2026-08-13_
+
+## English
+
+Added optional reboot-gated filesystem path hiding to the KPM backend.
+
+## Русский
+
+В KPM добавлено опциональное скрытие путей файловой системы, применяемое после перезагрузки.

--- a/crates/activator/src/bin/kpm.rs
+++ b/crates/activator/src/bin/kpm.rs
@@ -1,8 +1,8 @@
 use std::{env, process};
 
 use vpnhide_activator::{
-    KpmBootOutcome, Result, activate_kpm, activate_kpm_boot, load_kpm_boot, read_kpm_state,
-    read_kpm_stats, read_kpm_status,
+    KpmBootOutcome, Result, activate_kpm, activate_kpm_boot, kernel_boot_feature_enabled,
+    load_kpm_boot, read_kpm_state, read_kpm_stats, read_kpm_status,
 };
 
 /// Exit code returned from `--boot-wait` when the KPM stood down because the
@@ -32,6 +32,9 @@ fn run() -> Result<i32> {
         [] => activate_kpm().map(|()| 0),
         [arg] if arg == "--boot-wait" => Ok(boot_exit_code(activate_kpm_boot()?)),
         [arg] if arg == "--load-only" => Ok(boot_exit_code(load_kpm_boot()?)),
+        [command, feature] if command == "boot-feature-enabled" => {
+            Ok(if kernel_boot_feature_enabled(feature)? { 0 } else { 1 })
+        }
         [arg] if arg == "status" => {
             print!("{}", read_kpm_status()?);
             Ok(0)
@@ -44,7 +47,10 @@ fn run() -> Result<i32> {
             print!("{}", read_kpm_state()?);
             Ok(0)
         }
-        _ => Err("usage: activator [--boot-wait|--load-only|status|stats|state]".into()),
+        _ => Err(
+            "usage: activator [--boot-wait|--load-only|boot-feature-enabled <name>|status|stats|state]"
+                .into(),
+        ),
     }
 }
 

--- a/crates/activator/src/bin/kpm.rs
+++ b/crates/activator/src/bin/kpm.rs
@@ -6,7 +6,8 @@ use vpnhide_activator::{
 };
 
 /// Exit code returned from `--boot-wait` when the KPM stood down because the
-/// .ko backend is present (protocol §1.5). Distinct from 0 (configured) and 1
+/// .ko backend is present (docs/storage.md §4.3). Distinct from 0 (configured)
+/// and 1
 /// (error) so service.sh can record a truthful `conflict` load_status instead
 /// of falsely reporting the KPM as configured.
 const EXIT_DEFERRED_CONFLICT: i32 = 3;

--- a/crates/activator/src/kpm.rs
+++ b/crates/activator/src/kpm.rs
@@ -79,6 +79,34 @@ pub(crate) enum KpmClientDetection {
     AwaitingAuthentication(String),
 }
 
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub(crate) struct KpmLoadOptions {
+    pub(crate) filesystem_hiding: bool,
+}
+
+impl KpmLoadOptions {
+    fn args(self) -> Option<&'static str> {
+        self.filesystem_hiding.then_some("filesystem_hiding=1")
+    }
+}
+
+#[cfg(test)]
+mod load_options_tests {
+    use super::KpmLoadOptions;
+
+    #[test]
+    fn filesystem_hiding_is_an_opt_in_load_argument() {
+        assert_eq!(KpmLoadOptions::default().args(), None);
+        assert_eq!(
+            KpmLoadOptions {
+                filesystem_hiding: true,
+            }
+            .args(),
+            Some("filesystem_hiding=1")
+        );
+    }
+}
+
 /// Cross-process serialization for this project's KPM ctl0 callers. The
 /// KernelPatch runtime stores ctl args in one module-owned buffer before
 /// dispatching the handler, so boot activation, app reconciliation, and stats
@@ -147,14 +175,14 @@ impl KpmClient {
         Ok(KpmClientDetection::Ready(Self::KpatchCli { path }))
     }
 
-    pub(crate) fn ensure_loaded(&self) -> Result<()> {
+    pub(crate) fn ensure_loaded(&self, options: KpmLoadOptions) -> Result<()> {
         if self.list_contains()? {
             return Ok(());
         }
         if !Path::new(KPM_MODULE_FILE).is_file() {
             return Err(format!("{KPM_MODULE_FILE} not found").into());
         }
-        self.load()?;
+        self.load(options)?;
         if self.list_contains()? {
             Ok(())
         } else {
@@ -172,11 +200,14 @@ impl KpmClient {
         }
     }
 
-    fn load(&self) -> Result<()> {
+    fn load(&self, options: KpmLoadOptions) -> Result<()> {
         match self {
             Self::KpatchCli { path } => {
                 let mut cmd = Command::new(path);
                 cmd.args(["kpm", "load", KPM_MODULE_FILE]);
+                if let Some(args) = options.args() {
+                    cmd.arg(args);
+                }
                 let out = cmd.output()?;
                 if out.status.success() {
                     Ok(())
@@ -187,13 +218,14 @@ impl KpmClient {
             Self::ApatchSupercall { key, style } => {
                 let path = CString::new(KPM_MODULE_FILE)?;
                 let key = CString::new(key.as_str())?;
+                let args = options.args().map(CString::new).transpose()?;
                 let rc = unsafe {
                     syscall(
                         APATCH_SUPERCALL_NR,
                         key.as_ptr(),
                         supercall_cmd(*style, SUPERCALL_KPM_LOAD),
                         path.as_ptr(),
-                        ptr::null::<c_char>(),
+                        args.as_ref().map_or(ptr::null(), |args| args.as_ptr()),
                         ptr::null_mut::<c_void>(),
                     )
                 };

--- a/crates/activator/src/lib.rs
+++ b/crates/activator/src/lib.rs
@@ -161,7 +161,8 @@ fn validate_zygisk_config_wire(wire: &str) -> Result<()> {
 }
 
 /// Outcome of a KPM boot activation. A kmod conflict is a legitimate,
-/// non-error result (the KPM deliberately stands down — see §1.5), so it must
+/// non-error result (the KPM deliberately stands down — see docs/storage.md
+/// §4.3), so it must
 /// be distinguishable from a successful configure: the boot script reports
 /// each as a different `load_status`, and reporting a deferral as "configured"
 /// would lie to the diagnostics screen.
@@ -170,7 +171,7 @@ pub enum KpmBootOutcome {
     /// Wire snapshot was delivered to the KPM over ctl0.
     Configured,
     /// The .ko backend is present, so the KPM stood down without loading or
-    /// configuring (co-residence freezes the kernel — protocol §1.5).
+    /// configuring (co-residence freezes the kernel — docs/storage.md §4.3).
     DeferredConflict,
     /// APatch/FolkPatch is installed, but neither a saved superkey nor the
     /// trusted `su` supercall grant authenticated yet. Boot may legitimately
@@ -449,7 +450,7 @@ fn pm_output_has_package(output: &str, package: &str) -> bool {
 /// (e.g. a manually-loaded .ko whose module dir is gone). The boot scripts
 /// keep a cheaper directory-only check as a fail-safe floor (it cannot error
 /// and is ordering-independent); this superset is the authoritative gate on
-/// the config-delivery path. See protocol §1.5.
+/// the config-delivery path. See docs/storage.md §4.3.
 pub fn kmod_backend_present() -> bool {
     Path::new(KMOD_CTL).exists()
         || (Path::new(KMOD_MODULE_DIR).is_dir()

--- a/crates/activator/src/lib.rs
+++ b/crates/activator/src/lib.rs
@@ -210,7 +210,9 @@ pub fn load_kpm_boot() -> Result<KpmBootOutcome> {
             return Ok(KpmBootOutcome::AwaitingAuthentication);
         }
     };
-    client.ensure_loaded()?;
+    client.ensure_loaded(KpmLoadOptions {
+        filesystem_hiding: kernel_boot_feature_enabled(KERNEL_BOOT_FEATURE_FILESYSTEM_IFACE_PATHS)?,
+    })?;
     Ok(KpmBootOutcome::Configured)
 }
 
@@ -249,7 +251,12 @@ fn activate_kpm_with_pm_wait(wait: PmReadyWait, conflict_is_error: bool) -> Resu
         }
         return Ok(KpmBootOutcome::UnsupportedKernel);
     }
-    let wire = project_native_with_pm_wait(&read_canonical()?, NativeHookFamily::Kpm, wait)?;
+    let canonical = read_canonical()?;
+    let filesystem_hiding = parse_canonical(&canonical)?
+        .settings
+        .kernel_boot_features
+        .contains(KERNEL_BOOT_FEATURE_FILESYSTEM_IFACE_PATHS);
+    let wire = project_native_with_pm_wait(&canonical, NativeHookFamily::Kpm, wait)?;
     // Re-check after the (possibly long) PackageManager wait: the .ko may have
     // been loaded meanwhile, in which case we must not configure the KPM.
     if skip_kpm_for_kmod_conflict(conflict_is_error)? {
@@ -262,7 +269,7 @@ fn activate_kpm_with_pm_wait(wait: PmReadyWait, conflict_is_error: bool) -> Resu
         }
         KpmClientDetection::AwaitingAuthentication(detail) => return Err(detail.into()),
     };
-    client.ensure_loaded()?;
+    client.ensure_loaded(KpmLoadOptions { filesystem_hiding })?;
     client.ctl0_config(&wire)?;
     Ok(KpmBootOutcome::Configured)
 }

--- a/crates/activator/src/model.rs
+++ b/crates/activator/src/model.rs
@@ -3,7 +3,9 @@ use std::collections::{BTreeMap, BTreeSet};
 use serde::Deserialize;
 use vpnhide_protocol::Target;
 use vpnhide_protocol::format_config;
-use vpnhide_protocol::hook_ids::{Hook, KERNEL_HOOK_MASK, KMOD_HOOK_MASK, ZYGISK_HOOK_MASK};
+use vpnhide_protocol::hook_ids::{
+    Hook, KERNEL_HOOK_MASK, KMOD_HOOK_MASK, KPM_HOOK_MASK, ZYGISK_HOOK_MASK,
+};
 
 use crate::ports::build_ports_ruleset;
 use crate::{
@@ -150,7 +152,7 @@ impl NativeHookFamily {
     fn full_set(self) -> HookSet {
         match self {
             NativeHookFamily::Kmod => HookSet::from_bits(KERNEL_HOOK_MASK | KMOD_HOOK_MASK),
-            NativeHookFamily::Kpm => HookSet::from_bits(KERNEL_HOOK_MASK),
+            NativeHookFamily::Kpm => HookSet::from_bits(KERNEL_HOOK_MASK | KPM_HOOK_MASK),
             NativeHookFamily::Zygisk => HookSet::from_bits(ZYGISK_HOOK_MASK),
         }
     }

--- a/crates/activator/src/tests.rs
+++ b/crates/activator/src/tests.rs
@@ -106,7 +106,7 @@ fn projects_native_roles_to_wire() {
         "vpnhide 2 config\n\
          debug 1\n\
          targets 40 27fa\n\
-         targets 20003ff 278b f69cb\n\
+         targets a0003ff 278b f69cb\n\
          end 3\n",
     );
 }
@@ -132,7 +132,7 @@ fn native_projection_targets_only_the_main_profile_copy_of_vpnhide() {
         project_native_with_resolver(&cfg, &resolver),
         "vpnhide 2 config\n\
          debug 0\n\
-         targets 20003ff 278b 27fa f6a3a\n\
+         targets a0003ff 278b 27fa f6a3a\n\
          end 3\n",
     );
 }
@@ -162,7 +162,7 @@ fn native_projection_drops_platform_aids_but_keeps_preinstalled_apps() {
         project_native_with_resolver(&cfg, &resolver),
         "vpnhide 2 config\n\
          debug 0\n\
-         targets 20003ff 27fa f6a3a\n\
+         targets a0003ff 27fa f6a3a\n\
          end 2\n",
     );
 }
@@ -190,7 +190,7 @@ fn kmod_projection_includes_the_optional_filesystem_hook() {
     );
     assert_eq!(
         project_native_with_resolver_for_family(&cfg, &resolver, NativeHookFamily::Kpm),
-        "vpnhide 2 config\ndebug 0\ntargets 20003ff 278b\nend 1\n",
+        "vpnhide 2 config\ndebug 0\ntargets a0003ff 278b\nend 1\n",
     );
 }
 
@@ -368,7 +368,7 @@ fn parses_per_hook_java_selection_without_breaking_native() {
         project_native_with_resolver(&cfg, &resolver),
         "vpnhide 2 config\n\
          debug 0\n\
-         targets 20003ff 278b 278c\n\
+         targets a0003ff 278b 278c\n\
          end 2\n",
     );
 }

--- a/crates/protocol/src/generated/hook_ids.rs
+++ b/crates/protocol/src/generated/hook_ids.rs
@@ -157,7 +157,7 @@ pub enum StatusError {
     Ok = 0,
     /// no offset table for the running kernel — refused, no hooks
     UnsupportedKver = 1,
-    /// the other kernel backend (.ko<->KPM) is loaded — refused (protocol §1.2)
+    /// the other kernel backend (.ko<->KPM) is loaded — refused (docs/storage.md §4.3)
     ConflictingBackend = 2,
     /// a required kallsyms symbol was missing — refused
     SymbolResolutionFailed = 3,

--- a/crates/protocol/src/generated/hook_ids.rs
+++ b/crates/protocol/src/generated/hook_ids.rs
@@ -145,6 +145,7 @@ pub const HOOK_COUNT: u32 = 28;
 /// Hooks owned by each backend: apply `mask & own`.
 pub const KERNEL_HOOK_MASK: u32 = 0x20003ff;
 pub const KMOD_HOOK_MASK: u32 = 0x8000000;
+pub const KPM_HOOK_MASK: u32 = 0x8000000;
 pub const ZYGISK_HOOK_MASK: u32 = 0x5fc0000;
 pub const LSPOSED_HOOK_MASK: u32 = 0x3fc00;
 

--- a/crates/protocol/src/lib.rs
+++ b/crates/protocol/src/lib.rs
@@ -6,7 +6,7 @@
 //! tests at the bottom run against this implementation (protocol §8 Layer 1).
 //! When the spec changes, change both sides and add a vector.
 //!
-//! Roles (§1.4): backends PARSE config and EMIT stats/status. The activator
+//! Roles (§1.3): backends PARSE config and EMIT stats/status. The activator
 //! also uses this crate to FORMAT config snapshots for native backends.
 
 use core::iter;

--- a/data/hooks.toml
+++ b/data/hooks.toml
@@ -239,7 +239,7 @@ note = "no offset table for the running kernel — refused, no hooks"
 [[error]]
 id = 2
 name = "conflicting_backend"
-note = "the other kernel backend (.ko<->KPM) is loaded — refused (protocol §1.2)"
+note = "the other kernel backend (.ko<->KPM) is loaded — refused (docs/storage.md §4.3)"
 
 [[error]]
 id = 3

--- a/data/hooks.toml
+++ b/data/hooks.toml
@@ -189,12 +189,13 @@ name = "zygisk_setsockopt"
 backend = "zygisk"
 note = "libc setsockopt() best-effort socket-interface bind denial"
 
-# Optional .ko-only VFS interception. This is not part of the shared kernel
-# mask because KPM deliberately does not install these hot-path hooks.
+# Optional VFS interception shared by both kernel backends. This is not part of
+# the required kernel mask because neither backend installs these hot-path hooks
+# unless the reboot-gated feature was requested before load.
 [[hook]]
 id = 27
 name = "filesystem_iface_paths"
-backend = "kmod"
+backends = ["kmod", "kpm"]
 note = "Optional reboot-gated sysfs/proc-sys VPN interface path concealment"
 
 # --- backend ids (protocol §4.3 `status backend <id>`) ----------------------

--- a/docs/detection-vectors.md
+++ b/docs/detection-vectors.md
@@ -118,15 +118,15 @@ Legend: ✅ covered · ⚠️ partial / conditional · — not applicable to tha
 | `ioctl(SIOCGIF{FLAGS,MTU,INDEX,HWADDR,ADDR})` by name | native | ✅ `dev_ioctl` | ✅ `dev_ioctl` | ✅ pre-screen | — | |
 | netlink `RTM_GETLINK` dump | `recvmsg`/`recvfrom` of `RTM_NEWLINK` | ✅ `rtnl_fill_ifinfo` | ✅ `rtnl_fill_ifinfo` | ✅ filter by index | — | |
 | netlink `RTM_GETADDR` dump | `RTM_NEWADDR` | ✅ `inet*_fill_ifaddr` | ✅ `inet*_fill_ifaddr` | ✅ filter by index | — | |
-| `/sys/class/net/<iface>/*` | lookup/stat/open/readlink/readdir reveal iface nodes | ⚠️ optional reboot-gated VFS hooks | — | — | — | 🔒 usually denied |
-| `/proc/sys/net/{ipv4,ipv6}/{conf,neigh}/<iface>` | lookup/stat/open/readdir reveal per-iface sysctl dirs | ⚠️ optional reboot-gated VFS hooks | — | — | — | 🔒 usually denied |
+| `/sys/class/net/<iface>/*` | lookup/stat/open/readlink/readdir reveal iface nodes | ⚠️ optional reboot-gated VFS hooks | ⚠️ optional reboot-gated VFS hooks | — | — | 🔒 usually denied |
+| `/proc/sys/net/{ipv4,ipv6}/{conf,neigh}/<iface>` | lookup/stat/open/readlink/readdir reveal per-iface sysctl dirs | ⚠️ optional reboot-gated VFS hooks | ⚠️ optional reboot-gated VFS hooks | — | — | 🔒 usually denied |
 
 Notes: bionic's `getifaddrs` itself runs over netlink, so the kernel-backend
 `rtnl_fill_ifinfo` / `inet*_fill_ifaddr` hooks cover the Java and native paths
 at once. Zygisk additionally unlinks entries from the `getifaddrs` result list
 directly, so it works even if a future bionic stops using netlink.
 
-The `.ko` can additionally install four VFS entry redirects
+Both kernel backends can additionally install four VFS entry redirects
 (`filename_lookup`, `do_filp_open`, `vfs_getattr`, and `iterate_dir`) at boot.
 They recognize resolved sysfs/procfs dentries, not pathname strings, so relative
 `openat`, symlink-following, bind-mount, stat/access/readlink, open/fstat, and
@@ -134,7 +134,6 @@ directory-enumeration variants receive the same `ENOENT`/filtered view. This is
 disabled by default because the redirect points are global hot paths even
 though filtering remains per target UID. Enable **Hide VPN filesystem paths**
 in Settings and reboot; when disabled the probes are not registered at all.
-KPM deliberately does not claim this optional `.ko`-only coverage.
 
 **`SIOCGIFCONF` size-query subcase — closed in the `.ko`.** The classic two-step
 `SIOCGIFCONF` (first call with `ifc_req == NULL` to learn the buffer size, then a
@@ -314,9 +313,9 @@ detectors actually probe:
   yet; add hooks if it appears.
 - **Kernel-backend procfs gap:** no `if_inet6` / `tcp` / `tcp6` seq-file hooks
   in `.ko` or KPM (3C).
-- **Filesystem hiding is optional and `.ko`-only.** It must be selected before
-  reboot so the hot VFS probes are absent entirely on default boots. KPM and
-  Zygisk do not cover the sysfs/proc-sys interface-node vectors.
+- **Filesystem hiding is optional in both kernel backends.** It must be selected
+  before reboot so the hot VFS probes are absent entirely on default boots.
+  Zygisk does not cover the sysfs/proc-sys interface-node vectors.
 - **KPM SIOCGIFCONF size-query gap:** KPM compacts the returned ifreq array but
   does not yet reduce the `ifc_req == NULL` size query the `.ko` handles (3A).
 - **Single-lookup route** (`rt_fill_info`) is intentionally unhooked — no stable
@@ -337,7 +336,7 @@ detectors actually probe:
 | Layer | Entry points |
 |---|---|
 | kmod | `kmod/vpnhide_kmod.c` (10 kretprobes + socket-bind redirects + four optional VFS redirects); iface matcher `kmod/generated/iface_lists.h` |
-| KPM | `kmod/kpm/vpnhide_kpm.c` (KernelPatch inline hooks + ctl0); offsets in `kmod/kpm/kver_offsets.h` |
+| KPM | `kmod/kpm/vpnhide_kpm.c` (KernelPatch inline hooks + ctl0, including four optional VFS hooks); offsets in `kmod/kpm/kver_offsets.h` |
 | zygisk | `zygisk/src/hooks.rs` (ioctl/getifaddrs/openat/recv*); `zygisk/src/filter.rs` (procfs + netlink filters) |
 | lsposed | `lsposed/app/.../HookEntry.kt`, `PackageVisibilityHooks.kt`; iface matcher `.../generated/IfaceLists.kt` |
 | iface match rules | single source of truth `data/interfaces.toml` → `scripts/codegen-interfaces.py` renders all four targets (kmod/KPM C, zygisk Rust, lsposed native Rust, lsposed Kotlin) |

--- a/docs/diagnostics.md
+++ b/docs/diagnostics.md
@@ -106,8 +106,8 @@ results. A `null` answer (no root) does not block.
 - **SELinux can carry part of "protection", and it is invisible without the
   differential.** `/proc/net/if_inet6` and `/proc/net/dev` still have no kernel
   backend hook. `/sys/class/net` and the per-interface `/proc/sys/net` trees are
-  covered only when the optional `.ko` filesystem feature was enabled before
-  reboot; KPM does not claim them. When SELinux denies a path first, the
+  covered only when the optional kernel filesystem feature was enabled before
+  reboot. When SELinux denies a path first, the
   differential attributes that result to SELinux rather than overstating backend
   coverage. This is also why permissive devices need an explicit warning.
 - **The VPN lives in protected sockets + per-UID policy tables, not the main route
@@ -127,7 +127,8 @@ results. A `null` answer (no root) does not block.
 
 ## 7. Native check → owning hook (KPM/kmod), verified on Pixel 4a
 
-The kernel backend's 11 logical hooks map to the diagnostic checks below; the "gaps" rows are
+The kernel backend's 11 always-on hooks plus its optional filesystem hook map
+to the diagnostic checks below; the "gaps" rows are
 SELinux/zygisk territory by design, not bugs. Full hiding matrix in
 [detection-vectors.md](detection-vectors.md).
 
@@ -142,8 +143,8 @@ SELinux/zygisk territory by design, not bugs. Full hiding matrix in
 | `proc_ipv6_route` | `/proc/net/ipv6_route` | `ipv6_route_seq_show` | |
 | `proc_if_inet6` | `/proc/net/if_inet6` | **(none)** | no kernel seq_show hook — zygisk `openat` or SELinux only |
 | `proc_dev` | `/proc/net/dev` | **(none)** | zygisk `openat` or SELinux only |
-| `sys_class_net` | `/sys/class/net` | `filesystem_iface_paths` (`.ko`, optional) | reboot-gated; otherwise SELinux only |
-| `proc_sys_net` | `/proc/sys/net/*/{conf,neigh}` | `filesystem_iface_paths` (`.ko`, optional) | reboot-gated; otherwise SELinux only |
+| `sys_class_net` | `/sys/class/net` | `filesystem_iface_paths` (`.ko`/KPM, optional) | reboot-gated; otherwise SELinux only |
+| `proc_sys_net` | `/proc/sys/net/*/{conf,neigh}` | `filesystem_iface_paths` (`.ko`/KPM, optional) | reboot-gated; otherwise SELinux only |
 
 `socket_bind_interface` intentionally has no app-process root-differential row
 yet. An honest test needs the hidden interface name/index from the root view,

--- a/docs/limits.md
+++ b/docs/limits.md
@@ -71,7 +71,7 @@ single-record sizes from the real formatter, for 5-digit uids:
 | 2 hooks, counts < 256 | 25 | 160 |
 | 4 hooks, counts < 65k | 51 | 79 |
 | 8 hooks, counts ~1e6 | 103 | 39 |
-| all 11 kernel hooks, saturated u64 | 261 | 15 |
+| all 12 KPM hooks, saturated u64 | ~285 | ~14 |
 
 The two backends are not in the same position:
 
@@ -81,11 +81,11 @@ The two backends are not in the same position:
 - **kmod** — `/proc/vpnhide_ctl` is a real `seq_operations` stream with one UID
   per record. There is no whole-output buffer or formatter ceiling.
 
-KPM keeps no serialisation snapshot. Its live table stores only the 11
-kernel-owned hook counters rather than the 27-id global registry, and a zero UID
+KPM keeps no serialisation snapshot. Its live table stores only the 11 shared
+kernel hook counters plus its optional filesystem hook rather than the 28-id global registry, and a zero UID
 is the hash-table empty sentinel, so no separate `stats_used` array is needed.
 At the current 160-target cap, including the static config parse scratch, the
-resulting `.bss` is **18004 B**. That is still below the **23120 B** used by the
+resulting `.bss` is **19080 B**. That is still below the **23120 B** used by the
 old 64-target layout before compact storage and cursor output.
 
 ## Raising a ceiling — options and cost
@@ -94,8 +94,8 @@ Ordered by cost. None of these are scheduled; this is the menu.
 
 ### Control
 
-1. **The shipped cap is 160.** Compact 11-hook stats storage and cursor output
-   keep KPM `.bss` at 18004 B, and config parsing uses serialized static scratch
+1. **The shipped cap is 160.** Compact 12-hook stats storage and cursor output
+   keep KPM `.bss` at 19080 B, and config parsing uses serialized static scratch
    rather than growing the KPM stack. A typical one-mask, five-digit-UID wire is
    848 B and fits the KPM transport; maximum-width UIDs or many distinct masks
    may hit the independent byte limit sooner. The activator validates the exact

--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -1,155 +1,79 @@
 # vpnhide — control & stats protocol
 
-Single source of truth for the wire format exchanged between the app and every
-backend (`.ko`, KPM, Zygisk, LSPosed), and for the architecture that carries it.
-This document is the **arbiter**: when two implementations disagree, this file
-decides who is wrong. Every implementation (C / Rust / Kotlin) and every test
-vector references it.
+Single source of truth for the runtime wire exchanged with the native backends
+(`.ko`, KPM, Zygisk) and for the telemetry wire emitted by `.ko`, KPM, and
+LSPosed. This document is the **arbiter** for those bytes: when two
+implementations disagree, this file decides who is wrong. Every implementation
+(C / Rust / Kotlin) and every test vector references it.
 
 Status: **two protocols** over one lexical core and one hook-id registry —
 `control` **v2** (the `config` payload) and `telemetry` **v1** (`stats` +
 `status`). Both frozen; all seven OPEN items (§10) are resolved. See §3 for why
 the split exists and what it costs to move either number.
-Key shape: one always-on Java (LSPosed) layer + exactly one active native
-backend, priority `kmod > KPM >
-Zygisk` (§1.5); three `kind`s — `config` (in), `stats` + `status` (out, §4.3);
-UID is the key on every channel incl. Zygisk; `u64` cumulative counters; `debug`
-folded into config; the `.ko` channel is one folded node `/proc/vpnhide_ctl`
-(write=config, read=status+stats); KPM uses the `kpm ctl0` supercall (§7).
+Key shape: three `kind`s — `config` (in), `stats` + `status` (out, §4.3); UID
+is the key on every control channel including Zygisk; `u64` cumulative counters;
+`debug` folded into config; the `.ko` channel is one folded node
+`/proc/vpnhide_ctl` (write=config, read=status+stats); KPM uses the `kpm ctl0`
+supercall (§7).
 Threat model: an **unprivileged** app — root-level detection is out of scope.
 
-> **Storage & activation live in [storage.md](storage.md).** This document is the
-> frozen **wire** spec (the bytes exchanged at runtime). The layer above it — a
-> single JSON canonical on disk, the activator that derives this wire for the
-> native backends, LSPosed reading the JSON directly (it does **not** consume this
-> wire), and the APatch superkey — is specified there, and supersedes the
-> storage-related statements in §1.3–§1.4, §6, and §7.4 below. The wire format
-> (§4–§5) is unchanged.
+Configuration storage, activation policy, boot-only features, and loader
+arguments are deliberately outside this protocol. Their authoritative documents
+are [storage.md](storage.md) and [state.md](state.md); backend loader ABIs are in
+[the `.ko` README](../kmod/README.md) and
+[the KPM README](../kmod/kpm/README.md).
 
 ---
 
-## 1. Architecture
+## 1. Scope and runtime bindings
 
-### 1.1 No hub — app is the orchestrator
+### 1.1 Contract boundary
 
-There is no resident root daemon. The app (Kotlin) is the only orchestrator: it
-serialises config snapshots into every channel via `su`, and reads stats back
-the same way. Each backend reads *its own* channel independently. There is no
-intermediary process between the app and the backends.
+This document defines four things:
 
-Rationale: the exchange is rare (per user action) and pull-based; a resident
-root process would add a named, enumerable component on a device where node
-visibility is deliberately minimised, and it would not remove the unavoidable
-in-`system_server` Kotlin reader anyway (see §3). A hub buys nothing here and
-costs stealth + lifecycle complexity.
+- the control-v2 and telemetry-v1 grammars;
+- the shared hook-id and error-code registries;
+- the backend profiles that select which records and hook bits each consumer
+  understands;
+- transport framing where it affects the bytes, notably KPM truncation and
+  stats pagination.
 
-### 1.2 State is per-backend; the protocol is shared
+It does **not** define the canonical JSON schema, package-to-UID projection,
+native-backend selection, boot order, APatch credential persistence, or the
+arguments used to load `.ko`/KPM artifacts. In particular,
+`settings.kernelBootFeatures` and the `filesystem_hiding=1` loader argument are
+not control-v2 records. See [storage.md](storage.md) for desired state and
+activation, and [state.md](state.md) for paths, lifetimes, and boot sequencing.
 
-Two orthogonal axes, kept separate:
+### 1.2 Runtime channels
 
-- **State is NOT unified.** Each backend owns its own channel/file. Backends do
-  not know about each other. One writer per file, atomic replace
-  (`tmp` + `rename`). This is what prevents races and torn reads, and keeps each
-  SELinux label scoped to a single reader domain. Merging state into one file
-  would mean multi-writer across three domains and one label that must satisfy
-  every reader — rejected.
-- **The protocol IS unified.** One grammar, one parser core per language, one
-  codegen'd hook registry. Format is not a shared resource, so unifying it
-  creates no races. This is the *only* axis we unify.
+The grammar is shared, but the transports and supported directions differ:
 
-**One kernel backend at a time.** The `.ko` and KPM are alternatives, not
-co-residents: they wrap the *same* kernel functions
-(`rtnl_fill_ifinfo`, `inet6_fill_ifaddr`, `fib_route_seq_show`, …), and running
-both at once hard-froze a device (kretprobe + KernelPatch inline hook on one
-symbol, deadlocking the netlink path on the first target enumeration — observed
-on a Pixel 8 Pro, 6.1). Every shipped KPM load/configuration path therefore
-checks for an installed or live `.ko` first and refuses with
-`conflicting_backend` (§5.1). The check is in the boot scripts and activator,
-not in either kernel backend: KPM deliberately exposes no stable `/proc` or
-module marker, and an in-kernel check during the unordered post-fs-data load
-window would itself be racy. Loading either artifact manually outside the
-shipped activation path bypasses this guard, is unsupported, and can freeze the
-device.
-
-### 1.3 Channels
-
-Every channel carries the **same text snapshot format** (§4). They differ only
-in transport and in which records they carry (profiles, §6).
-
-| Channel | Write transport | Read transport | Reader runs in |
+| Runtime | Control v2 in | Telemetry v1 out | Consumer/producer |
 |---|---|---|---|
-| app ↔ `.ko` | `echo > /proc/vpnhide_ctl` | `cat /proc/vpnhide_ctl` (seq_file) | kernel |
-| app ↔ KPM | supercall `ctl0` (`args`) | supercall `ctl0` (`out_msg`) | kernel |
-| app ↔ Zygisk | `targets.txt` via module dir-fd | n/a (stats via §7 if added) | Zygisk process (zygote-forked) |
-| app ↔ LSPosed | `/data/system/vpnhide_*` files | same files | `system_server` |
+| `.ko` | write `/proc/vpnhide_ctl` | read `/proc/vpnhide_ctl` (`seq_file`) | kernel |
+| KPM | `ctl0` `args` | `ctl0` `out_msg` | kernel |
+| Zygisk | module-dir `targets.txt` | none | forked app process |
+| LSPosed | none; reads canonical JSON directly | `/data/system/vpnhide_lsposed_state` | `system_server` |
 
-Channel-specific notes:
+The Zygisk module reads `targets.txt` through the privileged module-directory fd
+provided before app specialisation (`openat(dir_fd, "targets.txt", …)`). It
+reloads on the next process launch. KPM is the only request/response transport
+without a file or proc node; its binding is specified in §7. LSPosed participates
+only in telemetry v1: its configuration input belongs to the storage contract.
 
-- **Zygisk** reads through the root-privileged module-directory fd Zygisk hands
-  the module *before* app specialisation (`openat(dir_fd, "targets.txt", …)`),
-  which bypasses SELinux. Read on every app launch; edits picked up on next
-  force-stop + relaunch. No companion, no socket.
-- **LSPosed** has no privileged endpoint with the app. The only shared medium is
-  the filesystem: app writes via `su`, the hook in `system_server` watches via
-  `FileObserver` (inotify) and reloads. Files are `root:system`, mode `0640`,
-  label `system_data_file` — `system_server` reads via group `system`,
-  `untrusted_app` falls to "other" and gets EACCES.
-- **KPM** is the only true request/response channel (no file, no node) — see §5.
+### 1.3 Implementation ownership
 
-### 1.4 Where protocol code lives
-
-No hub ⇒ the serialiser lives in the app (Kotlin). Three languages total, by
-process:
-
-| Language | Process | Role in protocol |
+| Language | Component | Wire responsibility |
 |---|---|---|
-| C | kernel (`.ko` + KPM) | parse config; emit stats. Freestanding, `kmod/shared/vpnhide_logic.h`. |
-| Rust | Zygisk process | parse its config profile (`targets.txt`). |
-| Kotlin | app | **serialise** all config snapshots into every channel; **parse** stats readback. The "thick" end. |
-| Kotlin | `system_server` (LSPosed hook) | parse its config profile from its file. Not removable — cannot inject a `.so` into `system_server`. |
+| C | `.ko` + KPM | parse control config; emit telemetry. Freestanding core in `kmod/shared/vpnhide_logic.h`. |
+| Rust | `crates/protocol` + activators | format control snapshots, validate native telemetry, and implement KPM framing. |
+| Rust | Zygisk cdylib | parse its control profile from `targets.txt`. |
+| Kotlin | app | parse telemetry for dashboard, diagnostics, and statistics. |
+| Kotlin | LSPosed hook | emit telemetry-shaped status/stats from `system_server`; config comes from canonical JSON. |
 
-The UI itself originates *data* (package→UID via PackageManager, per-app hook
-selection) but the app is also the orchestrator, so wire serialisation lives in
-Kotlin here. Parser parity across C / Rust / Kotlin is held by golden vectors +
-differential testing (§8), not by shared code.
-
-### 1.5 Backend selection: one Java layer + exactly one active native
-
-Backends split into two layers that run *together*:
-
-- **Java layer — LSPosed, always active.** It hooks Java APIs inside
-  `system_server` (PackageManager, ConnectivityManager, …) — a vantage no native
-  backend has. It is orthogonal to the native layer and is never "the one of N".
-- **Native layer — exactly one of {`.ko` kmod, KPM, Zygisk} is active.** They
-  cover the same native surface (netlink / proc / libc), so running two is at
-  best redundant double-hiding and at worst fatal: the `.ko` (kretprobe) and KPM
-  (KernelPatch inline) wrap the *same* kernel functions and deadlocked a device
-  when both fired (§1.2). So the product runs one native backend, period.
-
-**Selection is by fixed priority `kmod > KPM > Zygisk`,** among the backends
-actually *loaded* (read from each backend's `status`, §4.3). The app:
-
-1. reads `status` from every native backend that is present;
-2. picks the highest-priority loaded one as **active**, writes it the real config
-   snapshot, and writes the others an **empty** snapshot (no targets ⇒ hooks
-   installed but idle);
-3. if more than one native backend is loaded, **warns the user** (a second loaded
-   backend is a misconfiguration to clean up, not a supported mode).
-
-Two backstops make this safe before the app's policy has run:
-
-- **Guarded KPM delivery.** The KPM boot scripts reject an enabled `.ko` module
-  before loading KPM. The activator repeats the check, including the live
-  `/proc/vpnhide_ctl` endpoint, before every KPM load/configuration attempt and
-  reports `conflicting_backend` (§5.1). Repeating it closes the interval between
-  early boot and config delivery without requiring either backend to discover
-  the other in kernel space.
-- **No self-activation of dangerous overlap.** Boot scripts may *load* a backend,
-  but the single-active decision is the app's; a loaded-but-unconfigured native
-  backend filters nothing.
-
-This does not contradict §1.1 (no hub) or §1.2 (per-backend state): selection is
-a read-only policy the app computes from `status`, not a shared runtime store.
+Parser parity across C, Rust, and Kotlin is held by golden vectors and
+differential testing (§8), not by shared runtime code.
 
 ---
 
@@ -164,10 +88,10 @@ These are *why* the format is what it is. Do not "simplify" against them.
 - **KPM delivery is a CLI that takes a string and returns a string.** A binary
   format would have to be hex/base64-wrapped through argv anyway. Text matches
   the transport.
-- **Debugging is by an LLM agent reading/writing raw** over `adb` (`cat`/`echo`).
-  The format must survive shell quoting (no `"`, `$`, backtick, `\` in payload)
-  and be self-describing enough to read without external context. This is why
-  keywords are words, not magic numbers.
+- **Debugging uses raw `adb` reads and writes** (`cat`/`echo`). The format must
+  survive shell quoting (no `"`, `$`, backtick, `\` in payload) and be
+  self-describing enough to read without external context. This is why keywords
+  are words, not magic numbers.
 - **Pull only.** Kernel aggregates per-(uid, hook) counters; userspace reads
   periodically. No push, no per-hit events on the hot path.
 
@@ -179,8 +103,8 @@ These are *why* the format is what it is. Do not "simplify" against them.
   replaces its state wholesale. There is no add/remove/clear. This makes state a
   pure function of the last write — it never depends on history, which removes
   the whole class of "partially-applied" / "stale leftover" bugs. It also matches
-  `echo > node` (truncating redirect) and `FileObserver` ("file changed",
-  inotify gives no deltas).
+  `echo > node` (truncating redirect) and atomic replacement of Zygisk's derived
+  `targets.txt` snapshot.
 - **Mandatory header gating.** A payload without a valid header (§4.2) is
   rejected *whole* — a stray `echo 'debug 0' > node` does not silently wipe
   state, it errors. "Valid full state, or a loud refusal, never silent-partial."
@@ -220,7 +144,7 @@ These are *why* the format is what it is. Do not "simplify" against them.
   line → reject that line.
 - **Line separator:** `\n` only. On read, a trailing `\r` (CRLF) is stripped. On
   write, never emit `\r`. A trailing `\n` at end of payload is optional on read
-  (but see §5 for its meaning under KPM truncation).
+  (but see §7.2 for its meaning under KPM truncation).
 - **Whitespace:** one or more spaces/tabs between tokens is a single separator.
   On write, emit exactly one space.
 - **Comments:** a line whose first non-whitespace character is `#` is ignored
@@ -290,7 +214,7 @@ end <count>
   have no PackageManager so they cannot key on package names, and Zygisk (which
   runs in the target's own process and could match either way) keys on `getuid()`
   for one grammar across all channels. The package→UID resolution is the
-  producer's job (app / boot script), the same for all backends.
+  producer's job (the activator), the same for all backends.
 - `end <count>` — **mandatory**. `count` is the total number of uid tokens the
   producer wrote. Missing, or not equal to what the reader counted ⇒ reject the
   payload whole. This is the truncation fuse: the KPM copies a config through a
@@ -344,9 +268,10 @@ error <code>
 
 `status` exists because a kernel backend can refuse or only partially install for
 reasons the app cannot otherwise see (no node, no logs unless `debug`). It turns
-those into a readable state instead of a silent no-op. The delivery layer uses
-the same error vocabulary for activation failures; in particular, the KPM boot
-status reports `conflicting_backend` when its guard detects the `.ko` (§1.2).
+those into a readable state instead of a silent no-op. Activation diagnostics use
+the same error vocabulary; in particular, a KPM loader can report
+`conflicting_backend` when it detects the `.ko`. The guard itself is an activation
+rule documented in [storage.md](storage.md#43-native-backend-selection-and-safety).
 
 ### 4.4 Numeric primitive
 
@@ -388,7 +313,7 @@ and both are special-cased to their keyword/line.
 
 ### 4.6 Example
 
-config (app → kernel):
+config (activator → backend):
 
 ```
 vpnhide 2 config
@@ -441,7 +366,9 @@ Current shared kernel hooks (`.ko` / KPM, 11): `fib_route_seq_show`,
 `ipv6_route_seq_show`, `rtnl_fill_ifinfo`, `inet_fill_ifaddr`,
 `inet6_fill_ifaddr`, `dev_ioctl`, `sock_ioctl`, `fib_dump_info`, `rt6_fill_node`,
 `fib_nl_fill_rule`, `socket_bind_interface`. Both kernel backends also own the
-optional, reboot-gated `filesystem_iface_paths` hook. Current LSPosed Java hooks (8):
+optional `filesystem_iface_paths` capability bit. Whether its global hook group
+is installed is outside control v2; see
+[storage.md](storage.md#22-optional-kernel-boot-features). Current LSPosed Java hooks (8):
 `lsposed_link_properties`,
 `lsposed_network_capabilities`, `lsposed_network_info`, `lsposed_network`,
 `lsposed_connectivity_result`, `lsposed_connectivity_callback`,
@@ -461,7 +388,7 @@ of:
 |---|---|---|
 | `0x0` | `ok` | healthy; every requested, owned hook installed |
 | `0x1` | `unsupported_kver` | no offset table for the running kernel — refused, no hooks |
-| `0x2` | `conflicting_backend` | KPM activation found the `.ko` installed or live and refused before loading/configuring KPM (§1.2) |
+| `0x2` | `conflicting_backend` | KPM activation found the `.ko` installed or live and refused before loading/configuring KPM |
 | `0x3` | `symbol_resolution_failed` | a required kallsyms symbol was missing — refused |
 | `0x4` | `partial_hooks` | installed, but some owned hooks did not resolve (see the `hooks` mask) |
 
@@ -473,10 +400,9 @@ the per-hook detail when `error = partial_hooks`.
 
 ## 6. Profiles
 
-One grammar, N profiles. A **profile** is the subset of records a channel
-carries, by hook ownership — not by "how many features we shipped". Because
-per-app hooks and stats come to **all** backends, every channel carries the full
-grammar; there is no "bare" profile.
+One grammar, N profiles. A **profile** is the subset of records and hook bits a
+consumer or producer supports. It is not a storage schema and does not imply
+that every runtime implements both protocol directions.
 
 The parser is **profile-agnostic**: the §4.5 "unknown keyword → skip" rule means
 one parser reads any channel and acts only on records it understands. Each
@@ -485,20 +411,18 @@ backend reads its own profile.
 | Channel | config records it acts on | emits stats? | emits status? |
 |---|---|---|---|
 | `.ko` / KPM | `debug`, `default`, `targets`, `end` (kernel-owned mask bits) | yes | yes (§4.3) |
-| Zygisk | `debug`, `targets`, `end`; its activator rejects a non-zero `default` because it cannot inject into every unlisted process | no, not yet (§7) | yes, via the app heartbeat |
-| LSPosed | — does **not** consume this wire; it reads the canonical JSON directly (see [storage.md](storage.md)) | yes | yes |
+| Zygisk | `debug`, `targets`, `end`; its activator rejects a non-zero `default` because it cannot inject into every unlisted process | no | no; its app heartbeat is not telemetry v1 |
+| LSPosed | — does **not** consume control v2; it reads canonical JSON directly | yes | yes |
 
-A backend ignores mask bits it does not own (`mask & own_hooks`), so the same
-`targets 3ff 27fa` record is valid on every channel and each backend takes its
-slice.
+A control consumer ignores mask bits it does not own (`mask & own_hooks`). The
+same global-mask payload can therefore be delivered to any native backend; each
+backend takes only its slice. Telemetry producers use the same global hook IDs,
+so the app can merge `.ko`/KPM and LSPosed counters without remapping them.
 
-**Active vs idle (§1.5).** The grammar is the same on every channel, but the app
-only writes a *real* config to the LSPosed channel and the **one active** native
-channel; the other native channels get an empty config (or none), so a
-loaded-but-not-selected native backend parses nothing to act on. Selection is the
-app's policy from `status`, not part of the wire format — a backend never knows
-whether it is "the active one"; it just applies whatever config it is given (and
-the empty config makes it idle).
+Native-backend selection is not encoded in the payload. A backend simply applies
+the control snapshot it receives. The app-side priority and the KPM/`.ko` safety
+guard are activation policy; see
+[storage.md](storage.md#43-native-backend-selection-and-safety).
 
 ---
 
@@ -513,8 +437,8 @@ static long vpnhide_kpm_ctl0(const char *args, char *__user out_msg, int outlen)
 
 The config parser is *already* shared with `.ko` (`apply_targets` →
 `vpnhide_parse_config` from `kmod/shared/`). KPM reuses the §4 format unchanged;
-only the transport differs and `out_msg`/`outlen` (currently `(void)`) become the
-read-back channel for `stats` and `status`.
+only the transport differs, with `out_msg`/`outlen` forming the read-back channel
+for `stats` and `status`.
 
 **Confirmed on-device (OPEN-5):** the KPatch-Next `kpatch` CLI **does forward
 `out_msg` to stdout** — a probe build that wrote a marker into `out_msg` and
@@ -622,18 +546,17 @@ kpatch kpm ctl0 vpnhide "vpnhide 1 status"
 ```
 
 **The userspace entry must match the running KernelPatch runtime.** The `.kpm`
-module itself is cross-version (it loaded and ran on both `c02` and `d05`), but
-the userspace ABI is **not** portable. The low 16-bit KPM command ids are the
-same (`load=0x1020`, `ctl0=0x1022`, `list=0x1031`), and both runtimes currently
-dispatch on those low bits, but the calling conventions differ:
+module itself is cross-version, but the userspace ABI is **not** portable. Both
+runtimes use low command id `ctl0=0x1022`, but their calling conventions differ:
 
 - **APatch:** syscall number `45`, arg0 is the real SuperKey, command word uses
   APatch's `0x1158` marker. APatch's public `apd` CLI manages APM ZIP modules
-  only; it does **not** expose `kpm load/ctl0`. APatch's own app controls KPMs
-  through native JNI `sc_kpm_*` calls, so the vpnhide activator does the same
-  directly. The activator probes `SUPERCALL_HELLO` before load/control, so a
-  missing KernelPatch runtime or stale SuperKey fails before a stray original
-  syscall can run.
+  only; it does **not** expose `kpm ctl0`. APatch's own app controls KPMs through
+  native JNI `sc_kpm_*` calls, so the vpnhide activator does the same directly.
+  The activator probes `SUPERCALL_HELLO` before control, so a
+  missing KernelPatch runtime or invalid credential fails before a stray
+  original syscall can run. Credential storage is specified in
+  [storage.md](storage.md#6-apatch-superkey).
 - **KPatch-Next:** syscall number `45`, arg0 is `NULL`, and the kernel side gates
   calls by root UID rather than a SuperKey. The activator issues no raw
   command-word marker here — it drives KPatch-Next through the runtime's own
@@ -646,29 +569,6 @@ Do not ship one generic `kpatch` binary for both runtimes.
 Caveats from CLI/shell delivery on KPatch-Next: shell-quote the payload (single
 quotes; the format contains no `'`). APatch does not pass the key through an
 external CLI argv; the activator calls the supercall from its own process.
-
-### 7.4 Distribution & boot integration
-
-The `.kpm` ships as a **thin flashable module** (Magisk/KSU format; APatch reads
-it too). The module delivers the binary and a boot script; the actual KPM-load
-mechanism is delegated to the activator and runtime. KPatch-Next is keyless;
-APatch can also activate at boot when the user has opted into persisting the
-SuperKey under `/data/adb/vpnhide/superkey` (root-only DE storage):
-
-- **KPatch-Next (Magisk / KSU), `d05`, keyless — the recommended path.** The boot
-  script does everything itself: detect the runtime, enforce single-active (skip
-  KPM if the `.ko` is loaded, §1.5), `kpatch kpm load vpnhide.kpm`, then apply the
-  persisted config snapshot via `kpatch kpm ctl0`. Fully automatic, no user
-  interaction. This is what we recommend users run.
-- **APatch, `c02`, SuperKey-required.** If the user enabled
-  `rememberSuperkey`, the app persists the key root-only at
-  `/data/adb/vpnhide/superkey`, and the boot activator loads/configures APatch
-  via direct supercalls after the `SUPERCALL_HELLO` probe. Without that saved
-  key, boot writes `awaiting_superkey`; activation resumes after the app supplies
-  the key.
-
-This keeps KPatch-Next fully automatic, while APatch is automatic only when the
-user explicitly stores the root-only SuperKey for boot.
 
 ---
 
@@ -735,34 +635,13 @@ Recorded so they are not re-litigated.
   a future low-rate kernel→userspace *event* channel if one is ever needed.
 - **Binary fixed-layout structs at the kernel boundary (ioctl)** — type-safe and
   a clean single source via `bindgen`, but loses catability (no `cat`/`echo` for
-  the agent debugger), and `MAX_*` arrays bake ceilings into the ABI: a new field
+  direct debugging), and `MAX_*` arrays bake ceilings into the ABI: a new field
   shifts layout and forces a synchronous rebuild across 7 KMIs. Fragile to
   evolution. (If binary is ever needed, prefer TLV over flat structs.)
 - **Per-op commands / deltas** (`set`/`add`/`del`/`clear`) — friendlier to
   `echo >>`, but reintroduces stateful, history-dependent application: an
   interrupted batch leaves a half-applied state not derivable from `cat`. Snapshot
   is a pure function of the last write. Rejected.
-- **A resident root hub / daemon** — reconsidered explicitly (and after reviewing
-  `vpnhide_next`, whose daemon is a narrow netlink poller justified by an IP-spoof
-  feature we do not have; its real "hub" is the kmod's `/dev` misc device, which
-  couples everything to the `.ko` being loaded — incompatible with "any one of N
-  native backends"). Re-rejected: a resident named root process is enumerable
-  (`ps`/`/proc`), exactly the fingerprint this project minimises; it adds
-  keep-alive/SELinux/IPC surface; and it does not remove the irreducible
-  in-`system_server` Kotlin reader. Its one real win — *live* reaction to events
-  without the app open — is not a requirement (targets change rarely; boot +
-  app-open re-resolution suffice), and its other wins (single code path, root
-  syscalls, coordinated single-active) are had by the app-as-orchestrator + a
-  thin boot script + the kernel guard (§1.5) with no resident process. Revisit
-  only if a feature needs a live event loop. The narrow KPM coordination it would
-  buy is already covered by the kernel guard.
-- **Unified single state file across backends** — multi-writer across three
-  SELinux domains, torn reads, one label for all readers. State stays
-  per-backend.
-- **Routing LSPosed/Java state through the kmod via ioctl** (a fork's approach) —
-  centralises state but couples LSPosed to the kmod being loaded and needs
-  `system_server` sepolicy for the device node. We keep backends autonomous.
-
 ---
 
 ## 10. Historical wire decisions
@@ -771,11 +650,11 @@ Recorded so they are not re-litigated.
   mandatory as a visual/parse anchor; control v2 forbids it to reclaim two
   bytes per number under the KPM transport ceiling. Neither protocol makes the
   prefix optional, so each value still has one spelling.
-- **OPEN-2 — agent self-description level. RESOLVED: positional-after-keyword.**
+- **OPEN-2 — self-description level. RESOLVED: positional-after-keyword.**
   Control v2 uses `targets <hookmask> <uid>...`: the keyword names the grouped
   record and fields remain positional. `key=value` buys marginal readability
-  for extra bytes and a second split; the keyword already self-describes for an
-  agent reading raw.
+  for extra bytes and a second split; the keyword is already readable in a raw
+  capture.
 - **OPEN-3 — stats counter type. RESOLVED: `u64` cumulative-since-load.** Reads
   are non-destructive (no reset-on-read race between two readers), it never
   wraps in practice, and deltas are the app's job — which suits the pull model
@@ -793,18 +672,18 @@ Recorded so they are not re-litigated.
 - **OPEN-5 — KPM userspace transport. RESOLVED (on-device).** KPatch-Next
   exposes `kpm ctl0 <name> <payload>` through its keyless `kpatch` CLI, and the
   CLI **does forward `out_msg` to stdout** — so no extra root binary is needed
-  for read-back there. APatch does not expose `kpm load/ctl0` through `apd`; the
-  activator calls the runtime-specific supercalls directly with the saved
-  SuperKey. The `.kpm` is cross-version, but the userspace transport is not.
+  for read-back there. APatch does not expose `kpm ctl0` through `apd`; the
+  activator calls the runtime-specific supercall directly. Authentication and
+  credential persistence belong to [storage.md](storage.md#6-apatch-superkey).
+  The `.kpm` is cross-version, but the userspace transport is not.
 - **OPEN-6 — `debug` placement. RESOLVED: folded into the config snapshot.**
-  `debug <flag>` is the one global (non-`target`) config record (§4.3). Today
-  each backend has its own `debug_logging` file (and the `.ko` a
-  `/proc/vpnhide_debug` node); folding it into the config snapshot removes those
-  per-backend files/nodes (less enumerable surface), makes it atomic with the
-  rest of config, and needs one parse instead of a second channel.
+  `debug <flag>` is the one global (non-`target`) config record (§4.3). Earlier
+  designs used per-backend `debug_logging` files and a `.ko`
+  `/proc/vpnhide_debug` node. Folding the flag into the snapshot removed those
+  extra channels, made debug atomic with the rest of config, and reduced parsing.
 - **OPEN-7 — self-documenting read. RESOLVED: yes, emit an in-band header.** The
   read side prepends a one-line `#` comment (`# vpnhide v1 — WRITE REPLACES ENTIRE
   STATE …`) before the current state. It is a comment line (ignored by parsers,
-  §4.1), so it costs nothing structurally and lets an agent learn the grammar +
-  the replace-whole semantics from a single `cat` (§2). All seven OPEN items are
+  §4.1), so it costs nothing structurally and exposes the grammar +
+  replace-whole semantics in a single `cat` (§2). All seven OPEN items are
   now resolved; `version 1` is frozen.

--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -440,8 +440,8 @@ is global; a backend only acts on its own bits.
 Current shared kernel hooks (`.ko` / KPM, 11): `fib_route_seq_show`,
 `ipv6_route_seq_show`, `rtnl_fill_ifinfo`, `inet_fill_ifaddr`,
 `inet6_fill_ifaddr`, `dev_ioctl`, `sock_ioctl`, `fib_dump_info`, `rt6_fill_node`,
-`fib_nl_fill_rule`, `socket_bind_interface`. The optional `.ko`-only hook is
-`filesystem_iface_paths`; it is not part of KPM's owned mask. Current LSPosed Java hooks (8):
+`fib_nl_fill_rule`, `socket_bind_interface`. Both kernel backends also own the
+optional, reboot-gated `filesystem_iface_paths` hook. Current LSPosed Java hooks (8):
 `lsposed_link_properties`,
 `lsposed_network_capabilities`, `lsposed_network_info`, `lsposed_network`,
 `lsposed_connectivity_result`, `lsposed_connectivity_callback`,

--- a/docs/state.md
+++ b/docs/state.md
@@ -48,7 +48,9 @@ module reinstall. They hold binaries and boot scripts, not user-managed config.
 ### `/data/adb/modules/vpnhide_kmod/`
 
 - `module.prop`: module metadata, version, and stamped `gkiVariant=`.
-- `post-fs-data.sh`: loads `vpnhide_kmod.ko`, writes load diagnostics.
+- `post-fs-data.sh`: reads the canonical boot-feature set through the activator,
+  loads `vpnhide_kmod.ko` with `filesystem_hiding=0|1`, and writes load
+  diagnostics.
 - `service.sh`: starts `activator --boot-wait` in the background.
 - `uninstall.sh`: removes kmod-specific persistent diagnostics.
 - `activator`: Rust bin that reads canonical JSON, lists Android users and
@@ -60,9 +62,11 @@ module reinstall. They hold binaries and boot scripts, not user-managed config.
 ### `/data/adb/modules/vpnhide_kpm/`
 
 - `module.prop`: module metadata.
-- `post-fs-data.sh`: asks `activator --load-only` to validate the running
-  major.minor kernel family and load KPM automatically on keyless KPatch-Next;
-  on APatch/FolkPatch records a deferred status and leaves load/config to service.
+- `post-fs-data.sh`: reads the canonical boot-feature set, asks
+  `activator --load-only` to validate the running major.minor kernel family and
+  load KPM automatically on keyless KPatch-Next, passing
+  `filesystem_hiding=1` only when requested; on APatch/FolkPatch records a
+  deferred status and leaves load/config to service.
 - `service.sh`: starts `activator --boot-wait` in the background.
 - `uninstall.sh`: removes KPM-specific persistent status and the ctl0 lock.
 - `activator`: Rust bin that refuses to run when the `.ko` backend is present,
@@ -286,13 +290,17 @@ deleted after use.
 ```text
 post-fs-data:
   kmod post-fs-data
-    -> insmod vpnhide_kmod.ko
+    -> activator boot-feature-enabled filesystem_iface_paths
+    -> insmod vpnhide_kmod.ko filesystem_hiding=0|1
     -> write /data/adb/vpnhide_kmod/load_status and load_dmesg
   KPM post-fs-data
     -> refuse if .ko module is installed+enabled
-    -> keyless KPatch-Next: activator validates uname major.minor, then loads vpnhide.kpm
+    -> read filesystem_iface_paths from canonical JSON
+    -> keyless KPatch-Next: activator validates uname major.minor, then loads
+       vpnhide.kpm with filesystem_hiding=1 when enabled (no load arg otherwise)
     -> APatch/FolkPatch: defer to service activator; service tries saved key,
-       then trusted su token, else writes awaiting_superkey
+       then trusted su token, and uses the same optional KPM load arg; without
+       either credential it writes awaiting_superkey
 
 service:
   kmod / KPM / Zygisk service.sh

--- a/docs/state.md
+++ b/docs/state.md
@@ -110,7 +110,7 @@ module reinstall. They hold binaries and boot scripts, not user-managed config.
 
 | File | Format | Writer | Reader | Lifetime |
 |---|---|---|---|---|
-| `load_status` | `key=value`: timestamp, boot_id, uname_r, runtime, loaded, reason, detail | KPM `post-fs-data.sh` / `service.sh` | app dashboard | overwritten each boot |
+| `load_status` | `key=value`: timestamp, boot_id, uname_r, runtime, loaded, filesystem_hiding, reason, detail | KPM `post-fs-data.sh` / `service.sh` | app dashboard | overwritten each boot |
 | `ctl.lock` | empty advisory-lock inode, mode `0600` | KPM activator | KPM activators serialize ctl0 config/status/stats calls with `flock` | while the module is installed; removed on uninstall |
 
 ### `/data/adb/vpnhide_ports/`

--- a/docs/storage.md
+++ b/docs/storage.md
@@ -22,12 +22,12 @@ Two formats, by function — not one format stretched over everything:
   trivially import/export-able. Read by the app (Kotlin), the LSPosed hook
   (Kotlin), and the Rust activators.
 - **Runtime IPC = the text protocol** ([protocol.md](protocol.md)): control v2
-  for config, telemetry v1 for stats/status, both frozen.
-  uid-keyed, hand-parsed, kernel-safe. The runtime *config* wire for the
-  **native** backends (kmod / KPM / Zygisk): config in, stats/status out. Its
-  text format is also reused for LSPosed's read-only state file (§3).
+  for config, telemetry v1 for stats/status, both frozen. It is uid-keyed,
+  hand-parsed, and kernel-safe. All native backends consume control v2; kmod and
+  KPM emit telemetry v1. LSPosed also emits telemetry-shaped status/stats (§3)
+  but reads desired state directly from JSON.
 - **The bridge = the activator** (Rust). It projects the JSON onto the wire for
-  whichever native backend is installed.
+  the selected native backend.
 
 Why split: the kernel consumer (KPM, freestanding C) cannot parse JSON (see
 protocol.md §9), and the injected Zygisk `.so` should not carry a JSON parser into
@@ -35,7 +35,7 @@ every app process. But the *storage* layer has no such constraint, and JSON buys
 one-file import/export and natural Kotlin/Rust structs. So JSON serves the high
 level (storage + the Java hook, where `org.json` is free), the text protocol serves
 the low level (kernel / injected native), and the activator translates between
-them. The "agent reads/writes raw over adb" property (protocol.md §2) is preserved:
+them. Direct raw debugging over `adb` (protocol.md §2) is preserved:
 the live kernel state is still `cat /proc/vpnhide_ctl` text, and JSON is itself
 readable text.
 
@@ -68,6 +68,8 @@ shared canonical file nor consume extra native target slots.
 - **Import / export = copy this one file.** It contains no device-specific secret,
   so it is safe to back up / move / share. (This is *why* the superkey is **not**
   stored here — §6.)
+
+### 2.1 Canonical JSON schema
 
 Shape (illustrative):
 
@@ -138,14 +140,38 @@ selection; the native wire carries the resolved `hookmask`.
 The `rememberSuperkey` boolean lives here (it is a preference, not a secret). The
 superkey itself does **not** (§6).
 
-`kernelBootFeatures` is the desired set of optional, reboot-gated kernel
-features. The current `filesystem_iface_paths` entry enables the optional VFS
-hooks in either kernel backend. The `.ko` loader asks its Rust activator whether
-that entry is present before `insmod`; the KPM activator projects the same entry
-to the boot-time `filesystem_hiding=1` load argument. Changing the list in the
-app therefore requires a reboot. When an entry is absent, the hooks are never
-registered. Unknown names are preserved so newer versions can extend the list
-without a schema migration.
+### 2.2 Optional kernel boot features
+
+`settings.kernelBootFeatures` is a canonical **desired-state field**, not a
+control-v2 record. It names expensive or experimental kernel capabilities that
+must be selected before a backend installs its global hooks. Unknown names are
+preserved so newer versions can extend the set without a schema migration.
+
+The current projection is:
+
+| Canonical feature | `.ko` loader ABI | KPM loader ABI |
+|---|---|---|
+| `filesystem_iface_paths` | `insmod vpnhide_kmod.ko filesystem_hiding=1` | load `vpnhide.kpm` with the exact argument `filesystem_hiding=1` |
+
+When the feature is absent, the shipped `.ko` loader passes
+`filesystem_hiding=0`; the KPM loader omits the argument. Either choice is made
+before hook installation, so changing the canonical set takes effect only after
+a reboot. Backend-specific parsing and failure behavior are documented in the
+[`.ko` README](../kmod/README.md#optional-filesystem-hook-loader-contract) and
+[KPM README](../kmod/kpm/README.md#optional-filesystem-hook-loader-contract).
+
+Filesystem hiding then has two independent gates:
+
+1. The boot feature installs the four global VFS interception points. With the
+   feature off, the backend reports no `filesystem_iface_paths` capability and
+   pays no VFS hot-path trampoline cost.
+2. Control v2 hook bit 27 selects target UIDs allowed to use that installed
+   capability. Installing the hooks alone does not hide anything for a UID whose
+   target mask omits the bit.
+
+The symbolic feature name and loader arguments belong to storage/activation;
+hook ID 27, its mask semantics, and its installed/status bit belong to the
+[wire protocol](protocol.md#5-hook-registry-global-id-space).
 
 Ports are intentionally controlled in the canonical JSON, not in the native text
 protocol. `"ports": true` with no `portPolicy` is the legacy/default behavior:
@@ -204,10 +230,11 @@ does not: the hook self-reads the canonical JSON and resolves UIDs in-process.
 
 ## 4. The activator and its backends (native + ports)
 
-The native backends are **mutually exclusive** — exactly one is installed (the app
-warns/errors and asks the user to remove the extra otherwise). So the activator
-never writes "all three": it writes the **one** channel of the one installed native
-backend.
+The native backends are designed to be **mutually exclusive**: the supported
+installation has exactly one of kmod, KPM, or Zygisk. The app warns or errors and
+asks the user to remove extras. A Save invokes only the highest-priority enabled
+native activator; boot scripts remain module-local, which is why extra installed
+modules must still be removed rather than treated as idle replicas.
 
 ### 4.1 The activator — a Rust workspace, thin bins
 
@@ -275,8 +302,32 @@ Why Zygisk needs a file in its module dir even though there is one canonical: th
 `.so`'s **only** privileged read handle per fork is the module-dir fd Zygisk hands
 it (§7). This is a *mechanism* constraint, not a format one — the activator simply
 derives the protocol config there. (Note: the protocol text — not JSON — keeps the
-injected `.so` free of a JSON parser, and carries the per-hook `hookmask` + `debug`
-+ the native stats the way a flat package list never could.)
+injected `.so` free of a JSON parser and carries the per-hook `hookmask` + `debug`
+that a flat package list could not express.)
+
+### 4.3 Native backend selection and safety
+
+The Java and native layers are orthogonal: LSPosed may run alongside one native
+backend, while the native backend is exactly one of `.ko`, KPM, or Zygisk. On
+Save, the app runs at most one installed and enabled native activator in fixed
+priority order `kmod > KPM > Zygisk`. It does not fan one snapshot out to every
+installed backend and does not use empty snapshots as a selection mechanism.
+Multiple installed native modules are a configuration issue that the dashboard
+asks the user to resolve; `.ko` plus KPM is elevated to an error because that
+overlap is unsafe.
+
+The `.ko` and KPM restriction is also a kernel safety boundary. They wrap the
+same kernel functions with different mechanisms (kretprobes versus KernelPatch
+inline hooks); co-residence has hard-frozen a device. Every shipped KPM load and
+configuration path therefore refuses when an enabled `.ko` module directory or
+live `/proc/vpnhide_ctl` is present and reports `conflicting_backend`. The check
+runs in boot scripts and again in the activator to close the early-boot race.
+Manual loading outside those paths bypasses the guard and is unsupported.
+
+There is no resident root coordinator. Save-time activation and each module's
+boot scripts perform the rare projection/apply operation, while every backend
+owns its own runtime channel. This avoids a persistent enumerable process and
+keeps channel permissions and lifetimes backend-specific.
 
 ---
 
@@ -328,8 +379,8 @@ single-writer / atomic-replace, and stats are never written back into it.
   `(uid, hook_id)` cells for hooks that actually hid or rewrote a result.
 - **Zygisk: deferred.** Its counters would live **per app process** with no shared
   aggregation point. A unix socket is out — it violates protocol.md §2 (pull-only,
-  no per-hit push) and needs a collector process (a rejected resident root daemon,
-  §1.1). Shared memory is the pull-compatible direction, but there is no clean way
+  no per-hit push) and needs a resident root collector, contrary to §4.3. Shared
+  memory is the pull-compatible direction, but there is no clean way
   to share *writable* memory across all injected app-domain processes without a
   daemon (the module-dir file isn't writable by `untrusted_app` under SELinux; a
   zygote-inherited memfd must be created in the zygote, where our code does not run).
@@ -431,23 +482,24 @@ optional.
 | `/data/system/vpnhide_config.json` | **the** canonical config (managed, exported) | persistent |
 | `/proc/vpnhide_ctl` | kmod runtime channel (node, not a file) | per-boot, in-kernel |
 | KPM ctl0 supercall | KPM runtime channel (supercall, no file) | per-boot, in-kernel |
-| `/data/adb/modules/vpnhide_zygisk/<cfg>` | Zygisk runtime channel (derived copy) | regenerated |
+| `/data/adb/modules/vpnhide_zygisk/targets.txt` | Zygisk runtime channel (derived copy) | regenerated |
 | `/data/system/vpnhide_lsposed_state` | LSPosed status + stats (hook → dashboard) | per-boot |
 | `/data/adb/vpnhide/superkey` | APatch superkey (optional, flag-gated) | persistent, root-only |
 
-## 9. Relationship to [protocol.md](protocol.md)
+## 9. Contract ownership
 
-protocol.md remains the frozen **control-v2 / telemetry-v1 wire** specification
-and is still the runtime IPC for the native backends. This document supersedes
-its statements about the *storage/activation layer*, specifically:
+Each concern has one authoritative home; cross-links provide context without
+redefining the other contracts:
 
-- **LSPosed does not consume the wire** — it reads the canonical JSON directly
-  (§3). protocol.md's "LSPosed parses its config profile from its file" / the
-  LSPosed rows in its channel + profile tables are superseded here.
-- **APatch/FolkPatch boot is configurable** when the superkey is persisted (§6)
-  or the runtime grants the trusted `su` token; without either, boot records
-  `awaiting_superkey` and activation resumes after the app supplies the key.
-- **The app does not hand-build per-channel configs** — the activator does
-  (§4). The serialiser is the Rust `protocol` crate, shared with the Zygisk `.so`.
+| Concern | Authoritative document |
+|---|---|
+| Canonical JSON schema and desired state | this document (§2) |
+| JSON projection, native selection, and activation policy | this document (§4) |
+| Persistent paths, diagnostic files, lifetimes, and boot sequence | [state.md](state.md) |
+| Control-v2 / telemetry-v1 bytes, registries, and runtime framing | [protocol.md](protocol.md) |
+| `.ko` module parameters and hook-install behavior | [kmod README](../kmod/README.md) |
+| KPM load arguments and KernelPatch runtime behavior | [KPM README](../kmod/kpm/README.md) |
 
-The wire format itself (protocol.md §4–§5) is unchanged.
+LSPosed reads canonical JSON directly (§3), while the Rust activator serialises
+control v2 for the selected native backend (§4). The app persists desired state
+and invokes that activator; it does not hand-build per-channel wire payloads.

--- a/docs/storage.md
+++ b/docs/storage.md
@@ -139,11 +139,13 @@ The `rememberSuperkey` boolean lives here (it is a preference, not a secret). Th
 superkey itself does **not** (§6).
 
 `kernelBootFeatures` is the desired set of optional, reboot-gated kernel
-features. The current `filesystem_iface_paths` entry enables the `.ko` VFS
-probes. The kmod post-fs-data loader asks its Rust activator whether that entry
-is present before `insmod`; changing the list in the app therefore requires a
-reboot. When an entry is absent, its probes are never registered. Unknown names
-are preserved so newer versions can extend the list without a schema migration.
+features. The current `filesystem_iface_paths` entry enables the optional VFS
+hooks in either kernel backend. The `.ko` loader asks its Rust activator whether
+that entry is present before `insmod`; the KPM activator projects the same entry
+to the boot-time `filesystem_hiding=1` load argument. Changing the list in the
+app therefore requires a reboot. When an entry is absent, the hooks are never
+registered. Unknown names are preserved so newer versions can extend the list
+without a schema migration.
 
 Ports are intentionally controlled in the canonical JSON, not in the native text
 protocol. `"ports": true` with no `portPolicy` is the legacy/default behavior:
@@ -289,8 +291,9 @@ A common confusion (they are *not* the same):
 - **`status`: `hooks <mask>`** — per-backend, what is *actually installed*: did all
   the backend's hooks register this boot? It is capability/health, not per-target.
   Lets the app show "requested vs active" and detect a partial install
-  (`error = partial_hooks`). So `hooks 0x20003ff` in a status read means "all 11 kernel
-  hooks are installed in this backend", **not** "this target's hooks".
+  (`error = partial_hooks`). So `hooks 0x20003ff` in a status read means "all 11
+  shared kernel hooks are installed in this backend"; when filesystem hiding is
+  active, bit 27 is also present. This is **not** a target's hook selection.
 
 ### 5.2 Config and stats don't collide
 

--- a/kmod/README.md
+++ b/kmod/README.md
@@ -28,8 +28,8 @@ All filtering is **per-UID**: only processes whose UID is a `target` in the conf
 The VFS row is additionally **reboot-gated and disabled by default**. Enable
 **Settings → Experimental protection → Hide VPN filesystem paths** and reboot.
 When disabled, those four probes are not registered, so the default boot pays
-no VFS hot-path trampoline cost. The setting is `.ko`-only; KPM does not claim
-this coverage.
+no VFS hot-path trampoline cost. The same canonical setting also controls the
+equivalent optional KPM hooks.
 
 ## Why kernel-level?
 

--- a/kmod/README.md
+++ b/kmod/README.md
@@ -31,6 +31,22 @@ When disabled, those four probes are not registered, so the default boot pays
 no VFS hot-path trampoline cost. The same canonical setting also controls the
 equivalent optional KPM hooks.
 
+### Optional filesystem hook loader contract
+
+`filesystem_hiding` is a read-only boolean module parameter consumed only by
+`insmod`; it is not a control-v2 field. The shipped `post-fs-data.sh` asks the
+activator whether canonical boot feature `filesystem_iface_paths` is enabled and
+passes `filesystem_hiding=1` or `filesystem_hiding=0` accordingly. Omitting the
+parameter has the same disabled behavior as `0`.
+
+When enabled, module init registers `filename_lookup`, `do_filp_open`,
+`vfs_getattr`, and `iterate_dir` as one optional group. A registration failure
+rolls the whole group back; telemetry then omits hook bit 27 and reports a
+partial install. The control-v2 target mask remains a separate per-UID gate:
+loading the group does not hide paths for targets whose mask omits
+`filesystem_iface_paths`. Because the parameter is init-only and the module is
+not unloadable, changing it requires a reboot.
+
 ## Why kernel-level?
 
 Some anti-tamper SDKs read `/proc/self/maps` via raw `svc #0` syscalls (bypassing any libc hook) and check ELF relocation integrity. No userspace interposition can hide from them.
@@ -68,9 +84,13 @@ or remove it through the root module manager and reboot to apply that change;
 ordinary `rmmod` is not supported.
 
 On boot:
+
 - `post-fs-data.sh` reads the reboot-gated filesystem setting through the
-  activator, then runs `insmod` with the corresponding module parameter
-- `service.sh` runs the Rust activator, which reads `/data/system/vpnhide_config.json`, enumerates Android users, resolves package names for each user separately, and emits a `vpnhide 2 config` snapshot (docs/protocol.md) to `/proc/vpnhide_ctl`
+  activator, then runs `insmod` with the corresponding module parameter.
+- `service.sh` runs the Rust activator, which reads
+  `/data/system/vpnhide_config.json`, enumerates Android users, resolves package
+  names for each user separately, and emits a `vpnhide 2 config` snapshot
+  ([protocol](../docs/protocol.md)) to `/proc/vpnhide_ctl`.
 
 ### Target management
 
@@ -88,9 +108,10 @@ adb shell su -c '/data/adb/modules/vpnhide_kmod/activator'
 adb shell su -c 'printf "vpnhide 2 config\ndebug 0\ntargets a0003ff 28b7\nend 1\n" > /proc/vpnhide_ctl'
 ```
 
-The app writes to **two layers** simultaneously:
-1. `/data/system/vpnhide_config.json` -- persistent package-keyed roles (survives module updates and reboots)
-2. runtime channels derived from it -- `/proc/vpnhide_ctl` for the kernel module, direct canonical self-read for the [lsposed](../lsposed/) module's system_server hooks
+The app first writes `/data/system/vpnhide_config.json`, the persistent
+package-keyed desired state, and then invokes the selected native activator. The
+kmod activator derives `/proc/vpnhide_ctl` from that JSON; LSPosed independently
+reads the canonical JSON from `system_server`.
 
 ## Combined use with system_server hooks
 

--- a/kmod/generated/hook_ids.h
+++ b/kmod/generated/hook_ids.h
@@ -43,6 +43,7 @@ static inline unsigned int vpnhide_hook_bit(enum vpnhide_hook_id id)
 /* Hooks owned by each backend: apply `mask & own`, ignore foreign bits. */
 #define VPNHIDE_KERNEL_HOOK_MASK 0x20003ffu
 #define VPNHIDE_KMOD_HOOK_MASK 0x8000000u
+#define VPNHIDE_KPM_HOOK_MASK 0x8000000u
 #define VPNHIDE_ZYGISK_HOOK_MASK 0x5fc0000u
 #define VPNHIDE_LSPOSED_HOOK_MASK 0x3fc00u
 
@@ -110,6 +111,48 @@ static inline int vpnhide_kmod_stats_hook_slot(enum vpnhide_hook_id id)
 }
 
 static inline enum vpnhide_hook_id vpnhide_kmod_stats_hook_id(unsigned int slot)
+{
+	switch (slot) {
+	case 0: return VPNHIDE_HOOK_FIB_ROUTE_SEQ_SHOW;
+	case 1: return VPNHIDE_HOOK_IPV6_ROUTE_SEQ_SHOW;
+	case 2: return VPNHIDE_HOOK_RTNL_FILL_IFINFO;
+	case 3: return VPNHIDE_HOOK_INET_FILL_IFADDR;
+	case 4: return VPNHIDE_HOOK_INET6_FILL_IFADDR;
+	case 5: return VPNHIDE_HOOK_DEV_IOCTL;
+	case 6: return VPNHIDE_HOOK_SOCK_IOCTL;
+	case 7: return VPNHIDE_HOOK_FIB_DUMP_INFO;
+	case 8: return VPNHIDE_HOOK_RT6_FILL_NODE;
+	case 9: return VPNHIDE_HOOK_FIB_NL_FILL_RULE;
+	case 10: return VPNHIDE_HOOK_SOCKET_BIND_INTERFACE;
+	case 11: return VPNHIDE_HOOK_FILESYSTEM_IFACE_PATHS;
+	default: return VPNHIDE_HOOK_COUNT;
+	}
+}
+
+/* Dense stats slots for every hook the KPM can install.
+   The wire keeps global hook ids; these helpers only compact the
+   backend's in-memory counters. */
+#define VPNHIDE_KPM_STATS_HOOK_COUNT 12
+static inline int vpnhide_kpm_stats_hook_slot(enum vpnhide_hook_id id)
+{
+	switch (id) {
+	case VPNHIDE_HOOK_FIB_ROUTE_SEQ_SHOW: return 0;
+	case VPNHIDE_HOOK_IPV6_ROUTE_SEQ_SHOW: return 1;
+	case VPNHIDE_HOOK_RTNL_FILL_IFINFO: return 2;
+	case VPNHIDE_HOOK_INET_FILL_IFADDR: return 3;
+	case VPNHIDE_HOOK_INET6_FILL_IFADDR: return 4;
+	case VPNHIDE_HOOK_DEV_IOCTL: return 5;
+	case VPNHIDE_HOOK_SOCK_IOCTL: return 6;
+	case VPNHIDE_HOOK_FIB_DUMP_INFO: return 7;
+	case VPNHIDE_HOOK_RT6_FILL_NODE: return 8;
+	case VPNHIDE_HOOK_FIB_NL_FILL_RULE: return 9;
+	case VPNHIDE_HOOK_SOCKET_BIND_INTERFACE: return 10;
+	case VPNHIDE_HOOK_FILESYSTEM_IFACE_PATHS: return 11;
+	default: return -1;
+	}
+}
+
+static inline enum vpnhide_hook_id vpnhide_kpm_stats_hook_id(unsigned int slot)
 {
 	switch (slot) {
 	case 0: return VPNHIDE_HOOK_FIB_ROUTE_SEQ_SHOW;

--- a/kmod/kpm/README.md
+++ b/kmod/kpm/README.md
@@ -144,6 +144,14 @@ this is independent of KPatch-Next's generic `package_config` →
 config and pushes the same text wire through APatch/FolkPatch direct supercalls
 or KPatch-Next `kpatch kpm ctl0`.
 
+Optional boot features are intentionally outside that runtime wire. When the
+canonical `settings.kernelBootFeatures` set contains `filesystem_iface_paths`,
+the activator loads the KPM with `filesystem_hiding=1`. That atomically adds the
+four global VFS hooks (`filename_lookup`, `do_filp_open`, `vfs_getattr`, and
+`iterate_dir`); without the argument none of those hot-path hooks is installed.
+Changing the setting therefore takes effect after reboot, just like the `.ko`
+module parameter.
+
 ## Safety — read before testing on a device
 
 Inline hooks have **no kprobe safety net**: a wrong field offset in
@@ -162,10 +170,11 @@ offset table but can still fail to register a probe. Therefore:
 
 ## Validation and support boundary
 
-The KPM implements the same 11 logical kernel hooks as the `.ko`, including
-pre-mutation denial of `SO_BINDTODEVICE` and `SO_BINDTOIFINDEX`. The bind probe
-checks socket state from another UID so an errno-only override cannot pass.
-Shared host tests cover the filtering and wire-format logic.
+The KPM implements the same 11 always-on logical kernel hooks as the `.ko`,
+including pre-mutation denial of `SO_BINDTODEVICE` and `SO_BINDTOIFINDEX`, plus
+the optional filesystem-path hook group. The bind probe checks socket state
+from another UID so an errno-only override cannot pass. Shared host tests cover
+the filtering and wire-format logic.
 
 CI builds one relocatable `.kpm`, embeds it with KernelPatch, and boots these
 reference images:
@@ -185,9 +194,10 @@ reference images:
 | android16-6.12 | Android DDK GKI |
 
 For each image, the harness runs target/non-target A/B checks for interface,
-address, route, policy-rule, ioctl, and socket-bind behavior and checks for a
-kernel panic. The field offsets in `kver_offsets.h` come from the corresponding
-kernel sources and are accepted only after this harness passes.
+address, route, policy-rule, ioctl, socket-bind, and filesystem-path behavior
+and checks for a kernel panic. The field offsets in `kver_offsets.h` and the
+versioned `struct file::f_path` references come from the corresponding kernel
+sources and are accepted only after this harness passes.
 
 This matrix validates those reference kernel configurations under QEMU. Vendor
 trees can change structure layouts, compiler-generated symbols, configs, or CFI

--- a/kmod/kpm/README.md
+++ b/kmod/kpm/README.md
@@ -144,13 +144,26 @@ this is independent of KPatch-Next's generic `package_config` →
 config and pushes the same text wire through APatch/FolkPatch direct supercalls
 or KPatch-Next `kpatch kpm ctl0`.
 
-Optional boot features are intentionally outside that runtime wire. When the
-canonical `settings.kernelBootFeatures` set contains `filesystem_iface_paths`,
-the activator loads the KPM with `filesystem_hiding=1`. That atomically adds the
-four global VFS hooks (`filename_lookup`, `do_filp_open`, `vfs_getattr`, and
-`iterate_dir`); without the argument none of those hot-path hooks is installed.
-Changing the setting therefore takes effect after reboot, just like the `.ko`
-module parameter.
+### Optional filesystem hook loader contract
+
+Optional boot features are outside control v2. When canonical
+`settings.kernelBootFeatures` contains `filesystem_iface_paths`, the production
+activator passes the exact KPM load argument `filesystem_hiding=1`. When it is
+disabled, the activator passes a null/absent argument; the explicit
+`filesystem_hiding=0` spelling is also accepted as disabled but is not emitted by
+the shipped loader.
+
+The argument requests four global hooks: `filename_lookup`, `do_filp_open`,
+`vfs_getattr`, and `iterate_dir`. They install as one optional group; any failure
+rolls the group back, clears hook bit 27 from the installed mask, and produces
+`partial_hooks` telemetry while leaving the always-on KPM hooks available. The
+control-v2 `filesystem_iface_paths` bit remains the independent per-UID gate.
+Changing the boot feature therefore requires a reboot.
+
+The headless QEMU harness has no ctl0 userspace client during early bring-up, so
+KPM init additionally accepts a control-v2 snapshot in the load-argument buffer
+as a test transport. Production activation never uses that form: it loads with
+the boot-only argument above, then sends targets over ctl0.
 
 ## Safety — read before testing on a device
 

--- a/kmod/kpm/kver_offsets.h
+++ b/kmod/kpm/kver_offsets.h
@@ -107,6 +107,29 @@ struct vpnhide_offsets {
 	unsigned int fib_rule_uid_end;
 };
 
+/* VFS object layouts used only by the optional filesystem hook group. Keep
+ * them separate from vpnhide_offsets so 6.1 and 6.6 can continue sharing the
+ * much larger network-layout table even though struct file diverged in 6.6. */
+struct vpnhide_vfs_offsets {
+	unsigned int file_f_path;
+	unsigned int path_dentry;
+};
+
+static const struct vpnhide_vfs_offsets vpnhide_vfs_off_through_6_1 = {
+	.file_f_path = 16,
+	.path_dentry = 8,
+};
+
+static const struct vpnhide_vfs_offsets vpnhide_vfs_off_6_6 = {
+	.file_f_path = 168,
+	.path_dentry = 8,
+};
+
+static const struct vpnhide_vfs_offsets vpnhide_vfs_off_6_12 = {
+	.file_f_path = 64,
+	.path_dentry = 8,
+};
+
 /*
  * GKI 6.1 (android14-6.1, derived from AOSP common source + QEMU-validated).
  * Also covers 6.6 (android15-6.6): every offset here is byte-identical on 6.6,
@@ -464,6 +487,18 @@ vpnhide_select_offsets(unsigned int kver)
 	if (VPNHIDE_KVER_FAMILY(kver, 4, 9))
 		return &vpnhide_off_4_9;
 	return 0; /* never guess a layout for an unvalidated minor family */
+}
+
+static inline const struct vpnhide_vfs_offsets *
+vpnhide_select_vfs_offsets(unsigned int kver)
+{
+	if (VPNHIDE_KVER_FAMILY(kver, 6, 12))
+		return &vpnhide_vfs_off_6_12;
+	if (VPNHIDE_KVER_FAMILY(kver, 6, 6))
+		return &vpnhide_vfs_off_6_6;
+	if (vpnhide_select_offsets(kver))
+		return &vpnhide_vfs_off_through_6_1;
+	return 0;
 }
 
 #endif /* VPNHIDE_KVER_OFFSETS_H */

--- a/kmod/kpm/module/customize.sh
+++ b/kmod/kpm/module/customize.sh
@@ -17,7 +17,7 @@ set_perm "$MODPATH/service.sh" 0 0 0755
 set_perm "$MODPATH/vpnhide.kpm" 0 0 0644
 set_perm "$MODPATH/uninstall.sh" 0 0 0755
 
-# Single-active warning (protocol §1.5): the .ko and KPM wrap the SAME kernel
+# Single-active warning (docs/storage.md §4.3): .ko and KPM wrap the SAME kernel
 # functions; running both freezes the device. The boot loader refuses to load
 # the KPM while the .ko module is present AND enabled (post-fs-data.sh /
 # service.sh check the same `disable` flag), so warn here in exactly that case —

--- a/kmod/kpm/module/post-fs-data.sh
+++ b/kmod/kpm/module/post-fs-data.sh
@@ -3,9 +3,9 @@
 # apps start), and records load_status so the app can explain *why* the module
 # didn't come up without guessing. Targets are applied later, in service.sh,
 # once PackageManager is up (mirrors the .ko: post-fs-data loads, service
-# resolves UIDs). See docs/protocol.md §7.4.
+# resolves UIDs). See docs/state.md §10.
 #
-# Runtime split (protocol §7.4):
+# Runtime split (docs/state.md §10):
 #   - KPatch-Next (Magisk / KSU), keyless (d05): the activator validates the
 #     running kernel and loads here, without waiting for PackageManager.
 #   - APatch/FolkPatch: post-fs-data records a deferred status; service.sh
@@ -13,7 +13,7 @@
 #     with a saved /data/adb/vpnhide/superkey or the runtime's trusted `su`
 #     supercall grant.
 #
-# Single-active guard (protocol §1.5): if the .ko backend is installed, do NOT
+# Single-active guard (docs/storage.md §4.3): if .ko is installed, do NOT
 # load the KPM. They wrap the same kernel functions and co-residence freezes
 # the kernel. The guard is layered in userspace, fail-safe at every step:
 #   1. here (post-fs-data): defer before loading the .kpm at all;
@@ -56,7 +56,7 @@ write_status() {
     chmod 0644 "$STATUS_FILE" 2>/dev/null
 }
 
-# --- single-active guard (§1.5): defer to the .ko if it's installed+enabled --
+# --- single-active guard (docs/storage.md §4.3): defer to .ko if enabled ---
 if [ -d /data/adb/modules/vpnhide_kmod ] && \
    [ ! -f /data/adb/modules/vpnhide_kmod/disable ]; then
     log -t vpnhide "kpm: .ko backend present — not loading KPM (single-active)"

--- a/kmod/kpm/module/post-fs-data.sh
+++ b/kmod/kpm/module/post-fs-data.sh
@@ -32,6 +32,7 @@ KPM="$MODDIR/vpnhide.kpm"
 ACTIVATOR="$MODDIR/activator"
 STATUS_DIR="/data/adb/vpnhide_kpm"
 STATUS_FILE="$STATUS_DIR/load_status"
+FILESYSTEM_HIDING=""
 
 mkdir -p "$STATUS_DIR"
 
@@ -48,6 +49,7 @@ write_status() {
         printf 'uname_r=%s\n' "$(uname -r 2>/dev/null)"
         printf 'runtime=%s\n' "$1"
         printf 'loaded=%s\n' "$2"
+        printf 'filesystem_hiding=%s\n' "$FILESYSTEM_HIDING"
         printf 'reason=%s\n' "$3"
         printf 'detail=%s\n' "$(sanitize "$4")"
     } > "$STATUS_FILE.tmp" && mv "$STATUS_FILE.tmp" "$STATUS_FILE"
@@ -71,6 +73,14 @@ if [ ! -x "$ACTIVATOR" ]; then
     write_status activator 0 missing_activator "activator missing at $ACTIVATOR"
     exit 1
 fi
+
+"$ACTIVATOR" boot-feature-enabled filesystem_iface_paths >/dev/null 2>&1
+feature_rc=$?
+case "$feature_rc" in
+    0) FILESYSTEM_HIDING=1 ;;
+    1) FILESYSTEM_HIDING=0 ;;
+    *) FILESYSTEM_HIDING="" ;;
+esac
 
 # --- APatch/FolkPatch: service activator owns load/config -------------------
 if [ -d /data/adb/ap ]; then

--- a/kmod/kpm/module/service.sh
+++ b/kmod/kpm/module/service.sh
@@ -7,6 +7,7 @@ ACTIVATOR="$MODDIR/activator"
 KPM="$MODDIR/vpnhide.kpm"
 STATUS_DIR="/data/adb/vpnhide_kpm"
 STATUS_FILE="$STATUS_DIR/load_status"
+FILESYSTEM_HIDING=""
 
 sanitize() {
     printf '%s' "$1" | tr '\n' ' ' | cut -c 1-240
@@ -20,10 +21,32 @@ write_status() {
         printf 'uname_r=%s\n' "$(uname -r 2>/dev/null)"
         printf 'runtime=%s\n' "$1"
         printf 'loaded=%s\n' "$2"
+        printf 'filesystem_hiding=%s\n' "$FILESYSTEM_HIDING"
         printf 'reason=%s\n' "$3"
         printf 'detail=%s\n' "$(sanitize "$4")"
     } > "$STATUS_FILE.tmp" && mv "$STATUS_FILE.tmp" "$STATUS_FILE"
     chmod 0644 "$STATUS_FILE" 2>/dev/null
+}
+
+filesystem_hiding_for_load() {
+    current_boot_id="$(cat /proc/sys/kernel/random/boot_id 2>/dev/null)"
+    status_boot_id="$(sed -n 's/^boot_id=//p' "$STATUS_FILE" 2>/dev/null | head -n 1)"
+    status_loaded="$(sed -n 's/^loaded=//p' "$STATUS_FILE" 2>/dev/null | head -n 1)"
+    status_feature="$(sed -n 's/^filesystem_hiding=//p' "$STATUS_FILE" 2>/dev/null | head -n 1)"
+    if [ "$status_boot_id" = "$current_boot_id" ] && [ "$status_loaded" = 1 ]; then
+        case "$status_feature" in
+            0|1)
+                printf '%s' "$status_feature"
+                return
+                ;;
+        esac
+    fi
+
+    "$ACTIVATOR" boot-feature-enabled filesystem_iface_paths >/dev/null 2>&1
+    case "$?" in
+        0) printf '1' ;;
+        1) printf '0' ;;
+    esac
 }
 
 apply_at_boot() {
@@ -47,6 +70,8 @@ apply_at_boot() {
         write_status activator 0 missing_kpm "vpnhide.kpm missing at $KPM"
         return 1
     fi
+
+    FILESYSTEM_HIDING="$(filesystem_hiding_for_load)"
 
     out="$("$ACTIVATOR" --boot-wait 2>&1)"
     rc=$?

--- a/kmod/kpm/module/service.sh
+++ b/kmod/kpm/module/service.sh
@@ -50,7 +50,8 @@ filesystem_hiding_for_load() {
 }
 
 apply_at_boot() {
-    # Single-active guard (§1.5), checked before the APatch superkey branch so
+    # Single-active guard (docs/storage.md §4.3), checked before the APatch
+    # superkey branch so
     # a co-installed .ko isn't masked as `awaiting_superkey`. Cheap, fail-safe,
     # ordering-independent floor; the activator re-checks (a superset, incl. a
     # live /proc/vpnhide_ctl) below and exits 3 if it still sees the .ko.

--- a/kmod/kpm/vpnhide_kpm.c
+++ b/kmod/kpm/vpnhide_kpm.c
@@ -10,8 +10,9 @@
  *
  * STATUS: builds (`make kpm`) and runs end-to-end under QEMU via the KPM
  * harness (../test/run-kpm.sh). CI boots representative images for every
- * offset table and checks all enumeration vectors; socket-bind denial adds a
- * state-level check that verifies the socket stayed unbound, not just errno.
+ * offset table and checks all enumeration and optional filesystem vectors;
+ * socket-bind denial adds a state-level check that verifies the socket stayed
+ * unbound, not just errno.
  * Runtime config/status/stats use KernelPatch's ctl0 supercall; the QEMU A/B
  * harness passes the same control-v2 snapshot as load args for headless
  * bring-up. Every per-kver
@@ -64,6 +65,7 @@ KPM_DESCRIPTION("Hide VPN interfaces from selected UIDs (KPM backend, beta)");
 /* ------------------------------------------------------------------ */
 
 static const struct vpnhide_offsets *off; /* selected per running kver */
+static const struct vpnhide_vfs_offsets *vfs_off;
 
 /* Live config (protocol §4.3). Each target carries a per-hook mask so the app
  * can enable hooks individually; a hook fires only if its bit is set for the
@@ -97,6 +99,10 @@ static int nr_targets;
  * and makes it the exception list. */
 static uint32_t default_hookmask;
 static uint32_t active_hook_mask;
+/* Locked at module load: these globally hot hooks cannot be added or removed by
+ * a later ctl0 config. The canonical kernelBootFeatures setting is projected
+ * into KPM load args by the activator. */
+static bool filesystem_hiding_requested;
 
 /*
  * First uid Android hands to an ordinary app; everything below is a system AID
@@ -120,7 +126,7 @@ static uint32_t last_error;
 /* Exact registrations owned by this KPM. Teardown must unwrap the same
  * compiler clone that install_hook resolved, and only after hook_wrap actually
  * succeeded; resolving names again during exit cannot guarantee either. */
-#define VPNHIDE_MAX_HOOK_REGISTRATIONS 12
+#define VPNHIDE_MAX_HOOK_REGISTRATIONS 16
 struct vpnhide_hook_registration {
 	void *function;
 	void *before;
@@ -130,14 +136,14 @@ static struct vpnhide_hook_registration
 	hook_registrations[VPNHIDE_MAX_HOOK_REGISTRATIONS];
 static unsigned int nr_hook_registrations;
 
-/* Native interception stats, cumulative since KPM load. Only the 11
- * kernel-owned hooks need storage; the global 27-id space also contains
- * LSPosed/Zygisk hooks that can never fire here. A zero UID is the empty-slot
+/* Native interception stats, cumulative since KPM load. The dense KPM mapping
+ * stores the shared kernel hooks plus its optional filesystem hook; the global
+ * id space also contains LSPosed/Zygisk hooks that can never fire here. A zero UID is the empty-slot
  * sentinel (system AIDs are unconditionally excluded), claimed atomically by
  * open addressing so concurrent first hits for one UID converge on one slot. */
 static uint32_t stats_uids[MAX_TARGET_UIDS];
 static unsigned long long stats_counts[MAX_TARGET_UIDS]
-				      [VPNHIDE_KERNEL_HOOK_COUNT];
+				      [VPNHIDE_KPM_STATS_HOOK_COUNT];
 /* KernelPatch and both userspace clients cap one ctl0 reply at 4096 bytes.
  * Stats are cursor-paged by UID; status remains a small single reply. */
 #define VPNHIDE_OUT_MAX 4096
@@ -150,6 +156,10 @@ static unsigned long (*_copy_to_user)(void *, const void *, unsigned long);
 static uint64_t (*_read_sanitised_ftr_reg)(uint32_t);
 static void (*_skb_trim)(void *, unsigned int);
 static int (*_netdev_get_name)(void *, char *, int);
+static char *(*_dentry_path_raw)(void *, char *, int);
+static int (*_vfs_statfs)(const void *, void *);
+static void (*_path_put)(const void *);
+static void (*_fput)(void *);
 
 /* Linux sys_reg(3, 0, 0, 7, 1); ID_AA64MMFR1_EL1.PAN is bits [23:20]. */
 #define VPNHIDE_SYS_ID_AA64MMFR1_EL1 0x180720u
@@ -327,7 +337,7 @@ static void record_hook_hit(enum vpnhide_hook_id hook_id)
 {
 	int hook_slot, uid_slot;
 
-	hook_slot = vpnhide_kernel_hook_slot(hook_id);
+	hook_slot = vpnhide_kpm_stats_hook_slot(hook_id);
 	if (hook_slot < 0)
 		return;
 	uid_slot = stats_slot_for_uid((uint32_t)current_uid());
@@ -363,7 +373,7 @@ static unsigned long format_stats_row(char *buf, unsigned long cap,
 	int hook, have_count = 0;
 
 	vpnhide_put_hex(&b, uid);
-	for (hook = 0; hook < VPNHIDE_KERNEL_HOOK_COUNT; hook++) {
+	for (hook = 0; hook < VPNHIDE_KPM_STATS_HOOK_COUNT; hook++) {
 		unsigned long long count = __atomic_load_n(
 			&stats_counts[uid_slot][hook], __ATOMIC_RELAXED);
 
@@ -371,7 +381,7 @@ static unsigned long format_stats_row(char *buf, unsigned long cap,
 			continue;
 		have_count = 1;
 		vpnhide_putc(&b, ' ');
-		vpnhide_put_hex(&b, vpnhide_kernel_hook_id(hook));
+		vpnhide_put_hex(&b, vpnhide_kpm_stats_hook_id(hook));
 		vpnhide_putc(&b, ':');
 		vpnhide_put_hex(&b, count);
 	}
@@ -1228,6 +1238,346 @@ static void fib_rule_after(hook_fargs8_t *fargs, void *udata)
 	finish_skb_filter(fargs, VPNHIDE_HOOK_FIB_NL_FILL_RULE);
 }
 
+/* ================================================================== */
+/*  Optional filesystem path concealment                              */
+/*                                                                    */
+/*  Like the .ko backend, KPM evaluates the resolved dentry rather    */
+/*  than a userspace pathname, so relative openat, symlink traversal, */
+/*  and bind mounts cannot bypass it. dentry_path_raw owns the rename */
+/*  lock/RCU walk; vfs_statfs distinguishes sysfs/procfs without      */
+/*  duplicating unstable dentry/super_block layouts in this module.   */
+/* ================================================================== */
+
+#define VPNHIDE_ENOENT ((uint64_t)(-2))
+#define VPNHIDE_RESOLVED_PATH_MAX 512
+#define VPNHIDE_PROC_SUPER_MAGIC 0x9fa0UL
+#define VPNHIDE_SYSFS_MAGIC 0x62656572UL
+#define VPNHIDE_READDIR_MARKER 0x76706e6869646572ULL
+
+static void *file_path(void *file)
+{
+	return file ? (char *)file + vfs_off->file_f_path : 0;
+}
+
+static int string_equals(const char *left, const char *right)
+{
+	int i;
+
+	if (!left || !right)
+		return 0;
+	for (i = 0; left[i] && right[i]; i++)
+		if (left[i] != right[i])
+			return 0;
+	return left[i] == right[i];
+}
+
+static const char *string_after_prefix(const char *value, const char *prefix)
+{
+	int i;
+
+	if (!value || !prefix)
+		return 0;
+	for (i = 0; prefix[i]; i++)
+		if (value[i] != prefix[i])
+			return 0;
+	return value + i;
+}
+
+static int segment_equals(const char *segment, unsigned int len,
+			  const char *literal)
+{
+	unsigned int i;
+
+	for (i = 0; i < len && literal[i]; i++)
+		if (segment[i] != literal[i])
+			return 0;
+	return i == len && literal[i] == '\0';
+}
+
+static int vpn_segment(const char *segment)
+{
+	char iface[VPNHIDE_IFNAMSIZ];
+	unsigned int len = 0;
+
+	if (!segment)
+		return 0;
+	while (segment[len] && segment[len] != '/') {
+		if (len + 1 >= sizeof(iface))
+			return 0;
+		iface[len] = segment[len];
+		len++;
+	}
+	if (!len)
+		return 0;
+	iface[len] = '\0';
+	return iface_is_vpn(iface);
+}
+
+static int sysfs_iface_path(const char *path)
+{
+	const char *segment = path;
+	const char *previous = 0;
+	unsigned int previous_len = 0;
+
+	if (!path || *path != '/')
+		return 0;
+	while (*segment) {
+		const char *end;
+
+		while (*segment == '/')
+			segment++;
+		if (!*segment)
+			break;
+		end = segment;
+		while (*end && *end != '/')
+			end++;
+		if (previous && segment_equals(previous, previous_len, "net") &&
+		    vpn_segment(segment))
+			return 1;
+		previous = segment;
+		previous_len = (unsigned int)(end - segment);
+		segment = end;
+	}
+	return 0;
+}
+
+static int proc_iface_path(const char *path)
+{
+	static const char *const prefixes[] = {
+		"/sys/net/ipv4/conf/",
+		"/sys/net/ipv4/neigh/",
+		"/sys/net/ipv6/conf/",
+		"/sys/net/ipv6/neigh/",
+	};
+	unsigned int i;
+
+	for (i = 0; i < sizeof(prefixes) / sizeof(prefixes[0]); i++) {
+		const char *iface = string_after_prefix(path, prefixes[i]);
+
+		if (iface && vpn_segment(iface))
+			return 1;
+	}
+	return 0;
+}
+
+static int proc_iface_listing(const char *path)
+{
+	return string_equals(path, "/sys/net/ipv4/conf") ||
+	       string_equals(path, "/sys/net/ipv4/neigh") ||
+	       string_equals(path, "/sys/net/ipv6/conf") ||
+	       string_equals(path, "/sys/net/ipv6/neigh");
+}
+
+static int sysfs_iface_listing(const char *path)
+{
+	const char *last = path;
+	const char *cursor;
+
+	if (!path || *path != '/')
+		return 0;
+	for (cursor = path; *cursor; cursor++)
+		if (*cursor == '/' && cursor[1])
+			last = cursor + 1;
+	return string_equals(last, "net");
+}
+
+static int error_pointer(const void *pointer)
+{
+	return (unsigned long)pointer >= (unsigned long)-4095;
+}
+
+static const char *resolved_dentry_path(const void *path, char *buf, int buflen)
+{
+	void *dentry;
+	char *resolved;
+
+	if (!path || !_dentry_path_raw)
+		return 0;
+	dentry = *(void **)((char *)path + vfs_off->path_dentry);
+	if (!dentry)
+		return 0;
+	resolved = _dentry_path_raw(dentry, buf, buflen);
+	return !resolved || error_pointer(resolved) ? 0 : resolved;
+}
+
+static unsigned long path_filesystem_magic(const void *path)
+{
+	/* struct kstatfs.f_type is its first long on every supported arm64 ABI.
+	 * Keep ample opaque storage for the helper without importing kernel headers. */
+	unsigned long statfs_words[32] = { 0 };
+
+	if (!_vfs_statfs || _vfs_statfs(path, statfs_words) != 0)
+		return 0;
+	return statfs_words[0];
+}
+
+static int hidden_iface_path(const void *path)
+{
+	char buf[VPNHIDE_RESOLVED_PATH_MAX];
+	const char *resolved = resolved_dentry_path(path, buf, sizeof(buf));
+
+	if (!resolved)
+		return 0;
+	if (sysfs_iface_path(resolved))
+		return path_filesystem_magic(path) == VPNHIDE_SYSFS_MAGIC;
+	if (proc_iface_path(resolved))
+		return path_filesystem_magic(path) == VPNHIDE_PROC_SUPER_MAGIC;
+	return 0;
+}
+
+static int iface_listing_path(const void *path)
+{
+	char buf[VPNHIDE_RESOLVED_PATH_MAX];
+	const char *resolved = resolved_dentry_path(path, buf, sizeof(buf));
+
+	if (!resolved)
+		return 0;
+	if (sysfs_iface_listing(resolved))
+		return path_filesystem_magic(path) == VPNHIDE_SYSFS_MAGIC;
+	if (proc_iface_listing(resolved))
+		return path_filesystem_magic(path) == VPNHIDE_PROC_SUPER_MAGIC;
+	return 0;
+}
+
+static int filesystem_filter_active(void)
+{
+	return filesystem_hiding_requested &&
+	       hook_active(VPNHIDE_HOOK_FILESYSTEM_IFACE_PATHS);
+}
+
+static void filename_lookup_after(hook_fargs5_t *fargs, void *udata)
+{
+	void *path = (void *)fargs->arg3;
+
+	if ((long)fargs->ret != 0 || !filesystem_filter_active() ||
+	    !hidden_iface_path(path))
+		return;
+	_path_put(path);
+	*(uint64_t *)path = 0;
+	*(uint64_t *)((char *)path + vfs_off->path_dentry) = 0;
+	fargs->ret = VPNHIDE_ENOENT;
+	record_hook_hit(VPNHIDE_HOOK_FILESYSTEM_IFACE_PATHS);
+}
+
+static void do_filp_open_after(hook_fargs3_t *fargs, void *udata)
+{
+	void *file = (void *)fargs->ret;
+
+	if (!file || error_pointer(file) || !filesystem_filter_active() ||
+	    !hidden_iface_path(file_path(file)))
+		return;
+	_fput(file);
+	fargs->ret = VPNHIDE_ENOENT;
+	record_hook_hit(VPNHIDE_HOOK_FILESYSTEM_IFACE_PATHS);
+}
+
+static void vfs_getattr_after(hook_fargs4_t *fargs, void *udata)
+{
+	if ((long)fargs->ret != 0 || !filesystem_filter_active() ||
+	    !hidden_iface_path((void *)fargs->arg0))
+		return;
+	fargs->ret = VPNHIDE_ENOENT;
+	record_hook_hit(VPNHIDE_HOOK_FILESYSTEM_IFACE_PATHS);
+}
+
+struct vpnhide_readdir_context {
+	void *actor;
+	long long pos;
+	void *original_context;
+	void *original_actor;
+};
+
+static int filter_dirent_name(const char *name, int namelen)
+{
+	char iface[VPNHIDE_IFNAMSIZ];
+	int i;
+
+	if (!name || namelen <= 0 || namelen >= (int)sizeof(iface))
+		return 0;
+	for (i = 0; i < namelen; i++)
+		iface[i] = name[i];
+	iface[namelen] = '\0';
+	return iface_is_vpn(iface);
+}
+
+static int vpnhide_filldir_int(struct vpnhide_readdir_context *ctx,
+			       const char *name, int namelen, long long offset,
+			       uint64_t ino, unsigned int d_type)
+{
+	typedef int (*actor_fn)(void *, const char *, int, long long, uint64_t,
+				unsigned int);
+	long long *original_pos;
+	int result;
+
+	if (filter_dirent_name(name, namelen)) {
+		record_hook_hit(VPNHIDE_HOOK_FILESYSTEM_IFACE_PATHS);
+		return 0;
+	}
+	original_pos =
+		(long long *)((char *)ctx->original_context + sizeof(void *));
+	*original_pos = ctx->pos;
+	result = ((actor_fn)ctx->original_actor)(ctx->original_context, name,
+						 namelen, offset, ino, d_type);
+	ctx->pos = *original_pos;
+	return result;
+}
+
+static bool vpnhide_filldir_bool(struct vpnhide_readdir_context *ctx,
+				 const char *name, int namelen,
+				 long long offset, uint64_t ino,
+				 unsigned int d_type)
+{
+	typedef bool (*actor_fn)(void *, const char *, int, long long, uint64_t,
+				 unsigned int);
+	long long *original_pos;
+	bool result;
+
+	if (filter_dirent_name(name, namelen)) {
+		record_hook_hit(VPNHIDE_HOOK_FILESYSTEM_IFACE_PATHS);
+		return true;
+	}
+	original_pos =
+		(long long *)((char *)ctx->original_context + sizeof(void *));
+	*original_pos = ctx->pos;
+	result = ((actor_fn)ctx->original_actor)(ctx->original_context, name,
+						 namelen, offset, ino, d_type);
+	ctx->pos = *original_pos;
+	return result;
+}
+
+static void iterate_dir_before(hook_fargs2_t *fargs, void *udata)
+{
+	struct vpnhide_readdir_context *wrapper =
+		(struct vpnhide_readdir_context *)&fargs->local;
+	void *context = (void *)fargs->arg1;
+
+	fargs->local.data4 = 0;
+	if (!context || !*(void **)context || !filesystem_filter_active() ||
+	    !iface_listing_path(file_path((void *)fargs->arg0)))
+		return;
+	wrapper->actor = (unsigned int)kver >= VPNHIDE_KVER(6, 1, 0) ?
+				 (void *)vpnhide_filldir_bool :
+				 (void *)vpnhide_filldir_int;
+	wrapper->pos = *(long long *)((char *)context + sizeof(void *));
+	wrapper->original_context = context;
+	wrapper->original_actor = *(void **)context;
+	fargs->local.data4 = VPNHIDE_READDIR_MARKER;
+	fargs->arg1 = (uint64_t)wrapper;
+}
+
+static void iterate_dir_after(hook_fargs2_t *fargs, void *udata)
+{
+	struct vpnhide_readdir_context *wrapper =
+		(struct vpnhide_readdir_context *)&fargs->local;
+
+	if (fargs->local.data4 != VPNHIDE_READDIR_MARKER ||
+	    !wrapper->original_context)
+		return;
+	*(long long *)((char *)wrapper->original_context + sizeof(void *)) =
+		wrapper->pos;
+	fargs->arg1 = (uint64_t)wrapper->original_context;
+}
+
 /*
  * HOOK COVERAGE — parity with vpnhide_kmod.c (the .ko). CI exercises these
  * paths in booted QEMU images for 4.9, 4.14, 4.19, 5.4, 5.10, 5.15, 6.1,
@@ -1260,6 +1610,8 @@ static void fib_rule_after(hook_fargs8_t *fargs, void *udata)
  *   fib_nl_fill_rule       RTM_GETRULE            ✓ (fib_rule iif/oif/uid)
  *   socket_bind_interface SO_BINDTODEVICE/index  ✓ (pre-mutation ENODEV;
  *                                                   state-aware raw-syscall test)
+ *   filesystem_iface_paths sysfs/proc-sys VFS    ✓ (optional boot-time group;
+ *                                                   lookup/open/stat/readdir)
  *   ( rt_fill_info — intentionally NOT hooked; unstable arg->reg ABI )
  *
  * Both host-route predicates (v4 + v6) and their address/iface logic are
@@ -1422,6 +1774,20 @@ static int resolve_symbols(void)
 	return 0;
 }
 
+static int resolve_filesystem_symbols(void)
+{
+	_dentry_path_raw = (void *)kallsyms_lookup_name("dentry_path_raw");
+	_vfs_statfs = (void *)kallsyms_lookup_name("vfs_statfs");
+	_path_put = (void *)kallsyms_lookup_name("path_put");
+	_fput = (void *)kallsyms_lookup_name("fput");
+	if (_dentry_path_raw && _vfs_statfs && _path_put && _fput)
+		return 0;
+	logki(MODNAME
+	      ": filesystem helpers unavailable (dentry_path_raw=%p vfs_statfs=%p path_put=%p fput=%p)\n",
+	      _dentry_path_raw, _vfs_statfs, _path_put, _fput);
+	return -1;
+}
+
 /* Parse and atomically apply the one supported config representation. Both the
  * runtime ctl0 path and the QEMU harness's optional load args use the frozen
  * control-v2 wire, so they cannot drift into separate parsers or semantics. */
@@ -1448,12 +1814,14 @@ static int apply_config(const char *wire, unsigned long wire_len)
 				 __ATOMIC_RELAXED);
 		__atomic_store_n(&target_masks[i],
 				 config_staging[i].hookmask &
-					 VPNHIDE_KERNEL_HOOK_MASK,
+					 (VPNHIDE_KERNEL_HOOK_MASK |
+					  VPNHIDE_KPM_HOOK_MASK),
 				 __ATOMIC_RELAXED);
 	}
 	__atomic_store_n(&nr_targets, n, __ATOMIC_RELAXED);
 	__atomic_store_n(&default_hookmask,
-			 default_mask & VPNHIDE_KERNEL_HOOK_MASK,
+			 default_mask & (VPNHIDE_KERNEL_HOOK_MASK |
+					 VPNHIDE_KPM_HOOK_MASK),
 			 __ATOMIC_RELAXED);
 	__atomic_store_n(&active_hook_mask, compute_active_hook_mask(n),
 			 __ATOMIC_RELAXED);
@@ -1486,6 +1854,43 @@ static int install_hook(const char *name, int argno, void *before, void *after,
 	return 0;
 }
 
+static void rollback_hook_registrations(unsigned int keep)
+{
+	while (nr_hook_registrations > keep) {
+		struct vpnhide_hook_registration *registration =
+			&hook_registrations[--nr_hook_registrations];
+
+		hook_unwrap(registration->function, registration->before,
+			    registration->after);
+	}
+}
+
+static int install_filesystem_hooks(void)
+{
+	unsigned int registration_start = nr_hook_registrations;
+	int getattr_argno = (unsigned int)kver < VPNHIDE_KVER(4, 11, 0) ? 2 : 4;
+
+	if (resolve_filesystem_symbols() != 0)
+		return 0;
+	if (!install_hook("filename_lookup", 5, 0,
+			  (void *)filename_lookup_after,
+			  VPNHIDE_HOOK_FILESYSTEM_IFACE_PATHS) ||
+	    !install_hook("do_filp_open", 3, 0, (void *)do_filp_open_after,
+			  VPNHIDE_HOOK_FILESYSTEM_IFACE_PATHS) ||
+	    !install_hook("vfs_getattr", getattr_argno, 0,
+			  (void *)vfs_getattr_after,
+			  VPNHIDE_HOOK_FILESYSTEM_IFACE_PATHS) ||
+	    !install_hook("iterate_dir", 2, (void *)iterate_dir_before,
+			  (void *)iterate_dir_after,
+			  VPNHIDE_HOOK_FILESYSTEM_IFACE_PATHS)) {
+		rollback_hook_registrations(registration_start);
+		installed_hooks &=
+			~vpnhide_hook_bit(VPNHIDE_HOOK_FILESYSTEM_IFACE_PATHS);
+		return 0;
+	}
+	return 1;
+}
+
 static long vpnhide_kpm_init(const char *args, const char *event,
 			     void *__user reserved)
 {
@@ -1505,11 +1910,17 @@ static long vpnhide_kpm_init(const char *args, const char *event,
 	__atomic_store_n(&default_hookmask, 0, __ATOMIC_RELAXED);
 	__atomic_store_n(&active_hook_mask, 0, __ATOMIC_RELAXED);
 	__atomic_store_n(&debug_enabled, false, __ATOMIC_RELAXED);
+	filesystem_hiding_requested = false;
+	_dentry_path_raw = 0;
+	_vfs_statfs = 0;
+	_path_put = 0;
+	_fput = 0;
 
 	/* `kver` is KernelPatch's running-kernel version (common.h), encoded
 	 * the same way as VPNHIDE_KVER. NULL table = unsupported → bail. */
 	off = vpnhide_select_offsets((unsigned int)kver);
-	if (!off) {
+	vfs_off = vpnhide_select_vfs_offsets((unsigned int)kver);
+	if (!off || !vfs_off) {
 		logki(MODNAME
 		      ": unsupported kernel version — refusing to install\n");
 		return -1; /* never guess offsets */
@@ -1519,15 +1930,25 @@ static long vpnhide_kpm_init(const char *args, const char *event,
 		return -1;
 	}
 
-	/* The headless QEMU harness may supply an initial snapshot through load
-	 * args. It is the same control-v2 payload as ctl0, not a second legacy UID
-	 * grammar. Production activation normally applies it through ctl0. */
+	/* Production passes the same boot-only switch as the .ko module parameter.
+	 * The headless QEMU harness may instead supply its initial control-v2
+	 * snapshot through load args; presence of the KPM-owned optional bit in that
+	 * snapshot requests the same hook group. Runtime target config still uses
+	 * ctl0 and cannot add or remove globally installed hooks. */
 	if (args && args[0]) {
-		while (args[args_len])
-			args_len++;
-		if (apply_config(args, args_len) != 0) {
-			logki(MODNAME ": invalid initial config snapshot\n");
-			return -1;
+		if (string_equals(args, "filesystem_hiding=1")) {
+			filesystem_hiding_requested = true;
+		} else if (!string_equals(args, "filesystem_hiding=0")) {
+			while (args[args_len])
+				args_len++;
+			if (apply_config(args, args_len) != 0) {
+				logki(MODNAME ": invalid KPM load arguments\n");
+				return -1;
+			}
+			filesystem_hiding_requested =
+				(__atomic_load_n(&active_hook_mask,
+						 __ATOMIC_RELAXED) &
+				 VPNHIDE_KPM_HOOK_MASK) != 0;
 		}
 	}
 
@@ -1610,16 +2031,23 @@ static long vpnhide_kpm_init(const char *args, const char *event,
 			installed_hooks &= ~vpnhide_hook_bit(
 				VPNHIDE_HOOK_SOCKET_BIND_INTERFACE);
 	}
+	if (filesystem_hiding_requested && !install_filesystem_hooks())
+		logki(MODNAME
+		      ": optional filesystem hook group failed atomically\n");
 
-	/* Healthy iff every kernel-owned hook installed; otherwise honestly
+	/* Healthy iff every requested hook installed; otherwise honestly
 	 * report partial — the `hooks` mask carries which ones (§5.1). A kver
 	 * with an incomplete offset table lands here by design. */
-	last_error = (installed_hooks == VPNHIDE_KERNEL_HOOK_MASK) ?
-			     VPNHIDE_ERR_OK :
-			     VPNHIDE_ERR_PARTIAL_HOOKS;
+	last_error =
+		(installed_hooks ==
+		 (VPNHIDE_KERNEL_HOOK_MASK |
+		  (filesystem_hiding_requested ? VPNHIDE_KPM_HOOK_MASK : 0))) ?
+			VPNHIDE_ERR_OK :
+			VPNHIDE_ERR_PARTIAL_HOOKS;
 
-	logki(MODNAME ": KPM hooks installed (mask=0x%x err=%u)\n",
-	      installed_hooks, last_error);
+	logki(MODNAME
+	      ": KPM hooks installed (mask=0x%x filesystem_hiding=%d err=%u)\n",
+	      installed_hooks, filesystem_hiding_requested ? 1 : 0, last_error);
 	return 0;
 }
 
@@ -1701,13 +2129,7 @@ static long vpnhide_kpm_ctl0(const char *args, char *__user out_msg, int outlen)
 
 static long vpnhide_kpm_exit(void *__user reserved)
 {
-	while (nr_hook_registrations > 0) {
-		struct vpnhide_hook_registration *registration =
-			&hook_registrations[--nr_hook_registrations];
-
-		hook_unwrap(registration->function, registration->before,
-			    registration->after);
-	}
+	rollback_hook_registrations(0);
 	installed_hooks = 0;
 
 	logki(MODNAME ": KPM unloaded\n");

--- a/kmod/shared/vpnhide_logic.h
+++ b/kmod/shared/vpnhide_logic.h
@@ -240,10 +240,10 @@ vpnhide_compact_seq_lines(char *buf, unsigned long start, unsigned long count,
 /*  the C side of that parity — keep it byte-faithful to the spec, and pin */
 /*  every change with a vector in shared/protocol_vectors.tsv.            */
 /*                                                                        */
-/*  Roles (protocol §1.4): a kernel backend PARSES config and EMITS       */
+/*  Roles (protocol §1.3): a kernel backend PARSES config and EMITS       */
 /*  stats/status. So C implements vpnhide_parse_config + vpnhide_format_* */
-/*  only; the app side (parse stats/status, serialise config) lives in    */
-/*  Kotlin. peek_kind + clamp_to_line serve the KPM ctl0 transport (§7).  */
+/*  only; Rust activators serialise config and the Kotlin app parses      */
+/*  telemetry. peek_kind + clamp_to_line serve KPM ctl0 transport (§7).   */
 /* ====================================================================== */
 
 /*

--- a/kmod/test/README.md
+++ b/kmod/test/README.md
@@ -115,8 +115,8 @@ setup. The KPM loads at boot (KernelPatch hijacks `paging_init`), so there
 is no insmod and no `/proc` dependency — the same control-v2 snapshot used by
 runtime ctl0 is passed via embedded extra-args (`kptools -A`). The A/B is done across **two boots**
 (no target → app UID 10000 sees `vpn0`; target=10000 → it doesn't), driven by
-`init-kpm.sh`. The original 10 enumeration hooks plus socket-bind state checks
-run with no panic across the CI reference set — 4.9, 4.14, 4.19, 5.4, 5.10,
+`init-kpm.sh`. The 10 enumeration hooks, socket-bind state checks, and optional
+sysfs/proc-sys stat/open/readdir checks run with no panic across the CI reference set — 4.9, 4.14, 4.19, 5.4, 5.10,
 5.15, 6.1, 6.6, 6.12 (the modern GKI ones via
 the DDK `Image`, the legacy AOSP ones via a from-source `Image` passed with
 `VPNHIDE_QEMU_IMAGE=`). Legacy kernels that natively require `CAP_NET_RAW` for

--- a/kmod/test/init-kpm.sh
+++ b/kmod/test/init-kpm.sh
@@ -94,6 +94,13 @@ echo "VEC hostroute6=$(run_as_target "ip -6 route show table all 2>/dev/null | g
 echo "VEC netlink_route6=$(run_as_target 'ip -6 route show table all 2>/dev/null | grep -c vpn0')"  # rt6_fill_node
 echo "VEC policy_rule=$(run_as_target 'ip rule show 2>/dev/null | grep -c 199')"                    # fib_nl_fill_rule
 echo "VEC keep_policy_rule=$(run_as_target "ip rule show 2>/dev/null | grep -c 'lookup main'")"
+echo "VEC sysfs_stat=$(run_as_target 'test -e /sys/class/net/vpn0 && echo vpn0' | grep -c vpn0)"
+echo "VEC sysfs_open=$(run_as_target 'cat /sys/class/net/vpn0/mtu 2>/dev/null && echo vpn0' | grep -c vpn0)"
+echo "VEC sysfs_readdir=$(run_as_target 'ls /sys/class/net 2>/dev/null' | grep -c vpn0)"
+echo "VEC keep_sysfs_readdir=$(run_as_target 'ls /sys/class/net 2>/dev/null' | grep -c eth0)"
+echo "VEC proc_sys_stat=$(run_as_target 'test -e /proc/sys/net/ipv4/conf/vpn0 && echo vpn0' | grep -c vpn0)"
+echo "VEC proc_sys_readdir=$(run_as_target 'ls /proc/sys/net/ipv4/conf 2>/dev/null' | grep -c vpn0)"
+echo "VEC keep_proc_sys_readdir=$(run_as_target 'ls /proc/sys/net/ipv4/conf 2>/dev/null' | grep -c eth0)"
 # Native getifaddrs() (RTM_GETLINK+RTM_GETADDR) — isolates inet*_fill_ifaddr.
 if [ -x /gai ]; then
 	GAI_OUT=$(run_as_target /gai 2>/dev/null)

--- a/kmod/test/run-kpm.sh
+++ b/kmod/test/run-kpm.sh
@@ -194,7 +194,7 @@ NT_LOG="$(boot_phase "" notarget)"
 # Both shell vectors and the state-aware bind probe use app uid 10000 (0x2710).
 # The harness passes the same control-v2 snapshot as runtime ctl0; load args are
 # only the transport needed before the in-VM userspace client is available.
-TARGET_CONFIG=$'vpnhide 2 config\ndebug 0\ntargets 20003ff 2710\nend 1\n'
+TARGET_CONFIG=$'vpnhide 2 config\ndebug 0\ntargets a0003ff 2710\nend 1\n'
 TG_LOG="$(boot_phase "$TARGET_CONFIG" target)"
 
 vec_count() { grep -oE "VEC $1=[0-9]+" "$2" | head -1 | grep -oE '[0-9]+$' || echo "-1"; }
@@ -203,7 +203,7 @@ panic_count() { grep -oE 'PANIC=[0-9]+' "$1" | head -1 | grep -oE '[0-9]+$' || e
 kpmload() { grep -q 'KPMLOAD=ok' "$1" && echo ok || echo FAIL; }
 keep_mode() {
 	case "$1" in
-		keep_proc_route_v4|keep_getifaddrs|keep_siocgifconf|keep_dev_ioctl|keep_policy_rule)
+		keep_proc_route_v4|keep_getifaddrs|keep_siocgifconf|keep_dev_ioctl|keep_policy_rule|keep_sysfs_readdir|keep_proc_sys_readdir)
 			echo exact
 			;;
 		*)
@@ -347,7 +347,7 @@ else
 	fi
 fi
 
-for vec in proc_route_v4 getifaddrs proc_route_v6 siocgifconf dev_ioctl netlink_route4 hostroute4 netlink_route6 hostroute6 policy_rule gai_getifaddrs; do
+for vec in proc_route_v4 getifaddrs proc_route_v6 siocgifconf dev_ioctl netlink_route4 hostroute4 netlink_route6 hostroute6 policy_rule sysfs_stat sysfs_open sysfs_readdir proc_sys_stat proc_sys_readdir gai_getifaddrs; do
 	# The gai_getifaddrs vector only exists when the bionic probe is available
 	# (baked VPNHIDE_GAI_BIN, or built from an NDK on this host). If neither is
 	# present the probe can't run, so skip the vector instead of failing it.
@@ -368,7 +368,7 @@ for vec in proc_route_v4 getifaddrs proc_route_v6 siocgifconf dev_ioctl netlink_
 	fi
 done
 
-for vec in keep_proc_route_v4 keep_getifaddrs keep_siocgifconf keep_dev_ioctl keep_netlink_route4 keep_policy_rule keep_gai_getifaddrs; do
+for vec in keep_proc_route_v4 keep_getifaddrs keep_siocgifconf keep_dev_ioctl keep_netlink_route4 keep_policy_rule keep_sysfs_readdir keep_proc_sys_readdir keep_gai_getifaddrs; do
 	if [ "$vec" = keep_gai_getifaddrs ] && [ -z "$GAI" ]; then
 		echo "RESULT $vec=SKIP (no bionic getifaddrs probe available)"; SKIP=$((SKIP+1)); continue
 	fi

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/AppPickerScreen.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/AppPickerScreen.kt
@@ -57,9 +57,9 @@ import kotlinx.coroutines.withContext
  * selection in one place, and one Save writes the complete hiding config. Roles:
  *
  *  - [java]      "J" — LSPosed (the Java layer)
- *  - [native]    "N" — the one active native backend (kmod / KPM / Zygisk, §1.5);
- *                       written to every installed native backend, only the
- *                       active one acts.
+ *  - [native]    "N" — the one active native backend (kmod / KPM / Zygisk,
+ *                       docs/storage.md §4.3);
+ *                       the app invokes one installed activator by priority.
  *  - [appHiding] "A" — observer of the hidden-package view (which packages get
  *                       hidden is auto-detected; see autoDetectHiddenPackages).
  *  - [ports]     "P" — localhost-port blocking observer.

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/AppPickerScreen.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/AppPickerScreen.kt
@@ -507,7 +507,7 @@ private fun AppRow(
             selectedHooks = nativeHooks,
             roleEnabled = app.native,
             notice =
-                if (nativeHookFamily == NativeHookFamily.Kmod && !filesystemHidingEnabled) {
+                if (nativeHookFamily != NativeHookFamily.Zygisk && !filesystemHidingEnabled) {
                     stringResource(R.string.native_hooks_filesystem_hiding_disabled)
                 } else {
                     null

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DashboardData.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DashboardData.kt
@@ -104,8 +104,8 @@ internal enum class FlashableModuleKind { Kmod, Kpm, Zygisk, Ports }
 internal enum class MultiNativeSeverity { None, Warning, Error }
 
 /**
- * Severity of having more than one native backend active at runtime (protocol
- * §1.5). The .ko + KPM pair is an ERROR because they wrap the same kernel
+ * Severity of having more than one native backend active at runtime
+ * (docs/storage.md §4.3). The .ko + KPM pair is an ERROR because they wrap the same kernel
  * functions and co-residence can hard-freeze the kernel; any other active
  * overlap is a WARNING (merely redundant — the backstops pick one).
  */
@@ -125,7 +125,7 @@ internal fun classifyMultiNative(
 /**
  * True when the KPM boot script recorded that it deliberately stood down this
  * boot because the .ko backend is present (`load_status` runtime=conflict for
- * the current boot_id — see protocol §1.5 and kmod/kpm/module/post-fs-data.sh).
+ * the current boot_id — see docs/storage.md §4.3 and kmod/kpm/module/post-fs-data.sh).
  *
  * This is the only reliable way to surface the .ko+KPM co-installation: the
  * [classifyMultiNative] Error needs *both* backends active, but two active
@@ -142,7 +142,7 @@ internal fun kpmDeferredForConflict(
  * True when the KPM boot script stood down this boot because it runs under
  * APatch/FolkPatch and has no usable saved SuperKey or trusted `su` token
  * (`runtime=apatch, loaded=0, detail=awaiting_superkey` for the current
- * boot_id — see kmod/kpm/module/service.sh and protocol §1.5).
+ * boot_id — see kmod/kpm/module/service.sh and docs/storage.md §4.3).
  *
  * Distinct from [kpmDeferredForConflict] (that writes `runtime=conflict`): here the
  * module is installed and healthy but dormant, waiting for an APatch SuperKey

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DashboardData.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DashboardData.kt
@@ -1626,7 +1626,12 @@ internal suspend fun loadDashboardState(
     // differential and so aren't in nativeOutcomes. Set during the protection
     // computation, surfaced via the hero warning so a leak there is never invisible.
     var unownedNativeLeakCount = 0
-    val installedKmodHooks = installedHooks(shellSnapshot["kmod_state"].orEmpty())
+    val installedOptionalHooks =
+        when (nativeBackend.id) {
+            NativeBackendId.Kmod -> installedHooks(shellSnapshot["kmod_state"].orEmpty())
+            NativeBackendId.Kpm -> installedHooks(shellSnapshot["kpm_state"].orEmpty())
+            else -> emptySet()
+        }
     // Single source of truth: the cache does all the gating (VPN off / needs-restart /
     // self-not-routed) through the one fold. awaitTerminal returns the terminal state
     // itself, so the reason for "no results" (blocked gate vs a failed run) is carried
@@ -1649,7 +1654,7 @@ internal suspend fun loadDashboardState(
                         backend = nativeBackend,
                         lsposedActive = lsposed is LsposedState.Active,
                         complete = true,
-                        installedKmodHooks = installedKmodHooks,
+                        installedOptionalHooks = installedOptionalHooks,
                     )
                 unownedNativeLeakCount = report.native.unownedLeaks
                 ProtectionCheck.Checked(report.native.status, report.java.status)

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DashboardScreen.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DashboardScreen.kt
@@ -216,7 +216,7 @@ fun DashboardScreen(
         // Module status cards — one grouped block (byIndex corners).
         SectionHeader(stringResource(R.string.dashboard_modules))
         Spacer(Modifier.height(8.dp))
-        // Java, the one active native backend (§1.5), and the separate ports feature.
+        // Java, one native backend (docs/storage.md §4.3), and the separate ports feature.
         Column(verticalArrangement = Arrangement.spacedBy(3.dp)) {
             JavaBackendCard(loadedState.lsposed, index = 0, count = 3)
             NativeBackendCard(loadedState.nativeBackend, loadedState.nativeTargetCount, selfNeedsRestart, index = 1, count = 3)

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DebugExport.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DebugExport.kt
@@ -135,7 +135,12 @@ private suspend fun buildExportDiagnosticReport(
                 shellSnapshot.sections["current_boot_id"].orEmpty(),
             ),
         complete = true,
-        installedKmodHooks = installedHooks(shellSnapshot.sections["kmod_state"].orEmpty()),
+        installedOptionalHooks =
+            when (detectNativeBackendStates(shellSnapshot.sections).activeId) {
+                NativeBackendId.Kmod -> installedHooks(shellSnapshot.sections["kmod_state"].orEmpty())
+                NativeBackendId.Kpm -> installedHooks(shellSnapshot.sections["kpm_state"].orEmpty())
+                else -> emptySet()
+            },
     )
 
 // ── Debug-zip section builders (each produces one file in the export) ─────

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DiagnosticReport.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DiagnosticReport.kt
@@ -107,9 +107,9 @@ internal fun buildDiagnosticReport(
     backend: DisplayNativeBackend,
     lsposedActive: Boolean,
     complete: Boolean,
-    installedKmodHooks: Set<HookIds.Hook> = emptySet(),
+    installedOptionalHooks: Set<HookIds.Hook> = emptySet(),
 ): DiagnosticReport {
-    val nativeChecks = nativeDiagnosticChecks(results, backend, installedKmodHooks)
+    val nativeChecks = nativeDiagnosticChecks(results, backend, installedOptionalHooks)
     // The per-check outcome is the single source of truth; the by-id map the layer
     // summary needs is derived here (owned spec checks only), not stored a second
     // time on CheckResults.
@@ -118,7 +118,7 @@ internal fun buildDiagnosticReport(
         if (results == null) {
             0
         } else {
-            unownedNativeLeaks(backend, nativeOutcomes, installedKmodHooks) +
+            unownedNativeLeaks(backend, nativeOutcomes, installedOptionalHooks) +
                 results.nativeExtra.count { it.outcome is CheckOutcome.Leak }
         }
     return DiagnosticReport(
@@ -127,7 +127,7 @@ internal fun buildDiagnosticReport(
             LayerReport(
                 layer = CheckLayer.NATIVE,
                 backend = backend.id,
-                status = summarizeNativeLayer(backend, nativeOutcomes, installedKmodHooks),
+                status = summarizeNativeLayer(backend, nativeOutcomes, installedOptionalHooks),
                 unownedLeaks = unowned,
                 checks = nativeChecks,
             ),
@@ -146,10 +146,10 @@ internal fun buildDiagnosticReport(
 private fun nativeDiagnosticChecks(
     results: CheckResults?,
     backend: DisplayNativeBackend,
-    installedKmodHooks: Set<HookIds.Hook>,
+    installedOptionalHooks: Set<HookIds.Hook>,
 ): List<DiagnosticCheck> {
     if (results == null) return emptyList()
-    val ownedHooks = ownedNativeHooks(backend.id, installedKmodHooks)
+    val ownedHooks = ownedNativeHooks(backend.id, installedOptionalHooks)
     // native and nativeExtra are built in NATIVE_CHECKS order, so a positional zip
     // is stable by construction — the spec carries the stable id + hook coverage,
     // the result carries the localized label, outcome, and root ground-truth detail.

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/FilesystemHidingData.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/FilesystemHidingData.kt
@@ -16,32 +16,90 @@ internal data class FilesystemHidingState(
     val status: FilesystemHidingStatus,
     val errorDetail: String? = null,
 ) {
-    val kmodInstalled: Boolean
+    val kernelBackendInstalled: Boolean
         get() = status != FilesystemHidingStatus.Unavailable
 }
 
-/**
- * Compare the canonical next-boot choice with the hook set actually reported
- * by the running kmod. Boot diagnostics distinguish a newly changed setting
- * from a hook that was requested this boot but failed to install.
- */
-internal fun resolveFilesystemHidingState(
-    desiredEnabled: Boolean,
-    sections: Map<String, String>,
-): FilesystemHidingState {
-    if (sections["kmod_module_dir"]?.trim() != "1") {
-        return FilesystemHidingState(FilesystemHidingStatus.Unavailable)
-    }
+private data class FilesystemKernelBackend(
+    val id: NativeBackendId,
+    val statusRaw: String,
+)
 
-    val hookInstalled =
-        HookIds.Hook.FILESYSTEM_IFACE_PATHS in
-            installedHooks(sections["kmod_state"].orEmpty())
-    val load =
+private fun filesystemKernelBackend(sections: Map<String, String>): FilesystemKernelBackend? {
+    val kmodRaw = sections["kmod_state"].orEmpty()
+    val kpmRaw = sections["kpm_state"].orEmpty()
+    val kmodStatus = parseProtocolStatusBlock(kmodRaw)
+    val kpmStatus = parseProtocolStatusBlock(kpmRaw)
+    return when {
+        kmodStatus?.backend ==
+            HookIds.Backend.KMOD.id
+                .toLong() -> FilesystemKernelBackend(NativeBackendId.Kmod, kmodRaw)
+
+        kpmStatus?.backend ==
+            HookIds.Backend.KPM.id
+                .toLong() -> FilesystemKernelBackend(NativeBackendId.Kpm, kpmRaw)
+
+        sections["kmod_module_dir"]?.trim() == "1" -> FilesystemKernelBackend(NativeBackendId.Kmod, kmodRaw)
+
+        sections["kpm_module_dir"]?.trim() == "1" -> FilesystemKernelBackend(NativeBackendId.Kpm, kpmRaw)
+
+        else -> null
+    }
+}
+
+private fun currentKmodLoadStatus(
+    backend: FilesystemKernelBackend,
+    sections: Map<String, String>,
+): KmodLoadStatus? =
+    if (backend.id == NativeBackendId.Kmod) {
         readKmodLoadStatus(
             currentBootId = sections["current_boot_id"].orEmpty().trim(),
             raw = sections["kmod_load_status"].orEmpty(),
             dmesgRaw = "",
         )?.takeIf { it.freshForCurrentBoot }
+    } else {
+        null
+    }
+
+private fun filesystemHookSetupFailed(
+    backend: FilesystemKernelBackend,
+    load: KmodLoadStatus?,
+    sections: Map<String, String>,
+): Boolean =
+    when (backend.id) {
+        NativeBackendId.Kmod -> {
+            load?.let { it.loaded == true && it.filesystemHiding == true } == true
+        }
+
+        NativeBackendId.Kpm -> {
+            val kpmLoad = parseKpmLoadStatus(sections["kpm_load_status"].orEmpty())
+            kpmLoad.loaded == true &&
+                kpmLoad.filesystemHiding == true &&
+                kpmLoad.isFreshFor(sections["current_boot_id"].orEmpty()) &&
+                parseProtocolStatusBlock(backend.statusRaw)?.statusError == HookIds.StatusError.PARTIAL_HOOKS
+        }
+
+        NativeBackendId.Zygisk -> {
+            false
+        }
+    }
+
+/**
+ * Compare the canonical next-boot choice with the hook set actually reported
+ * by the running kernel backend. Boot diagnostics distinguish a newly changed
+ * setting from a hook that was requested this boot but failed to install.
+ */
+internal fun resolveFilesystemHidingState(
+    desiredEnabled: Boolean,
+    sections: Map<String, String>,
+): FilesystemHidingState {
+    val backend =
+        filesystemKernelBackend(sections)
+            ?: return FilesystemHidingState(FilesystemHidingStatus.Unavailable)
+    val hookInstalled =
+        HookIds.Hook.FILESYSTEM_IFACE_PATHS in
+            installedHooks(backend.statusRaw)
+    val load = currentKmodLoadStatus(backend, sections)
     val configExit = load?.filesystemConfigExit
     if (configExit != null && configExit != 0 && configExit != 1) {
         return FilesystemHidingState(
@@ -59,7 +117,7 @@ internal fun resolveFilesystemHidingState(
             FilesystemHidingState(FilesystemHidingStatus.PendingDisable)
         }
 
-        desiredEnabled && load?.loaded == true && load.filesystemHiding == true -> {
+        desiredEnabled && filesystemHookSetupFailed(backend, load, sections) -> {
             FilesystemHidingState(FilesystemHidingStatus.HookSetupError)
         }
 

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/FilesystemHidingSettings.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/FilesystemHidingSettings.kt
@@ -104,7 +104,7 @@ internal fun FilesystemHidingSettingsSection() {
             subtitle = filesystemHidingStatusText(runtimeState),
             icon = Icons.Default.VisibilityOff,
             checked = enabled,
-            enabled = targets != null && !saving && (runtimeState.kmodInstalled || enabled),
+            enabled = targets != null && !saving && (runtimeState.kernelBackendInstalled || enabled),
             onCheckedChange = { value ->
                 if (value) confirmationOpen = true else persist(false)
             },

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/HookRegistry.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/HookRegistry.kt
@@ -25,7 +25,7 @@ internal fun hooksInMask(mask: Long): Set<HookIds.Hook> = HookIds.Hook.entries.f
 
 /**
  * Hooks each backend owns, derived **once** from the generated per-backend masks.
- * A backend acts only on the hooks it owns and ignores foreign bits (protocol §1.4).
+ * A backend acts only on the hooks it owns and ignores foreign bits (protocol §5).
  */
 internal val KERNEL_HOOKS: Set<HookIds.Hook> = hooksInMask(HookIds.KERNEL_HOOK_MASK.toLong())
 internal val KMOD_HOOKS: Set<HookIds.Hook> = hooksInMask(HookIds.KMOD_HOOK_MASK.toLong())

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/HookRegistry.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/HookRegistry.kt
@@ -29,6 +29,7 @@ internal fun hooksInMask(mask: Long): Set<HookIds.Hook> = HookIds.Hook.entries.f
  */
 internal val KERNEL_HOOKS: Set<HookIds.Hook> = hooksInMask(HookIds.KERNEL_HOOK_MASK.toLong())
 internal val KMOD_HOOKS: Set<HookIds.Hook> = hooksInMask(HookIds.KMOD_HOOK_MASK.toLong())
+internal val KPM_HOOKS: Set<HookIds.Hook> = hooksInMask(HookIds.KPM_HOOK_MASK.toLong())
 internal val ZYGISK_HOOKS: Set<HookIds.Hook> = hooksInMask(HookIds.ZYGISK_HOOK_MASK.toLong())
 internal val LSPOSED_HOOKS: Set<HookIds.Hook> = hooksInMask(HookIds.LSPOSED_HOOK_MASK.toLong())
 
@@ -36,7 +37,7 @@ internal val LSPOSED_HOOKS: Set<HookIds.Hook> = hooksInMask(HookIds.LSPOSED_HOOK
 internal fun ownedHooks(backend: HookIds.Backend): Set<HookIds.Hook> =
     when (backend) {
         HookIds.Backend.KMOD -> KERNEL_HOOKS + KMOD_HOOKS
-        HookIds.Backend.KPM -> KERNEL_HOOKS
+        HookIds.Backend.KPM -> KERNEL_HOOKS + KPM_HOOKS
         HookIds.Backend.ZYGISK -> ZYGISK_HOOKS
         HookIds.Backend.LSPOSED -> LSPOSED_HOOKS
     }
@@ -49,18 +50,22 @@ internal fun ownedHooks(backend: HookIds.Backend): Set<HookIds.Hook> =
  */
 internal fun ownedNativeHooks(
     id: NativeBackendId?,
-    installedKmodHooks: Set<HookIds.Hook> = emptySet(),
+    installedOptionalHooks: Set<HookIds.Hook> = emptySet(),
 ): Set<HookIds.Hook> =
     when (id) {
         NativeBackendId.Kmod -> {
-            KERNEL_HOOKS + installedKmodHooks.intersect(KMOD_HOOKS)
+            KERNEL_HOOKS + installedOptionalHooks.intersect(KMOD_HOOKS)
+        }
+
+        NativeBackendId.Kpm -> {
+            KERNEL_HOOKS + installedOptionalHooks.intersect(KPM_HOOKS)
         }
 
         NativeBackendId.Zygisk -> {
             ZYGISK_HOOKS
         }
 
-        NativeBackendId.Kpm, null -> {
+        null -> {
             KERNEL_HOOKS
         }
     }
@@ -68,7 +73,7 @@ internal fun ownedNativeHooks(
 /** Decode a backend's installed-hook wire mask into the typed registry set. */
 internal fun installedHooks(statusRaw: String): Set<HookIds.Hook> = parseProtocolStatusBlock(statusRaw)?.hooks?.let(::hooksInMask).orEmpty()
 
-/** Hooks expected in a live status snapshot. Kmod-only hooks are optional and
+/** Hooks expected in a live status snapshot. Backend-specific hooks are optional and
  * become part of the expectation only when that boot actually installed them. */
 internal fun expectedInstalledHooks(
     backend: HookIds.Backend,
@@ -76,6 +81,7 @@ internal fun expectedInstalledHooks(
 ): Set<HookIds.Hook> =
     when (backend) {
         HookIds.Backend.KMOD -> KERNEL_HOOKS + installed.intersect(KMOD_HOOKS)
+        HookIds.Backend.KPM -> KERNEL_HOOKS + installed.intersect(KPM_HOOKS)
         else -> ownedHooks(backend)
     }
 

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/KpmLoadStatus.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/KpmLoadStatus.kt
@@ -26,11 +26,19 @@ internal data class KpmLoadStatus(
     val unameR: String?,
     val runtime: KpmRuntime,
     val loaded: Boolean?,
+    val filesystemHiding: Boolean?,
     val reason: KpmFailureReason,
     val detail: String?,
 ) {
     fun isFreshFor(currentBootId: String): Boolean = !bootId.isNullOrEmpty() && bootId == currentBootId.trim()
 }
+
+private fun Map<String, String>.optionalBoolean(key: String): Boolean? =
+    when (this[key]?.trim()) {
+        "1" -> true
+        "0" -> false
+        else -> null
+    }
 
 internal fun parseKpmLoadStatus(raw: String): KpmLoadStatus {
     val values = parseKeyValueLines(raw)
@@ -46,12 +54,8 @@ internal fun parseKpmLoadStatus(raw: String): KpmLoadStatus {
                 "conflict" -> KpmRuntime.Conflict
                 else -> KpmRuntime.Unknown
             },
-        loaded =
-            when (values["loaded"]?.trim()) {
-                "1" -> true
-                "0" -> false
-                else -> null
-            },
+        loaded = values.optionalBoolean("loaded"),
+        filesystemHiding = values.optionalBoolean("filesystem_hiding"),
         reason =
             when (values["reason"]?.trim()) {
                 "ok" -> KpmFailureReason.Ok

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/LayerStatus.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/LayerStatus.kt
@@ -43,9 +43,9 @@ val LayerStatus.Active.verdict: Verdict
  * backend covers. One derivation shared by the tile summary and the unowned count. */
 private fun ownedNativeCheckIds(
     backend: DisplayNativeBackend,
-    installedKmodHooks: Set<HookIds.Hook> = emptySet(),
+    installedOptionalHooks: Set<HookIds.Hook> = emptySet(),
 ): Set<String> {
-    val owned = ownedNativeHooks(backend.id, installedKmodHooks)
+    val owned = ownedNativeHooks(backend.id, installedOptionalHooks)
     return NATIVE_CHECKS.filter { it.coveredBy(owned) }.map { it.id }.toSet()
 }
 
@@ -59,11 +59,11 @@ private fun ownedNativeCheckIds(
 internal fun summarizeNativeLayer(
     backend: DisplayNativeBackend,
     outcomes: Map<String, CheckOutcome>,
-    installedKmodHooks: Set<HookIds.Hook> = emptySet(),
+    installedOptionalHooks: Set<HookIds.Hook> = emptySet(),
 ): LayerStatus {
     if (backend.state is ModuleState.NotInstalled) return LayerStatus.Absent
     if (!moduleActive(backend.state)) return LayerStatus.Inactive
-    val ownedIds = ownedNativeCheckIds(backend, installedKmodHooks)
+    val ownedIds = ownedNativeCheckIds(backend, installedOptionalHooks)
     // Both counts are scoped to vectors this backend owns, so hidden and leaks
     // describe the same vector set — a cross-backend hidden (only possible if the
     // one-active-backend invariant ever breaks) can't mask an owned Broken verdict.
@@ -97,9 +97,9 @@ internal fun summarizeJavaLayer(
 internal fun unownedNativeLeaks(
     backend: DisplayNativeBackend,
     outcomes: Map<String, CheckOutcome>,
-    installedKmodHooks: Set<HookIds.Hook> = emptySet(),
+    installedOptionalHooks: Set<HookIds.Hook> = emptySet(),
 ): Int {
     if (backend.state !is ModuleState.Installed || !moduleActive(backend.state)) return 0
-    val ownedIds = ownedNativeCheckIds(backend, installedKmodHooks)
+    val ownedIds = ownedNativeCheckIds(backend, installedOptionalHooks)
     return outcomes.count { (id, outcome) -> outcome is CheckOutcome.Leak && id !in ownedIds }
 }

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/NativeBackendData.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/NativeBackendData.kt
@@ -1,6 +1,6 @@
 package dev.okhsunrog.vpnhide
 
-// The native layer is exactly one of these at runtime (protocol §1.5).
+// The native layer is exactly one of these at runtime (docs/storage.md §4.3).
 internal enum class NativeBackendId { Kmod, Kpm, Zygisk }
 
 internal data class NativeBackendStates(

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/generated/HookIds.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/generated/HookIds.kt
@@ -97,6 +97,7 @@ internal object HookIds {
     // Hooks owned by each backend: apply `mask and own`.
     const val KERNEL_HOOK_MASK = 0x20003ff
     const val KMOD_HOOK_MASK = 0x8000000
+    const val KPM_HOOK_MASK = 0x8000000
     const val ZYGISK_HOOK_MASK = 0x5fc0000
     const val LSPOSED_HOOK_MASK = 0x3fc00
 

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/generated/HookIds.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/generated/HookIds.kt
@@ -111,7 +111,7 @@ internal object HookIds {
         // no offset table for the running kernel — refused, no hooks
         UNSUPPORTED_KVER(1),
 
-        // the other kernel backend (.ko<->KPM) is loaded — refused (protocol §1.2)
+        // the other kernel backend (.ko<->KPM) is loaded — refused (docs/storage.md §4.3)
         CONFLICTING_BACKEND(2),
 
         // a required kallsyms symbol was missing — refused

--- a/lsposed/app/src/main/res/values-ru/strings.xml
+++ b/lsposed/app/src/main/res/values-ru/strings.xml
@@ -410,13 +410,13 @@
     <string name="settings_experimental_protection">Экспериментальная защита</string>
     <string name="settings_filesystem_hiding">Скрывать VPN-пути в файловой системе</string>
     <string name="settings_filesystem_hiding_sub">Экспериментальный и потенциально дорогой хук: он перехватывает глобальные операции поиска и перечисления в файловой системе и может замедлить устройство. Сейчас неизвестны реальные приложения, использующие этот вектор обнаружения; обычной Native-защиты, как правило, достаточно. Оставьте функцию выключенной, если вы специально не тестируете обнаружение по путям файловой системы.</string>
-    <string name="settings_filesystem_hiding_unavailable">Требуется модуль ядра kmod.</string>
+    <string name="settings_filesystem_hiding_unavailable">Требуется ядерный бэкенд kmod или KPM.</string>
     <string name="settings_filesystem_hiding_disabled">Выключено — рекомендуется обычная Native-защита.</string>
     <string name="settings_filesystem_hiding_active">Активно для выбранных Native-целей.</string>
     <string name="settings_filesystem_hiding_pending_enable">Включится после перезагрузки.</string>
     <string name="settings_filesystem_hiding_pending_disable">Выключится после перезагрузки.</string>
     <string name="settings_filesystem_hiding_boot_error">Не удалось прочитать настройку при загрузке: %1$s</string>
-    <string name="settings_filesystem_hiding_setup_error">kmod загружен, но хуки файловой системы не установились. Проверьте диагностику перед следующей перезагрузкой.</string>
+    <string name="settings_filesystem_hiding_setup_error">Ядерный бэкенд загружен, но хуки файловой системы не установились. Проверьте диагностику перед следующей перезагрузкой.</string>
     <string name="settings_filesystem_hiding_confirm_title">Включить экспериментальные хуки файловой системы?</string>
     <string name="settings_filesystem_hiding_confirm_body">Эти глобальные VFS-хуки могут замедлять операции с файловой системой и сейчас не нужны известным реальным приложениям. Обычной Native-защиты, как правило, достаточно. Включайте их только для целевого тестирования обнаружения по путям файловой системы; потребуется перезагрузка.</string>
     <string name="settings_filesystem_hiding_enable">Всё равно включить</string>

--- a/lsposed/app/src/main/res/values/strings.xml
+++ b/lsposed/app/src/main/res/values/strings.xml
@@ -439,13 +439,13 @@
     <string name="settings_experimental_protection">Experimental protection</string>
     <string name="settings_filesystem_hiding">Hide VPN filesystem paths</string>
     <string name="settings_filesystem_hiding_sub">Experimental and potentially expensive: this hook intercepts global filesystem lookup and directory-enumeration paths and may slow the device. No known real-world apps currently rely on this detection vector; standard Native protection should normally be sufficient. Leave it off unless you specifically need to test filesystem-path detection.</string>
-    <string name="settings_filesystem_hiding_unavailable">Requires the kmod kernel module.</string>
+    <string name="settings_filesystem_hiding_unavailable">Requires the kmod or KPM kernel backend.</string>
     <string name="settings_filesystem_hiding_disabled">Off — standard Native protection is recommended.</string>
     <string name="settings_filesystem_hiding_active">Active for selected Native targets.</string>
     <string name="settings_filesystem_hiding_pending_enable">Will be enabled after reboot.</string>
     <string name="settings_filesystem_hiding_pending_disable">Will be disabled after reboot.</string>
     <string name="settings_filesystem_hiding_boot_error">Could not read the boot setting: %1$s</string>
-    <string name="settings_filesystem_hiding_setup_error">kmod loaded, but the filesystem hooks failed to install. Check Diagnostics before rebooting again.</string>
+    <string name="settings_filesystem_hiding_setup_error">The kernel backend loaded, but the filesystem hooks failed to install. Check Diagnostics before rebooting again.</string>
     <string name="settings_filesystem_hiding_confirm_title">Enable experimental filesystem hooks?</string>
     <string name="settings_filesystem_hiding_confirm_body">These global VFS hooks may slow filesystem operations and are not currently needed for known real-world apps. Ordinary Native protection should normally be sufficient. Enable them only for explicit filesystem-path detection testing; a reboot is required.</string>
     <string name="settings_filesystem_hiding_enable">Enable anyway</string>

--- a/lsposed/app/src/test/kotlin/dev/okhsunrog/vpnhide/FilesystemHidingDataTest.kt
+++ b/lsposed/app/src/test/kotlin/dev/okhsunrog/vpnhide/FilesystemHidingDataTest.kt
@@ -15,10 +15,57 @@ class FilesystemHidingDataTest {
     }
 
     @Test
-    fun `feature is unavailable without kmod`() {
+    fun `feature is unavailable without a kernel backend`() {
         assertEquals(
             FilesystemHidingStatus.Unavailable,
             resolveFilesystemHidingState(desiredEnabled = false, sections = emptyMap()).status,
+        )
+    }
+
+    @Test
+    fun `KPM owns the same reboot gated feature`() {
+        assertEquals(
+            FilesystemHidingStatus.Active,
+            resolveFilesystemHidingState(
+                desiredEnabled = true,
+                sections = sections(hookInstalled = true, backend = HookIds.Backend.KPM),
+            ).status,
+        )
+        assertEquals(
+            FilesystemHidingStatus.PendingEnable,
+            resolveFilesystemHidingState(
+                desiredEnabled = true,
+                sections = sections(backend = HookIds.Backend.KPM),
+            ).status,
+        )
+    }
+
+    @Test
+    fun `active KPM status wins over an installed inactive kmod`() {
+        val sections =
+            sections(hookInstalled = true, backend = HookIds.Backend.KPM) +
+                ("kmod_module_dir" to "1")
+
+        assertEquals(
+            FilesystemHidingStatus.Active,
+            resolveFilesystemHidingState(desiredEnabled = true, sections = sections).status,
+        )
+    }
+
+    @Test
+    fun `KPM partial hook setup is reported as an error`() {
+        assertEquals(
+            FilesystemHidingStatus.HookSetupError,
+            resolveFilesystemHidingState(
+                desiredEnabled = true,
+                sections =
+                    sections(
+                        filesystemRequested = true,
+                        moduleLoaded = true,
+                        backend = HookIds.Backend.KPM,
+                        statusError = HookIds.StatusError.PARTIAL_HOOKS,
+                    ),
+            ).status,
         )
     }
 
@@ -85,6 +132,8 @@ class FilesystemHidingDataTest {
         moduleLoaded: Boolean = false,
         configExit: Int = if (filesystemRequested) 0 else 1,
         configError: String = "",
+        backend: HookIds.Backend = HookIds.Backend.KMOD,
+        statusError: HookIds.StatusError = HookIds.StatusError.OK,
     ): Map<String, String> {
         val hookMask =
             if (hookInstalled) {
@@ -96,12 +145,12 @@ class FilesystemHidingDataTest {
             Protocol.formatStatus(
                 Protocol.Status(
                     backend =
-                        HookIds.Backend.KMOD.id
+                        backend.id
                             .toLong(),
                     kver = 0,
                     hooks = hookMask,
                     error =
-                        HookIds.StatusError.OK.code
+                        statusError.code
                             .toLong(),
                 ),
             )
@@ -113,11 +162,12 @@ class FilesystemHidingDataTest {
             filesystem_config_error=$configError
             loaded=${if (moduleLoaded) 1 else 0}
             """.trimIndent()
+        val loadStatusKey = if (backend == HookIds.Backend.KPM) "kpm_load_status" else "kmod_load_status"
         return mapOf(
-            "kmod_module_dir" to "1",
-            "kmod_state" to status,
+            (if (backend == HookIds.Backend.KPM) "kpm_module_dir" else "kmod_module_dir") to "1",
+            (if (backend == HookIds.Backend.KPM) "kpm_state" else "kmod_state") to status,
             "current_boot_id" to "test-boot",
-            "kmod_load_status" to loadStatus,
+            loadStatusKey to loadStatus,
         )
     }
 }

--- a/lsposed/app/src/test/kotlin/dev/okhsunrog/vpnhide/HookDiagnosticsTest.kt
+++ b/lsposed/app/src/test/kotlin/dev/okhsunrog/vpnhide/HookDiagnosticsTest.kt
@@ -27,6 +27,23 @@ class HookDiagnosticsTest {
     }
 
     @Test
+    fun `disabled optional kpm hooks are not reported as missing`() {
+        assertEquals(
+            KERNEL_HOOKS,
+            expectedInstalledHooks(HookIds.Backend.KPM, installed = KERNEL_HOOKS),
+        )
+    }
+
+    @Test
+    fun `installed optional kpm hooks are preserved as a typed set`() {
+        val filesystemHook = HookIds.Hook.FILESYSTEM_IFACE_PATHS
+        assertEquals(
+            KERNEL_HOOKS + filesystemHook,
+            expectedInstalledHooks(HookIds.Backend.KPM, KERNEL_HOOKS + filesystemHook),
+        )
+    }
+
+    @Test
     fun `no baseline captured yields n a`() {
         // A baseline that was never captured must read n/a — but this is driven by
         // an explicit hasBaseline flag, NOT by the baseline map being empty (a

--- a/lsposed/app/src/test/kotlin/dev/okhsunrog/vpnhide/KpmLoadStatusTest.kt
+++ b/lsposed/app/src/test/kotlin/dev/okhsunrog/vpnhide/KpmLoadStatusTest.kt
@@ -16,6 +16,7 @@ class KpmLoadStatusTest {
                 uname_r=6.1.0-android
                 runtime=kpatch-next
                 loaded=0
+                filesystem_hiding=1
                 reason=unsupported_kernel
                 detail=unsupported kernel
                 """.trimIndent(),
@@ -26,6 +27,7 @@ class KpmLoadStatusTest {
         assertEquals("6.1.0-android", status.unameR)
         assertEquals(KpmRuntime.KpatchNext, status.runtime)
         assertEquals(false, status.loaded)
+        assertEquals(true, status.filesystemHiding)
         assertEquals(KpmFailureReason.UnsupportedKernel, status.reason)
         assertEquals("unsupported kernel", status.detail)
         assertTrue(status.isFreshFor("boot-1"))
@@ -37,6 +39,7 @@ class KpmLoadStatusTest {
 
         assertEquals(KpmRuntime.Unknown, status.runtime)
         assertEquals(null, status.loaded)
+        assertEquals(null, status.filesystemHiding)
         assertEquals(KpmFailureReason.Unknown, status.reason)
         assertFalse(status.isFreshFor("boot-1"))
     }

--- a/lsposed/app/src/test/kotlin/dev/okhsunrog/vpnhide/LayerStatusTest.kt
+++ b/lsposed/app/src/test/kotlin/dev/okhsunrog/vpnhide/LayerStatusTest.kt
@@ -94,7 +94,7 @@ class LayerStatusTest {
             summarizeNativeLayer(
                 backend,
                 outcomes,
-                installedKmodHooks = setOf(HookIds.Hook.FILESYSTEM_IFACE_PATHS),
+                installedOptionalHooks = setOf(HookIds.Hook.FILESYSTEM_IFACE_PATHS),
             ),
         )
         assertEquals(
@@ -102,7 +102,7 @@ class LayerStatusTest {
             unownedNativeLeaks(
                 backend,
                 outcomes,
-                installedKmodHooks = setOf(HookIds.Hook.FILESYSTEM_IFACE_PATHS),
+                installedOptionalHooks = setOf(HookIds.Hook.FILESYSTEM_IFACE_PATHS),
             ),
         )
     }

--- a/scripts/codegen-hooks.py
+++ b/scripts/codegen-hooks.py
@@ -69,12 +69,9 @@ class Hook:
         backends = raw.get("backends")
         if (backend is None) == (backends is None):
             sys.exit(
-                f"error: hook {self.name!r} must define exactly one of "
-                "'backend' or 'backends'"
+                f"error: hook {self.name!r} must define exactly one of 'backend' or 'backends'"
             )
-        self.backends: tuple[str, ...] = (
-            (backend,) if backend is not None else tuple(backends)
-        )
+        self.backends: tuple[str, ...] = (backend,) if backend is not None else tuple(backends)
         if not self.backends or len(set(self.backends)) != len(self.backends):
             sys.exit(f"error: hook {self.name!r} has invalid backends {self.backends!r}")
         self.note: str = raw.get("note", "")

--- a/scripts/codegen-hooks.py
+++ b/scripts/codegen-hooks.py
@@ -53,7 +53,7 @@ OUT_LSP_KT = lsposed_generated_kt("HookIds.kt")
 
 GENERATED_HEADER_LINE = generated_header("data/hooks.toml", "uv run scripts/codegen-hooks.py")
 
-KNOWN_BACKENDS = ("kernel", "kmod", "zygisk", "lsposed")
+KNOWN_BACKENDS = ("kernel", "kmod", "kpm", "zygisk", "lsposed")
 
 
 # ---------------------------------------------------------------------------
@@ -65,7 +65,18 @@ class Hook:
     def __init__(self, raw: dict[str, Any]) -> None:
         self.id: int = raw["id"]
         self.name: str = raw["name"]
-        self.backend: str = raw["backend"]
+        backend = raw.get("backend")
+        backends = raw.get("backends")
+        if (backend is None) == (backends is None):
+            sys.exit(
+                f"error: hook {self.name!r} must define exactly one of "
+                "'backend' or 'backends'"
+            )
+        self.backends: tuple[str, ...] = (
+            (backend,) if backend is not None else tuple(backends)
+        )
+        if not self.backends or len(set(self.backends)) != len(self.backends):
+            sys.exit(f"error: hook {self.name!r} has invalid backends {self.backends!r}")
         self.note: str = raw.get("note", "")
 
 
@@ -100,15 +111,16 @@ def load() -> tuple[list[Hook], list[Err], list[Backend]]:
         if len(set(names)) != len(names):
             sys.exit(f"error: duplicate {label} name in {names}")
     for h in hooks:
-        if h.backend not in KNOWN_BACKENDS:
-            sys.exit(f"error: hook {h.name!r} has unknown backend {h.backend!r}")
+        unknown = set(h.backends) - set(KNOWN_BACKENDS)
+        if unknown:
+            sys.exit(f"error: hook {h.name!r} has unknown backends {sorted(unknown)!r}")
     return hooks, errs, backends
 
 
 def backend_mask(hooks: list[Hook], backend: str) -> int:
     m = 0
     for h in hooks:
-        if h.backend == backend:
+        if backend in h.backends:
             m |= 1 << h.id
     return m
 
@@ -185,19 +197,26 @@ def emit_kmod(hooks: list[Hook], errs: list[Err], backends: list[Backend]) -> st
     for b in KNOWN_BACKENDS:
         L.append(f"#define VPNHIDE_{upper(b)}_HOOK_MASK 0x{backend_mask(hooks, b):x}u")
     L.append("")
-    kernel_hooks = [h for h in hooks if h.backend == "kernel"]
+    kernel_hooks = [h for h in hooks if "kernel" in h.backends]
     append_dense_hook_mapping(
         L,
         "kernel",
         kernel_hooks,
         "Dense stats slots shared by the .ko and KPM kernel hooks.",
     )
-    kmod_hooks = [h for h in hooks if h.backend in ("kernel", "kmod")]
+    kmod_hooks = [h for h in hooks if set(h.backends) & {"kernel", "kmod"}]
     append_dense_hook_mapping(
         L,
         "kmod_stats",
         kmod_hooks,
         "Dense stats slots for every hook the .ko can install.",
+    )
+    kpm_hooks = [h for h in hooks if set(h.backends) & {"kernel", "kpm"}]
+    append_dense_hook_mapping(
+        L,
+        "kpm_stats",
+        kpm_hooks,
+        "Dense stats slots for every hook the KPM can install.",
     )
     L.append("/* status error codes (protocol §5.1). */")
     ewidth = max(len(f"VPNHIDE_ERR_{upper(e.name)}") for e in errs)

--- a/scripts/codegen-hooks.py
+++ b/scripts/codegen-hooks.py
@@ -42,7 +42,7 @@ from codegen_lib import (  # type: ignore[import-not-found]
 
 TOML_PATH = REPO_ROOT / "data" / "hooks.toml"
 
-# Targets are only the protocol participants (§1.4): the kernel backends (C),
+# Targets are only the protocol participants (§1.3): the kernel backends (C),
 # the Zygisk backend (Rust), and the app + system_server hook (Kotlin). NOT
 # lsposed/native — that Rust crate is the uniffi diagnostic-probe library; it
 # consumes iface_lists (VPN-name matching) but never the protocol/registry.

--- a/zygisk/src/generated/hook_ids.rs
+++ b/zygisk/src/generated/hook_ids.rs
@@ -157,7 +157,7 @@ pub enum StatusError {
     Ok = 0,
     /// no offset table for the running kernel — refused, no hooks
     UnsupportedKver = 1,
-    /// the other kernel backend (.ko<->KPM) is loaded — refused (protocol §1.2)
+    /// the other kernel backend (.ko<->KPM) is loaded — refused (docs/storage.md §4.3)
     ConflictingBackend = 2,
     /// a required kallsyms symbol was missing — refused
     SymbolResolutionFailed = 3,

--- a/zygisk/src/generated/hook_ids.rs
+++ b/zygisk/src/generated/hook_ids.rs
@@ -145,6 +145,7 @@ pub const HOOK_COUNT: u32 = 28;
 /// Hooks owned by each backend: apply `mask & own`.
 pub const KERNEL_HOOK_MASK: u32 = 0x20003ff;
 pub const KMOD_HOOK_MASK: u32 = 0x8000000;
+pub const KPM_HOOK_MASK: u32 = 0x8000000;
 pub const ZYGISK_HOOK_MASK: u32 = 0x5fc0000;
 pub const LSPOSED_HOOK_MASK: u32 = 0x3fc00;
 


### PR DESCRIPTION
Adds the optional reboot-gated filesystem path hiding feature to the KPM backend while retaining the canonical boot-feature setting and frozen control-v2 runtime protocol. The hooks remain disabled by default so normal boots pay no global VFS interception cost.

- model optional hook ownership for both kernel backends in the generated hook registry
- project `settings.kernelBootFeatures` into the KPM boot-time `filesystem_hiding=1` load argument
- add atomic KPM VFS hook installation for lookup, open, stat, and directory enumeration under sysfs and proc-sys
- expose installed-hook and boot-load state to diagnostics, statistics, and the existing settings UI
- keep version-dependent VFS layouts in the KPM ABI offset tables
- extend the KPM QEMU A/B harness across kernels 4.9 through 6.12 with filesystem hide and non-VPN preservation checks
- validate with workspace tests, Clippy, Android unit tests, ktlint, detekt, C `-Werror`, flashable ZIP assembly, and the full KPM QEMU matrix