### PR TITLE
Build the Zygisk backend for armeabi-v7a

### DIFF
--- a/.github/docker/ci/Dockerfile
+++ b/.github/docker/ci/Dockerfile
@@ -56,7 +56,7 @@ ENV RUSTUP_HOME=/usr/local/rustup \
 
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | \
         sh -s -- -y --default-toolchain "${RUST_VERSION}" --profile minimal --no-modify-path && \
-    rustup target add aarch64-linux-android && \
+    rustup target add aarch64-linux-android armv7-linux-androideabi && \
     rustup component add rustfmt clippy && \
     cargo install cargo-ndk --version "${CARGO_NDK_VERSION}" --locked && \
     chmod -R a+w /usr/local/rustup /usr/local/cargo

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -152,8 +152,14 @@ jobs:
       # `--tests` so generated test modules are also linted
       # (catches `bool_assert_comparison`-style regressions in
       # codegen output).
+      # armv7 target for the 32-bit zygisk build. Baked into the CI image
+      # (see .github/docker/ci/Dockerfile), but added here too so a PR that
+      # introduces it is green before the post-merge image rebuild catches
+      # up — rustup is a no-op once the image already carries the target.
+      - name: rustup target add armv7 (zygisk 32-bit)
+        run: rustup target add armv7-linux-androideabi
       - name: clippy (zygisk)
-        run: cargo ndk -t arm64-v8a clippy -p vpnhide_zygisk --tests -- -D warnings
+        run: cargo ndk -t arm64-v8a -t armeabi-v7a clippy -p vpnhide_zygisk --tests -- -D warnings
       - name: clippy (lsposed native)
         run: cd lsposed/native && cargo ndk -t arm64-v8a clippy --tests -- -D warnings
       - name: cargo test (workspace)
@@ -554,6 +560,12 @@ jobs:
             zygisk/target
           key: cargo-${{ runner.os }}-${{ hashFiles('Cargo.lock') }}
           restore-keys: cargo-${{ runner.os }}-
+
+      # armv7 target for the 32-bit zygisk .so. Baked into the CI image, but
+      # added here too so this PR is green before the post-merge image rebuild
+      # (ci-image.yml runs on push to main, not on PRs). No-op once present.
+      - name: rustup target add armv7 (zygisk 32-bit)
+        run: rustup target add armv7-linux-androideabi
 
       - name: Build module zip
         env:

--- a/changelog.d/fixed-zygisk-native-mode-now-works-in-a48a.md
+++ b/changelog.d/fixed-zygisk-native-mode-now-works-in-a48a.md
@@ -1,0 +1,9 @@
+_2026-08-13_
+
+## English
+
+Zygisk native mode now works in 32-bit app processes: the module ships an armeabi-v7a build alongside arm64-v8a (previously NeoZygisk failed to load it into processes forked from zygote32, e.g. on Samsung devices).
+
+## Русский
+
+Нативный режим Zygisk теперь работает в 32-битных процессах приложений: модуль включает сборку armeabi-v7a наряду с arm64-v8a (раньше NeoZygisk не мог загрузить его в процессы, форкнутые из zygote32, например на устройствах Samsung).

--- a/zygisk/build.py
+++ b/zygisk/build.py
@@ -53,10 +53,15 @@ def main() -> int:
     # rewriting it (a dirtied tree stamps artifacts "-dirty").
     subprocess.run(
         [
-            "cargo", "ndk",
-            "-t", "arm64-v8a",
-            "-t", "armeabi-v7a",
-            "build", "--release", "--locked",
+            "cargo",
+            "ndk",
+            "-t",
+            "arm64-v8a",
+            "-t",
+            "armeabi-v7a",
+            "build",
+            "--release",
+            "--locked",
         ],
         env=env,
         check=True,
@@ -71,12 +76,23 @@ def main() -> int:
     # One .so per ABI. NeoZygisk's loader picks the matching file for each
     # target process by its bitness, so both must ship in the module.
     so_by_abi = {
-        "arm64-v8a": script_dir / "target" / "aarch64-linux-android" / "release" / "libvpnhide_zygisk.so",
-        "armeabi-v7a": script_dir / "target" / "armv7-linux-androideabi" / "release" / "libvpnhide_zygisk.so",
+        "arm64-v8a": script_dir
+        / "target"
+        / "aarch64-linux-android"
+        / "release"
+        / "libvpnhide_zygisk.so",
+        "armeabi-v7a": script_dir
+        / "target"
+        / "armv7-linux-androideabi"
+        / "release"
+        / "libvpnhide_zygisk.so",
     }
     for abi, so_src in so_by_abi.items():
         if not so_src.exists():
-            print(f"error: expected {abi} .so at {so_src} after cargo ndk build, not found", file=sys.stderr)
+            print(
+                f"error: expected {abi} .so at {so_src} after cargo ndk build, not found",
+                file=sys.stderr,
+            )
             return 1
 
     # Assemble the module staging directory

--- a/zygisk/build.py
+++ b/zygisk/build.py
@@ -45,10 +45,19 @@ def main() -> int:
     env["ANDROID_NDK_HOME"] = android_ndk_home
     env["CARGO_TARGET_DIR"] = str(target_dir)
 
-    # Build the cdylib for arm64-v8a. --locked: fail if Cargo.lock drifted
-    # rather than rewriting it (a dirtied tree stamps artifacts "-dirty").
+    # Build the cdylib for both ABIs. arm64-v8a covers 64-bit app processes;
+    # armeabi-v7a is required to inject into 32-bit processes forked from
+    # zygote32 (still present on many devices, e.g. Samsung) — without it
+    # NeoZygisk logs "No such file or directory" and native mode is dead
+    # in those processes. --locked: fail if Cargo.lock drifted rather than
+    # rewriting it (a dirtied tree stamps artifacts "-dirty").
     subprocess.run(
-        ["cargo", "ndk", "-t", "arm64-v8a", "build", "--release", "--locked"],
+        [
+            "cargo", "ndk",
+            "-t", "arm64-v8a",
+            "-t", "armeabi-v7a",
+            "build", "--release", "--locked",
+        ],
         env=env,
         check=True,
     )
@@ -59,10 +68,16 @@ def main() -> int:
         target_dir=target_dir,
     )
 
-    so_src = script_dir / "target" / "aarch64-linux-android" / "release" / "libvpnhide_zygisk.so"
-    if not so_src.exists():
-        print(f"error: expected {so_src} after cargo ndk build, not found", file=sys.stderr)
-        return 1
+    # One .so per ABI. NeoZygisk's loader picks the matching file for each
+    # target process by its bitness, so both must ship in the module.
+    so_by_abi = {
+        "arm64-v8a": script_dir / "target" / "aarch64-linux-android" / "release" / "libvpnhide_zygisk.so",
+        "armeabi-v7a": script_dir / "target" / "armv7-linux-androideabi" / "release" / "libvpnhide_zygisk.so",
+    }
+    for abi, so_src in so_by_abi.items():
+        if not so_src.exists():
+            print(f"error: expected {abi} .so at {so_src} after cargo ndk build, not found", file=sys.stderr)
+            return 1
 
     # Assemble the module staging directory
     staging = script_dir / "target" / "module-staging"
@@ -70,7 +85,8 @@ def main() -> int:
         shutil.rmtree(staging)
     shutil.copytree(script_dir / "module", staging)
     (staging / "zygisk").mkdir(parents=True, exist_ok=True)
-    shutil.copy(so_src, staging / "zygisk" / "arm64-v8a.so")
+    for abi, so_src in so_by_abi.items():
+        shutil.copy(so_src, staging / "zygisk" / f"{abi}.so")
     shutil.copy(activator, staging / "activator")
     (staging / "activator").chmod(0o755)
 

--- a/zygisk/build.rs
+++ b/zygisk/build.rs
@@ -24,10 +24,20 @@ fn main() {
         // the Android cdylib; skip the whole native build step.
         return;
     }
-    assert!(
-        target.starts_with("aarch64"),
-        "vpnhide-zygisk currently only supports aarch64-linux-android (target={target})"
-    );
+    // Map the Rust target triple to the NDK's ANDROID_ABI name and the
+    // compiler-rt builtins arch suffix. Both 64-bit (arm64-v8a) and 32-bit
+    // (armeabi-v7a) are supported: shadowhook ships an inline-hook backend
+    // for each (arch/arm64 and arch/arm), selected via ${ARCH} in its
+    // CMakeLists, and the hook logic here is symbol-name based, so it's
+    // ABI-agnostic. 32-bit is needed to inject into 32-bit app processes
+    // (forked from zygote32) — otherwise NeoZygisk fails to load us there.
+    let (android_abi, builtins_arch) = if target.starts_with("aarch64") {
+        ("arm64-v8a", "aarch64")
+    } else if target.starts_with("armv7") || target.starts_with("thumbv7") {
+        ("armeabi-v7a", "arm")
+    } else {
+        panic!("vpnhide-zygisk supports arm64-v8a / armeabi-v7a only (target={target})");
+    };
 
     // cargo-ndk sets ANDROID_NDK_HOME before invoking us.
     let ndk = env::var("ANDROID_NDK_HOME")
@@ -55,7 +65,7 @@ fn main() {
     // pin the exact CMake target to build.
     let dst = cmake::Config::new(&shadowhook_src)
         .define("CMAKE_TOOLCHAIN_FILE", &toolchain_file)
-        .define("ANDROID_ABI", "arm64-v8a")
+        .define("ANDROID_ABI", android_abi)
         .define("ANDROID_PLATFORM", "android-24")
         .define("SHADOWHOOK_STATIC", "ON")
         .no_build_target(true)
@@ -83,19 +93,21 @@ fn main() {
     // dynamic linker rejects it at dlopen time:
     //   cannot locate symbol "__clear_cache" referenced by ...
     // Pull it from the NDK's compiler-rt builtins archive.
-    if let Some(builtins) = find_ndk_builtins(&ndk) {
+    if let Some(builtins) = find_ndk_builtins(&ndk, builtins_arch) {
         println!("cargo:rustc-link-arg={}", builtins.display());
     } else {
         println!(
-            "cargo:warning=libclang_rt.builtins-aarch64-android.a not found under {ndk}; \
+            "cargo:warning=libclang_rt.builtins-{builtins_arch}-android.a not found under {ndk}; \
              __clear_cache may be unresolved at dlopen time"
         );
     }
 }
 
-/// Locate `libclang_rt.builtins-aarch64-android.a` inside an NDK tree.
+/// Locate `libclang_rt.builtins-<arch>-android.a` inside an NDK tree, where
+/// `<arch>` is `aarch64` (arm64-v8a) or `arm` (armeabi-v7a).
 /// Typical layout: `<ndk>/toolchains/llvm/prebuilt/<host>/lib/clang/<ver>/lib/linux/…`.
-fn find_ndk_builtins(ndk: &str) -> Option<PathBuf> {
+fn find_ndk_builtins(ndk: &str, arch: &str) -> Option<PathBuf> {
+    let file_name = format!("libclang_rt.builtins-{arch}-android.a");
     let base = PathBuf::from(ndk).join("toolchains/llvm/prebuilt");
     for host in fs::read_dir(&base).ok()?.flatten() {
         let clang_dir = host.path().join("lib/clang");
@@ -103,9 +115,7 @@ fn find_ndk_builtins(ndk: &str) -> Option<PathBuf> {
             continue;
         };
         for v in versions.flatten() {
-            let candidate = v
-                .path()
-                .join("lib/linux/libclang_rt.builtins-aarch64-android.a");
+            let candidate = v.path().join("lib/linux").join(&file_name);
             if candidate.is_file() {
                 return Some(candidate);
             }

--- a/zygisk/module/customize.sh
+++ b/zygisk/module/customize.sh
@@ -9,8 +9,10 @@ MOD_VER="$(grep '^version=' "$MODPATH/module.prop" | cut -d= -f2)"
 ui_print "- VPN Hide (Zygisk) ${MOD_VER:-unknown}"
 ui_print "- Installing to $MODPATH"
 
-# Make the native library readable/executable by zygote
+# Make the native libraries readable/executable by zygote (one per ABI:
+# arm64-v8a for 64-bit processes, armeabi-v7a for 32-bit ones).
 set_perm "$MODPATH/zygisk/arm64-v8a.so" 0 0 0755
+[ -f "$MODPATH/zygisk/armeabi-v7a.so" ] && set_perm "$MODPATH/zygisk/armeabi-v7a.so" 0 0 0755
 set_perm "$MODPATH/activator" 0 0 0755
 set_perm "$MODPATH/service.sh" 0 0 0755
 set_perm "$MODPATH/uninstall.sh" 0 0 0755

--- a/zygisk/src/hooks.rs
+++ b/zygisk/src/hooks.rs
@@ -576,7 +576,12 @@ pub unsafe extern "C" fn hooked_ioctl(
 /// (0x8970) sat above the ceiling too. SIOCGIFNAME (0x8910) and SIOCGIFCONF
 /// (0x8912) are handled in their own branches before this check.
 fn is_siocgif(request: libc::c_ulong) -> bool {
-    (0x8910..=0x8970).contains(&(request as u32))
+    // c_ulong is u64 on 64-bit (the `as u32` truncates the ioctl request to
+    // its low 32 bits) but already u32 on armeabi-v7a, where clippy sees the
+    // cast as unnecessary — the truncation is intended, so allow it.
+    #[allow(clippy::unnecessary_cast)]
+    let request = request as u32;
+    (0x8910..=0x8970).contains(&request)
 }
 
 /// Walk the `ifreq[]` array inside an `ifconf`, shift non-VPN entries forward,
@@ -1578,6 +1583,10 @@ mod setsockopt_tests {
     static REAL_CALLS: AtomicUsize = AtomicUsize::new(0);
     static LAST_OPTLEN: AtomicU32 = AtomicU32::new(0);
 
+    // socklen_t is u32 on 64-bit bionic but i32 on 32-bit (armeabi-v7a); the
+    // `as u32` below is required on arm and a no-op on arm64, so allow the
+    // "unnecessary cast" clippy fires on the 64-bit build.
+    #[allow(clippy::unnecessary_cast)]
     unsafe extern "C" fn fake_setsockopt(
         _fd: c_int,
         _level: c_int,
@@ -1586,7 +1595,7 @@ mod setsockopt_tests {
         optlen: libc::socklen_t,
     ) -> c_int {
         REAL_CALLS.fetch_add(1, Ordering::Relaxed);
-        LAST_OPTLEN.store(optlen, Ordering::Relaxed);
+        LAST_OPTLEN.store(optlen as u32, Ordering::Relaxed);
         73
     }
 


### PR DESCRIPTION
The Zygisk module only shipped `arm64-v8a.so`, so NeoZygisk failed to load it into 32-bit app processes forked from zygote32 (`No such file or directory` in the Magisk log) and native-mode hiding was dead in those processes — the case reported on a Galaxy S9+, which is 64-bit but still runs 32-bit apps. shadowhook already has a 32-bit backend (`arch/arm`); the only real blockers were arm64 hardcodes in the Rust build glue plus two casts that only compiled on 64-bit. The module now ships one `.so` per ABI and NeoZygisk picks the right one per process bitness.

Fixes #251.

- build.rs: derive `ANDROID_ABI` and the compiler-rt builtins arch from the Rust target triple instead of hardcoding aarch64 / arm64-v8a
- build.py: build both ABIs and ship `arm64-v8a.so` + `armeabi-v7a.so`
- customize.sh: set perms on the armeabi-v7a `.so` when present
- hooks.rs: fix `socklen_t` (u32 vs i32) and `c_ulong` (u64 vs u32) casts that only compiled cleanly on 64-bit
- CI: add `armv7-linux-androideabi` to the image and to the lint/zygisk jobs so PRs are green before the post-merge image rebuild

Testing: builds locally for both ABIs; the produced `armeabi-v7a.so` is a 32-bit ARM ELF with 16 KiB-aligned LOAD segments and `__clear_cache` resolved. Still needs a device with 32-bit app processes (e.g. the reporter's S9+) to confirm the missing-`.so` error is gone and hooks attach in a 32-bit process.