### PR TITLE
fix(kpm): hide ioctl(SIOCGIFINDEX) interface-index probes

### DIFF
--- a/changelog.d/fixed-kpm-backend-now-hides-ioctl-siocgifindex-5fbb.md
+++ b/changelog.d/fixed-kpm-backend-now-hides-ioctl-siocgifindex-5fbb.md
@@ -1,0 +1,9 @@
+_2026-08-14_
+
+## English
+
+KPM backend now hides ioctl(SIOCGIFINDEX) interface-index probes (used by if_nametoindex), closing a VPN-presence leak that the .ko and Zygisk backends already blocked.
+
+## Русский
+
+KPM-бэкенд теперь скрывает запросы индекса интерфейса через ioctl(SIOCGIFINDEX) (их использует if_nametoindex) — закрыта утечка присутствия VPN, которую бэкенды .ko и Zygisk уже блокировали.

--- a/docs/detection-vectors.md
+++ b/docs/detection-vectors.md
@@ -154,6 +154,17 @@ saw a one-interface discrepancy. `sock_ioctl_ret` now also handles the
 exact set/naming `inet_gifconf` would have emitted), so the size query agrees with
 the filtered fill. Validated by the harness `ifconf_probe` vector.
 
+**By-name `SIOCGIF*` range — the whole `0x8910`–`0x8970` family, not just the
+common few.** The by-name row above covers every get-by-name ioctl, and the gate
+must span the full range: `SIOCGIFINDEX` (0x8933, the ioctl `if_nametoindex()`
+issues), `SIOCGIFTXQLEN` (0x8942), and `SIOCGIFMAP` (0x8970) all sit above the
+"obvious" FLAGS/MTU/HWADDR cluster. A too-narrow ceiling leaks: `if_nametoindex`
+returning a non-zero index for a hidden `vpn0` is a positive fingerprint. The
+`.ko` avoids the trap entirely by filtering on the *returned* name with no cmd
+gate; zygisk and KPM both use an explicit `0x8910..=0x8970` range check. (KPM
+briefly capped at `0x8930` and leaked `SIOCGIFINDEX` before this was widened to
+match.)
+
 All three native implementations also clear the compacted part of the
 kernel-written buffer before shortening `ifc_len`. Without that cleanup, a
 caller could scan its oversized buffer past the reported length and recover a

--- a/kmod/kpm/vpnhide_kpm.c
+++ b/kmod/kpm/vpnhide_kpm.c
@@ -875,13 +875,10 @@ static void socket_bind_sk_before(hook_fargs8_t *fargs, void *udata)
 	socket_bind_before_common(fargs, 1);
 }
 
-/* SIOCGIF* range (0x8910..0x8930). SIOCGIFCONF (0x8912) goes via sock_ioctl,
- * never dev_ioctl, so the overlap is harmless here. */
-static int is_siocgif(unsigned long cmd)
-{
-	return cmd >= 0x8910 && cmd <= 0x8930;
-}
-
+/* The get-interface-by-name opcode range (0x8910..0x8970) is the shared
+ * predicate vpnhide_ioctl_is_get_by_name() in shared/vpnhide_logic.h — one
+ * source of truth so this gate cannot narrow below SIOCGIFINDEX (0x8933) again
+ * while the zygisk copy stays wide, which is exactly how a leak crept in before. */
 static void dev_ioctl_after(hook_fargs5_t *fargs, void *udata)
 {
 	unsigned long cmd = (unsigned long)fargs->arg1;
@@ -891,7 +888,8 @@ static void dev_ioctl_after(hook_fargs5_t *fargs, void *udata)
 
 	if ((long)fargs->ret != 0 || !ifr)
 		return;
-	if (!hook_active(VPNHIDE_HOOK_DEV_IOCTL) || !is_siocgif(cmd))
+	if (!hook_active(VPNHIDE_HOOK_DEV_IOCTL) ||
+	    !vpnhide_ioctl_is_get_by_name(cmd))
 		return;
 
 	if (ptr_is_kernel(ifr)) {

--- a/kmod/shared/test_vpnhide_logic.c
+++ b/kmod/shared/test_vpnhide_logic.c
@@ -141,6 +141,33 @@ static void test_is_physical_iface(void)
 	expect_int("phys NULL", vpnhide_iface_is_physical((const char *)0), 0);
 }
 
+static void test_ioctl_is_get_by_name(void)
+{
+	/* The whole get-by-name SIOCGIF* family must be inside the range. The
+	 * regression that motivated this vector: a 0x8930 ceiling excluded
+	 * SIOCGIFINDEX (0x8933), so `if_nametoindex("vpn0")` leaked the index. */
+	expect_int("ioctl SIOCGIFNAME 0x8910",
+		   vpnhide_ioctl_is_get_by_name(0x8910), 1);
+	expect_int("ioctl SIOCGIFCONF 0x8912",
+		   vpnhide_ioctl_is_get_by_name(0x8912), 1);
+	expect_int("ioctl SIOCGIFFLAGS 0x8913",
+		   vpnhide_ioctl_is_get_by_name(0x8913), 1);
+	expect_int("ioctl SIOCGIFHWADDR 0x8927",
+		   vpnhide_ioctl_is_get_by_name(0x8927), 1);
+	expect_int("ioctl SIOCGIFINDEX 0x8933 (regression)",
+		   vpnhide_ioctl_is_get_by_name(0x8933), 1);
+	expect_int("ioctl SIOCGIFTXQLEN 0x8942",
+		   vpnhide_ioctl_is_get_by_name(0x8942), 1);
+	expect_int("ioctl SIOCGIFMAP 0x8970",
+		   vpnhide_ioctl_is_get_by_name(0x8970), 1);
+	/* Just outside the range on both ends. */
+	expect_int("ioctl 0x890f below range",
+		   vpnhide_ioctl_is_get_by_name(0x890f), 0);
+	expect_int("ioctl 0x8971 above range",
+		   vpnhide_ioctl_is_get_by_name(0x8971), 0);
+	expect_int("ioctl 0 non-ioctl", vpnhide_ioctl_is_get_by_name(0), 0);
+}
+
 int main(void)
 {
 	test_route_first_field();
@@ -149,6 +176,7 @@ int main(void)
 	test_is_public_ipv4();
 	test_is_public_ipv6();
 	test_is_physical_iface();
+	test_ioctl_is_get_by_name();
 	if (failures) {
 		fprintf(stderr, "%d test(s) failed\n", failures);
 		return 1;

--- a/kmod/shared/vpnhide_logic.h
+++ b/kmod/shared/vpnhide_logic.h
@@ -85,6 +85,23 @@ static inline int vpnhide_iface_is_physical(const char *name)
 	       vpnhide_str_starts_with_ci(name, "seth");
 }
 
+/* True if `cmd` is a get-interface-by-name ioctl: the whole SIOCGIF* family
+ * from SIOCGIFNAME (0x8910) through SIOCGIFMAP (0x8970), each of which takes a
+ * `struct ifreq` with the interface name in `ifr_name`. A backend that gates
+ * dev_ioctl on the opcode (the KPM does; the zygisk libc hook carries the same
+ * range in Rust) MUST span the full range: `SIOCGIFINDEX` (0x8933, the ioctl
+ * `if_nametoindex()` issues), `SIOCGIFTXQLEN` (0x8942), and `SIOCGIFMAP`
+ * (0x8970) all sit above the obvious FLAGS/MTU/HWADDR cluster, and a too-narrow
+ * ceiling leaks VPN presence (a non-zero `if_nametoindex("vpn0")` is a positive
+ * fingerprint). SIOCGIFCONF (0x8912) is handled on a separate path (sock_ioctl),
+ * so its membership here is harmless. The `.ko` needs no opcode gate at all — it
+ * filters on the returned `ifr_name` — but the predicate stays freestanding and
+ * available to any opcode-gated backend. */
+static inline int vpnhide_ioctl_is_get_by_name(unsigned long cmd)
+{
+	return cmd >= 0x8910 && cmd <= 0x8970;
+}
+
 /* Public-IPv4 test on the 4 network-order bytes of an address (be[0] is the
  * first octet, so this is endianness-explicit — no host byte-swap needed).
  * Rejects 0/8, 10/8, 127/8, 224/4+, 100.64/10, 169.254/16, 172.16/12,


### PR DESCRIPTION
The KPM backend's `dev_ioctl` gate capped the `SIOCGIF*` opcode range at `0x8930`, which excluded `SIOCGIFINDEX` (0x8933) — the ioctl `if_nametoindex()` issues — along with `SIOCGIFTXQLEN` (0x8942) and `SIOCGIFMAP` (0x8970). On a KPM-backed device a target app could call `if_nametoindex("vpn0")` and get back the real interface index, a positive VPN-presence fingerprint, even though the `.ko` (which filters on the returned name with no opcode gate) and the Zygisk libc hook (range already `0x8910..0x8970`) both hid it. The Zygisk copy was widened for exactly this reason in an earlier release; the KPM never received the same fix, and `docs/detection-vectors.md` claimed coverage the code didn't provide.

- Widen the KPM `dev_ioctl` opcode gate to the full by-name range `0x8910..0x8970`.
- Hoist the range into `kmod/shared/vpnhide_logic.h` as `vpnhide_ioctl_is_get_by_name()` so it is a single source of truth instead of a per-backend literal that can silently narrow again.
- Pin the boundary — `SIOCGIFINDEX` included — with host vectors in `kmod/shared/test_vpnhide_logic.c`.
- Add a pin-point note for the by-name range to `docs/detection-vectors.md`.

## Testing

- `gcc -O2 -Wall -Wextra -Werror -I.. -o /tmp/t test_vpnhide_logic.c && /tmp/t` passes.
- Verified the new vectors catch the regression: reverting the ceiling to `0x8930` fails the test on `SIOCGIFINDEX 0x8933`, `SIOCGIFTXQLEN 0x8942`, and `SIOCGIFMAP 0x8970` (this host test already runs in CI).