### PR TITLE
fix(protocol): reject non-digit header version in the Kotlin parser

### DIFF
--- a/kmod/shared/protocol_vectors.tsv
+++ b/kmod/shared/protocol_vectors.tsv
@@ -96,6 +96,12 @@ kind|vpnhide 0 stats\n|INVALID
 kind|vpnhide 2 stats\n|INVALID
 kind|vpnhide 2 status\n|INVALID
 kind|garbage\n|INVALID
+# The version token is DIGITS ONLY (§4.2). A leading `+` is not a digit, so the
+# header is rejected whole — even though `+1`/`+2` name a current version. This
+# pins a classic silent-drift corner: C/Rust reject `+`, but a naive decimal
+# parse (e.g. Kotlin's toIntOrNull) would fold `+2` to 2 and misclassify it.
+kind|vpnhide +1 stats\n|INVALID
+kind|vpnhide +2 config\n|INVALID
 # non-ASCII first significant line rejects the whole payload — the parser must
 # NOT skip it and find the header on the following line (§4.2 parity).
 kind|\x80bad\nvpnhide 2 config\n|INVALID

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/Protocol.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/Protocol.kt
@@ -125,7 +125,14 @@ internal object Protocol {
             if (!isAscii(line)) return null
             val toks = tokens(contentAfterWs(line))
             if (toks.getOrNull(0) != "vpnhide") return null
-            val ver = toks.getOrNull(1)?.toIntOrNull() ?: return null
+            // Digits only, matching the C (`vpnhide_tok_decimal`) and Rust
+            // (`parse_decimal`) version parsers. Kotlin's `toIntOrNull()` would
+            // otherwise accept a leading `+` (`"+2".toIntOrNull() == 2`), which
+            // those reject — a silent three-parser drift the shared `kind`
+            // vectors (`vpnhide +1 stats`) now pin.
+            val verTok = toks.getOrNull(1) ?: return null
+            if (verTok.isEmpty() || verTok.any { it !in '0'..'9' }) return null
+            val ver = verTok.toIntOrNull() ?: return null
             val kind =
                 when (toks.getOrNull(2)) {
                     "config" -> Kind.CONFIG


### PR DESCRIPTION
The wire header version is digits-only (§4.2), and the C (`vpnhide_tok_decimal`) and Rust (`parse_decimal`) parsers enforce that. The Kotlin parser used `String.toIntOrNull()`, which accepts a leading `+` (`"+2".toIntOrNull() == 2`), so it would classify `vpnhide +2 config` / `vpnhide +1 stats` as a valid header while C and Rust reject them — a silent three-parser drift on a corner the golden vectors did not cover.

This parses the version as digits-only in Kotlin and pins the corner with shared `kind` vectors, so the divergence is caught in CI across all three parsers. The drift is not reachable in practice — the app only ever parses backend-generated telemetry and its own self-written LSPosed state file — so there is no user-visible behavior change; this is a conformance/robustness fix (hence no changelog fragment).

- `Protocol.kt`: reject a version token containing any non-digit.
- `protocol_vectors.tsv`: add `vpnhide +1 stats` / `vpnhide +2 config` → `INVALID`.

## Testing

- C: `test_protocol` passes all 58 vectors (incl. the two new ones).
- Rust: `cargo test -p vpnhide_protocol` passes (same TSV).
- Kotlin: `ProtocolTest` passes with the fix; verified it **fails** at the `+` vector when the fix is reverted, so the vector genuinely catches the drift.
- `ktlintCheck` + `detekt` clean.