### PR TITLE
refactor(lsposed): extract ButtonSpinner and SettingsStatusLine helpers

### DIFF
--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DiagnosticsScreen.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DiagnosticsScreen.kt
@@ -36,6 +36,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import dev.okhsunrog.vpnhide.generated.IfaceLists
+import dev.okhsunrog.vpnhide.ui.components.ButtonSpinner
 import dev.okhsunrog.vpnhide.ui.components.EnhancedButton
 import dev.okhsunrog.vpnhide.ui.components.EnhancedCard
 import dev.okhsunrog.vpnhide.ui.components.GroupedCard
@@ -241,11 +242,7 @@ fun DebugToolsSection(
                 modifier = Modifier.fillMaxWidth(),
             ) {
                 if (exporting) {
-                    CircularProgressIndicator(
-                        modifier = Modifier.size(18.dp),
-                        strokeWidth = 2.dp,
-                        color = MaterialTheme.colorScheme.onPrimary,
-                    )
+                    ButtonSpinner()
                     Spacer(Modifier.width(8.dp))
                 }
                 Text(
@@ -327,11 +324,7 @@ private fun KernelImageExportCard() {
                     modifier = Modifier.fillMaxWidth(),
                 ) {
                     if (exporting) {
-                        CircularProgressIndicator(
-                            modifier = Modifier.size(18.dp),
-                            strokeWidth = 2.dp,
-                            color = MaterialTheme.colorScheme.onPrimary,
-                        )
+                        ButtonSpinner()
                     } else {
                         Icon(
                             Icons.Default.FileDownload,

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/FullResetDialog.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/FullResetDialog.kt
@@ -6,9 +6,7 @@ import android.net.Uri
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.size
 import androidx.compose.material3.AlertDialog
-import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
@@ -19,10 +17,10 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
-import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
+import dev.okhsunrog.vpnhide.ui.components.ButtonSpinner
 import kotlinx.coroutines.launch
 
 private fun resetBlockerLabel(blocker: ResetBlocker): Int =
@@ -182,7 +180,7 @@ private fun ProgressRow(textRes: Int) {
         horizontalArrangement = Arrangement.spacedBy(12.dp),
         verticalAlignment = androidx.compose.ui.Alignment.CenterVertically,
     ) {
-        CircularProgressIndicator(modifier = Modifier.size(20.dp), strokeWidth = 2.dp)
+        ButtonSpinner(size = 20.dp, color = MaterialTheme.colorScheme.primary)
         Text(stringResource(textRes))
     }
 }

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/HiddenAppsSettingsScreen.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/HiddenAppsSettingsScreen.kt
@@ -58,6 +58,7 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
+import dev.okhsunrog.vpnhide.ui.components.ButtonSpinner
 import dev.okhsunrog.vpnhide.ui.components.EnhancedButton
 import dev.okhsunrog.vpnhide.ui.theme.AppColors
 import kotlinx.coroutines.Dispatchers
@@ -463,11 +464,7 @@ private fun HiddenAppsSaveBar(
             }
             EnhancedButton(onClick = onSave, enabled = dirty && !saving) {
                 if (saving) {
-                    CircularProgressIndicator(
-                        modifier = Modifier.size(18.dp),
-                        strokeWidth = 2.dp,
-                        color = MaterialTheme.colorScheme.onPrimary,
-                    )
+                    ButtonSpinner()
                     Spacer(Modifier.width(8.dp))
                 }
                 Text(stringResource(R.string.btn_save))

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/MainActivity.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/MainActivity.kt
@@ -52,6 +52,7 @@ import dev.okhsunrog.vpnhide.settings.LocalSettingsState
 import dev.okhsunrog.vpnhide.settings.RepositorySettingsInteractor
 import dev.okhsunrog.vpnhide.settings.SettingsRepository
 import dev.okhsunrog.vpnhide.ui.components.BlockingErrorCard
+import dev.okhsunrog.vpnhide.ui.components.ButtonSpinner
 import dev.okhsunrog.vpnhide.ui.components.EnhancedButton
 import dev.okhsunrog.vpnhide.ui.components.EnhancedCard
 import dev.okhsunrog.vpnhide.ui.components.pulse
@@ -608,11 +609,7 @@ private fun MainScreen() {
                                 enabled = !refreshContext.loading,
                             ) {
                                 if (refreshContext.loading) {
-                                    CircularProgressIndicator(
-                                        modifier = Modifier.size(20.dp),
-                                        strokeWidth = 2.dp,
-                                        color = MaterialTheme.colorScheme.onSurfaceVariant,
-                                    )
+                                    ButtonSpinner(size = 20.dp)
                                 } else {
                                     Icon(
                                         Icons.Default.Refresh,

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/SettingsScreen.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/SettingsScreen.kt
@@ -79,6 +79,7 @@ import dev.okhsunrog.vpnhide.settings.CornerStyle
 import dev.okhsunrog.vpnhide.settings.LocalSettingsInteractor
 import dev.okhsunrog.vpnhide.settings.LocalSettingsState
 import dev.okhsunrog.vpnhide.settings.ThemeMode
+import dev.okhsunrog.vpnhide.ui.components.ButtonSpinner
 import dev.okhsunrog.vpnhide.ui.components.EnhancedButton
 import dev.okhsunrog.vpnhide.ui.components.EnhancedOutlinedButton
 import dev.okhsunrog.vpnhide.ui.components.PreferenceRow
@@ -89,6 +90,20 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import java.nio.charset.StandardCharsets
+
+/** The small status line shown under a settings action (import/export result,
+ * superkey save outcome). Renders nothing when [status] is null. */
+@Composable
+private fun SettingsStatusLine(status: String?) {
+    status?.let {
+        Text(
+            text = it,
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            modifier = Modifier.padding(start = 4.dp),
+        )
+    }
+}
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -523,11 +538,7 @@ private fun ConfigBackupSection() {
                 modifier = Modifier.weight(1f),
             ) {
                 if (operation == ConfigOperation.Export) {
-                    CircularProgressIndicator(
-                        modifier = Modifier.size(18.dp).padding(end = 8.dp),
-                        strokeWidth = 2.dp,
-                        color = MaterialTheme.colorScheme.primary,
-                    )
+                    ButtonSpinner(Modifier.padding(end = 8.dp))
                 } else {
                     Icon(Icons.Default.FileDownload, contentDescription = null, modifier = Modifier.size(18.dp))
                     Spacer(Modifier.width(8.dp))
@@ -550,11 +561,7 @@ private fun ConfigBackupSection() {
                 modifier = Modifier.weight(1f),
             ) {
                 if (operation == ConfigOperation.Import) {
-                    CircularProgressIndicator(
-                        modifier = Modifier.size(18.dp).padding(end = 8.dp),
-                        strokeWidth = 2.dp,
-                        color = MaterialTheme.colorScheme.onPrimary,
-                    )
+                    ButtonSpinner(Modifier.padding(end = 8.dp))
                 } else {
                     Icon(Icons.Default.FileUpload, contentDescription = null, modifier = Modifier.size(18.dp))
                     Spacer(Modifier.width(8.dp))
@@ -575,14 +582,7 @@ private fun ConfigBackupSection() {
             enabled = targets != null && operation == ConfigOperation.Idle,
             onClick = { packageListDialogOpen = true },
         )
-        status?.let {
-            Text(
-                text = it,
-                style = MaterialTheme.typography.bodySmall,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
-                modifier = Modifier.padding(start = 4.dp),
-            )
-        }
+        SettingsStatusLine(status)
     }
 
     val packageListConfig = targets?.let(::buildConfigExportCanonical)
@@ -818,23 +818,12 @@ private fun SuperkeySettingsSection() {
                 modifier = Modifier.weight(1f),
             ) {
                 if (saving) {
-                    CircularProgressIndicator(
-                        modifier = Modifier.size(18.dp).padding(end = 8.dp),
-                        strokeWidth = 2.dp,
-                        color = MaterialTheme.colorScheme.onPrimary,
-                    )
+                    ButtonSpinner(Modifier.padding(end = 8.dp))
                 }
                 Text(stringResource(R.string.settings_superkey_store))
             }
         }
-        status?.let {
-            Text(
-                text = it,
-                style = MaterialTheme.typography.bodySmall,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
-                modifier = Modifier.padding(start = 4.dp),
-            )
-        }
+        SettingsStatusLine(status)
     }
 }
 
@@ -1046,14 +1035,7 @@ private fun AutoHideSettingsSection(onOpenHiddenApps: () -> Unit) {
             enabled = canWrite && unavailableConfigured.isNotEmpty(),
             onClick = { unavailableDialogOpen = true },
         )
-        status?.let {
-            Text(
-                text = it,
-                style = MaterialTheme.typography.bodySmall,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
-                modifier = Modifier.padding(start = 4.dp),
-            )
-        }
+        SettingsStatusLine(status)
     }
 
     if (unavailableDialogOpen) {

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/ui/components/Enhanced.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/ui/components/Enhanced.kt
@@ -8,9 +8,11 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.RowScope
+import androidx.compose.foundation.layout.size
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonColors
 import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.IconButtonColors
@@ -31,6 +33,8 @@ import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.graphics.takeOrElse
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
 import dev.okhsunrog.vpnhide.ui.theme.AppColors
 import dev.okhsunrog.vpnhide.ui.theme.AppMotion
 import dev.okhsunrog.vpnhide.ui.theme.groupCornerRadii
@@ -211,6 +215,25 @@ fun EnhancedIconButton(
     ) {
         Icon(imageVector = icon, contentDescription = contentDescription)
     }
+}
+
+/**
+ * A small circular progress spinner sized for inline use inside a button or a
+ * compact status row (the `strokeWidth = 2.dp` look repeated across the app).
+ * [color] defaults to [LocalContentColor], so inside a Material button it inherits
+ * the button's content color automatically — pass it explicitly only outside one.
+ */
+@Composable
+fun ButtonSpinner(
+    modifier: Modifier = Modifier,
+    size: Dp = 18.dp,
+    color: Color = LocalContentColor.current,
+) {
+    CircularProgressIndicator(
+        modifier = modifier.size(size),
+        strokeWidth = 2.dp,
+        color = color,
+    )
 }
 
 @Composable


### PR DESCRIPTION
Pure Compose cleanup — no behavior or visual change. Two small pieces of markup were duplicated across the app; this folds each into a shared helper.

- Add `ButtonSpinner` in `ui/components/Enhanced.kt` — the in-button/inline progress spinner (`strokeWidth = 2.dp`) was copy-pasted eight times across five files. Its `color` defaults to `LocalContentColor`, so callers inside a Material button drop the explicit content-color argument (and it now auto-adapts to the button's content color).
- Add a file-local `SettingsStatusLine` in `SettingsScreen.kt` — three byte-identical `status?.let { Text(...) }` blocks collapse into one helper.
- Drop the now-unused `CircularProgressIndicator`/`Modifier`/`layout.size` imports from `FullResetDialog.kt`.

Colors are preserved exactly: `LocalContentColor` inside each button equals the color that was passed before (primary for the outlined export button, onPrimary for the filled buttons, onSurfaceVariant for the inactive toolbar refresh), and the one standalone spinner in `FullResetDialog`'s progress row keeps its explicit `primary`.

Net −63/+53 across six files.