### PR TITLE
refactor(lsposed): collapse duplicated UI markup and mappings into shared helpers

### DIFF
--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/AppPickerData.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/AppPickerData.kt
@@ -188,10 +188,9 @@ internal fun applyAutoHiddenPackages(
     val observerPkgs = config.apps.filterValues { it.appHiding }.keys
     val manualHiddenPkgs = config.apps.filterValues { it.hidden }.keys - config.settings.autoHiddenPackages
     val autoHiddenPkgs = resolveAutoHiddenPackages(signals, config.settings, selfPkg)
-    val effectiveAutoHiddenPkgs = autoHiddenPkgs
     val hiddenPkgs =
         resolveHiddenPackages(
-            existing = manualHiddenPkgs + effectiveAutoHiddenPkgs,
+            existing = manualHiddenPkgs + autoHiddenPkgs,
             selfPkg = selfPkg,
         )
     return buildCanonicalConfig(
@@ -201,7 +200,7 @@ internal fun applyAutoHiddenPackages(
         hiddenPkgs = hiddenPkgs,
         observerPkgs = observerPkgs,
         portsPkgs = config.apps.filterValues { it.ports }.keys,
-        existing = config.copy(settings = config.settings.copy(autoHiddenPackages = effectiveAutoHiddenPkgs.toSortedSet())),
+        existing = config.copy(settings = config.settings.copy(autoHiddenPackages = autoHiddenPkgs.toSortedSet())),
     )
 }
 
@@ -294,32 +293,29 @@ private fun Collection<AppRoleSelection>.selectedPortPolicies(): Map<String, Por
             selection.packageName to normalizePortPolicy(selection.portPolicy)
         }
 
-private fun CanonicalConfig.withJavaHooks(hooks: Map<String, List<String>?>): CanonicalConfig {
-    if (hooks.isEmpty()) return this
+/**
+ * Rewrite the per-app [values] onto matching packages, preserving the sorted-map
+ * invariant. A no-op when [values] is empty; apps not in [values] are untouched.
+ * [set] applies one entry's value (which may itself be null, e.g. cleared hooks).
+ */
+private fun <V> CanonicalConfig.withAppValues(
+    values: Map<String, V>,
+    set: (CanonicalApp, V) -> CanonicalApp,
+): CanonicalConfig {
+    if (values.isEmpty()) return this
     val updated =
         apps
             .mapValues { (pkg, app) ->
-                if (pkg in hooks) app.copy(javaHooks = hooks[pkg]) else app
+                if (pkg in values) set(app, values.getValue(pkg)) else app
             }.toSortedMap()
     return copy(apps = updated)
 }
 
-private fun CanonicalConfig.withNativeRoles(roles: Map<String, NativeRole>): CanonicalConfig {
-    if (roles.isEmpty()) return this
-    val updated =
-        apps
-            .mapValues { (pkg, app) ->
-                roles[pkg]?.let { app.copy(native = it) } ?: app
-            }.toSortedMap()
-    return copy(apps = updated)
-}
+private fun CanonicalConfig.withJavaHooks(hooks: Map<String, List<String>?>): CanonicalConfig =
+    withAppValues(hooks) { app, v -> app.copy(javaHooks = v) }
 
-private fun CanonicalConfig.withPortPolicies(policies: Map<String, PortPolicy?>): CanonicalConfig {
-    if (policies.isEmpty()) return this
-    val updated =
-        apps
-            .mapValues { (pkg, app) ->
-                if (pkg in policies) app.copy(portPolicy = policies[pkg]) else app
-            }.toSortedMap()
-    return copy(apps = updated)
-}
+private fun CanonicalConfig.withNativeRoles(roles: Map<String, NativeRole>): CanonicalConfig =
+    withAppValues(roles) { app, v -> app.copy(native = v) }
+
+private fun CanonicalConfig.withPortPolicies(policies: Map<String, PortPolicy?>): CanonicalConfig =
+    withAppValues(policies) { app, v -> app.copy(portPolicy = v) }

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/AppSearchTopBar.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/AppSearchTopBar.kt
@@ -1,0 +1,58 @@
+package dev.okhsunrog.vpnhide
+
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Clear
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.SearchBar
+import androidx.compose.material3.SearchBarDefaults
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+
+/**
+ * The collapsed in-place search top bar shared by the app-picker and hidden-apps
+ * screens: a full-width [SearchBar] whose leading arrow closes search ([onClose])
+ * and whose trailing clear button appears only when [query] is non-empty. State
+ * lives with the caller; this is pure chrome.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+internal fun AppSearchTopBar(
+    query: String,
+    onQueryChange: (String) -> Unit,
+    onClose: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    SearchBar(
+        inputField = {
+            SearchBarDefaults.InputField(
+                query = query,
+                onQueryChange = onQueryChange,
+                onSearch = {},
+                expanded = false,
+                onExpandedChange = {},
+                placeholder = { Text(stringResource(R.string.search_placeholder)) },
+                leadingIcon = {
+                    IconButton(onClick = onClose) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = null)
+                    }
+                },
+                trailingIcon = {
+                    if (query.isNotEmpty()) {
+                        IconButton(onClick = { onQueryChange("") }) {
+                            Icon(Icons.Default.Clear, contentDescription = null)
+                        }
+                    }
+                },
+            )
+        },
+        expanded = false,
+        onExpandedChange = {},
+        modifier = modifier.fillMaxWidth(),
+    ) {}
+}

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DashboardScreen.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DashboardScreen.kt
@@ -231,56 +231,44 @@ fun DashboardScreen(
             UpdateAvailableCard(info)
         }
 
-        if (errors.isNotEmpty()) {
-            Spacer(Modifier.height(20.dp))
-            SectionHeader(stringResource(R.string.dashboard_issues, errors.size), color = errorHeader)
-            Spacer(Modifier.height(8.dp))
-            for (issue in errors) {
-                StatusBanner(
-                    text = issue.text,
-                    containerColor = errorBg,
-                    contentColor = onBannerColor,
-                    action = messageActionSlot(issue, onOpenDiagnostics) { showContact = true },
-                )
-                Spacer(Modifier.height(6.dp))
-            }
-        }
-
-        if (warnings.isNotEmpty()) {
-            Spacer(Modifier.height(20.dp))
-            SectionHeader(stringResource(R.string.dashboard_warnings, warnings.size), color = warningHeader)
-            Spacer(Modifier.height(8.dp))
-            for (issue in warnings) {
-                StatusBanner(
-                    text = issue.text,
-                    containerColor = warningBg,
-                    contentColor = onBannerColor,
-                    action = messageActionSlot(issue, onOpenDiagnostics) { showContact = true },
-                )
-                Spacer(Modifier.height(6.dp))
-            }
-        }
-
-        if (infos.isNotEmpty()) {
-            Spacer(Modifier.height(20.dp))
-            SectionHeader(stringResource(R.string.dashboard_info, infos.size), color = infoHeader)
-            Spacer(Modifier.height(8.dp))
-            for (message in infos) {
-                StatusBanner(
-                    text = message.text,
-                    containerColor = infoBg,
-                    contentColor = onBannerColor,
-                    action = messageActionSlot(message, onOpenDiagnostics) { showContact = true },
-                )
-                Spacer(Modifier.height(6.dp))
-            }
-        }
+        val onContact = { showContact = true }
+        MessageSection(errors, R.string.dashboard_issues, errorHeader, errorBg, onBannerColor, onOpenDiagnostics, onContact)
+        MessageSection(warnings, R.string.dashboard_warnings, warningHeader, warningBg, onBannerColor, onOpenDiagnostics, onContact)
+        MessageSection(infos, R.string.dashboard_info, infoHeader, infoBg, onBannerColor, onOpenDiagnostics, onContact)
 
         Spacer(Modifier.height(16.dp))
     }
 }
 
 // ── UI Components ────────────────────────────────────────────────────────
+
+// One severity block (issues / warnings / info): a counted section header over a
+// list of StatusBanners. No-op when [messages] is empty, so the three call sites
+// can't drift in spacing or action wiring. [titleRes] takes the count as its arg.
+@Composable
+private fun MessageSection(
+    messages: List<DashboardMessage>,
+    titleRes: Int,
+    headerColor: Color,
+    containerColor: Color,
+    contentColor: Color,
+    onOpenDiagnostics: () -> Unit,
+    onContact: () -> Unit,
+) {
+    if (messages.isEmpty()) return
+    Spacer(Modifier.height(20.dp))
+    SectionHeader(stringResource(titleRes, messages.size), color = headerColor)
+    Spacer(Modifier.height(8.dp))
+    for (message in messages) {
+        StatusBanner(
+            text = message.text,
+            containerColor = containerColor,
+            contentColor = contentColor,
+            action = messageActionSlot(message, onOpenDiagnostics, onContact),
+        )
+        Spacer(Modifier.height(6.dp))
+    }
+}
 
 // Maps a message's data-layer action tag to the actual button + handler in ONE
 // place, so a new action is an enum case + one branch here — not an edit in
@@ -600,18 +588,20 @@ private fun DashboardHeroCard(
                         accent = moduleSummaryAccent(state),
                         modifier = Modifier.weight(1f),
                     )
+                    val nativeMetric = protectionMetric(state.protection) { it.native }
                     MetricTile(
                         label = stringResource(R.string.dashboard_native_protection),
-                        value = nativeSummaryText(state.protection),
-                        accent = nativeSummaryAccent(state.protection),
+                        value = nativeMetric.text,
+                        accent = nativeMetric.accent,
                         modifier = Modifier.weight(1f),
                     )
                 }
                 Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                    val javaMetric = protectionMetric(state.protection) { it.java }
                     MetricTile(
                         label = stringResource(R.string.dashboard_java_protection),
-                        value = javaSummaryText(state.protection),
-                        accent = javaSummaryAccent(state.protection),
+                        value = javaMetric.text,
+                        accent = javaMetric.accent,
                         modifier = Modifier.weight(1f),
                     )
                     MetricTile(
@@ -643,86 +633,50 @@ private fun moduleSummaryAccent(state: DashboardState): Color {
     }
 }
 
-/** One tile label for any layer, from its [LayerStatus]/[Verdict]. Native and
- * Java tiles now share this mapping. */
+/** A metric tile's text + accent, kept in lock-step so they can't diverge. */
+private data class MetricSpec(
+    val text: String,
+    val accent: Color,
+)
+
+/** One tile's text + accent for any protection layer, from its
+ * [LayerStatus]/[Verdict]. Native and Java tiles share this mapping. */
 @Composable
-private fun layerSummaryText(layer: LayerStatus): String =
+private fun layerSummary(layer: LayerStatus): MetricSpec =
     when (layer) {
         LayerStatus.Absent -> {
-            stringResource(R.string.dashboard_protection_no_module)
+            MetricSpec(stringResource(R.string.dashboard_protection_no_module), MaterialTheme.colorScheme.onSurfaceVariant)
         }
 
         LayerStatus.Inactive -> {
-            stringResource(R.string.dashboard_protection_not_active)
+            MetricSpec(stringResource(R.string.dashboard_protection_not_active), MaterialTheme.colorScheme.onSurfaceVariant)
         }
 
         is LayerStatus.Active -> {
             when (layer.verdict) {
-                Verdict.Ok -> stringResource(R.string.dashboard_protection_ok)
-                Verdict.Partial -> stringResource(R.string.dashboard_protection_partial)
-                Verdict.Broken -> stringResource(R.string.dashboard_protection_fail)
+                Verdict.Ok -> MetricSpec(stringResource(R.string.dashboard_protection_ok), StatusColors.successDot)
+                Verdict.Partial -> MetricSpec(stringResource(R.string.dashboard_protection_partial), StatusColors.warningAccent)
+                Verdict.Broken -> MetricSpec(stringResource(R.string.dashboard_protection_fail), StatusColors.errorAccent)
             }
         }
     }
 
+/** The native/java tile metric for [protection]. [layer] picks which measured
+ * layer to summarize. VPN off / app not in the tunnel / needs restart reads
+ * "not checked" — the hero and banner carry the actual reason. */
 @Composable
-private fun layerSummaryAccent(layer: LayerStatus): Color =
-    when (layer) {
-        LayerStatus.Absent -> {
-            MaterialTheme.colorScheme.onSurfaceVariant
-        }
-
-        LayerStatus.Inactive -> {
-            MaterialTheme.colorScheme.onSurfaceVariant
-        }
-
-        is LayerStatus.Active -> {
-            when (layer.verdict) {
-                Verdict.Ok -> StatusColors.successDot
-                Verdict.Partial -> StatusColors.warningAccent
-                Verdict.Broken -> StatusColors.errorAccent
-            }
-        }
-    }
-
-@Composable
-private fun nativeSummaryText(protection: ProtectionCheck): String =
+private fun protectionMetric(
+    protection: ProtectionCheck,
+    layer: (ProtectionCheck.Checked) -> LayerStatus,
+): MetricSpec =
     when (protection) {
-        // VPN off / app not in the tunnel / needs restart: the layer wasn't measured, so the
-        // tile just reads "not checked" — the hero and banner carry the actual reason.
         is ProtectionCheck.Blocked, ProtectionCheck.Failed -> {
-            stringResource(R.string.dashboard_protection_unknown)
+            MetricSpec(stringResource(R.string.dashboard_protection_unknown), MaterialTheme.colorScheme.onSurfaceVariant)
         }
 
         is ProtectionCheck.Checked -> {
-            layerSummaryText(protection.native)
+            layerSummary(layer(protection))
         }
-    }
-
-@Composable
-private fun nativeSummaryAccent(protection: ProtectionCheck): Color =
-    when (protection) {
-        is ProtectionCheck.Blocked, ProtectionCheck.Failed -> MaterialTheme.colorScheme.onSurfaceVariant
-        is ProtectionCheck.Checked -> layerSummaryAccent(protection.native)
-    }
-
-@Composable
-private fun javaSummaryText(protection: ProtectionCheck): String =
-    when (protection) {
-        is ProtectionCheck.Blocked, ProtectionCheck.Failed -> {
-            stringResource(R.string.dashboard_protection_unknown)
-        }
-
-        is ProtectionCheck.Checked -> {
-            layerSummaryText(protection.java)
-        }
-    }
-
-@Composable
-private fun javaSummaryAccent(protection: ProtectionCheck): Color =
-    when (protection) {
-        is ProtectionCheck.Blocked, ProtectionCheck.Failed -> MaterialTheme.colorScheme.onSurfaceVariant
-        is ProtectionCheck.Checked -> layerSummaryAccent(protection.java)
     }
 
 private data class InstalledVisual(

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DiagnosticsScreen.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DiagnosticsScreen.kt
@@ -7,6 +7,7 @@ import android.net.NetworkCapabilities
 import android.net.Uri
 import android.os.Build
 import android.util.Log
+import androidx.activity.compose.ManagedActivityResultLauncher
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.animation.core.animateFloatAsState
@@ -186,6 +187,35 @@ fun DiagnosticsScreen(
     }
 }
 
+/**
+ * A "Save As…" launcher for a generated `application/zip` file: on a picked uri it
+ * copies [source]`()` off the main thread and swallows IO errors (a large zip would
+ * block the UI, and a write failure would crash) — logging under [errorLabel].
+ * [source] is read at launch time, so it always sees the latest generated file.
+ */
+@Composable
+private fun rememberZipSaveLauncher(
+    errorLabel: String,
+    source: () -> File?,
+): ManagedActivityResultLauncher<String, Uri?> {
+    val context = LocalContext.current
+    val scope = rememberCoroutineScope()
+    return rememberLauncherForActivityResult(
+        ActivityResultContracts.CreateDocument("application/zip"),
+    ) { uri: Uri? ->
+        val src = source() ?: return@rememberLauncherForActivityResult
+        if (uri != null) {
+            scope.launch(Dispatchers.IO) {
+                runCatching {
+                    context.contentResolver.openOutputStream(uri)?.use { out ->
+                        src.inputStream().use { it.copyTo(out) }
+                    }
+                }.onFailure { HookLog.e("VpnHide: $errorLabel save failed: ${it.message}") }
+            }
+        }
+    }
+}
+
 @Composable
 fun DebugToolsSection(
     selfNeedsRestart: Boolean?,
@@ -197,23 +227,7 @@ fun DebugToolsSection(
     var exporting by remember { mutableStateOf(false) }
     var debugZipFile by remember { mutableStateOf<File?>(null) }
 
-    val saveLauncher =
-        rememberLauncherForActivityResult(
-            ActivityResultContracts.CreateDocument("application/zip"),
-        ) { uri: Uri? ->
-            val zip = debugZipFile ?: return@rememberLauncherForActivityResult
-            if (uri != null) {
-                // Copy off the main thread and swallow IO errors — a large zip
-                // would otherwise block the UI and a write failure would crash.
-                scope.launch(Dispatchers.IO) {
-                    runCatching {
-                        context.contentResolver.openOutputStream(uri)?.use { out ->
-                            zip.inputStream().use { it.copyTo(out) }
-                        }
-                    }.onFailure { HookLog.e("VpnHide: debug-zip save failed: ${it.message}") }
-                }
-            }
-        }
+    val saveLauncher = rememberZipSaveLauncher("debug-zip") { debugZipFile }
 
     Column(
         modifier = modifier.fillMaxWidth(),
@@ -272,21 +286,7 @@ private fun KernelImageExportCard() {
     var exporting by remember { mutableStateOf(false) }
     var kernelImagesFile by remember { mutableStateOf<File?>(null) }
 
-    val saveLauncher =
-        rememberLauncherForActivityResult(
-            ActivityResultContracts.CreateDocument("application/zip"),
-        ) { uri: Uri? ->
-            val zip = kernelImagesFile ?: return@rememberLauncherForActivityResult
-            if (uri != null) {
-                scope.launch(Dispatchers.IO) {
-                    runCatching {
-                        context.contentResolver.openOutputStream(uri)?.use { out ->
-                            zip.inputStream().use { it.copyTo(out) }
-                        }
-                    }.onFailure { HookLog.e("VpnHide: kernel-image save failed: ${it.message}") }
-                }
-            }
-        }
+    val saveLauncher = rememberZipSaveLauncher("kernel-image") { kernelImagesFile }
 
     EnhancedCard(
         modifier = Modifier.fillMaxWidth(),
@@ -373,20 +373,7 @@ private fun LogcatRecordCard(selfNeedsRestart: Boolean?) {
     }
 
     val saveLauncher =
-        rememberLauncherForActivityResult(
-            ActivityResultContracts.CreateDocument("application/zip"),
-        ) { uri: Uri? ->
-            val src = (state as? LogcatRecorder.State.Stopped)?.lastFile ?: return@rememberLauncherForActivityResult
-            if (uri != null) {
-                scope.launch(Dispatchers.IO) {
-                    runCatching {
-                        context.contentResolver.openOutputStream(uri)?.use { out ->
-                            src.inputStream().use { it.copyTo(out) }
-                        }
-                    }.onFailure { HookLog.e("VpnHide: logcat save failed: ${it.message}") }
-                }
-            }
-        }
+        rememberZipSaveLauncher("logcat") { (state as? LogcatRecorder.State.Stopped)?.lastFile }
 
     EnhancedCard(
         modifier = Modifier.fillMaxWidth(),

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/HiddenAppsSettingsScreen.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/HiddenAppsSettingsScreen.kt
@@ -21,7 +21,6 @@ import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
-import androidx.compose.material.icons.filled.Clear
 import androidx.compose.material.icons.filled.Search
 import androidx.compose.material3.Checkbox
 import androidx.compose.material3.CircularProgressIndicator
@@ -33,8 +32,6 @@ import androidx.compose.material3.IconButton
 import androidx.compose.material3.IconButtonDefaults
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
-import androidx.compose.material3.SearchBar
-import androidx.compose.material3.SearchBarDefaults
 import androidx.compose.material3.SnackbarDuration
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
@@ -160,36 +157,14 @@ internal fun HiddenAppsSettingsScreen(onBack: () -> Unit) {
         containerColor = AppColors.screenBackground,
         topBar = {
             if (searchActive) {
-                SearchBar(
-                    inputField = {
-                        SearchBarDefaults.InputField(
-                            query = query,
-                            onQueryChange = { query = it },
-                            onSearch = {},
-                            expanded = false,
-                            onExpandedChange = {},
-                            placeholder = { Text(stringResource(R.string.search_placeholder)) },
-                            leadingIcon = {
-                                IconButton(onClick = {
-                                    searchActive = false
-                                    query = ""
-                                }) {
-                                    Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = null)
-                                }
-                            },
-                            trailingIcon = {
-                                if (query.isNotEmpty()) {
-                                    IconButton(onClick = { query = "" }) {
-                                        Icon(Icons.Default.Clear, contentDescription = null)
-                                    }
-                                }
-                            },
-                        )
+                AppSearchTopBar(
+                    query = query,
+                    onQueryChange = { query = it },
+                    onClose = {
+                        searchActive = false
+                        query = ""
                     },
-                    expanded = false,
-                    onExpandedChange = {},
-                    modifier = Modifier.fillMaxWidth(),
-                ) {}
+                )
             } else {
                 TopAppBar(
                     title = { Text(stringResource(R.string.settings_hidden_apps)) },

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/MainActivity.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/MainActivity.kt
@@ -21,10 +21,8 @@ import androidx.compose.animation.scaleOut
 import androidx.compose.animation.togetherWith
 import androidx.compose.foundation.layout.*
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.automirrored.filled.List
 import androidx.compose.material.icons.filled.BarChart
-import androidx.compose.material.icons.filled.Clear
 import androidx.compose.material.icons.filled.ErrorOutline
 import androidx.compose.material.icons.filled.Home
 import androidx.compose.material.icons.filled.Refresh
@@ -240,13 +238,16 @@ private data class RefreshContext(
 )
 
 @Composable
+private fun tabLabel(tab: Tab): String =
+    when (tab) {
+        Tab.Dashboard -> stringResource(R.string.tab_dashboard)
+        Tab.Statistics -> stringResource(R.string.tab_statistics)
+        Tab.Protection -> stringResource(R.string.tab_protection)
+    }
+
+@Composable
 private fun AppTopBarTitle(currentTab: Tab) {
-    val tabLabel =
-        when (currentTab) {
-            Tab.Dashboard -> stringResource(R.string.tab_dashboard)
-            Tab.Statistics -> stringResource(R.string.tab_statistics)
-            Tab.Protection -> stringResource(R.string.tab_protection)
-        }
+    val tabLabel = tabLabel(currentTab)
     // The full-size brand block (logo + wordmark) wants ~190dp. Material3's
     // TopAppBar hands the title only the width left over after the action
     // buttons, so on very narrow / high-density screens that slot shrinks.
@@ -295,12 +296,7 @@ private fun AppHeaderBrand(
     progress: Float,
     modifier: Modifier = Modifier,
 ) {
-    val tabLabel =
-        when (currentTab) {
-            Tab.Dashboard -> stringResource(R.string.tab_dashboard)
-            Tab.Statistics -> stringResource(R.string.tab_statistics)
-            Tab.Protection -> stringResource(R.string.tab_protection)
-        }
+    val tabLabel = tabLabel(currentTab)
     BoxWithConstraints(modifier) {
         val narrowScale = (maxWidth.value / 200f).coerceIn(0.6f, 1f)
         val logoSize = lerp(38.dp * narrowScale, 58.dp, progress)
@@ -486,36 +482,14 @@ private fun MainScreen() {
         containerColor = AppColors.screenBackground,
         topBar = {
             if (searchActive && currentTab == Tab.Protection) {
-                SearchBar(
-                    inputField = {
-                        SearchBarDefaults.InputField(
-                            query = searchQuery,
-                            onQueryChange = { searchQuery = it },
-                            onSearch = {},
-                            expanded = false,
-                            onExpandedChange = {},
-                            placeholder = { Text(stringResource(R.string.search_placeholder)) },
-                            leadingIcon = {
-                                IconButton(onClick = {
-                                    searchActive = false
-                                    searchQuery = ""
-                                }) {
-                                    Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = null)
-                                }
-                            },
-                            trailingIcon = {
-                                if (searchQuery.isNotEmpty()) {
-                                    IconButton(onClick = { searchQuery = "" }) {
-                                        Icon(Icons.Default.Clear, contentDescription = null)
-                                    }
-                                }
-                            },
-                        )
+                AppSearchTopBar(
+                    query = searchQuery,
+                    onQueryChange = { searchQuery = it },
+                    onClose = {
+                        searchActive = false
+                        searchQuery = ""
                     },
-                    expanded = false,
-                    onExpandedChange = {},
-                    modifier = Modifier.fillMaxWidth(),
-                ) {}
+                )
             } else {
                 // Dashboard on a tall screen gets an "airy" header: the brand
                 // grows and drops below the (fixed) action buttons. Everywhere

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/StatisticsScreen.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/StatisticsScreen.kt
@@ -792,12 +792,13 @@ private fun AppProbeDetailDialog(
                     .entries
                     .sortedByDescending { (_, hooks) -> hooks.sumOf { it.value } }
                     .forEach { (surface, surfaceHooks) ->
+                        val visual = surfaceVisual(surface)
                         Column(verticalArrangement = Arrangement.spacedBy(10.dp)) {
                             Text(
-                                text = surfaceLabel(surface),
+                                text = visual.label,
                                 style = MaterialTheme.typography.labelMedium,
                                 fontWeight = FontWeight.Bold,
-                                color = surfaceAccentColor(surface),
+                                color = visual.accent,
                             )
                             surfaceHooks
                                 .groupBy { DetectionMethod.of(it.key) }
@@ -874,7 +875,7 @@ private fun MethodChip(
         modifier =
             Modifier
                 .clip(MaterialTheme.shapes.small)
-                .background(surfaceContainerColor(method.surface))
+                .background(surfaceVisual(method.surface).container)
                 .padding(horizontal = 10.dp, vertical = 5.dp),
         verticalAlignment = Alignment.CenterVertically,
     ) {
@@ -893,31 +894,30 @@ private fun MethodChip(
     }
 }
 
-@Composable
-private fun surfaceContainerColor(surface: MethodSurface): Color =
+/** The container/accent colours and localized label for a detection surface,
+ * folded into one lookup (mirrors [HealthVisual]) so the three used to drift. */
+private data class SurfaceVisual(
+    val container: Color,
+    val accent: Color,
+    val label: String,
+)
+
+private fun surfaceLabelRes(surface: MethodSurface): Int =
     when (surface) {
-        MethodSurface.Java -> StatusColors.infoContainer()
-        MethodSurface.Native -> StatusColors.successContainer()
-        MethodSurface.Package -> StatusColors.neutralContainer()
+        MethodSurface.Java -> R.string.surface_java
+        MethodSurface.Native -> R.string.surface_native
+        MethodSurface.Package -> R.string.surface_package
     }
 
 @Composable
-private fun surfaceAccentColor(surface: MethodSurface): Color =
-    when (surface) {
-        MethodSurface.Java -> StatusColors.infoAccent
-        MethodSurface.Native -> StatusColors.successDot
-        MethodSurface.Package -> StatusColors.neutralAccent
+private fun surfaceVisual(surface: MethodSurface): SurfaceVisual {
+    val label = stringResource(surfaceLabelRes(surface))
+    return when (surface) {
+        MethodSurface.Java -> SurfaceVisual(StatusColors.infoContainer(), StatusColors.infoAccent, label)
+        MethodSurface.Native -> SurfaceVisual(StatusColors.successContainer(), StatusColors.successDot, label)
+        MethodSurface.Package -> SurfaceVisual(StatusColors.neutralContainer(), StatusColors.neutralAccent, label)
     }
-
-@Composable
-private fun surfaceLabel(surface: MethodSurface): String =
-    stringResource(
-        when (surface) {
-            MethodSurface.Java -> R.string.surface_java
-            MethodSurface.Native -> R.string.surface_native
-            MethodSurface.Package -> R.string.surface_package
-        },
-    )
+}
 
 @Composable
 private fun AppStatAvatar(icon: Drawable?) {
@@ -990,9 +990,9 @@ private fun appLabel(app: AppProbeStats): String =
 private fun appSurfacesText(app: AppProbeStats): String {
     // Resolve labels up front: stringResource can't be called inside the
     // joinToString transform (not a @Composable context).
-    val java = stringResource(R.string.surface_java)
-    val native = stringResource(R.string.surface_native)
-    val pkg = stringResource(R.string.surface_package)
+    val java = stringResource(surfaceLabelRes(MethodSurface.Java))
+    val native = stringResource(surfaceLabelRes(MethodSurface.Native))
+    val pkg = stringResource(surfaceLabelRes(MethodSurface.Package))
     return app.surfaces.sorted().joinToString(" · ") { surface ->
         when (surface) {
             MethodSurface.Java -> java

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/ui/components/Modifiers.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/ui/components/Modifiers.kt
@@ -8,9 +8,6 @@ import androidx.compose.animation.core.tween
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
-import androidx.compose.foundation.interaction.MutableInteractionSource
-import androidx.compose.foundation.interaction.collectIsPressedAsState
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -117,13 +114,3 @@ fun Modifier.pulse(
         scaleY = scale
     }
 }
-
-/** Tracks the pressed state of [interactionSource] (for press-scale effects). */
-@Composable
-fun rememberIsPressed(interactionSource: MutableInteractionSource): Boolean {
-    val pressed by interactionSource.collectIsPressedAsState()
-    return pressed
-}
-
-/** A medium rounded shape constant for ad-hoc use where the theme scale doesn't fit. */
-val DefaultRowShape: Shape = RoundedCornerShape(20.dp)

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/ui/theme/Motion.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/ui/theme/Motion.kt
@@ -70,12 +70,13 @@ object AppMotion {
 @OptIn(ExperimentalMaterial3ExpressiveApi::class)
 val AppMotionScheme: MotionScheme =
     object : MotionScheme {
-        private val defaultSpatial = tween<Any>(durationMillis = 400, easing = AppEasing.FancyTransition)
-        private val fastSpatial = spring<Any>(dampingRatio = 0.6f, stiffness = 800f)
-        private val slowSpatial = spring<Any>(dampingRatio = 0.8f, stiffness = 200f)
-        private val defaultEffects = spring<Any>(dampingRatio = 1.0f, stiffness = 1600f)
-        private val fastEffects = tween<Any>(durationMillis = 300, easing = AppEasing.FancyTransition)
-        private val slowEffects = tween<Any>(durationMillis = 500, easing = AppEasing.FancyTransition)
+        // Single-sourced from AppMotion so the spec literals live in exactly one place.
+        private val defaultSpatial = AppMotion.defaultSpatial<Any>()
+        private val fastSpatial = AppMotion.fastSpatial<Any>()
+        private val slowSpatial = AppMotion.slowSpatial<Any>()
+        private val defaultEffects = AppMotion.defaultEffects<Any>()
+        private val fastEffects = AppMotion.fastEffects<Any>()
+        private val slowEffects = AppMotion.slowEffects<Any>()
 
         @Suppress("UNCHECKED_CAST")
         override fun <T> defaultSpatialSpec(): FiniteAnimationSpec<T> = defaultSpatial as FiniteAnimationSpec<T>


### PR DESCRIPTION
Second Compose cleanup pass, following a full read of the UI layer. Every change is a pure refactor — no behavior or visual change, verified by ktlint + detekt + unit tests. It stacks on #276 (base points at that branch); retarget to main once #276 merges.

- Dashboard: fold the three issues/warnings/info blocks into one `MessageSection`, and the six `native*`/`java*` layer-summary functions into a `MetricSpec`-returning `layerSummary` plus a selector-driven `protectionMetric` — the mechanical duplicates could silently diverge.
- Statistics: consolidate the four `surface -> container/accent/label` mappings into one `SurfaceVisual` lookup (mirroring the existing `HealthVisual`), single-sourcing the label resource that the tile and `appSurfacesText` previously duplicated by hand.
- Diagnostics: extract `rememberZipSaveLauncher` for the three byte-identical `CreateDocument("application/zip")` save launchers.
- AppPicker: collapse `withJavaHooks`/`withNativeRoles`/`withPortPolicies` into one generic `withAppValues`, and inline a redundant alias.
- Share the collapsed in-place search bar between the hidden-apps and main screens as `AppSearchTopBar`, and pull the duplicated tab-label `when` block into `tabLabel`.
- Drop dead code (`rememberIsPressed`, `DefaultRowShape`) and single-source the motion spec table so `AppMotionScheme` delegates to `AppMotion` (which also revives four otherwise-unused spec functions).

Net roughly -300/+170 across eight files plus one small new component file.

Intentionally left alone: the `EnhancedIconButton` / `AppEasing.FastInvoke` "symmetry" API (kept as public surface), and borderline collapses the review flagged as churn-risk (help-role blocks, the two chip color helpers).