### PR TITLE
feat: don't alarm on uncoverable vectors, and close two of them in Zygisk

### DIFF
--- a/changelog.d/added-zygisk-filesystem-interface-hiding-now-also-659c.md
+++ b/changelog.d/added-zygisk-filesystem-interface-hiding-now-also-659c.md
@@ -1,0 +1,9 @@
+_2026-08-15_
+
+## English
+
+Zygisk filesystem interface hiding now also filters raw getdents64 directory enumeration (e.g. of /sys/class/net), not just libc readdir, closing that listing path for native and Rust callers.
+
+## Русский
+
+Скрытие сетевых интерфейсов Zygisk на уровне файловой системы теперь фильтрует и перечисление каталогов через getdents64 (например, /sys/class/net), а не только через readdir из libc — это закрывает путь перечисления для нативных и Rust-приложений.

--- a/changelog.d/added-zygisk-now-hides-vpn-routing-policy-59ba.md
+++ b/changelog.d/added-zygisk-now-hides-vpn-routing-policy-59ba.md
@@ -1,0 +1,9 @@
+_2026-08-15_
+
+## English
+
+Zygisk now hides VPN routing policy rules (ip rule / RTM_GETRULE) from target apps — a detection vector that previously only the kernel backends (.ko / KPM) covered, so Zygisk-only devices leaked it.
+
+## Русский
+
+Zygisk теперь скрывает правила маршрутизации VPN (ip rule / RTM_GETRULE) от целевых приложений — этот вектор раньше закрывали только модули уровня ядра (.ko / KPM), поэтому на устройствах только с Zygisk он утекал.

--- a/changelog.d/changed-diagnostics-no-longer-treats-detection-vectors-c93c.md
+++ b/changelog.d/changed-diagnostics-no-longer-treats-detection-vectors-c93c.md
@@ -1,0 +1,9 @@
+_2026-08-15_
+
+## English
+
+Diagnostics no longer treats detection vectors that no active backend can cover on this device as errors: the dashboard stays clean when the active module hides everything it can, and such vectors are shown neutrally ("not covered") in the detailed breakdown instead of as red leaks.
+
+## Русский
+
+Диагностика больше не считает ошибкой способы обнаружения, которые не может закрыть ни один активный модуль на этом устройстве: на дашборде чисто, когда модуль скрывает всё, что в его силах, а такие векторы показаны нейтрально («Вне зоны») в подробной диагностике, а не как красные утечки.

--- a/crates/activator/src/kpm.rs
+++ b/crates/activator/src/kpm.rs
@@ -87,6 +87,10 @@ pub(crate) struct KpmLoadOptions {
 
 impl KpmLoadOptions {
     fn args(self) -> Option<&'static str> {
+        // When off, omit the arg rather than passing `=0`: the KPM parser defaults
+        // filesystem_hiding to off, so absence == disabled. (The .ko path in
+        // lifecycle.rs instead passes an explicit `filesystem_hiding=0` — same
+        // intent, different loader ABIs.)
         self.filesystem_hiding.then_some("filesystem_hiding=1")
     }
 }

--- a/crates/activator/src/lifecycle.rs
+++ b/crates/activator/src/lifecycle.rs
@@ -6,9 +6,10 @@ use std::thread;
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
 use crate::{
-    APATCH_DIR, KPM_CTL_LOCK, KpmBootOutcome, KpmBootReport, PORTS_CHAIN4, PORTS_CHAIN6,
-    PORTS_STATUS_DIR, Result, activate_kmod_boot, activate_kpm_boot, activate_ports_recorded,
-    activate_zygisk_boot, kmod_backend_present, load_kpm_boot, optional_feature_enabled,
+    APATCH_DIR, KPM_CTL_LOCK, KpmBootOutcome, KpmBootReport,
+    OPTIONAL_FEATURE_FILESYSTEM_IFACE_PATHS, PORTS_CHAIN4, PORTS_CHAIN6, PORTS_STATUS_DIR, Result,
+    activate_kmod_boot, activate_kpm_boot, activate_ports_recorded, activate_zygisk_boot,
+    kmod_backend_present, load_kpm_boot, optional_feature_enabled,
     optional_feature_enabled_or_default, write_atomic,
 };
 
@@ -18,7 +19,6 @@ const KMOD_LOAD_DMESG: &str = "/data/adb/vpnhide_kmod/load_dmesg";
 const KMOD_NAME: &str = "vpnhide_kmod";
 const KPM_STATUS_DIR: &str = "/data/adb/vpnhide_kpm";
 const KPM_LOAD_STATUS: &str = "/data/adb/vpnhide_kpm/load_status";
-const FILESYSTEM_BOOT_FEATURE: &str = "filesystem_iface_paths";
 pub(crate) const CHILD_COMMAND_TIMEOUT: Duration = Duration::from_secs(10);
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -198,7 +198,7 @@ pub fn boot_load_kmod() -> Result<()> {
     let module_prop = read_module_properties(&module_dir.join("module.prop"));
     let (kprobes, kretprobes) = read_kprobe_config();
     let (filesystem_hiding, filesystem_config_exit, filesystem_config_error) =
-        match optional_feature_enabled(FILESYSTEM_BOOT_FEATURE) {
+        match optional_feature_enabled(OPTIONAL_FEATURE_FILESYSTEM_IFACE_PATHS) {
             Ok(enabled) => (enabled, i32::from(!enabled), String::new()),
             Err(err) => (false, 2, err.to_string()),
         };
@@ -332,7 +332,9 @@ pub fn boot_load_kpm() -> Result<()> {
     }
 
     if Path::new(APATCH_DIR).is_dir() {
-        let filesystem_hiding = Some(optional_feature_enabled_or_default(FILESYSTEM_BOOT_FEATURE));
+        let filesystem_hiding = Some(optional_feature_enabled_or_default(
+            OPTIONAL_FEATURE_FILESYSTEM_IFACE_PATHS,
+        ));
         log_android(
             "vpnhide",
             "kpm: APatch/FolkPatch runtime — deferring load to service activator",

--- a/docs/detection-vectors.md
+++ b/docs/detection-vectors.md
@@ -71,9 +71,10 @@ Key consequences:
       any arm64 kernel, but only catches libc-routed calls (a raw `svc #0` slips
       past) and runs in-process, visible to aggressive anti-tamper.
   The small deltas between backends — e.g. Zygisk also filters
-  `/proc/net/{if_inet6,tcp,tcp6}`, kmod/KPM also handle `RTM_GETRULE` and the
-  server host-route — are noted in the matrix; neither delta is a reason to
-  stack native backends.
+  `/proc/net/{if_inet6,tcp,tcp6}`, kmod/KPM also handle the server host-route —
+  are noted in the matrix; neither delta is a reason to stack native backends.
+  (`RTM_GETRULE` used to be a kernel-only vector; Zygisk now parses it in the
+  same recv netlink filter as `RTM_GETLINK`/`RTM_GETROUTE`.)
 - So a complete install is **two components**: exactly one native backend (kmod,
   KPM, or Zygisk) **plus** lsposed — which covers both the Java network vectors
   and package visibility — with SELinux as an unreliable platform backstop
@@ -118,7 +119,7 @@ Legend: ✅ covered · ⚠️ partial / conditional · — not applicable to tha
 | `ioctl(SIOCGIF{FLAGS,MTU,INDEX,HWADDR,ADDR})` by name | native | ✅ `dev_ioctl` | ✅ `dev_ioctl` | ✅ pre-screen | — | |
 | netlink `RTM_GETLINK` dump | `recvmsg`/`recvfrom` of `RTM_NEWLINK` | ✅ `rtnl_fill_ifinfo` | ✅ `rtnl_fill_ifinfo` | ✅ filter by index | — | |
 | netlink `RTM_GETADDR` dump | `RTM_NEWADDR` | ✅ `inet*_fill_ifaddr` | ✅ `inet*_fill_ifaddr` | ✅ filter by index | — | |
-| `/sys/class/net/<iface>/*` | lookup/stat/open/readlink/readdir reveal iface nodes | ⚠️ optional reboot-gated VFS hooks | ⚠️ optional reboot-gated VFS hooks | ⚠️ optional best-effort libc hooks | — | 🔒 usually denied |
+| `/sys/class/net/<iface>/*` | lookup/stat/open/readlink/readdir reveal iface nodes | ⚠️ optional reboot-gated VFS hooks | ⚠️ optional reboot-gated VFS hooks | ⚠️ optional best-effort libc hooks (incl. `readdir`/`getdents64` listing filter) | — | 🔒 usually denied |
 | `/proc/sys/net/{ipv4,ipv6}/{conf,neigh}/<iface>` | lookup/stat/open/readlink/readdir reveal per-iface sysctl dirs | ⚠️ optional reboot-gated VFS hooks | ⚠️ optional reboot-gated VFS hooks | ⚠️ optional best-effort libc hooks | — | 🔒 usually denied |
 
 Notes: bionic's `getifaddrs` itself runs over netlink, so the kernel-backend
@@ -197,7 +198,7 @@ subcase is therefore `.ko`-only for now and remains a known KPM gap.
 | `/proc/net/ipv6_route` | text, iface last field | ✅ `ipv6_route_seq_show` | ✅ `ipv6_route_seq_show` | ✅ | — | 🔒 |
 | netlink `RTM_GETROUTE` **dump** | `RTA_OIF` index per route | ✅ `fib_dump_info` / `rt6_fill_node` | ✅ `fib_dump_info` / `rt6_fill_node` | ✅ `RTM_NEWROUTE` filter (issue #86) | — | |
 | netlink `RTM_GETROUTE` **single** (`ip route get`) | one `rt_fill_info` reply | ⚠️ intentionally unhooked (see ROADMAP) | ⚠️ intentionally unhooked | ⚠️ not filtered | — | |
-| netlink `RTM_GETRULE` (policy rules) | per-UID lookup tables | ✅ `fib_nl_fill_rule` | ✅ `fib_nl_fill_rule` | — | — | |
+| netlink `RTM_GETRULE` (policy rules) | per-UID lookup tables | ✅ `fib_nl_fill_rule` | ✅ `fib_nl_fill_rule` | ✅ `rule_hides_vpn` (recv filter) | — | |
 | host-route to the VPN **server** | `/32`·`/128` to a public IP via a *physical* iface | ✅ `is_public_host_route_via_physical` | ✅ `kpm_is_public_host_route{4,6}` | — | — | |
 | `LinkProperties.getRoutes()` (Java) | framework route list | — | — | — | ✅ filter `mRoutes` | |
 

--- a/docs/diagnostics.md
+++ b/docs/diagnostics.md
@@ -83,9 +83,17 @@ tile's verdict:
 probe — otherwise Partial and Broken are indistinguishable. The native tile is judged
 **only on vectors the active backend owns** (has a hook for): a leak on a not-owned
 vector (e.g. `/proc/net/dev` under a kernel backend — no kernel hook exists) does not
-turn the tile red; it surfaces as a hero warning instead. So the **tile** answers "is
-this module doing its job" and the **hero** answers "is the VPN hidden at all". The
-Java tile uses the same rollup; LSPosed owns every Java check, so all its leaks count.
+turn the tile red. Such an **unowned leak is a surface no active backend can close on
+this device**, so it also does **not** raise a dashboard warning or the "Issues" count
+— alarming about a gap the user cannot act on is just noise (and support churn).
+Instead it is shown neutrally ("not covered") in a separate group of the per-check
+breakdown, so the residual surface stays honest without reading as a failure. The
+only thing that raises the hero to *attention* is an **owned** leak — a vector the
+active backend should hide but didn't (the user can act: report the device / switch
+backend) — or a genuine module/version problem. So the **tile** answers "is this
+module doing its job", and the dashboard stays clean whenever the active backend
+hides everything it *can*. The Java tile uses the same rollup; LSPosed owns every Java
+check, so all its leaks count.
 
 ## 5. Self-in-tunnel gate
 

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DashboardData.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DashboardData.kt
@@ -270,6 +270,10 @@ internal data class DashboardState(
     val kmodLoadStatus: KmodLoadStatus?,
     val protection: ProtectionCheck,
     val messages: List<DashboardMessage>,
+    // Optional native hooks this boot actually installed. Retained so the Detailed
+    // diagnostics screen can rebuild the canonical DiagnosticReport (which vectors
+    // the active backend owns) rather than deriving ownership a second way.
+    val installedOptionalHooks: Set<HookIds.Hook> = emptySet(),
 )
 
 internal enum class HeroStatus { Protected, Attention, Unprotected, VpnOff }
@@ -1634,12 +1638,6 @@ internal suspend fun loadDashboardState(
     val vpnActive = isVpnActiveFromSnapshot(shellSnapshot["vpn_ifaces"].orEmpty())
     VpnHideLog.i(TAG, "vpnActive=$vpnActive selfNeedsRestart=$selfNeedsRestart")
 
-    // Native leaks the tile doesn't score: vectors the active backend does not own
-    // (SELinux/zygisk territory), plus the Java-implemented native-level probes
-    // (NetworkInterface enum, /proc/net/route via ART) which carry no root
-    // differential and so aren't in nativeOutcomes. Set during the protection
-    // computation, surfaced via the hero warning so a leak there is never invisible.
-    var unownedNativeLeakCount = 0
     val installedOptionalHooks =
         installedNativeOptionalHooks(nativeBackend.id, shellSnapshot, currentBootId)
     // Single source of truth: the cache does all the gating (VPN off / needs-restart /
@@ -1666,7 +1664,6 @@ internal suspend fun loadDashboardState(
                         complete = true,
                         installedOptionalHooks = installedOptionalHooks,
                     )
-                unownedNativeLeakCount = report.native.unownedLeaks
                 ProtectionCheck.Checked(report.native.status, report.java.status)
             }
 
@@ -1685,17 +1682,19 @@ internal suspend fun loadDashboardState(
         }
     }
 
-    // A hiding layer is active but some of its runtime probes still leak (native
-    // partial/full, or a Java probe fails). Without this the state shows only as
-    // an amber hero/tile with no explanation — surface a warning that links to
-    // the full diagnostics for the per-check breakdown.
-    // A leak is a leak: an active layer's owned vector leaks, or a native surface
-    // the backend doesn't cover leaks (only SELinux would). Either way the VPN is
-    // detectable — link to the per-check breakdown.
+    // A hiding layer is active but a vector it OWNS still leaks — the backend
+    // should hide it and didn't, so the VPN is detectable AND the user can act on
+    // it (report the device). Surface a warning linking to the per-check breakdown.
+    //
+    // Unowned leaks — vectors no active backend covers on this device (e.g.
+    // RTM_GETRULE with no kernel backend loaded, or a best-effort sysfs path) — are
+    // deliberately NOT surfaced here: the active backend is already doing everything
+    // it can, so alarming about a gap the user cannot close just generates noise (and
+    // support churn). Those still appear, neutrally, in the per-check breakdown.
     val checked = protection as? ProtectionCheck.Checked
     val nativeLeaks = (checked?.native as? LayerStatus.Active)?.leaks ?: 0
     val javaLeaks = (checked?.java as? LayerStatus.Active)?.leaks ?: 0
-    if (nativeLeaks > 0 || javaLeaks > 0 || unownedNativeLeakCount > 0) {
+    if (nativeLeaks > 0 || javaLeaks > 0) {
         messages +=
             DashboardMessage(
                 DashboardMessageSeverity.WARNING,
@@ -1722,5 +1721,6 @@ internal suspend fun loadDashboardState(
         kmodLoadStatus = kmodLoadStatus,
         protection = protection,
         messages = messages,
+        installedOptionalHooks = installedOptionalHooks,
     )
 }

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DiagnosticsScreen.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DiagnosticsScreen.kt
@@ -67,6 +67,11 @@ fun DiagnosticsScreen(
     val scope = rememberCoroutineScope()
 
     val diagState by DiagnosticsCache.state.collectAsState()
+    // The dashboard state carries which native backend is active + the optional hooks
+    // it installed — the inputs needed to rebuild the canonical DiagnosticReport here,
+    // so each check can be shown against the vectors the backend actually OWNS. Null
+    // until the dashboard has loaded (then we fall back to the raw, ownership-less list).
+    val dashState by DashboardCache.state.collectAsState()
     val tallyFmt = stringResource(R.string.diag_summary_tally)
 
     // Kick off the diagnostics run once per process. The cache parks at
@@ -74,6 +79,9 @@ fun DiagnosticsScreen(
     // app yet, so a run would be meaningless); run is idempotent otherwise.
     LaunchedEffect(selfNeedsRestart) {
         DiagnosticsCache.run(scope, context, selfNeedsRestart)
+        // Ensure the backend/ownership state is available even when the user opens
+        // Diagnostics without visiting the Dashboard first (cheap no-op if cached).
+        DashboardCache.ensureLoaded(scope, context, selfNeedsRestart)
     }
 
     val results = (diagState as? DiagnosticsCache.State.Ready)?.results
@@ -82,13 +90,6 @@ fun DiagnosticsScreen(
     // NotMeasured(NoNetworkPermission). Java-level checks never produce that state,
     // so this isolates the "app has no network permission" banner from everything else.
     val networkBlocked = results?.native?.anyNetworkBlocked() == true
-    // Honest headline: how many vectors we hide vs still leak (the misleading
-    // "N/total passed" score was the thing the report redesign retired).
-    val summary =
-        results?.let { r ->
-            val counts = r.all.protectionCounts()
-            String.format(tallyFmt, counts.hidden, counts.leaks)
-        }
 
     Column(
         modifier =
@@ -150,35 +151,23 @@ fun DiagnosticsScreen(
                     )
                 }
 
-                if (summary != null) {
-                    Spacer(Modifier.height(12.dp))
-                    Text(
-                        text = summary,
-                        style = MaterialTheme.typography.titleMedium,
-                        fontWeight = FontWeight.Bold,
-                    )
-                }
-
                 results?.let { r ->
-                    Spacer(Modifier.height(16.dp))
-
-                    SectionHeader(stringResource(R.string.section_native))
-                    Spacer(Modifier.height(6.dp))
-                    Column(verticalArrangement = Arrangement.spacedBy(3.dp)) {
-                        r.nativeAll.forEachIndexed { i, check ->
-                            CheckCard(check, index = i, count = r.nativeAll.size)
+                    // Build the canonical report when the dashboard has loaded so each
+                    // check knows whether the active backend OWNS its vector; otherwise
+                    // render the raw list (every leak reads as a leak — the pre-report
+                    // behaviour, used only in the brief window before the dashboard loads).
+                    val report =
+                        dashState?.let { ds ->
+                            buildDiagnosticReport(
+                                gate = DiagnosticGate.ROUTED,
+                                results = r,
+                                backend = ds.nativeBackend,
+                                lsposedActive = ds.lsposed is LsposedState.Active,
+                                complete = (diagState as? DiagnosticsCache.State.Ready)?.complete == true,
+                                installedOptionalHooks = ds.installedOptionalHooks,
+                            )
                         }
-                    }
-
-                    Spacer(Modifier.height(16.dp))
-
-                    SectionHeader(stringResource(R.string.section_java))
-                    Spacer(Modifier.height(6.dp))
-                    Column(verticalArrangement = Arrangement.spacedBy(3.dp)) {
-                        r.java.forEachIndexed { i, check ->
-                            CheckCard(check, index = i, count = r.java.size)
-                        }
-                    }
+                    DiagnosticsResults(report = report, results = r, tallyFmt = tallyFmt)
                 }
             }
         }
@@ -485,6 +474,97 @@ private fun formatSize(bytes: Long): String {
 }
 
 /**
+ * One row on the Diagnostics list, unified across sources so [CheckCard] renders one
+ * shape. [uncovered] marks a native leak on a vector the active backend does not own
+ * — a detection surface no active hook covers on this device. It is shown neutrally
+ * (see [diagStatusUncovered]), never as a red leak, and grouped apart from the
+ * backend's own vectors.
+ */
+private data class DiagCard(
+    val name: String,
+    val detail: String,
+    val groundTruthDetail: String?,
+    val outcome: CheckOutcome,
+    val uncovered: Boolean,
+)
+
+/** From a canonical report check — the only source that knows [DiagnosticCheck.owned],
+ * so it is the only one that can flag an uncovered native leak. */
+private fun DiagnosticCheck.toDiagCard(): DiagCard =
+    DiagCard(
+        name = label,
+        detail = appDetail,
+        groundTruthDetail = groundTruthDetail,
+        outcome = outcome,
+        uncovered = layer == CheckLayer.NATIVE && outcome is CheckOutcome.Leak && !owned,
+    )
+
+/** Raw-list fallback (dashboard not yet loaded): no ownership known, so nothing is
+ * marked uncovered — a leak reads as a leak, the pre-report behaviour. */
+private fun CheckResult.toDiagCard(): DiagCard = DiagCard(name, detail, groundTruthDetail, outcome, uncovered = false)
+
+/**
+ * The results body: the honest headline (hidden vs still-leaking) plus the check
+ * cards, split into the backend's own vectors, the vectors no active backend covers
+ * on this device (shown neutrally), and the Java layer. [report] is null only in the
+ * brief window before the dashboard loads, when we fall back to the raw list.
+ */
+@Composable
+private fun DiagnosticsResults(
+    report: DiagnosticReport?,
+    results: CheckResults,
+    tallyFmt: String,
+) {
+    val nativeCards = report?.native?.checks?.map { it.toDiagCard() } ?: results.nativeAll.map { it.toDiagCard() }
+    val javaCards = report?.java?.checks?.map { it.toDiagCard() } ?: results.java.map { it.toDiagCard() }
+    val covered = nativeCards.filterNot { it.uncovered }
+    val uncovered = nativeCards.filter { it.uncovered }
+
+    // Headline counts the backend's job: hidden vectors vs still-leaking OWNED
+    // vectors. Uncovered vectors are out of the active backend's scope, so they are
+    // reported below rather than folded into "leaking".
+    val scored = covered + javaCards
+    val hidden = scored.count { it.outcome is CheckOutcome.HiddenByBackend || it.outcome is CheckOutcome.HiddenBySelinux }
+    val leaks = scored.count { it.outcome is CheckOutcome.Leak }
+
+    Spacer(Modifier.height(12.dp))
+    Text(
+        text = String.format(tallyFmt, hidden, leaks),
+        style = MaterialTheme.typography.titleMedium,
+        fontWeight = FontWeight.Bold,
+    )
+
+    Spacer(Modifier.height(16.dp))
+    SectionHeader(stringResource(R.string.section_native))
+    Spacer(Modifier.height(6.dp))
+    Column(verticalArrangement = Arrangement.spacedBy(3.dp)) {
+        covered.forEachIndexed { i, c -> CheckCard(c, index = i, count = covered.size) }
+    }
+
+    if (uncovered.isNotEmpty()) {
+        Spacer(Modifier.height(16.dp))
+        SectionHeader(stringResource(R.string.section_native_uncovered))
+        Spacer(Modifier.height(4.dp))
+        Text(
+            text = stringResource(R.string.diag_uncovered_caption),
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+        Spacer(Modifier.height(6.dp))
+        Column(verticalArrangement = Arrangement.spacedBy(3.dp)) {
+            uncovered.forEachIndexed { i, c -> CheckCard(c, index = i, count = uncovered.size) }
+        }
+    }
+
+    Spacer(Modifier.height(16.dp))
+    SectionHeader(stringResource(R.string.section_java))
+    Spacer(Modifier.height(6.dp))
+    Column(verticalArrangement = Arrangement.spacedBy(3.dp)) {
+        javaCards.forEachIndexed { i, c -> CheckCard(c, index = i, count = javaCards.size) }
+    }
+}
+
+/**
  * One check's status: a coloured **dot + short word** (the "3-B" treatment — the
  * app's own status-dot idiom from the module rows). The card colour tracks current
  * reality only — green when hidden (by backend OR SELinux) or nothing-to-leak, red
@@ -528,13 +608,26 @@ private fun diagStatus(outcome: CheckOutcome): DiagStatus =
         }
     }
 
+/** Neutral "out of scope" status for a native leak on a vector the active backend
+ * does not own: no active hook covers it on this device, so it is not the backend
+ * failing — it is reported calmly (grey dot + word, no alarm, collapsed), never as a
+ * red leak, so a working backend never reads as broken over a gap it cannot close. */
+@Composable
+private fun diagStatusUncovered(): DiagStatus =
+    DiagStatus(
+        stringResource(R.string.diag_status_uncovered),
+        StatusColors.neutralAccent,
+        StatusColors.neutralContainer(),
+        false,
+    )
+
 @Composable
 private fun CheckCard(
-    r: CheckResult,
+    r: DiagCard,
     index: Int = -1,
     count: Int = 1,
 ) {
-    val status = diagStatus(r.outcome)
+    val status = if (r.uncovered) diagStatusUncovered() else diagStatus(r.outcome)
     var expanded by remember(r.name) { mutableStateOf(status.expandedByDefault) }
     val caretRotation by animateFloatAsState(if (expanded) 90f else 0f, label = "caret")
     GroupedCard(

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/NativeChecks.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/NativeChecks.kt
@@ -78,11 +78,20 @@ internal val NATIVE_CHECKS: List<NativeCheckSpec> =
                 ),
         ),
         NativeCheckSpec(
-            // Kernel-only vector: no zygisk hook parses RTM_NEWRULE. The
-            // fib_nl_fill_rule kernel hook trims the per-UID tun policy rules.
+            // Kernel backends trim the per-UID tun policy rules via fib_nl_fill_rule;
+            // zygisk parses RTM_NEWRULE in the same recv netlink filter as GETLINK/
+            // GETROUTE, dropping rules that name a VPN iface or steer this uid into a
+            // tun table (see filter::rule_hides_vpn).
             id = "netlink_getrule",
             labelRes = R.string.check_netlink_getrule,
-            expectedHooks = setOf(HookIds.Hook.FIB_NL_FILL_RULE),
+            expectedHooks =
+                setOf(
+                    HookIds.Hook.FIB_NL_FILL_RULE,
+                    HookIds.Hook.ZYGISK_RECVMSG,
+                    HookIds.Hook.ZYGISK_RECV,
+                    HookIds.Hook.ZYGISK_RECVFROM,
+                    HookIds.Hook.ZYGISK_RECVFROM_CHK,
+                ),
         ),
         NativeCheckSpec(
             id = "proc_route",

--- a/lsposed/app/src/main/res/values-ru/strings.xml
+++ b/lsposed/app/src/main/res/values-ru/strings.xml
@@ -379,10 +379,13 @@
     <string name="diag_status_leak">Утечка</string>
     <string name="diag_status_nomeasure">Нет данных</string>
     <string name="diag_status_nothing">Нечего скрывать</string>
+    <string name="diag_status_uncovered">Вне зоны</string>
     <string name="banner_ready">VPN активен. Для этого приложения включено скрытие. Результаты проверок ниже.</string>
     <string name="banner_added_self">Для VPN Hide включено скрытие. Принудительно остановите VPN Hide и откройте снова, чтобы нативные проверки начали работать — перезагрузка устройства не нужна.</string>
     <string name="banner_network_blocked">Доступ к сети отключён для этого приложения. Проверки ioctl (SIOCGIFFLAGS, SIOCGIFMTU, SIOCGIFCONF) не могут быть выполнены. Включите в Настройки → Приложения → VPN Hide → Мобильный интернет и Wi-Fi.</string>
     <string name="section_native">Нативный уровень (kmod / KPM / Zygisk)</string>
+    <string name="section_native_uncovered">Вне зоны активного модуля</string>
+    <string name="diag_uncovered_caption">Способы обнаружения, которые не закрывает ни один активный модуль на этом устройстве. Это не ошибка работающего модуля: их закрыл бы модуль уровня ядра (kmod / KPM), если устройство его поддерживает.</string>
     <string name="section_java">Java API уровень (LSPosed)</string>
 
     <!-- Экран настроек -->

--- a/lsposed/app/src/main/res/values-ru/strings.xml
+++ b/lsposed/app/src/main/res/values-ru/strings.xml
@@ -385,7 +385,7 @@
     <string name="banner_network_blocked">Доступ к сети отключён для этого приложения. Проверки ioctl (SIOCGIFFLAGS, SIOCGIFMTU, SIOCGIFCONF) не могут быть выполнены. Включите в Настройки → Приложения → VPN Hide → Мобильный интернет и Wi-Fi.</string>
     <string name="section_native">Нативный уровень (kmod / KPM / Zygisk)</string>
     <string name="section_native_uncovered">Вне зоны активного модуля</string>
-    <string name="diag_uncovered_caption">Способы обнаружения, которые не закрывает ни один активный модуль на этом устройстве. Это не ошибка работающего модуля: их закрыл бы модуль уровня ядра (kmod / KPM), если устройство его поддерживает.</string>
+    <string name="diag_uncovered_caption">Способы обнаружения, которые активный модуль не покрывает — это не ошибка работающего модуля. VPN-пути в файловой системе (например /sys/class/net) закрываются включением «Экспериментальной защиты» в Настройках; остальные могут потребовать модуль уровня ядра (kmod / KPM), если устройство его поддерживает.</string>
     <string name="section_java">Java API уровень (LSPosed)</string>
 
     <!-- Экран настроек -->

--- a/lsposed/app/src/main/res/values/strings.xml
+++ b/lsposed/app/src/main/res/values/strings.xml
@@ -113,7 +113,7 @@
     <string name="banner_network_blocked">Network access is disabled for this app. ioctl checks (SIOCGIFFLAGS, SIOCGIFMTU, SIOCGIFCONF) cannot run without it. Enable in Settings → Apps → VPN Hide → Mobile data &amp; Wi-Fi.</string>
     <string name="section_native">Native level (kmod / KPM / Zygisk)</string>
     <string name="section_native_uncovered">Outside the active backend\'s reach</string>
-    <string name="diag_uncovered_caption">Detection surfaces no active backend covers on this device — not a failure of the running module. A kernel-level backend (kmod / KPM) would close these where the device supports one.</string>
+    <string name="diag_uncovered_caption">Detection surfaces the active backend doesn\'t cover — not a failure of the running module. VPN filesystem paths (e.g. /sys/class/net) are closed by turning on Experimental protection in Settings; other surfaces may need a kernel-level backend (kmod / KPM) where the device supports one.</string>
     <string name="section_java">Java API level (LSPosed)</string>
 
     <!-- Dashboard -->

--- a/lsposed/app/src/main/res/values/strings.xml
+++ b/lsposed/app/src/main/res/values/strings.xml
@@ -107,10 +107,13 @@
     <string name="diag_status_leak">Leak</string>
     <string name="diag_status_nomeasure">No data</string>
     <string name="diag_status_nothing">Nothing to hide</string>
+    <string name="diag_status_uncovered">Not covered</string>
     <string name="banner_ready">VPN is active. Hiding is enabled for this app. Results below.</string>
     <string name="banner_added_self">Enabled hiding for VPN Hide. Restart VPN Hide (force-stop and reopen) for native-level checks to take effect — no device reboot needed.</string>
     <string name="banner_network_blocked">Network access is disabled for this app. ioctl checks (SIOCGIFFLAGS, SIOCGIFMTU, SIOCGIFCONF) cannot run without it. Enable in Settings → Apps → VPN Hide → Mobile data &amp; Wi-Fi.</string>
     <string name="section_native">Native level (kmod / KPM / Zygisk)</string>
+    <string name="section_native_uncovered">Outside the active backend\'s reach</string>
+    <string name="diag_uncovered_caption">Detection surfaces no active backend covers on this device — not a failure of the running module. A kernel-level backend (kmod / KPM) would close these where the device supports one.</string>
     <string name="section_java">Java API level (LSPosed)</string>
 
     <!-- Dashboard -->

--- a/lsposed/app/src/test/kotlin/dev/okhsunrog/vpnhide/DiagnosticReportTest.kt
+++ b/lsposed/app/src/test/kotlin/dev/okhsunrog/vpnhide/DiagnosticReportTest.kt
@@ -65,10 +65,11 @@ class DiagnosticReportTest {
     // ── unowned leaks are surfaced separately, never against the verdict ────
 
     @Test
-    fun `a kernel-only leak under zygisk is unowned, not a verdict leak`() {
-        // netlink_getrule (fib_nl_fill_rule) has no zygisk hook → out of scope for
-        // the zygisk tile, so the verdict stays Ok and the leak is counted as unowned.
-        val r = report(results = CheckResults(native = nativeResults("netlink_getrule" to CheckOutcome.Leak)))
+    fun `a not-owned leak under zygisk is unowned, not a verdict leak`() {
+        // sys_class_net is covered only by the optional FILESYSTEM_IFACE_PATHS hook,
+        // which this report is built without installing → out of scope for the zygisk
+        // tile, so the verdict stays Ok and the leak is counted as unowned.
+        val r = report(results = CheckResults(native = nativeResults("sys_class_net" to CheckOutcome.Leak)))
         assertEquals(Verdict.Ok, r.nativeVerdict)
         assertEquals(1, r.native.unownedLeaks)
     }

--- a/lsposed/app/src/test/kotlin/dev/okhsunrog/vpnhide/LayerStatusTest.kt
+++ b/lsposed/app/src/test/kotlin/dev/okhsunrog/vpnhide/LayerStatusTest.kt
@@ -67,7 +67,8 @@ class LayerStatusTest {
             )
         val layer = summarizeNativeLayer(kmod(installed(active = true)), outcomes)
         assertEquals(LayerStatus.Active(hidden = 2, leaks = 0), layer)
-        // …but it is still surfaced, via the unowned-leak count (the hero warning).
+        // …but it is still surfaced, via the unowned-leak count (shown neutrally in
+        // the per-check breakdown — it never raises a dashboard warning).
         assertEquals(1, unownedNativeLeaks(kmod(installed(active = true)), outcomes))
     }
 
@@ -129,14 +130,14 @@ class LayerStatusTest {
     @Test
     fun `ownership is per backend family - zygisk owns what the kernel does not`() {
         // Mirror image of the kmod case: proc_dev (zygisk openat) is zygisk-owned;
-        // netlink_getrule (fib_nl_fill_rule, kernel-only — no zygisk parses rule
-        // dumps) is not. That kernel-only leak is out of scope for the zygisk tile
-        // and shows up as an unowned leak instead. (Note: ioctl_flags would NOT
-        // work here — it is zygisk-owned too, via zygisk_ioctl.)
+        // sys_class_net (only the optional FILESYSTEM_IFACE_PATHS hook, not installed
+        // here) is not. That not-owned leak is out of scope for the zygisk tile and
+        // shows up as an unowned leak instead. (Note: ioctl_flags would NOT work here
+        // — it is zygisk-owned too, via zygisk_ioctl.)
         val outcomes =
             mapOf(
                 "proc_dev" to CheckOutcome.Leak,
-                "netlink_getrule" to CheckOutcome.Leak,
+                "sys_class_net" to CheckOutcome.Leak,
             )
         assertEquals(
             LayerStatus.Active(hidden = 0, leaks = 1),

--- a/zygisk/src/filesystem.rs
+++ b/zygisk/src/filesystem.rs
@@ -507,6 +507,13 @@ saved_original!(
     set_real_readdir64_ptr,
     unsafe extern "C" fn(*mut libc::DIR) -> *mut libc::dirent64
 );
+saved_original!(
+    Getdents64Fn,
+    REAL_GETDENTS64,
+    real_getdents64,
+    set_real_getdents64_ptr,
+    unsafe extern "C" fn(c_int, *mut c_void, usize) -> libc::ssize_t
+);
 
 fn denied() -> c_int {
     set_errno(libc::ENOENT);
@@ -707,6 +714,84 @@ pub(crate) unsafe extern "C" fn hooked_readdir64(dir: *mut libc::DIR) -> *mut li
     }
 }
 
+// Offsets within a packed `struct linux_dirent64`: d_ino(8) + d_off(8) then
+// d_reclen(u16) at 16 and the NUL-terminated d_name at 19. Records are
+// variable-length (d_reclen), so the buffer is walked by d_reclen, never by a
+// fixed struct stride.
+const DENTS64_RECLEN_OFF: usize = 16;
+const DENTS64_NAME_OFF: usize = 19;
+
+/// Whether a single packed `linux_dirent64` record (`rec` = one whole record,
+/// `d_reclen` bytes) names a VPN interface.
+fn dent64_name_is_vpn(rec: &[u8]) -> bool {
+    let Some(name) = rec.get(DENTS64_NAME_OFF..) else {
+        return false;
+    };
+    let end = name
+        .iter()
+        .position(|byte| *byte == 0)
+        .unwrap_or(name.len());
+    end != 0 && is_vpn_iface_bytes(&name[..end])
+}
+
+/// Drop VPN-interface entries from a raw `getdents64` buffer, compacting the
+/// surviving records toward the front in place. Returns the new byte length.
+/// A malformed record (bad `d_reclen`) stops parsing and the remainder is kept
+/// verbatim, mirroring the netlink filter's conservative tail handling.
+fn compact_dents64(buf: &mut [u8]) -> usize {
+    let len = buf.len();
+    let mut read_pos = 0usize;
+    let mut write_pos = 0usize;
+
+    while read_pos + DENTS64_NAME_OFF <= len {
+        let reclen = u16::from_ne_bytes([
+            buf[read_pos + DENTS64_RECLEN_OFF],
+            buf[read_pos + DENTS64_RECLEN_OFF + 1],
+        ]) as usize;
+        if reclen < DENTS64_NAME_OFF || read_pos + reclen > len {
+            break;
+        }
+        if !dent64_name_is_vpn(&buf[read_pos..read_pos + reclen]) {
+            if write_pos != read_pos {
+                buf.copy_within(read_pos..read_pos + reclen, write_pos);
+            }
+            write_pos += reclen;
+        }
+        read_pos += reclen;
+    }
+
+    if read_pos < len {
+        let tail = len - read_pos;
+        if write_pos != read_pos {
+            buf.copy_within(read_pos..len, write_pos);
+        }
+        write_pos += tail;
+    }
+    write_pos
+}
+
+/// `getdents64` is the raw directory-enumeration syscall wrapper `readdir`/
+/// `readdir64` (and Rust/Go/native readers) sit on. Hooking it — not just the
+/// higher-level `readdir*` — closes the `/sys/class/net` (and `.../net`,
+/// `/proc/sys/net/.../{conf,neigh}`) listing for callers that read dirents
+/// directly. Still best-effort: an inlined `svc #0` getdents64 bypasses it.
+pub(crate) unsafe extern "C" fn hooked_getdents64(
+    fd: c_int,
+    dirp: *mut c_void,
+    count: usize,
+) -> libc::ssize_t {
+    let Some(real) = real_getdents64() else {
+        set_errno(libc::EFAULT);
+        return -1;
+    };
+    let n = unsafe { real(fd, dirp, count) };
+    if n <= 0 || dirp.is_null() || !listing_fd(fd) {
+        return n;
+    }
+    let buf = unsafe { slice::from_raw_parts_mut(dirp.cast::<u8>(), n as usize) };
+    compact_dents64(buf) as libc::ssize_t
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -751,5 +836,47 @@ mod tests {
 
         let path = normalize_absolute(b"/../../sys/class/net/wlan0").unwrap();
         assert_eq!(path.as_bytes(), b"/sys/class/net/wlan0");
+    }
+
+    /// Build one packed `linux_dirent64` record for `name` (8-byte aligned, as
+    /// the kernel emits), with `d_reclen` filled in and the rest zeroed.
+    fn make_dent64(name: &[u8]) -> Vec<u8> {
+        let reclen = (DENTS64_NAME_OFF + name.len() + 1 + 7) & !7; // +1 NUL, align to 8
+        let mut rec = vec![0u8; reclen];
+        rec[DENTS64_RECLEN_OFF..DENTS64_RECLEN_OFF + 2]
+            .copy_from_slice(&(reclen as u16).to_ne_bytes());
+        rec[DENTS64_NAME_OFF..DENTS64_NAME_OFF + name.len()].copy_from_slice(name);
+        rec
+    }
+
+    #[test]
+    fn compact_dents64_drops_vpn_entries() {
+        let mut buf = Vec::new();
+        buf.extend(make_dent64(b"lo"));
+        buf.extend(make_dent64(b"tun0"));
+        buf.extend(make_dent64(b"wlan0"));
+        let expect = make_dent64(b"lo").len() + make_dent64(b"wlan0").len();
+        let n = compact_dents64(&mut buf);
+        assert_eq!(n, expect);
+        assert!(
+            buf[DENTS64_NAME_OFF..].starts_with(b"lo\0"),
+            "lo kept first"
+        );
+        assert!(!buf[..n].windows(4).any(|w| w == b"tun0"), "tun0 removed");
+    }
+
+    #[test]
+    fn compact_dents64_keeps_all_when_no_vpn() {
+        let mut buf = Vec::new();
+        buf.extend(make_dent64(b"lo"));
+        buf.extend(make_dent64(b"wlan0"));
+        let orig = buf.len();
+        assert_eq!(compact_dents64(&mut buf), orig);
+    }
+
+    #[test]
+    fn compact_dents64_removes_all_vpn() {
+        let mut buf = make_dent64(b"wg0");
+        assert_eq!(compact_dents64(&mut buf), 0);
     }
 }

--- a/zygisk/src/filter.rs
+++ b/zygisk/src/filter.rs
@@ -248,6 +248,20 @@ const RTA_ALIGNTO: usize = 4;
 /// `rtattr` type carrying the output interface index (`RTA_OIF`).
 const RTA_OIF: u16 = 4;
 
+/// `RTM_NEWRULE` — the reply the kernel emits for an `RTM_GETRULE` policy-rule
+/// dump. `struct fib_rule_hdr` shares `struct rtmsg`'s 12-byte layout, so
+/// [`RTMSG_HDRLEN`] doubles as the rule header length.
+pub(crate) const RTM_NEWRULE: u16 = 32;
+// fib_rule attribute (`FRA_*`) types and standard table ids
+// (linux/fib_rules.h, linux/rtnetlink.h).
+const FRA_IIFNAME: u16 = 3;
+const FRA_TABLE: u16 = 15;
+const FRA_OIFNAME: u16 = 17;
+const FRA_UID_RANGE: u16 = 20;
+const RT_TABLE_DEFAULT: u32 = 253;
+const RT_TABLE_MAIN: u32 = 254;
+const RT_TABLE_LOCAL: u32 = 255;
+
 const fn nlmsg_align(len: usize) -> usize {
     (len + NLMSG_ALIGNTO - 1) & !(NLMSG_ALIGNTO - 1)
 }
@@ -282,6 +296,71 @@ fn route_oif(msg: &[u8]) -> Option<u32> {
     None
 }
 
+/// Whether a single `RTM_NEWRULE` message `msg` (the whole message, starting at
+/// the `nlmsghdr`) reveals the VPN. Mirrors the app-side probe predicate exactly
+/// (`check_netlink_getrule_uid`): a policy rule leaks the VPN if it names a VPN
+/// interface (`FRA_IIFNAME`/`FRA_OIFNAME`), or steers this process's own uid into
+/// a non-standard routing table — the per-app tun policy rule Android installs.
+///
+/// `vpn_uid` is the calling app's uid (`getuid()`); the hook runs in-process so it
+/// is the same uid the probe compares against. The `0..=u32::MAX` uid range is the
+/// catch-all default rule, not a VPN rule, so it is excluded.
+fn rule_hides_vpn(msg: &[u8], vpn_uid: u32) -> bool {
+    // fib_rule_hdr shares struct rtmsg's layout: the table id's low byte sits at
+    // header offset 4, and the full u32 (Android tun tables are > 255) arrives in
+    // an FRA_TABLE attribute.
+    let mut table = msg.get(NLMSG_HDRLEN + 4).copied().map_or(0u32, u32::from);
+    let mut uid_lo = 0u32;
+    let mut uid_hi = 0u32;
+    let mut has_uidrange = false;
+    let mut names_vpn = false;
+
+    let mut pos = NLMSG_HDRLEN + RTMSG_HDRLEN;
+    while pos + 4 <= msg.len() {
+        let Some(rta_len) = read_u16_ne(msg, pos).map(usize::from) else {
+            break;
+        };
+        let Some(rta_type) = read_u16_ne(msg, pos + 2) else {
+            break;
+        };
+        if rta_len < 4 || pos + rta_len > msg.len() {
+            break;
+        }
+        let payload = &msg[pos + 4..pos + rta_len];
+        match rta_type {
+            FRA_IIFNAME | FRA_OIFNAME if !payload.is_empty() => {
+                if is_vpn_iface_bytes(payload) {
+                    names_vpn = true;
+                }
+            }
+            FRA_TABLE if payload.len() >= 4 => {
+                table = read_u32_ne(payload, 0).unwrap_or(table);
+            }
+            FRA_UID_RANGE if payload.len() >= 8 => {
+                if let (Some(lo), Some(hi)) = (read_u32_ne(payload, 0), read_u32_ne(payload, 4)) {
+                    uid_lo = lo;
+                    uid_hi = hi;
+                    has_uidrange = true;
+                }
+            }
+            _ => {}
+        }
+        pos += rta_align(rta_len);
+    }
+
+    if names_vpn {
+        return true;
+    }
+    has_uidrange
+        && uid_lo <= vpn_uid
+        && vpn_uid <= uid_hi
+        && !(uid_lo == 0 && uid_hi == u32::MAX)
+        && table != RT_TABLE_MAIN
+        && table != RT_TABLE_LOCAL
+        && table != RT_TABLE_DEFAULT
+        && table > 100
+}
+
 fn read_u32_ne(data: &[u8], off: usize) -> Option<u32> {
     let bytes: &[u8; 4] = data.get(off..off + 4)?.try_into().ok()?;
     Some(u32::from_ne_bytes(*bytes))
@@ -307,9 +386,14 @@ fn read_u16_ne(data: &[u8], off: usize) -> Option<u16> {
 /// sees the VPN's default route by oif index even when the interface
 /// name itself is hidden, then renders it as the synthetic `if<index>`.
 ///
+/// `RTM_NEWRULE` (an `RTM_GETRULE` policy-rule dump) is matched by name/uid
+/// rather than by index — see [`rule_hides_vpn`] — so `vpn_uid` (the calling
+/// app's `getuid()`) is threaded through. This closes the routing-policy-rule
+/// leak that no zygisk hook previously covered.
+///
 /// Returns the new valid length of the buffer.
-pub fn filter_netlink_dump(data: &mut [u8], vpn_indices: &[u32]) -> usize {
-    if vpn_indices.is_empty() || data.len() < NLMSG_HDRLEN {
+pub fn filter_netlink_dump(data: &mut [u8], vpn_indices: &[u32], vpn_uid: u32) -> usize {
+    if data.len() < NLMSG_HDRLEN {
         return data.len();
     }
 
@@ -341,6 +425,9 @@ pub fn filter_netlink_dump(data: &mut [u8], vpn_indices: &[u32]) -> usize {
             // Output interface is an RTA_OIF rtattr after struct rtmsg.
             route_oif(&data[read_pos..read_pos + nlmsg_len])
                 .is_some_and(|oif| vpn_indices.contains(&oif))
+        } else if nlmsg_type == RTM_NEWRULE && nlmsg_len >= NLMSG_HDRLEN + RTMSG_HDRLEN {
+            // Policy rule: matched by VPN iface name / this uid's tun table.
+            rule_hides_vpn(&data[read_pos..read_pos + nlmsg_len], vpn_uid)
         } else {
             false
         };
@@ -518,7 +605,7 @@ tun0:  300    3    0    0\n"
         buf.extend(make_nlmsg(RTM_NEWADDR, wlan_idx));
 
         let orig_msgs = 3;
-        let new_len = filter_netlink_dump(&mut buf, &[vpn_idx]);
+        let new_len = filter_netlink_dump(&mut buf, &[vpn_idx], 0);
 
         // Should have removed exactly the vpn_idx message (24 bytes).
         assert_eq!(new_len, 24 * (orig_msgs - 1));
@@ -537,7 +624,7 @@ tun0:  300    3    0    0\n"
         buf.extend(make_nlmsg(RTM_NEWLINK, vpn_idx));
         buf.extend(make_nlmsg(RTM_NEWLINK, lo_idx));
 
-        let new_len = filter_netlink_dump(&mut buf, &[vpn_idx]);
+        let new_len = filter_netlink_dump(&mut buf, &[vpn_idx], 0);
         assert_eq!(new_len, 24); // only lo remains
         assert_eq!(read_u16_ne(&buf, 4), Some(RTM_NEWLINK));
         assert_eq!(read_u32_ne(&buf, NLMSG_HDRLEN + 4), Some(lo_idx));
@@ -550,7 +637,7 @@ tun0:  300    3    0    0\n"
         buf.extend(make_nlmsg(RTM_NEWADDR, 2));
         let orig_len = buf.len();
 
-        let new_len = filter_netlink_dump(&mut buf, &[99]);
+        let new_len = filter_netlink_dump(&mut buf, &[99], 0);
         assert_eq!(new_len, orig_len);
     }
 
@@ -560,7 +647,7 @@ tun0:  300    3    0    0\n"
         buf.extend(make_nlmsg(RTM_NEWADDR, 7));
         buf.extend(make_nlmsg(RTM_NEWADDR, 7));
 
-        let new_len = filter_netlink_dump(&mut buf, &[7]);
+        let new_len = filter_netlink_dump(&mut buf, &[7], 0);
         assert_eq!(new_len, 0);
     }
 
@@ -572,7 +659,7 @@ tun0:  300    3    0    0\n"
         buf.extend(make_nlmsg(nlmsg_done_type, 0)); // DONE — keep
         buf.extend(make_nlmsg(RTM_NEWADDR, 2)); // wlan — keep
 
-        let new_len = filter_netlink_dump(&mut buf, &[7]);
+        let new_len = filter_netlink_dump(&mut buf, &[7], 0);
         // Should keep DONE + wlan = 48 bytes
         assert_eq!(new_len, 48);
         assert_eq!(read_u16_ne(&buf, 4), Some(nlmsg_done_type));
@@ -584,7 +671,7 @@ tun0:  300    3    0    0\n"
     fn netlink_filter_empty_indices() {
         let mut buf = make_nlmsg(RTM_NEWADDR, 7);
         let orig_len = buf.len();
-        let new_len = filter_netlink_dump(&mut buf, &[]);
+        let new_len = filter_netlink_dump(&mut buf, &[], 0);
         assert_eq!(new_len, orig_len);
     }
 
@@ -642,7 +729,7 @@ tun0:  300    3    0    0\n"
         buf.extend(make_route_nlmsg(vpn_idx)); // tun0 — remove
         buf.extend(make_route_nlmsg(4)); // rmnet — keep
 
-        let new_len = filter_netlink_dump(&mut buf, &[vpn_idx]);
+        let new_len = filter_netlink_dump(&mut buf, &[vpn_idx], 0);
         assert_eq!(new_len, route_len * 2);
         // Remaining messages are wlan0 then rmnet, VPN route gone.
         assert_eq!(read_u32_ne(&buf, ROUTE_OIF_OFF), Some(2));
@@ -654,7 +741,7 @@ tun0:  300    3    0    0\n"
         // Multipath / oif-less routes must pass through untouched.
         let mut buf = make_route_nlmsg_inner(None);
         let orig_len = buf.len();
-        let new_len = filter_netlink_dump(&mut buf, &[33]);
+        let new_len = filter_netlink_dump(&mut buf, &[33], 0);
         assert_eq!(new_len, orig_len);
     }
 
@@ -667,9 +754,110 @@ tun0:  300    3    0    0\n"
         buf.extend(make_route_nlmsg(2)); // keep (wlan0)
         buf.extend(make_route_nlmsg(vpn_idx)); // remove (tun0)
 
-        let new_len = filter_netlink_dump(&mut buf, &[vpn_idx]);
+        let new_len = filter_netlink_dump(&mut buf, &[vpn_idx], 0);
         assert_eq!(new_len, make_route_nlmsg(0).len());
         assert_eq!(read_u16_ne(&buf, 4), Some(RTM_NEWROUTE));
         assert_eq!(read_u32_ne(&buf, ROUTE_OIF_OFF), Some(2));
+    }
+
+    // ---- RTM_GETRULE (policy rule) tests ----
+
+    fn push_rule_attr(attrs: &mut Vec<u8>, rta_type: u16, payload: &[u8]) {
+        let rta_len = 4 + payload.len();
+        attrs.extend_from_slice(&(rta_len as u16).to_ne_bytes());
+        attrs.extend_from_slice(&rta_type.to_ne_bytes());
+        attrs.extend_from_slice(payload);
+        while attrs.len() % RTA_ALIGNTO != 0 {
+            attrs.push(0);
+        }
+    }
+
+    /// Build an RTM_NEWRULE message: nlmsghdr + fib_rule_hdr + optional
+    /// FRA_OIFNAME / FRA_UID_RANGE / FRA_TABLE attributes. Header table byte = 0.
+    fn make_rule_nlmsg(
+        oifname: Option<&[u8]>,
+        uidrange: Option<(u32, u32)>,
+        table: Option<u32>,
+    ) -> Vec<u8> {
+        let mut attrs = Vec::new();
+        if let Some(name) = oifname {
+            let mut p = name.to_vec();
+            p.push(0);
+            push_rule_attr(&mut attrs, FRA_OIFNAME, &p);
+        }
+        if let Some((lo, hi)) = uidrange {
+            let mut p = Vec::new();
+            p.extend_from_slice(&lo.to_ne_bytes());
+            p.extend_from_slice(&hi.to_ne_bytes());
+            push_rule_attr(&mut attrs, FRA_UID_RANGE, &p);
+        }
+        if let Some(t) = table {
+            push_rule_attr(&mut attrs, FRA_TABLE, &t.to_ne_bytes());
+        }
+        let body_len = NLMSG_HDRLEN + RTMSG_HDRLEN + attrs.len();
+        let mut msg = Vec::new();
+        msg.extend_from_slice(&(body_len as u32).to_ne_bytes()); // nlmsg_len
+        msg.extend_from_slice(&RTM_NEWRULE.to_ne_bytes()); // nlmsg_type
+        msg.extend_from_slice(&0u16.to_ne_bytes()); // nlmsg_flags
+        msg.extend_from_slice(&1u32.to_ne_bytes()); // nlmsg_seq
+        msg.extend_from_slice(&0u32.to_ne_bytes()); // nlmsg_pid
+        // fib_rule_hdr: family, dst_len, src_len, tos, table, res1, res2, action, flags(u32).
+        msg.extend_from_slice(&[2u8, 0, 0, 0, 0, 0, 0, 1]);
+        msg.extend_from_slice(&0u32.to_ne_bytes());
+        msg.extend_from_slice(&attrs);
+        msg
+    }
+
+    #[test]
+    fn rule_hides_vpn_by_oifname() {
+        assert!(rule_hides_vpn(
+            &make_rule_nlmsg(Some(b"tun0"), None, None),
+            10253
+        ));
+        assert!(!rule_hides_vpn(
+            &make_rule_nlmsg(Some(b"wlan0"), None, None),
+            10253
+        ));
+    }
+
+    #[test]
+    fn rule_hides_vpn_by_uid_table() {
+        // uid 10253 steered into a non-standard table (>255) → per-app tun rule.
+        let msg = make_rule_nlmsg(None, Some((10253, 10253)), Some(1027));
+        assert!(rule_hides_vpn(&msg, 10253));
+        // another uid's rule doesn't reveal *this* app's VPN.
+        assert!(!rule_hides_vpn(&msg, 10000));
+    }
+
+    #[test]
+    fn rule_keeps_standard_tables_and_catchall() {
+        // main/local/default and low table ids are not VPN tables.
+        assert!(!rule_hides_vpn(
+            &make_rule_nlmsg(None, Some((10253, 10253)), Some(RT_TABLE_MAIN)),
+            10253
+        ));
+        assert!(!rule_hides_vpn(
+            &make_rule_nlmsg(None, Some((10253, 10253)), Some(99)),
+            10253
+        ));
+        // the 0..=u32::MAX catch-all default rule is not a VPN rule.
+        assert!(!rule_hides_vpn(
+            &make_rule_nlmsg(None, Some((0, u32::MAX)), Some(1027)),
+            10253
+        ));
+    }
+
+    #[test]
+    fn netlink_filter_removes_vpn_rules() {
+        let uid = 10253u32;
+        let keep = make_rule_nlmsg(None, Some((0, u32::MAX)), Some(RT_TABLE_MAIN)); // catch-all — keep
+        let mut buf = Vec::new();
+        buf.extend(keep.clone());
+        buf.extend(make_rule_nlmsg(Some(b"tun0"), None, None)); // iface tun0 — remove
+        buf.extend(make_rule_nlmsg(None, Some((uid, uid)), Some(1027))); // uid→tun table — remove
+
+        let new_len = filter_netlink_dump(&mut buf, &[7], uid);
+        assert_eq!(new_len, keep.len());
+        assert_eq!(read_u16_ne(&buf, 4), Some(RTM_NEWRULE));
     }
 }

--- a/zygisk/src/hooks.rs
+++ b/zygisk/src/hooks.rs
@@ -30,9 +30,9 @@ use core::{mem, ptr, slice};
 use libc::{SIOCGIFCONF, SIOCGIFNAME, ifreq};
 
 use crate::filter::{
-    MAX_VPN_ADDRS, RTM_NEWADDR, RTM_NEWLINK, RTM_NEWROUTE, filter_dev_buf, filter_if_inet6_buf,
-    filter_ipv6_route_buf, filter_netlink_dump, filter_route_buf, filter_tcp4_buf, filter_tcp6_buf,
-    is_vpn_iface_bytes, is_vpn_iface_cstr,
+    MAX_VPN_ADDRS, RTM_NEWADDR, RTM_NEWLINK, RTM_NEWROUTE, RTM_NEWRULE, filter_dev_buf,
+    filter_if_inet6_buf, filter_ipv6_route_buf, filter_netlink_dump, filter_route_buf,
+    filter_tcp4_buf, filter_tcp6_buf, is_vpn_iface_bytes, is_vpn_iface_cstr,
 };
 use crate::generated::hook_ids::Hook;
 
@@ -1252,6 +1252,7 @@ pub unsafe extern "C" fn hooked_recvmsg(fd: c_int, msg: *mut libc::msghdr, flags
     if n == 0 {
         return ret;
     }
+    let vpn_uid = unsafe { libc::getuid() };
 
     NETLINK_IOV_BUF.with(|cell| {
         let Ok(mut scratch) = cell.try_borrow_mut() else {
@@ -1263,7 +1264,7 @@ pub unsafe extern "C" fn hooked_recvmsg(fd: c_int, msg: *mut libc::msghdr, flags
                 hdr.msg_iovlen,
                 in_iovecs,
                 &mut scratch,
-                |data| filter_netlink_dump(data, &indices[..n]),
+                |data| filter_netlink_dump(data, &indices[..n], vpn_uid),
             )
         }) else {
             return ret;
@@ -1397,7 +1398,11 @@ unsafe fn maybe_filter_netlink_buf(fd: c_int, buf: *mut u8, ret: isize) -> isize
     // (RTM_GETROUTE) come back as RTM_NEWROUTE and must not be skipped —
     // that gap was the issue #86 `if<N>` leak.
     let nlmsg_type = u16::from_ne_bytes([data[4], data[5]]);
-    if nlmsg_type != RTM_NEWADDR && nlmsg_type != RTM_NEWLINK && nlmsg_type != RTM_NEWROUTE {
+    if nlmsg_type != RTM_NEWADDR
+        && nlmsg_type != RTM_NEWLINK
+        && nlmsg_type != RTM_NEWROUTE
+        && nlmsg_type != RTM_NEWRULE
+    {
         return ret;
     }
 
@@ -1405,8 +1410,9 @@ unsafe fn maybe_filter_netlink_buf(fd: c_int, buf: *mut u8, ret: isize) -> isize
     if n == 0 {
         return ret;
     }
+    let vpn_uid = unsafe { libc::getuid() };
 
-    filter_netlink_dump(data, &indices[..n]) as isize
+    filter_netlink_dump(data, &indices[..n], vpn_uid) as isize
 }
 
 // ============================================================================
@@ -1806,7 +1812,7 @@ mod iovec_tests {
                 iovecs.len(),
                 copied,
                 &mut scratch,
-                |data| filter_netlink_dump(data, &[7]),
+                |data| filter_netlink_dump(data, &[7], 0),
             )
             .unwrap()
         };

--- a/zygisk/src/lib.rs
+++ b/zygisk/src/lib.rs
@@ -101,15 +101,15 @@ use zygisk_api::{ZygiskModule, register_companion, register_module};
 
 use crate::filesystem::{
     hooked_access, hooked_faccessat, hooked_fstat, hooked_fstat64, hooked_fstatat,
-    hooked_fstatat64, hooked_lstat, hooked_lstat64, hooked_open, hooked_open_2, hooked_open64,
-    hooked_openat_2, hooked_openat64, hooked_readdir, hooked_readdir64, hooked_readlink,
-    hooked_readlink_chk, hooked_readlinkat, hooked_readlinkat_chk, hooked_stat, hooked_stat64,
-    set_real_access_ptr, set_real_faccessat_ptr, set_real_fstat_ptr, set_real_fstat64_ptr,
-    set_real_fstatat_ptr, set_real_fstatat64_ptr, set_real_lstat_ptr, set_real_lstat64_ptr,
-    set_real_open_2_ptr, set_real_open_ptr, set_real_open64_ptr, set_real_openat_2_ptr,
-    set_real_openat64_ptr, set_real_readdir_ptr, set_real_readdir64_ptr, set_real_readlink_chk_ptr,
-    set_real_readlink_ptr, set_real_readlinkat_chk_ptr, set_real_readlinkat_ptr, set_real_stat_ptr,
-    set_real_stat64_ptr,
+    hooked_fstatat64, hooked_getdents64, hooked_lstat, hooked_lstat64, hooked_open, hooked_open_2,
+    hooked_open64, hooked_openat_2, hooked_openat64, hooked_readdir, hooked_readdir64,
+    hooked_readlink, hooked_readlink_chk, hooked_readlinkat, hooked_readlinkat_chk, hooked_stat,
+    hooked_stat64, set_real_access_ptr, set_real_faccessat_ptr, set_real_fstat_ptr,
+    set_real_fstat64_ptr, set_real_fstatat_ptr, set_real_fstatat64_ptr, set_real_getdents64_ptr,
+    set_real_lstat_ptr, set_real_lstat64_ptr, set_real_open_2_ptr, set_real_open_ptr,
+    set_real_open64_ptr, set_real_openat_2_ptr, set_real_openat64_ptr, set_real_readdir_ptr,
+    set_real_readdir64_ptr, set_real_readlink_chk_ptr, set_real_readlink_ptr,
+    set_real_readlinkat_chk_ptr, set_real_readlinkat_ptr, set_real_stat_ptr, set_real_stat64_ptr,
 };
 use crate::hooks::{
     hooked_getifaddrs, hooked_ioctl, hooked_openat, hooked_recv, hooked_recvfrom,
@@ -681,6 +681,19 @@ fn install_hooks(hookmask: u32) -> Result<HookInstallReport, String> {
                     filesystem_error = Some(err);
                     break;
                 }
+            }
+        }
+        // getdents64 is a best-effort addition on top of readdir*: some bionic
+        // versions do not export it as a dynamic symbol, and its absence must NOT
+        // tear down the whole filesystem feature (readdir/open/stat still hide the
+        // paths). So hook it outside the fatal loop and ignore a resolution failure.
+        if filesystem_error.is_none() {
+            if let Ok(stub) = hook_libc_sym(
+                c"getdents64",
+                hooked_getdents64 as *mut _,
+                set_real_getdents64_ptr,
+            ) {
+                filesystem_stubs.push(stub);
             }
         }
     }


### PR DESCRIPTION
Two related improvements to how VPN Hide reports and closes VPN-detection vectors. First, diagnostics no longer alarms about a vector that no active backend can cover on this device — a working module used to read as "Needs attention" over a gap the user cannot close, which generated support noise. Second, Zygisk now actually closes two of those vectors, so on Zygisk-only devices (no kernel backend) they move from uncovered to hidden.

- Unowned leaks (vectors no active backend owns) no longer raise a dashboard warning or the "Issues" count; the dashboard reads Protected / 0 issues whenever the active backend hides everything it owns.
- Those vectors render neutrally ("not covered") in a separate group of the detailed diagnostics instead of as red leaks, so the residual surface stays honest without reading as a module failure.
- Zygisk hides VPN routing policy rules (`ip rule` / `RTM_GETRULE`) via the same recv netlink filter as `RTM_GETLINK`/`RTM_GETROUTE`, mirroring the app probe predicate exactly (drop a rule that names a VPN iface or steers this uid into a tun table).
- Zygisk filesystem hiding also filters raw `getdents64` directory enumeration (e.g. of `/sys/class/net`), not just libc `readdir`; installed best-effort so a missing symbol can't disable the whole filesystem feature.
- `netlink_getrule` is now attributed to the zygisk recv hooks, so it reads as owned/hidden under Zygisk instead of uncovered.

Testing

- CI covers it: lsposed ktlint/detekt/unit tests, zygisk host `cargo test` + android `clippy --tests -D warnings` (arm64-v8a + armeabi-v7a) — all green locally.
- Wants on-device validation on a Zygisk-only device (the Samsung S9+ from #251): the two previously-red diagnostics cards (netlink RTM_GETRULE, /sys/class/net) should now read hidden/neutral, and the dashboard should stay clean.