### PR TITLE
feat(lsposed): support Android 9 (API 28)

### DIFF
--- a/changelog.d/added-lowered-the-minimum-supported-android-version-1a08.md
+++ b/changelog.d/added-lowered-the-minimum-supported-android-version-1a08.md
@@ -1,0 +1,9 @@
+_2026-08-19_
+
+## English
+
+Lowered the minimum supported Android version to 9 (API 28).
+
+## Русский
+
+Минимальная поддерживаемая версия Android понижена до 9 (API 28).

--- a/docs/avd-magisk-testing.md
+++ b/docs/avd-magisk-testing.md
@@ -1,0 +1,165 @@
+# Testing vpnhide on a rooted x86_64 AVD (Magisk + Zygisk + LSPosed)
+
+How to stand up a **rooted Android emulator** to test the vpnhide LSPosed/Zygisk
+layers — including **Android 9 (API 28)**, which the stock emulator cannot root
+out of the box. This cost hours to work out; follow it and skip the dead ends.
+
+The native kernel/KPM backends **cannot** be tested this way (the emulator runs
+a goldfish/ranchu kernel, not GKI; zygisk's shadowhook has no x86 backend). This
+setup verifies the **Java/LSPosed layer** and Zygisk module *loading*.
+
+## TL;DR
+
+- Host is **x86_64** → only **x86_64** system images run (`emulator` 36.x refuses
+  arm64 on x86: `FATAL | Avd's CPU Architecture 'arm64' is not supported ... on
+  x86_64 host`). No arm64 emulation here.
+- **API 30+**: `rootAVD` + Magisk works normally. Just root, enable Zygisk,
+  flash LSPosed, done.
+- **API 28 (Android 9)**: the emulator kernel cmdline hard-codes
+  `skip_initramfs`, so Magisk's ramdisk `magiskinit` is **never executed** and
+  rootAVD's patch has no effect. Fix = boot a **custom kernel** with the
+  `skip_initramfs` handler neutered (below).
+
+## Prereqs
+
+- `~/Android/Sdk` with `cmdline-tools`, `emulator`, `adb`.
+- A **non-Play** system image (Play images can't be rooted):
+  `sdkmanager "system-images;android-28;google_apis;x86_64"`.
+- AVD: `avdmanager create avd -n <name> -k "...;x86_64" --abi x86_64`.
+  Note: modern `avdmanager` writes AVDs under `$XDG_CONFIG_HOME/.android/avd`
+  (`~/.config/.android/avd`), while `emulator -list-avds` reads `~/.android/avd`.
+  Export `ANDROID_AVD_HOME` to the same path for both.
+
+## Rooting API 30+ (the easy path)
+
+1. Boot the AVD once (`-writable-system -no-snapshot`).
+2. `rootAVD` (GitLab, maintained): `git clone https://gitlab.com/newbit/rootAVD`
+   then `./rootAVD.sh system-images/android-XX/google_apis/x86_64/ramdisk.img`.
+   Feed input with `printf '\n%.0s' {1..40} | ./rootAVD.sh ...` — **not** `yes ""`
+   (an unbounded pipe breaks rootAVD's `adb shell` probe → "no ADB connection").
+3. Cold-boot; open Magisk; enable Zygisk; reboot.
+
+## Rooting API 28 (Android 9) — custom kernel
+
+The stock kernel cmdline is `... skip_initramfs rootwait ro init=/init
+root=/dev/vda1 ...`. `skip_initramfs` makes the kernel mount system directly and
+run system's `/init`, never the ramdisk's `magiskinit`. It is **not** removable
+via flags (`-qemu -append` only *appends*; the token then still wins). Build a
+kernel that ignores it.
+
+```sh
+# toolchain matching the 4.4 kernel era (host gcc is far too new for 4.4)
+git clone --depth 1 -b android10-c2f2-release \
+  https://android.googlesource.com/platform/prebuilts/gcc/linux-x86/x86/x86_64-linux-android-4.9 gcc49
+git clone --depth 1 -b android-goldfish-4.4-dev \
+  https://android.googlesource.com/kernel/goldfish goldfish
+
+cd goldfish
+# 1) neuter skip_initramfs: in init/initramfs.c, skip_initramfs_param(), set
+#    `do_skip_initramfs = 0;` (was 1). Kernel now always unpacks the (Magisk-
+#    patched) initramfs as rootfs and runs /init = magiskinit.
+# 2) use the STOCK kernel config (a generic defconfig mismatches the emulator HW
+#    and panics in MM once userspace starts — "Bad swap file entry" etc.):
+./scripts/extract-ikconfig \
+  ~/Android/Sdk/system-images/android-28/google_apis/x86_64/kernel-ranchu > stock.config
+cp stock.config .config
+export PATH=$PWD/../gcc49/bin:$PATH ARCH=x86_64 CROSS_COMPILE=x86_64-linux-android-
+# stock-like build id (the emulator's version parser is picky):
+export KBUILD_BUILD_USER=android-build KBUILD_BUILD_HOST=localhost \
+       KBUILD_BUILD_TIMESTAMP="Wed Jan 30 07:13:09 UTC 2019"
+make olddefconfig
+make -j"$(nproc)" bzImage      # ~2 min, out: arch/x86/boot/bzImage
+```
+
+**Emulator kernel-version gotcha:** the emulator reads the version string from
+the bzImage setup header (2-byte pointer at file offset `0x20E`) and **rejects
+`4.4.302`**. Patch the reported version to the stock `4.4.124` (same length):
+
+```sh
+cp arch/x86/boot/bzImage bzImage_124
+printf '124' | dd of=bzImage_124 bs=1 seek=12788 count=3 conv=notrunc  # "302"->"124"
+```
+
+Boot with the custom kernel + the Magisk-patched ramdisk (rootAVD makes the
+ramdisk; you only swap the kernel):
+
+```sh
+emulator -avd <name> -no-window -no-snapshot -writable-system \
+  -gpu swiftshader_indirect -memory 3072 -show-kernel \
+  -kernel .../bzImage_124 -ramdisk .../ramdisk.img.<magisk-patched>
+```
+
+It boots Android 9 with Magisk active.
+
+## Completing Magisk / Zygisk (needed after messy rootAVD runs)
+
+If `magisk --install-module` says **"Incomplete Magisk install"** and Zygisk
+doesn't inject (`/data/adb/magisk` empty), populate it from the matching Magisk
+APK. Match the version to the running core (`magisk -V`, e.g. 25.2):
+
+```sh
+# from Magisk-vXX.apk: push lib/x86_64/lib*.so and assets/, then on device:
+#   cp libmagisk64.so magisk64; cp libmagisk32.so magisk32 (from lib/x86);
+#   cp libmagiskinit.so magiskinit; libmagiskboot.so magiskboot;
+#   libmagiskpolicy.so magiskpolicy; libbusybox.so busybox;
+#   assets/util_functions.sh, boot_patch.sh, addon.d.sh -> /data/adb/magisk/
+#   chmod 755 magisk* busybox
+adb shell 'magisk --sqlite "REPLACE INTO settings (key,value) VALUES(\"zygisk\",1)"'
+adb shell 'magisk --sqlite "REPLACE INTO policies (uid,policy,until,logging,notification) VALUES(2000,2,0,0,0)"' # grant shell root
+adb reboot
+```
+
+Verify Zygisk from logcat after reboot: `Magisk: zygisk64: replaced
+com/android/internal/os/Zygote#nativeForkAndSpecialize`.
+
+## Installing & enabling LSPosed + a module (headless)
+
+```sh
+# LSPosed framework (supports 8.1-14):
+curl -LO https://github.com/LSPosed/LSPosed/releases/download/v1.9.2/LSPosed-v1.9.2-7024-zygisk-release.zip
+adb push LSPosed-*.zip /data/local/tmp/ && adb shell magisk --install-module /data/local/tmp/LSPosed-*.zip
+adb reboot                                   # zygisk companion should log "welcome to LSPosed!"
+adb shell pm install -r -g /data/adb/modules/zygisk_lsposed/manager.apk   # LSPosed manager
+
+adb install -r -g <vpnhide app-debug.apk>    # the module
+
+# enable + scope via LSPosed's config db (no GUI):
+DB=/data/adb/lspd/config/modules_config.db
+adb shell "sqlite3 $DB \"UPDATE modules SET enabled=1 WHERE module_pkg_name='dev.okhsunrog.vpnhide'\""
+# scope 'android' = system_server (needed for ConnectivityService hooks):
+adb shell "sqlite3 $DB \"INSERT OR REPLACE INTO scope(mid,app_pkg_name,user_id) VALUES(2,'android',0)\""
+adb reboot
+```
+
+On API 28, LSPosed logs a non-fatal `NoClassDefFoundError:
+android.os.IServiceCallback$Stub` (that binder class is API 29+) and falls back
+to polling — LSPosed still works.
+
+## Reading the vpnhide hooks
+
+The system_server hooks log at ERROR only for missing targets; the per-call
+telemetry (`VpnHide-NC/-LP/-NI`) is gated by the **debug** flag in the canonical
+config. Enable it (we have root; the app can't flip it itself):
+
+```sh
+printf '{"version":1,"debug":true,"debugSwitch":true}' > c.json
+adb push c.json /data/system/vpnhide_config.json
+adb shell 'chown root:system /data/system/vpnhide_config.json; chmod 640 /data/system/vpnhide_config.json'
+adb reboot
+adb shell 'logcat -d | grep -aoE "VpnHide-[A-Za-z]+" | sort | uniq -c'
+```
+
+## Gotchas that wasted the most time
+
+- **arm64 images don't run on an x86_64 host** with emulator 36.x. Full stop.
+- **`skip_initramfs`** on API 28 defeats rootAVD; needs the custom kernel.
+- **Generic defconfig panics** (MM corruption once userspace starts). Use the
+  stock kernel-ranchu config via `extract-ikconfig`. In particular do **not**
+  leave `RANDOMIZE_MEMORY=y` with `RANDOMIZE_BASE=n`.
+- **Emulator rejects the kernel version** unless it parses; keep it stock-like
+  and patch the reported number if needed.
+- **Leftover `multiinstance.lock`** after `kill -9` makes the next launch fail
+  with no output. `find .../<avd>.avd -name '*.lock' -delete` before each boot.
+- **Emulator daemonizes on an accepted `-kernel`**, so its `-show-kernel`
+  output detaches — capture kernel console from a **real terminal** with a
+  direct `> file` redirect (not a pipe), or read the pstore/ramoops file.

--- a/lsposed/app/build.gradle.kts
+++ b/lsposed/app/build.gradle.kts
@@ -84,6 +84,13 @@ val rustNdkDir =
 val nativeCrateDir = projectDir.parentFile.resolve("native")
 val rustAssetsOut = rustAssetsDir.get().asFile
 
+// Opt-in x86_64 native + APK ABI for running the app on an Android x86_64
+// emulator (arm64 system images don't run on x86 hosts). Enable with
+// `-PvpnhideEmulatorX86` (or `vpnhideEmulatorX86=true` in gradle.properties).
+// Off by default: release and normal dev builds stay arm64-only. Only the
+// `debug` build type honours it. See docs/avd-magisk-testing.md.
+val emulatorX86 = (project.findProperty("vpnhideEmulatorX86") as String?)?.toBoolean() == true
+
 val buildRustProbe =
     tasks.register<Exec>("buildRustProbe") {
         group = "build"
@@ -96,21 +103,42 @@ val buildRustProbe =
         outputs.dir(rustJniLibsDir)
         outputs.dir(rustAssetsDir)
         commandLine(
-            "cargo", "ndk",
-            "-t", "arm64-v8a",
-            "-P", "29",
-            "-o", rustJniLibsDir.get().asFile.absolutePath,
-            // --locked: fail if Cargo.lock drifted rather than rewriting it (a
-            // dirtied tree stamps the build "-dirty" via git describe --dirty).
-            "build", "--release", "--locked",
+            buildList {
+                add("cargo")
+                add("ndk")
+                add("-t")
+                add("arm64-v8a")
+                // Opt-in second ABI for the x86_64 emulator (see emulatorX86).
+                if (emulatorX86) {
+                    add("-t")
+                    add("x86_64")
+                }
+                // -P 28 matches minSdk; getifaddrs needs API >= 24, so 28 is safe.
+                add("-P")
+                add("28")
+                add("-o")
+                add(rustJniLibsDir.get().asFile.absolutePath)
+                // --locked: fail if Cargo.lock drifted rather than rewriting it
+                // (a dirtied tree stamps the build "-dirty" via git describe).
+                add("build")
+                add("--release")
+                add("--locked")
+            },
         )
         // Locals (not top-level script vals) so the doLast action captures only
-        // File values — required for configuration-cache serialization.
-        val probeBin = nativeCrateDir.resolve("target/aarch64-linux-android/release/vhprobe")
-        val probeDest = rustAssetsOut.resolve("bin/arm64-v8a/vhprobe")
+        // File/Boolean values — required for configuration-cache serialization.
+        val probeBinArm = nativeCrateDir.resolve("target/aarch64-linux-android/release/vhprobe")
+        val probeDestArm = rustAssetsOut.resolve("bin/arm64-v8a/vhprobe")
+        val probeBinX86 = nativeCrateDir.resolve("target/x86_64-linux-android/release/vhprobe")
+        val probeDestX86 = rustAssetsOut.resolve("bin/x86_64/vhprobe")
+        val copyX86 = emulatorX86
         doLast {
-            probeDest.parentFile.mkdirs()
-            probeBin.copyTo(probeDest, overwrite = true)
+            probeDestArm.parentFile.mkdirs()
+            probeBinArm.copyTo(probeDestArm, overwrite = true)
+            if (copyX86) {
+                probeDestX86.parentFile.mkdirs()
+                probeBinX86.copyTo(probeDestX86, overwrite = true)
+            }
         }
     }
 
@@ -149,7 +177,7 @@ android {
 
     defaultConfig {
         applicationId = "dev.okhsunrog.vpnhide"
-        minSdk = 29
+        minSdk = 28
         targetSdk = 36
         versionCode = 10101
         versionName = buildVersion
@@ -198,6 +226,14 @@ android {
                 "proguard-rules.pro",
                 "proguard-debug-rules.pro",
             )
+            // Opt-in x86_64 (via -PvpnhideEmulatorX86) so the debug APK installs
+            // on an x86_64 API-28 emulator. Release stays arm64-only (defaultConfig
+            // above) regardless of the flag. See docs/avd-magisk-testing.md.
+            if (emulatorX86) {
+                ndk {
+                    abiFilters += "x86_64"
+                }
+            }
         }
         create("rawDebug") {
             initWith(getByName("debug"))

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/HookEntry.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/HookEntry.kt
@@ -282,7 +282,11 @@ class HookEntry : IXposedHookLoadPackage {
 
     private fun sanitizeNetworkCapabilities(copy: NetworkCapabilities): Boolean {
         val hasVpnTransport = copy.hasTransport(NetworkCapabilities.TRANSPORT_VPN)
-        val hasVpnInfo = copy.transportInfo?.javaClass?.name == "android.net.VpnTransportInfo"
+        // NetworkCapabilities.getTransportInfo() is API 29+; VpnTransportInfo does
+        // not exist on Android 9, so there is nothing to clear there.
+        val hasVpnInfo =
+            Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q &&
+                copy.transportInfo?.javaClass?.name == "android.net.VpnTransportInfo"
 
         if (!hasVpnTransport && !hasVpnInfo) return false
 
@@ -1090,7 +1094,14 @@ class HookEntry : IXposedHookLoadPackage {
             // known-good device.
             counts[method] = hooked.size
             if (hooked.isEmpty()) {
-                HookLog.e("VpnHide: no ConnectivityService.$method result hook target on ${csClass.name}")
+                val minApi = CONNECTIVITY_RESULT_METHOD_MIN_API[method]
+                if (minApi != null && Build.VERSION.SDK_INT < minApi) {
+                    // The method (and the detection vector it covers) doesn't exist
+                    // on this Android version — absence is expected, not an error.
+                    HookLog.i("VpnHide: ConnectivityService.$method absent on API ${Build.VERSION.SDK_INT} (added in API $minApi)")
+                } else {
+                    HookLog.e("VpnHide: no ConnectivityService.$method result hook target on ${csClass.name}")
+                }
             } else {
                 HookLog.i("VpnHide: hooked ConnectivityService.$method result (${hooked.size})")
             }
@@ -1251,6 +1262,16 @@ class HookEntry : IXposedHookLoadPackage {
                 "getNetworkInfo" to null,
                 "getNetworkInfoForUid" to 1,
                 "getAllNetworkInfo" to null,
+            )
+
+        // Result methods that AOSP only added in a later API. Below that level the
+        // method (and the detection vector it covers) simply doesn't exist, so a
+        // missing hook target is expected — log it at INFO, not ERROR.
+        private val CONNECTIVITY_RESULT_METHOD_MIN_API =
+            mapOf(
+                // getRedacted*ForPackage arrived with the per-package redaction API.
+                "getRedactedLinkPropertiesForPackage" to Build.VERSION_CODES.S,
+                "getRedactedNetworkCapabilitiesForPackage" to Build.VERSION_CODES.S,
             )
 
         // Per-hook critical-probe sets. A hook is skipped if any key in

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/JavaChecks.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/JavaChecks.kt
@@ -290,11 +290,17 @@ internal fun checkTransportInfo(
     name: String,
 ): CheckResult =
     withActiveCaps(cm, name) { caps ->
-        val info = caps.transportInfo
-        val className = info?.javaClass?.name ?: "null"
-        val isVpn = className.contains("VpnTransportInfo")
-        val detail = if (!isVpn) "transportInfo=$className" else "VpnTransportInfo: $info"
-        javaCheck(name, !isVpn, detail)
+        // NetworkCapabilities.getTransportInfo() is API 29+. On Android 9 the
+        // VpnTransportInfo leak path does not exist, so the check trivially passes.
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.Q) {
+            javaCheck(name, true, "transportInfo unavailable (API < 29)")
+        } else {
+            val info = caps.transportInfo
+            val className = info?.javaClass?.name ?: "null"
+            val isVpn = className.contains("VpnTransportInfo")
+            val detail = if (!isVpn) "transportInfo=$className" else "VpnTransportInfo: $info"
+            javaCheck(name, !isVpn, detail)
+        }
     }
 
 private fun checkNetworkInterfaceEnum(name: String): CheckResult =

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/PackageVisibilityHooks.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/PackageVisibilityHooks.kt
@@ -4,6 +4,7 @@ import android.content.pm.ApplicationInfo
 import android.content.pm.PackageInfo
 import android.content.pm.ResolveInfo
 import android.os.Binder
+import android.os.Build
 import android.os.FileObserver
 import android.os.Process
 import de.robv.android.xposed.XC_MethodHook
@@ -89,7 +90,12 @@ internal object PackageVisibilityHooks {
         hook(ipmClass, "getPackageInfo", singleHideByFirstStringArg("getPackageInfo"))
         hook(ipmClass, "getApplicationInfo", singleHideByFirstStringArg("getApplicationInfo"))
         hook(ipmClass, "getInstallerPackageName", singleHideByFirstStringArg("getInstallerPackageName"))
-        hook(ipmClass, "getInstallSourceInfo", singleHideByFirstStringArg("getInstallSourceInfo"))
+        hook(
+            ipmClass,
+            "getInstallSourceInfo",
+            singleHideByFirstStringArg("getInstallSourceInfo"),
+            minApi = Build.VERSION_CODES.R,
+        )
         hook(ipmClass, "getPackageUid", packageUidHide())
         hook(ipmClass, "resolveIntent", resolveInfoSingleHide("resolveIntent"))
         hook(ipmClass, "resolveService", resolveInfoSingleHide("resolveService"))
@@ -136,11 +142,19 @@ internal object PackageVisibilityHooks {
         clazz: Class<*>,
         methodName: String,
         handler: XC_MethodHook,
+        // AOSP API level that introduced the method. Below it the method (and the
+        // detection vector it covers) doesn't exist, so a missing target is
+        // expected — logged at INFO instead of ERROR. 0 = present on all supported.
+        minApi: Int = 0,
     ) {
         try {
             val hooked = XposedBridge.hookAllMethods(clazz, methodName, handler)
             if (hooked.isEmpty()) {
-                HookLog.e("VpnHide/PV: no method '$methodName' on ${clazz.name}")
+                if (minApi > 0 && Build.VERSION.SDK_INT < minApi) {
+                    HookLog.i("VpnHide/PV: $methodName absent on API ${Build.VERSION.SDK_INT} (added in API $minApi)")
+                } else {
+                    HookLog.e("VpnHide/PV: no method '$methodName' on ${clazz.name}")
+                }
             } else {
                 HookLog.i("VpnHide/PV: hooked $methodName (${hooked.size} overload(s))")
             }

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/SystemDataFileWatcher.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/SystemDataFileWatcher.kt
@@ -1,9 +1,10 @@
 package dev.okhsunrog.vpnhide
 
 import android.os.FileObserver
-import java.io.File
 
-private val SYSTEM_DATA_DIR = File("/data/system")
+// String path, not File: FileObserver(File, Int) is API 29+, while the
+// FileObserver(String, Int) form works back to API 28 (Android 9).
+private const val SYSTEM_DATA_DIR = "/data/system"
 
 /**
  * Watch `/data/system` for the events our config writers produce and invoke
@@ -26,6 +27,7 @@ internal fun watchSystemDataDir(
     onChange: (filename: String) -> Unit,
 ): FileObserver {
     val observer =
+        @Suppress("DEPRECATION")
         object : FileObserver(
             SYSTEM_DATA_DIR,
             CREATE or CLOSE_WRITE or MOVED_TO or extraEvents,


### PR DESCRIPTION
Lowers the minimum supported Android version from 10 (API 29) to 9 (API 28) so the LSPosed module and picker app install and run on Android 9. The Java/LSPosed hiding layer attaches and hides the VPN on API 28 out of the box — verified on a rooted x86_64 API-28 emulator with an active NetGuard VPN, all 12 Java detection vectors reported hidden. The native kmod/KPM/zygisk backends are unaffected and unrelated to this change.

- lower `minSdk` 29 → 28 and cargo-ndk `-P` 29 → 28
- guard members that only exist on API 29+: use `FileObserver(String)` instead of `FileObserver(File)`; gate `NetworkCapabilities.getTransportInfo()` / `VpnTransportInfo` behind `SDK_INT >= Q` in both the hook and the diagnostics check
- stop logging ERROR for hook targets absent on the running API: the redacted per-package `ConnectivityService` methods (API 31) and `getInstallSourceInfo` (API 30) now log at INFO on older Android where the method cannot exist
- add an opt-in x86_64 native + APK build behind `-PvpnhideEmulatorX86` for emulator testing; release and normal dev builds stay arm64-only
- document how to root an x86_64 AVD (including Android 9) with Magisk + Zygisk + LSPosed in `docs/avd-magisk-testing.md`

Testing: CI covers unit tests, ktlint, detekt, lint (no NewApi findings) and `assembleDebug`. Additionally verified by hand on a rooted x86_64 Android 9 (API 28) emulator — the Java hooks attach in system_server and hide an active VPN across all Java detection vectors.