### PR TITLE
fix(lsposed): recover framed sections glued to their end marker

### DIFF
--- a/changelog.d/fixed-the-app-no-longer-fails-to-202f.md
+++ b/changelog.d/fixed-the-app-no-longer-fails-to-202f.md
@@ -1,0 +1,9 @@
+_2026-08-19_
+
+## English
+
+The app no longer fails to load its state when a config file lacks a trailing newline.
+
+## Русский
+
+Приложение больше не перестаёт загружать своё состояние, если у файла конфигурации нет завершающего перевода строки.

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/FramedSections.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/FramedSections.kt
@@ -43,8 +43,19 @@ internal fun parseFramedSections(
                 currentBody.clear()
             }
 
-            line.startsWith(endPrefix) -> {
-                val endName = line.removePrefix(endPrefix)
+            line.contains(endPrefix) -> {
+                val markerStart = line.indexOf(endPrefix)
+                // Recover content glued onto the marker: a file emitted without a
+                // trailing newline (e.g. `cat`'d) puts its last line and the END
+                // marker on the same line (`...}__..._END__:name`). Without this
+                // the marker wouldn't be recognised and the section would be
+                // dropped as unterminated. The prefixes are unique sentinels, so a
+                // mid-line occurrence is always a glued marker, never real content.
+                if (markerStart > 0 && currentName != null) {
+                    if (currentBody.isNotEmpty()) currentBody.append('\n')
+                    currentBody.append(line, 0, markerStart)
+                }
+                val endName = line.substring(markerStart + endPrefix.length)
                 if (currentName == endName) {
                     sections[endName] = body()
                     clearCurrent()

--- a/lsposed/app/src/test/kotlin/dev/okhsunrog/vpnhide/RootSnapshotCacheTest.kt
+++ b/lsposed/app/src/test/kotlin/dev/okhsunrog/vpnhide/RootSnapshotCacheTest.kt
@@ -62,6 +62,32 @@ class RootSnapshotCacheTest {
     }
 
     @Test
+    fun `parser recovers content glued onto the end marker without a trailing newline`() {
+        // A file emitted without a trailing newline (e.g. a hand-edited config
+        // cat'd by the snapshot script) puts its last line and the END marker on
+        // the same line. The section must still parse, not be dropped as unclosed.
+        val raw =
+            "__VPNHIDE_ROOT_SECTION_BEGIN__:canonical_config\n" +
+                "{\"version\":1,\"debug\":true}__VPNHIDE_ROOT_SECTION_END__:canonical_config\n"
+
+        val sections = parseRootShellSnapshot(raw, recordMetric = { _, _ -> })
+
+        assertEquals("{\"version\":1,\"debug\":true}", sections["canonical_config"])
+    }
+
+    @Test
+    fun `parser recovers a multiline body whose last line is glued to the end marker`() {
+        val raw =
+            "__VPNHIDE_ROOT_SECTION_BEGIN__:canonical_config\n" +
+                "line1\n" +
+                "line2__VPNHIDE_ROOT_SECTION_END__:canonical_config\n"
+
+        val sections = parseRootShellSnapshot(raw, recordMetric = { _, _ -> })
+
+        assertEquals("line1\nline2", sections["canonical_config"])
+    }
+
+    @Test
     fun `snapshot validation rejects missing sections`() {
         val sections = REQUIRED_ROOT_SNAPSHOT_SECTIONS.associateWith { "" } - "vpn_ifaces"
         var thrown: RootSnapshotException? = null


### PR DESCRIPTION
The root/debug snapshot parser splits stdout into named sections delimited by unique `BEGIN`/`END` sentinel lines. A section whose content is read from a file with no trailing newline puts the file's last line and the `END` marker on the same output line (`...}__..._END__:name`). The parser only matched the marker at the start of a line, so it never recognised the glued marker, treated the section as unterminated, and dropped it — surfacing to the user as `root snapshot incomplete, missing sections: canonical_config` and a failure to load app state.

- match the end marker anywhere on the line and recover the content that precedes it (the prefixes are unique sentinels, so a mid-line occurrence is always a glued marker, never real content)
- fixes every emitter uniformly (`emit_file` / `emit_cmd` / `emit_eval`), not just file reads
- add unit tests for the single-line and multi-line glued cases