### PR TITLE
docs: collapse manual activator commands under a dev spoiler

### DIFF
--- a/kmod/README.md
+++ b/kmod/README.md
@@ -95,19 +95,7 @@ On boot:
 
 ### Target management
 
-**VPN Hide app (recommended):** open the VPN Hide app (the [lsposed](../lsposed/) APK). It lists all installed apps with icons, search, and checkboxes. Saves the canonical JSON config and runs the installed native activator immediately. Works on KernelSU, Magisk, and APatch.
-
-**Shell:**
-```bash
-# Edit /data/system/vpnhide_config.json, then run the module activator.
-adb shell su -c '/data/adb/modules/vpnhide_kmod/activator'
-
-# Or push a control-config snapshot straight to the kernel (docs/protocol.md):
-# header + folded debug flag + grouped target UIDs + mandatory end count
-# (a0003ff = shared kernel hooks plus the optional .ko filesystem hook;
-# control v2 uses bare hex).
-adb shell su -c 'printf "vpnhide 2 config\ndebug 0\ntargets a0003ff 28b7\nend 1\n" > /proc/vpnhide_ctl'
-```
+**VPN Hide app (recommended):** open the VPN Hide app (the [lsposed](../lsposed/) APK). It lists all installed apps with icons, search, and checkboxes. Saves the canonical JSON config and runs the installed native activator immediately. Works on KernelSU, Magisk, and APatch. Managing targets this way is all a normal setup needs; the shell equivalents are in the collapsible **For developers / advanced usage** section at the end of this file.
 
 The app first writes `/data/system/vpnhide_config.json`, the persistent
 package-keyed desired state, and then invokes the selected native activator. The
@@ -184,6 +172,26 @@ We do **not** return `-EMSGSIZE` to skip a VPN entry. On Android 14 / 6.1 GKI ke
 The kretprobe entry handler saves the `seq` pointer and `seq->count` (current buffer position) in `ri->data`. The return handler scans the newly written region `[saved_count, seq->count)` line by line, extracts the first tab-delimited field (interface name), and compacts out VPN lines using `memmove`. Finally, `seq->count` is adjusted to reflect the reduced content.
 
 **Why we save seq in the entry handler:** in a kretprobe return handler, `regs->regs[0]` (x0 on arm64) contains the function's *return value*, not the original first argument. The original code tried to read `seq` from x0 in the return handler, which was reading the return value (0) as a pointer -- a bug that would crash or silently fail. The fix is standard kretprobe practice: save arguments in `ri->data` during the entry handler.
+
+<details>
+<summary><strong>For developers / advanced usage</strong></summary>
+
+You do not need these to use the module — the VPN Hide app writes the canonical
+config and runs the activator for you. They are shell equivalents for
+development and debugging.
+
+```bash
+# Edit /data/system/vpnhide_config.json, then run the module activator.
+adb shell su -c '/data/adb/modules/vpnhide_kmod/activator'
+
+# Or push a control-config snapshot straight to the kernel (docs/protocol.md):
+# header + folded debug flag + grouped target UIDs + mandatory end count
+# (a0003ff = shared kernel hooks plus the optional .ko filesystem hook;
+# control v2 uses bare hex).
+adb shell su -c 'printf "vpnhide 2 config\ndebug 0\ntargets a0003ff 28b7\nend 1\n" > /proc/vpnhide_ctl'
+```
+
+</details>
 
 ## License
 

--- a/portshide/README.md
+++ b/portshide/README.md
@@ -41,36 +41,10 @@ Hide app (it invokes the ports activator via `su`).
 ## Configuration
 
 Managed by the VPN Hide app (**Hiding** tab -> **Ports** / **P**, settings icon
-next to the role label). Direct shell
-alternative:
-
-```
-# Edit /data/system/vpnhide_config.json:
-# "com.example.app": { "java": false, "native": false, "appHiding": false, "ports": true }
-# or with ranges:
-# "com.example.app": {
-#   "ports": true,
-#   "portPolicy": {
-#     "mode": "custom",
-#     "rules": [
-#       { "protocol": "both", "start": 1080 },
-#       { "protocol": "tcp", "start": 7890, "end": 7892 }
-#     ]
-#   }
-# }
-```
-
-Then:
-
-```sh
-su -c /data/adb/modules/vpnhide_ports/activator
-```
-
-The latest apply result is recorded in:
-
-```sh
-su -c 'cat /data/adb/vpnhide_ports/load_status; cat /data/adb/vpnhide_ports/load_log'
-```
+next to the role label). The settings icon also exposes optional per-app port
+ranges when the whole-loopback block is too broad. The shell equivalent (edit
+JSON + run the activator) is in the collapsible **For developers / advanced
+usage** section at the end of this file.
 
 ## Why just localhost, and why for selected apps only
 
@@ -106,3 +80,34 @@ su -c 'cat /data/adb/vpnhide_ports/load_status; cat /data/adb/vpnhide_ports/load
 
 Via root manager — `uninstall.sh` execs the activator, which flushes and removes
 our chains and persistent diagnostics.
+
+<details>
+<summary><strong>For developers / advanced usage</strong></summary>
+
+You do not need these to use the module — the VPN Hide app writes the canonical
+config and applies the rules for you. Direct shell alternative for development
+and debugging:
+
+```jsonc
+// Edit /data/system/vpnhide_config.json:
+"com.example.app": { "java": false, "native": false, "appHiding": false, "ports": true }
+// or with ranges:
+"com.example.app": {
+  "ports": true,
+  "portPolicy": {
+    "mode": "custom",
+    "rules": [
+      { "protocol": "both", "start": 1080 },
+      { "protocol": "tcp", "start": 7890, "end": 7892 }
+    ]
+  }
+}
+```
+
+```sh
+# apply, then inspect the result:
+su -c /data/adb/modules/vpnhide_ports/activator
+su -c 'cat /data/adb/vpnhide_ports/load_status; cat /data/adb/vpnhide_ports/load_log'
+```
+
+</details>

--- a/zygisk/README.md
+++ b/zygisk/README.md
@@ -117,9 +117,7 @@ cargo ndk -t arm64-v8a build --release \
 1. `adb push target/vpnhide-zygisk.zip /sdcard/Download/`
 2. KernelSU/Magisk manager -> Modules -> Install from storage -> pick the zip.
 3. Reboot.
-4. Pick target apps:
-   - **VPN Hide app (recommended):** open the VPN Hide app (the [lsposed](../lsposed/) APK). Lists all installed apps with icons, search, and checkboxes. Works on both KernelSU and Magisk.
-   - **Shell:** edit `/data/system/vpnhide_config.json`, then run `/data/adb/modules/vpnhide_zygisk/activator` as root to regenerate the module-dir runtime config.
+4. Pick target apps with the **VPN Hide app (recommended)** (the [lsposed](../lsposed/) APK). Lists all installed apps with icons, search, and checkboxes. Works on both KernelSU and Magisk. The shell equivalent is in the collapsible **For developers / advanced usage** section at the end of this file.
 5. Force-stop target apps: `adb shell am force-stop <pkg>`
 6. Verify: `adb logcat | grep vpnhide-zygisk`
 
@@ -151,6 +149,22 @@ VPN interface prefixes: `tun`, `ppp`, `tap`, `wg`, `ipsec`, `xfrm`, `utun`, `l2t
 - `third_party/android-inline-hook/` -- submodule (our shadowhook fork)
 - `module/` -- KernelSU/Magisk module metadata
 - `build.py` -- cross-compile + package script
+
+<details>
+<summary><strong>For developers / advanced usage</strong></summary>
+
+You do not need this to use the module — the VPN Hide app writes the canonical
+config and runs the activator for you. Shell equivalent for development and
+debugging:
+
+```sh
+# Edit /data/system/vpnhide_config.json, then regenerate the module-dir runtime
+# wire and force-stop the target so it re-forks with the new config:
+adb shell su -c '/data/adb/modules/vpnhide_zygisk/activator'
+adb shell am force-stop <pkg>
+```
+
+</details>
 
 ## License
 


### PR DESCRIPTION
The kmod, zygisk and ports module READMEs showed the shell "edit `/data/system/vpnhide_config.json` + run the module activator" path inline, right next to the app workflow. There it reads as a required step and misleads users — a reviewer in a video manually ran the ports activator that the app already runs on Save. Everyone manages targets through the VPN Hide app, which writes the canonical config and runs the activator itself.

The shell path is still a useful developer/debugging tool, so instead of deleting it, this moves it out of the normal flow: to the end of each module README, inside a collapsed `<details>` block labelled "For developers / advanced usage", with a note that the app does this for you. No commands are lost.

- `kmod/README.md`, `zygisk/README.md`, `portshide/README.md`: relocate the manual activator / edit-JSON / raw `/proc/vpnhide_ctl` push / ports `load_status`+`load_log` snippets into a collapsed "For developers / advanced usage" section at the end of each file
- keep the app-based workflow inline as the normal path and point to the collapsed section from it