### PR TITLE
feat(lsposed): add donation support to the app and the READMEs

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,4 @@
+# Renders the "Sponsor" button in the repository header.
+# Crypto addresses live in the README's "Support the project" section.
+custom:
+  - https://boosty.to/okhsunrog

--- a/README.en.md
+++ b/README.en.md
@@ -280,6 +280,21 @@ vpnhide hides an active VPN from specific apps. It is NOT designed for:
 - Direct `svc #0` syscalls bypass Zygisk's libc hooks — use a kernel-level backend (kmod or KPM) for that
 - Server-side detection is unfixable client-side — use split tunneling
 
+## Support the project
+
+vpnhide is free, with no ads and no telemetry. There will be no paid features — donating unlocks nothing.
+
+The same list is in the app under **Settings → Support the project**, where addresses copy on tap.
+
+**Boosty** — card payment, one-off or recurring: <https://boosty.to/okhsunrog>
+
+| Coin | Network | Address |
+| --- | --- | --- |
+| USDT | Tron (TRC20) | `TMskx2wKmPg11VYvHoS93vUQGm7yhcetUU` |
+| BTC | Bitcoin | `bc1pmt9u6nux4x7n86zknwdgt9v02lah2tu6d983ak2prc5cwt8hsetq82ganh` |
+| GRAM | The Open Network | `UQADYTtMBQdZvmNNEX02R9sACpdnXKlPV8RbuFrxo7JFBRGS` |
+| LTC | Litecoin | `MBLKJfPNANH3U41UPJFtha7EPJGdbiW5dZ` |
+
 ## License
 
 MIT. See [LICENSE](LICENSE).

--- a/README.md
+++ b/README.md
@@ -281,6 +281,21 @@ vpnhide скрывает активный VPN от конкретных прил
 - Прямые системные вызовы `svc #0` обходят хуки libc в Zygisk — для этого нужен kernel-level backend (kmod или KPM)
 - Серверная детекция неисправима на стороне клиента — используйте раздельное туннелирование
 
+## Поддержать проект
+
+vpnhide бесплатный, без рекламы и телеметрии. Платных функций не будет — донат ничего не открывает.
+
+Тот же список есть в приложении: **Настройки → Поддержать проект**, там адреса копируются по тапу.
+
+**Boosty** — оплата картой, разово или подпиской: <https://boosty.to/okhsunrog>
+
+| Монета | Сеть | Адрес |
+| --- | --- | --- |
+| USDT | Tron (TRC20) | `TMskx2wKmPg11VYvHoS93vUQGm7yhcetUU` |
+| BTC | Bitcoin | `bc1pmt9u6nux4x7n86zknwdgt9v02lah2tu6d983ak2prc5cwt8hsetq82ganh` |
+| GRAM | The Open Network | `UQADYTtMBQdZvmNNEX02R9sACpdnXKlPV8RbuFrxo7JFBRGS` |
+| LTC | Litecoin | `MBLKJfPNANH3U41UPJFtha7EPJGdbiW5dZ` |
+
 ## Лицензия
 
 MIT. См. [LICENSE](LICENSE).

--- a/README.zh.md
+++ b/README.zh.md
@@ -281,6 +281,19 @@ vpnhide 对特定应用隐藏活动的 VPN。它并非为以下用途设计：
 - 直接的 `svc #0` 系统调用会绕过 Zygisk 的 libc 钩子 —— 为此请使用内核级后端（kmod 或 KPM）
 - 服务端检测在客户端无法解决 —— 请使用分应用代理
 
+## 支持项目
+
+vpnhide 免费，无广告、无遥测。不会有付费功能，捐赠不会解锁任何内容。
+
+应用内的 **设置 → 支持项目** 中也有同样的列表，点按地址即可复制。
+
+| 币种 | 网络 | 地址 |
+| --- | --- | --- |
+| USDT | Tron (TRC20) | `TMskx2wKmPg11VYvHoS93vUQGm7yhcetUU` |
+| BTC | Bitcoin | `bc1pmt9u6nux4x7n86zknwdgt9v02lah2tu6d983ak2prc5cwt8hsetq82ganh` |
+| GRAM | The Open Network | `UQADYTtMBQdZvmNNEX02R9sACpdnXKlPV8RbuFrxo7JFBRGS` |
+| LTC | Litecoin | `MBLKJfPNANH3U41UPJFtha7EPJGdbiW5dZ` |
+
 ## 许可证
 
 MIT。见 [LICENSE](LICENSE)。

--- a/changelog.d/added-dashboard-shows-a-one-time-support-1431.md
+++ b/changelog.d/added-dashboard-shows-a-one-time-support-1431.md
@@ -1,0 +1,9 @@
+_2026-08-19_
+
+## English
+
+Dashboard shows a one-time support request once hiding is confirmed working, with Support and Hide
+
+## Русский
+
+На обзоре появляется разовая просьба о поддержке, когда скрытие подтверждённо работает — с кнопками «Поддержать» и «Скрыть»

--- a/changelog.d/added-settings-now-has-a-support-the-eb6a.md
+++ b/changelog.d/added-settings-now-has-a-support-the-eb6a.md
@@ -1,0 +1,9 @@
+_2026-08-19_
+
+## English
+
+Settings now has a "Support the project" entry with Boosty and crypto donation options
+
+## Русский
+
+В настройках появился пункт «Поддержать проект» с донатами через Boosty и криптовалюту

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DashboardScreen.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DashboardScreen.kt
@@ -37,6 +37,7 @@ import androidx.compose.ui.text.font.FontStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
+import dev.okhsunrog.vpnhide.settings.LocalSettingsInteractor
 import dev.okhsunrog.vpnhide.settings.LocalSettingsState
 import dev.okhsunrog.vpnhide.settings.SettingsRepository
 import dev.okhsunrog.vpnhide.ui.components.EnhancedButton
@@ -67,9 +68,13 @@ fun DashboardScreen(
     var showChangelog by remember { mutableStateOf(false) }
     var changelogData by remember { mutableStateOf<ChangelogData?>(null) }
     var showContact by remember { mutableStateOf(false) }
+    var showDonate by remember { mutableStateOf(false) }
 
     if (showContact) {
         ContactModal(onDismiss = { showContact = false })
+    }
+    if (showDonate) {
+        DonateModal(onDismiss = { showDonate = false })
     }
 
     // Both caches are reactive to tab switches without re-doing work:
@@ -235,6 +240,30 @@ fun DashboardScreen(
         MessageSection(errors, R.string.dashboard_issues, errorHeader, errorBg, onBannerColor, onOpenDiagnostics, onContact)
         MessageSection(warnings, R.string.dashboard_warnings, warningHeader, warningBg, onBannerColor, onOpenDiagnostics, onContact)
         MessageSection(infos, R.string.dashboard_info, infoHeader, infoBg, onBannerColor, onOpenDiagnostics, onContact)
+
+        // Asks for support only on a setup that provably works, and only once —
+        // see shouldShowDonatePrompt for the full gate.
+        val now = remember { System.currentTimeMillis() }
+        if (shouldShowDonatePrompt(
+                dismissed = LocalSettingsState.current.donatePromptDismissed,
+                installedAtMillis = remember { appInstalledAtMillis(context, now) },
+                nowMillis = now,
+                protection = loadedState.protection,
+                hasIssues = errors.isNotEmpty() || warnings.isNotEmpty(),
+            )
+        ) {
+            val interactor = LocalSettingsInteractor.current
+            Spacer(Modifier.height(20.dp))
+            DonatePromptBanner(
+                containerColor = infoBg,
+                contentColor = onBannerColor,
+                onDonate = {
+                    interactor.setDonatePromptDismissed(true)
+                    showDonate = true
+                },
+                onHide = { interactor.setDonatePromptDismissed(true) },
+            )
+        }
 
         Spacer(Modifier.height(16.dp))
     }

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DonateModal.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DonateModal.kt
@@ -1,0 +1,160 @@
+package dev.okhsunrog.vpnhide
+
+import android.content.ClipData
+import android.content.ClipboardManager
+import android.content.Context
+import android.content.Intent
+import android.net.Uri
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.AccountBalanceWallet
+import androidx.compose.material.icons.filled.ContentCopy
+import androidx.compose.material.icons.filled.Favorite
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.booleanResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import dev.okhsunrog.vpnhide.ui.components.PreferenceRow
+
+// Donation rails, deliberately Kotlin constants rather than translatable string
+// resources: a wallet address must be byte-identical in every locale and must
+// never pass through a translation round-trip.
+//
+// A blank constant hides its row, so an unfinished rail simply doesn't render.
+internal const val DONATE_BOOSTY_URL = "https://boosty.to/okhsunrog"
+internal const val DONATE_USDT_TRC20_ADDRESS = "TMskx2wKmPg11VYvHoS93vUQGm7yhcetUU"
+internal const val DONATE_BTC_ADDRESS = "bc1pmt9u6nux4x7n86zknwdgt9v02lah2tu6d983ak2prc5cwt8hsetq82ganh"
+
+/** GRAM is the coin of The Open Network — the ticker doesn't name its chain. */
+internal const val DONATE_GRAM_ADDRESS = "UQADYTtMBQdZvmNNEX02R9sACpdnXKlPV8RbuFrxo7JFBRGS"
+
+internal const val DONATE_LTC_ADDRESS = "MBLKJfPNANH3U41UPJFtha7EPJGdbiW5dZ"
+
+/** One tap-to-copy crypto row: a display label and the address it copies. */
+private data class CryptoRail(
+    val label: String,
+    val address: String,
+)
+
+/**
+ * "Support the project" modal — Boosty for cards, a few crypto addresses that
+ * copy to the clipboard on tap, and a link to the full list.
+ *
+ * Opened from Settings. Like [ContactModal] it only ever fires an
+ * [Intent.ACTION_VIEW]: the app itself makes no network request and carries no
+ * payment SDK.
+ */
+@Composable
+internal fun DonateModal(onDismiss: () -> Unit) {
+    val context = LocalContext.current
+    var copied by remember { mutableStateOf(false) }
+
+    // Locale-gated: Boosty is unreachable from mainland China (see bools.xml).
+    val showBoosty = booleanResource(R.bool.donate_show_boosty) && DONATE_BOOSTY_URL.isNotBlank()
+
+    val rails =
+        listOf(
+            CryptoRail(stringResource(R.string.donate_usdt), DONATE_USDT_TRC20_ADDRESS),
+            CryptoRail(stringResource(R.string.donate_btc), DONATE_BTC_ADDRESS),
+            CryptoRail(stringResource(R.string.donate_gram), DONATE_GRAM_ADDRESS),
+            CryptoRail(stringResource(R.string.donate_ltc), DONATE_LTC_ADDRESS),
+        ).filter { it.address.isNotBlank() }
+
+    fun open(url: String) {
+        runCatching {
+            context.startActivity(
+                Intent(Intent.ACTION_VIEW, Uri.parse(url)).addFlags(Intent.FLAG_ACTIVITY_NEW_TASK),
+            )
+        }
+        onDismiss()
+    }
+
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text(stringResource(R.string.donate_title)) },
+        text = {
+            Column(
+                modifier = Modifier.verticalScroll(rememberScrollState()),
+                verticalArrangement = Arrangement.spacedBy(4.dp),
+            ) {
+                Text(
+                    text = stringResource(R.string.donate_body),
+                    style = MaterialTheme.typography.bodyMedium,
+                )
+                if (showBoosty) {
+                    PreferenceRow(
+                        title = stringResource(R.string.donate_boosty),
+                        subtitle = stringResource(R.string.donate_boosty_sub),
+                        icon = Icons.Default.Favorite,
+                        onClick = { open(DONATE_BOOSTY_URL) },
+                    )
+                }
+                rails.forEach { rail ->
+                    PreferenceRow(
+                        title = rail.label,
+                        subtitle = shortenAddress(rail.address),
+                        icon = Icons.Default.AccountBalanceWallet,
+                        onClick = {
+                            copyAddressToClipboard(context, rail.label, rail.address)
+                            copied = true
+                        },
+                        trailing = {
+                            Icon(
+                                imageVector = Icons.Default.ContentCopy,
+                                contentDescription = null,
+                                tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                            )
+                        },
+                    )
+                }
+                if (copied) {
+                    Text(
+                        text = stringResource(R.string.donate_copied),
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.primary,
+                    )
+                }
+            }
+        },
+        confirmButton = {
+            TextButton(onClick = onDismiss) { Text(stringResource(R.string.donate_close)) }
+        },
+    )
+}
+
+/**
+ * Middle-elided address for the row subtitle — enough to eyeball against the
+ * README, short enough that three rails still fit in a dialog. The clipboard
+ * always gets the full string.
+ */
+private fun shortenAddress(address: String): String =
+    if (address.length <= ADDRESS_PREVIEW_KEEP * 2) {
+        address
+    } else {
+        address.take(ADDRESS_PREVIEW_KEEP) + "…" + address.takeLast(ADDRESS_PREVIEW_KEEP)
+    }
+
+private const val ADDRESS_PREVIEW_KEEP = 8
+
+private fun copyAddressToClipboard(
+    context: Context,
+    label: String,
+    address: String,
+) {
+    val clipboard = context.getSystemService(ClipboardManager::class.java)
+    clipboard.setPrimaryClip(ClipData.newPlainText(label, address))
+}

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DonatePrompt.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DonatePrompt.kt
@@ -1,0 +1,94 @@
+package dev.okhsunrog.vpnhide
+
+import android.content.Context
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import dev.okhsunrog.vpnhide.ui.components.EnhancedOutlinedButton
+
+/**
+ * How long after install the donation prompt stays quiet.
+ *
+ * The first days are when the user is still finding out whether hiding works at
+ * all — wrong kernel, wrong root manager, module not loading — and when most of
+ * the people who will uninstall do. Asking then is asking on credit.
+ */
+private const val DONATE_PROMPT_MIN_AGE_MILLIS = 7L * 24 * 60 * 60 * 1000
+
+/**
+ * Whether the Dashboard should show the donation banner.
+ *
+ * Deliberately strict: we ask only when the app has *demonstrably* done its job
+ * on this device — a diagnostics run that wasn't gated (VPN up, self routed, no
+ * pending restart) with every layer active and leaking nothing, and no issues
+ * on screen to sit next to. Anything less and the banner would be asking for
+ * money over a broken setup.
+ *
+ * Pure so the gate is readable in one place; the caller supplies the clock.
+ */
+internal fun shouldShowDonatePrompt(
+    dismissed: Boolean,
+    installedAtMillis: Long,
+    nowMillis: Long,
+    protection: ProtectionCheck,
+    hasIssues: Boolean,
+): Boolean {
+    if (dismissed || hasIssues) return false
+    if (nowMillis - installedAtMillis < DONATE_PROMPT_MIN_AGE_MILLIS) return false
+    val checked = protection as? ProtectionCheck.Checked ?: return false
+    return listOf(checked.native, checked.java).all { layer ->
+        layer is LayerStatus.Active && layer.verdict == Verdict.Ok
+    }
+}
+
+/**
+ * Install time of this app, used as the prompt's age reference — no separate
+ * "first run" timestamp to persist. Survives updates and resets on reinstall.
+ * Falls back to [nowMillis] (age 0 → no prompt) if the lookup fails.
+ */
+internal fun appInstalledAtMillis(
+    context: Context,
+    nowMillis: Long,
+): Long {
+    val installed =
+        runCatching {
+            context.packageManager.getPackageInfo(context.packageName, 0).firstInstallTime
+        }.getOrNull()
+    return installed?.takeIf { it > 0 } ?: nowMillis
+}
+
+/**
+ * The Dashboard donation banner: one line of text, "Support" and "Hide".
+ *
+ * Both buttons dismiss for good — [onDonate] opens the same [DonateModal] the
+ * Settings entry uses, and someone who opened it and walked away doesn't need
+ * to be asked again. There is no "later": a prompt that comes back is a nag,
+ * and Settings keeps a permanent entry for anyone who changes their mind.
+ */
+@Composable
+internal fun DonatePromptBanner(
+    containerColor: Color,
+    contentColor: Color,
+    onDonate: () -> Unit,
+    onHide: () -> Unit,
+) {
+    StatusBanner(
+        text = stringResource(R.string.donate_banner),
+        containerColor = containerColor,
+        contentColor = contentColor,
+        action = {
+            Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                EnhancedOutlinedButton(onClick = onDonate) {
+                    Text(stringResource(R.string.donate_banner_support))
+                }
+                EnhancedOutlinedButton(onClick = onHide) {
+                    Text(stringResource(R.string.donate_banner_hide))
+                }
+            }
+        },
+    )
+}

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/SettingsScreen.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/SettingsScreen.kt
@@ -34,6 +34,7 @@ import androidx.compose.material.icons.filled.ContentCopy
 import androidx.compose.material.icons.filled.DarkMode
 import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.filled.DeleteForever
+import androidx.compose.material.icons.filled.Favorite
 import androidx.compose.material.icons.filled.FileDownload
 import androidx.compose.material.icons.filled.FileUpload
 import androidx.compose.material.icons.filled.Forum
@@ -309,8 +310,12 @@ private fun ResetSettingsSection(selfNeedsRestart: Boolean?) {
 @Composable
 private fun CommunitySettingsSection() {
     var showContact by remember { mutableStateOf(false) }
+    var showDonate by remember { mutableStateOf(false) }
     if (showContact) {
         ContactModal(onDismiss = { showContact = false })
+    }
+    if (showDonate) {
+        DonateModal(onDismiss = { showDonate = false })
     }
     Column(verticalArrangement = Arrangement.spacedBy(3.dp)) {
         SettingsSectionHeader(stringResource(R.string.settings_community_section))
@@ -318,7 +323,17 @@ private fun CommunitySettingsSection() {
             title = stringResource(R.string.settings_community),
             subtitle = stringResource(R.string.settings_community_sub),
             icon = Icons.Default.Forum,
+            index = 0,
+            count = 2,
             onClick = { showContact = true },
+        )
+        PreferenceRow(
+            title = stringResource(R.string.settings_donate),
+            subtitle = stringResource(R.string.settings_donate_sub),
+            icon = Icons.Default.Favorite,
+            index = 1,
+            count = 2,
+            onClick = { showDonate = true },
         )
     }
 }

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/settings/AppSettings.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/settings/AppSettings.kt
@@ -59,6 +59,12 @@ data class AppSettings(
      * effect on release builds (their versions carry no dev suffix).
      */
     val suppressVersionWarnings: Boolean = false,
+    /**
+     * The donation prompt on the Dashboard has been acted on — either "Support"
+     * or "Hide". Set by both, so the banner is shown until the first deliberate
+     * reaction and never again.
+     */
+    val donatePromptDismissed: Boolean = false,
 ) {
     companion object {
         /** Brand seed — a crisp blue-teal, used as the non-dynamic fallback palette. */

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/settings/SettingsInteractor.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/settings/SettingsInteractor.kt
@@ -45,6 +45,8 @@ interface SettingsInteractor {
     fun setSettingsHintSeen(value: Boolean)
 
     fun setSuppressVersionWarnings(value: Boolean)
+
+    fun setDonatePromptDismissed(value: Boolean)
 }
 
 /**
@@ -80,6 +82,8 @@ class RepositorySettingsInteractor(
     override fun setSettingsHintSeen(value: Boolean) = launch { repository.setSettingsHintSeen(value) }
 
     override fun setSuppressVersionWarnings(value: Boolean) = launch { repository.setSuppressVersionWarnings(value) }
+
+    override fun setDonatePromptDismissed(value: Boolean) = launch { repository.setDonatePromptDismissed(value) }
 
     private inline fun launch(crossinline block: suspend () -> Unit) {
         scope.launch { block() }

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/settings/SettingsRepository.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/settings/SettingsRepository.kt
@@ -40,6 +40,7 @@ class SettingsRepository(
         val AGENT_CONTROL = booleanPreferencesKey("agent_control_enabled")
         val SETTINGS_HINT_SEEN = booleanPreferencesKey("settings_hint_seen")
         val SUPPRESS_VERSION_WARNINGS = booleanPreferencesKey("suppress_version_warnings")
+        val DONATE_PROMPT_DISMISSED = booleanPreferencesKey("donate_prompt_dismissed")
 
         // Worker-internal state (not a user-facing setting, so not surfaced in
         // AppSettings): the last release the background update worker already
@@ -68,6 +69,8 @@ class SettingsRepository(
                 settingsHintSeen = p[Keys.SETTINGS_HINT_SEEN] ?: defaults.settingsHintSeen,
                 suppressVersionWarnings =
                     p[Keys.SUPPRESS_VERSION_WARNINGS] ?: defaults.suppressVersionWarnings,
+                donatePromptDismissed =
+                    p[Keys.DONATE_PROMPT_DISMISSED] ?: defaults.donatePromptDismissed,
             )
         }
 
@@ -96,6 +99,8 @@ class SettingsRepository(
     suspend fun setSettingsHintSeen(value: Boolean) = edit { it[Keys.SETTINGS_HINT_SEEN] = value }
 
     suspend fun setSuppressVersionWarnings(value: Boolean) = edit { it[Keys.SUPPRESS_VERSION_WARNINGS] = value }
+
+    suspend fun setDonatePromptDismissed(value: Boolean) = edit { it[Keys.DONATE_PROMPT_DISMISSED] = value }
 
     /** Last release the background update worker has already notified about, if any. */
     suspend fun lastNotifiedUpdateVersion(): String? =

--- a/lsposed/app/src/main/res/values-ru/strings.xml
+++ b/lsposed/app/src/main/res/values-ru/strings.xml
@@ -252,6 +252,21 @@
     <string name="settings_community_section">Сообщество</string>
     <string name="settings_community">Сообщество и обратная связь</string>
     <string name="settings_community_sub">Контакты автора: GitHub, Telegram, 4PDA</string>
+    <string name="settings_donate">Поддержать проект</string>
+    <string name="settings_donate_sub">Boosty или криптовалюта</string>
+    <string name="donate_title">Поддержать проект</string>
+    <string name="donate_body">VPN Hide бесплатный, без рекламы и ничего никуда не отправляет. Платных функций не будет — донат ничего не открывает. Если приложение пригодилось, можно скинуться на его развитие.</string>
+    <string name="donate_boosty">Boosty</string>
+    <string name="donate_boosty_sub">Оплата картой, разово или ежемесячно</string>
+    <string name="donate_usdt">USDT (TRC20)</string>
+    <string name="donate_gram">GRAM</string>
+    <string name="donate_ltc">LTC</string>
+    <string name="donate_btc">BTC</string>
+    <string name="donate_copied">Адрес скопирован</string>
+    <string name="donate_close">Закрыть</string>
+    <string name="donate_banner">VPN Hide бесплатный и без рекламы. Если он вам полезен — можно поддержать разработку.</string>
+    <string name="donate_banner_support">Поддержать</string>
+    <string name="donate_banner_hide">Скрыть</string>
     <!-- Full reset / leftover cleanup -->
     <string name="settings_reset_section">Сброс</string>
     <string name="reset_button">Удалить оставшиеся файлы</string>

--- a/lsposed/app/src/main/res/values-zh-rCN/bools.xml
+++ b/lsposed/app/src/main/res/values-zh-rCN/bools.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <bool name="donate_show_boosty">false</bool>
+</resources>

--- a/lsposed/app/src/main/res/values-zh-rCN/strings.xml
+++ b/lsposed/app/src/main/res/values-zh-rCN/strings.xml
@@ -273,6 +273,21 @@
     <string name="settings_community_section">社区</string>
     <string name="settings_community">社区与反馈</string>
     <string name="settings_community_sub">作者联系方式：GitHub、Telegram、4PDA</string>
+    <string name="settings_donate">支持项目</string>
+    <string name="settings_donate_sub">加密货币</string>
+    <string name="donate_title">支持项目</string>
+    <string name="donate_body">VPN Hide 免费、无广告，也不会向任何地方发送数据。不会有付费功能，捐赠不会解锁任何内容。如果这个应用对你有帮助，可以为它的开发出一份力。</string>
+    <string name="donate_boosty">Boosty</string>
+    <string name="donate_boosty_sub">银行卡支付，单次或定期</string>
+    <string name="donate_usdt">USDT (TRC20)</string>
+    <string name="donate_gram">GRAM</string>
+    <string name="donate_ltc">LTC</string>
+    <string name="donate_btc">BTC</string>
+    <string name="donate_copied">地址已复制到剪贴板</string>
+    <string name="donate_close">关闭</string>
+    <string name="donate_banner">VPN Hide 免费且无广告。如果它对你有用，可以支持它的开发。</string>
+    <string name="donate_banner_support">支持</string>
+    <string name="donate_banner_hide">隐藏</string>
     <!-- Full reset / leftover cleanup -->
     <string name="settings_reset_section">重置</string>
     <string name="reset_button">移除残留文件</string>

--- a/lsposed/app/src/main/res/values/bools.xml
+++ b/lsposed/app/src/main/res/values/bools.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!--
+      Boosty is a Russian platform and is not reachable from mainland China, so
+      the zh-rCN locale overrides this to false and shows only the crypto rails.
+      A locale qualifier (rather than a Locale check in Kotlin) so it follows the
+      per-app language setting the same way every other resource does.
+    -->
+    <bool name="donate_show_boosty">true</bool>
+</resources>

--- a/lsposed/app/src/main/res/values/strings.xml
+++ b/lsposed/app/src/main/res/values/strings.xml
@@ -284,6 +284,21 @@
     <string name="settings_community_section">Community</string>
     <string name="settings_community">Community &amp; feedback</string>
     <string name="settings_community_sub">Author contacts: GitHub, Telegram, 4PDA</string>
+    <string name="settings_donate">Support the project</string>
+    <string name="settings_donate_sub">Boosty or crypto</string>
+    <string name="donate_title">Support the project</string>
+    <string name="donate_body">VPN Hide is free, has no ads and sends nothing anywhere. There will be no paid features — donating unlocks nothing. If the app turned out useful, you can chip in for its development.</string>
+    <string name="donate_boosty">Boosty</string>
+    <string name="donate_boosty_sub">Card payment, one-off or recurring</string>
+    <string name="donate_usdt">USDT (TRC20)</string>
+    <string name="donate_gram">GRAM</string>
+    <string name="donate_ltc">LTC</string>
+    <string name="donate_btc">BTC</string>
+    <string name="donate_copied">Address copied to clipboard</string>
+    <string name="donate_close">Close</string>
+    <string name="donate_banner">VPN Hide is free and has no ads. If it is useful to you, you can support its development.</string>
+    <string name="donate_banner_support">Support</string>
+    <string name="donate_banner_hide">Hide</string>
     <!-- Full reset / leftover cleanup -->
     <string name="settings_reset_section">Reset</string>
     <string name="reset_button">Remove leftover files</string>


### PR DESCRIPTION
The project has had no way for a user to support it: nothing in the app, nothing in the READMEs. This adds one, deliberately kept to a single Settings entry plus a one-time Dashboard prompt — the app is a stealth-first utility, and a recurring ask on the main screen would read as nagging.

Settings gets a "Support the project" row next to the existing "Contact the author" one, opening a modal with Boosty for card payments and four crypto addresses that copy to the clipboard on tap. Nothing leaves the app: no payment SDK, no network request, only the same `ACTION_VIEW` intent the contact modal already fires. The Dashboard asks once, and only on a setup that provably works — an ungated diagnostics run with every layer active and leaking nothing, no issues or warnings on screen, and at least a week since install, so the ask lands when the user is looking at a green screen rather than a broken one.

- new `DonateModal` (Boosty + USDT TRC20 / BTC / GRAM / LTC) opened from Settings and from the Dashboard prompt
- new `DonatePrompt`: a pure `shouldShowDonatePrompt` gate plus the banner, with "Support" and "Hide" both dismissing for good — there is no "later"
- addresses are Kotlin constants, not string resources, so they can't differ between locales or pass through a translation round-trip
- install age comes from `firstInstallTime`, so `donatePromptDismissed` is the only persisted state
- Boosty hidden in the `zh-rCN` locale, which can't reach it, via a bool resource with a locale qualifier rather than a `Locale` check
- "Support the project" sections listing every rail in the three READMEs, plus `FUNDING.yml` for the repository's Sponsor button

The Dashboard banner has not been exercised on a device: its gate requires an install at least a week old. The modal and the Settings entry are reachable immediately.