### PR TITLE
fix(lsposed): show "reboot needed" for a freshly installed native module

### DIFF
--- a/changelog.d/fixed-a-freshly-installed-native-module-kmod-ac0c.md
+++ b/changelog.d/fixed-a-freshly-installed-native-module-kmod-ac0c.md
@@ -1,0 +1,9 @@
+_2026-08-19_
+
+## English
+
+A freshly installed native module (kmod/KPM) that is only waiting for its first reboot now shows "Installed, reboot needed" instead of a misleading "installation corrupted — reinstall" error.
+
+## Русский
+
+Свежеустановленный нативный модуль (kmod/KPM), которому нужна лишь первая перезагрузка, теперь показывает «Установлен, нужна перезагрузка» вместо вводящей в заблуждение ошибки «установка повреждена — переустановите».

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DashboardData.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DashboardData.kt
@@ -24,6 +24,11 @@ sealed interface ModuleState {
         // is permanently broken (distinct from "active=false" which usually
         // just means a reboot is pending). UI colors the card red.
         val brokenReason: ModuleBrokenReason? = null,
+        // True when a complete install is staged in modules_update/ and the
+        // active dir has no activator yet — the module just needs a reboot to
+        // take effect. UI colors the card orange, not red, and the dashboard
+        // surfaces a reboot warning rather than a corruption error.
+        val pendingReboot: Boolean = false,
     ) : ModuleState
 }
 
@@ -1225,48 +1230,71 @@ internal suspend fun loadDashboardState(
         )
     VpnHideLog.i(TAG, "kmodLoadStatus=$kmodLoadStatus")
 
+    // A freshly-installed module staged in modules_update/ needs a reboot, not
+    // a reinstall — suppress its integrity/runtime error and warn instead.
+    val kmodPendingReboot = modulePendingReboot(FlashableModuleKind.Kmod, kmodRaw, shellSnapshot)
+    val kpmPendingReboot = modulePendingReboot(FlashableModuleKind.Kpm, kpmRaw, shellSnapshot)
+    val zygiskPendingReboot = modulePendingReboot(FlashableModuleKind.Zygisk, zygiskRaw, shellSnapshot)
+    val portsPendingReboot = modulePendingReboot(FlashableModuleKind.Ports, portsRaw, shellSnapshot)
+
     // Integrity takes priority; one problem drives both card color and banner.
     val kmodProblem: ModuleProblem? =
-        moduleIntegrityProblem(
-            kind = FlashableModuleKind.Kmod,
-            module = kmodRaw,
-            sections = shellSnapshot,
-            activatorPath = KMOD_ACTIVATOR,
-        )?.let { renderModuleIntegrityProblem(it, res) }
-            ?: classifyKmodProblem(kmodRaw, kernelRecommendation, kmodLoadStatus)
-                ?.let { renderKmodProblem(it, res) }
-    val kmod = kmodRaw.withBrokenReason(kmodProblem?.reason)
+        if (kmodPendingReboot) {
+            null
+        } else {
+            moduleIntegrityProblem(
+                kind = FlashableModuleKind.Kmod,
+                module = kmodRaw,
+                sections = shellSnapshot,
+                activatorPath = KMOD_ACTIVATOR,
+            )?.let { renderModuleIntegrityProblem(it, res) }
+                ?: classifyKmodProblem(kmodRaw, kernelRecommendation, kmodLoadStatus)
+                    ?.let { renderKmodProblem(it, res) }
+        }
+    val kmod = kmodRaw.withBrokenReason(kmodProblem?.reason).withPendingReboot(kmodPendingReboot)
     VpnHideLog.i(TAG, "kmod (with brokenReason): $kmod")
 
     val kpmProblem: ModuleProblem? =
-        moduleIntegrityProblem(
-            kind = FlashableModuleKind.Kpm,
-            module = kpmRaw,
-            sections = shellSnapshot,
-            activatorPath = KPM_ACTIVATOR,
-        )?.let { renderModuleIntegrityProblem(it, res) }
-            ?: classifyKpmProblem(kpmRaw, kpmLoadStatus, currentBootId)
-                ?.let { renderKpmProblem(it, res) }
-    val kpm = kpmRaw.withBrokenReason(kpmProblem?.reason)
+        if (kpmPendingReboot) {
+            null
+        } else {
+            moduleIntegrityProblem(
+                kind = FlashableModuleKind.Kpm,
+                module = kpmRaw,
+                sections = shellSnapshot,
+                activatorPath = KPM_ACTIVATOR,
+            )?.let { renderModuleIntegrityProblem(it, res) }
+                ?: classifyKpmProblem(kpmRaw, kpmLoadStatus, currentBootId)
+                    ?.let { renderKpmProblem(it, res) }
+        }
+    val kpm = kpmRaw.withBrokenReason(kpmProblem?.reason).withPendingReboot(kpmPendingReboot)
     VpnHideLog.i(TAG, "kpm (with brokenReason): $kpm")
 
     val zygiskProblem =
-        moduleIntegrityProblem(
-            kind = FlashableModuleKind.Zygisk,
-            module = zygiskRaw,
-            sections = shellSnapshot,
-            activatorPath = ZYGISK_ACTIVATOR,
-        )?.let { renderModuleIntegrityProblem(it, res) }
-    val zygisk = zygiskRaw.withBrokenReason(zygiskProblem?.reason)
+        if (zygiskPendingReboot) {
+            null
+        } else {
+            moduleIntegrityProblem(
+                kind = FlashableModuleKind.Zygisk,
+                module = zygiskRaw,
+                sections = shellSnapshot,
+                activatorPath = ZYGISK_ACTIVATOR,
+            )?.let { renderModuleIntegrityProblem(it, res) }
+        }
+    val zygisk = zygiskRaw.withBrokenReason(zygiskProblem?.reason).withPendingReboot(zygiskPendingReboot)
 
     val portsProblem =
-        moduleIntegrityProblem(
-            kind = FlashableModuleKind.Ports,
-            module = portsRaw,
-            sections = shellSnapshot,
-            activatorPath = PORTS_ACTIVATOR,
-        )?.let { renderModuleIntegrityProblem(it, res) }
-    val ports = portsRaw.withBrokenReason(portsProblem?.reason)
+        if (portsPendingReboot) {
+            null
+        } else {
+            moduleIntegrityProblem(
+                kind = FlashableModuleKind.Ports,
+                module = portsRaw,
+                sections = shellSnapshot,
+                activatorPath = PORTS_ACTIVATOR,
+            )?.let { renderModuleIntegrityProblem(it, res) }
+        }
+    val ports = portsRaw.withBrokenReason(portsProblem?.reason).withPendingReboot(portsPendingReboot)
 
     // The one place all three backends are grouped together — every
     // "is anything installed / active" gate below reads from this instead of
@@ -1632,6 +1660,15 @@ internal suspend fun loadDashboardState(
     kpmProblem?.let { err(it.text) }
     zygiskProblem?.let { err(it.text) }
     portsProblem?.let { err(it.text) }
+
+    // ── Warnings: modules installed but staged for the next reboot ──
+    fun rebootWarn(moduleName: String) {
+        warn(res.getString(R.string.dashboard_issue_module_reboot_to_activate, moduleName))
+    }
+    if (kmodPendingReboot) rebootWarn("kmod")
+    if (kpmPendingReboot) rebootWarn("KPM")
+    if (zygiskPendingReboot) rebootWarn("Zygisk")
+    if (portsPendingReboot) rebootWarn("Ports")
 
     // ── Protection checks ──
     StartupTrace.mark("dashboard_protection_start")

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DashboardScreen.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DashboardScreen.kt
@@ -746,6 +746,7 @@ private fun installedVisual(
     return InstalledVisual(
         subtitle =
             when {
+                state.pendingReboot -> stringResource(R.string.dashboard_module_installed_reboot_needed)
                 brokenSubtitleRes != null -> stringResource(brokenSubtitleRes)
                 active -> stringResource(R.string.dashboard_active_targets, targetCount) + variantSuffix
                 selfNeedsRestart -> stringResource(R.string.dashboard_installed_restart_app)
@@ -753,12 +754,14 @@ private fun installedVisual(
             },
         accentColor =
             when {
+                state.pendingReboot -> StatusColors.warningAccent
                 broken != null -> StatusColors.errorDot
                 active -> StatusColors.successDot
                 else -> StatusColors.warningAccent
             },
         accentContainerColor =
             when {
+                state.pendingReboot -> StatusColors.warningContainer()
                 broken != null -> StatusColors.errorContainer()
                 active -> StatusColors.successContainer()
                 else -> StatusColors.warningContainer()

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DebugShellSnapshot.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DebugShellSnapshot.kt
@@ -121,6 +121,22 @@ internal fun buildDebugShellSnapshotCommand(): String =
         echo "(missing: ${'$'}PATH_TO_HASH)"
       fi
     }
+    # Reports the copy staged in modules_update/ awaiting the next reboot. A
+    # complete staged install with the active activator absent means "installed,
+    # reboot needed" rather than a corrupt install (matches pending_update in the
+    # runtime snapshot).
+    staged_state() {
+      STAGED=/data/adb/modules_update/${'$'}{1##*/}
+      if [ ! -d "${'$'}STAGED" ]; then
+        echo "staged=0"
+      elif [ -x "${'$'}STAGED/activator" ]; then
+        echo "staged=1 staged_activator=executable"
+      elif [ -e "${'$'}STAGED/activator" ]; then
+        echo "staged=1 staged_activator=not_executable"
+      else
+        echo "staged=1 staged_activator=missing"
+      fi
+    }
     redact_cmdline() {
       sed -E \
         -e 's/(androidboot[.]serialno=)[^ ]+/\1<redacted>/g' \
@@ -223,13 +239,13 @@ internal fun buildDebugShellSnapshotCommand(): String =
     '
 
     emit_file kmod_prop $KMOD_MODULE_DIR/module.prop
-    emit_eval kmod_module_state 'file_flags $KMOD_MODULE_DIR; hash_file $KMOD_MODULE_DIR/vpnhide_kmod.ko; hash_file $KMOD_ACTIVATOR'
+    emit_eval kmod_module_state 'file_flags $KMOD_MODULE_DIR; hash_file $KMOD_MODULE_DIR/vpnhide_kmod.ko; hash_file $KMOD_ACTIVATOR; staged_state $KMOD_MODULE_DIR'
     emit_file kmod_load_status $KMOD_LOAD_STATUS_FILE
     emit_file kmod_load_dmesg $KMOD_LOAD_DMESG_FILE
     emit_eval kmod_state '[ -e $PROC_CTL ] && cat $PROC_CTL 2>&1 || echo "(missing: $PROC_CTL)"'
 
     emit_file kpm_prop $KPM_MODULE_DIR/module.prop
-    emit_eval kpm_module_state 'file_flags $KPM_MODULE_DIR; hash_file $KPM_MODULE_DIR/vpnhide.kpm; hash_file $KPM_ACTIVATOR'
+    emit_eval kpm_module_state 'file_flags $KPM_MODULE_DIR; hash_file $KPM_MODULE_DIR/vpnhide.kpm; hash_file $KPM_ACTIVATOR; staged_state $KPM_MODULE_DIR'
     emit_file kpm_load_status $KPM_LOAD_STATUS_FILE
     emit_eval kpm_state '
       if [ -x $KPM_ACTIVATOR ] && [ ! -f $KPM_MODULE_DIR/disable ]; then
@@ -262,7 +278,7 @@ internal fun buildDebugShellSnapshotCommand(): String =
     '
 
     emit_file zygisk_prop $ZYGISK_MODULE_DIR/module.prop
-    emit_eval zygisk_module_state 'file_flags $ZYGISK_MODULE_DIR; hash_file $ZYGISK_MODULE_DIR/zygisk/arm64-v8a.so; hash_file $ZYGISK_ACTIVATOR'
+    emit_eval zygisk_module_state 'file_flags $ZYGISK_MODULE_DIR; hash_file $ZYGISK_MODULE_DIR/zygisk/arm64-v8a.so; hash_file $ZYGISK_ACTIVATOR; staged_state $ZYGISK_MODULE_DIR'
     emit_file zygisk_status $ZYGISK_STATUS_FILE
     emit_eval zygisk_runtime '
       for BASE in /data/adb/modules /data/adb/modules_update; do
@@ -272,7 +288,7 @@ internal fun buildDebugShellSnapshotCommand(): String =
     '
 
     emit_file ports_prop $PORTS_MODULE_DIR/module.prop
-    emit_eval ports_module_state 'file_flags $PORTS_MODULE_DIR; hash_file $PORTS_ACTIVATOR'
+    emit_eval ports_module_state 'file_flags $PORTS_MODULE_DIR; hash_file $PORTS_ACTIVATOR; staged_state $PORTS_MODULE_DIR'
     emit_file ports_load_status $PORTS_LOAD_STATUS_FILE
     emit_file ports_load_log $PORTS_LOAD_LOG_FILE
     emit_eval ports_state '

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/ModuleIntegrityData.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/ModuleIntegrityData.kt
@@ -40,19 +40,42 @@ internal fun classifyModuleIntegrity(
     return ModuleIntegrityProblem(kind, activatorState, activatorPath)
 }
 
+private fun sectionPrefix(kind: FlashableModuleKind): String =
+    when (kind) {
+        FlashableModuleKind.Kmod -> "kmod"
+        FlashableModuleKind.Kpm -> "kpm"
+        FlashableModuleKind.Zygisk -> "zygisk"
+        FlashableModuleKind.Ports -> "ports"
+    }
+
+/**
+ * True when the module's activator is absent/non-executable only because a
+ * complete install is staged in modules_update/ awaiting the next reboot (the
+ * root manager swaps it into modules/ on boot). This is "installed, reboot
+ * needed", not a corrupt install — callers suppress the integrity error and
+ * surface a reboot warning instead. Absent snapshot field ⇒ false.
+ */
+internal fun modulePendingReboot(
+    kind: FlashableModuleKind,
+    module: ModuleState,
+    sections: Map<String, String>,
+): Boolean {
+    val prefix = sectionPrefix(kind)
+    if (module !is ModuleState.Installed || sections["${prefix}_disabled"]?.trim() == "1") return false
+    val activatorState = parseActivatorState(sections["${prefix}_activator_state"].orEmpty())
+    if (activatorState !in ACTIVATOR_FAILURE_STATES) return false
+    return sections["${prefix}_pending_update"]?.trim() == "1"
+}
+
 internal fun moduleIntegrityProblem(
     kind: FlashableModuleKind,
     module: ModuleState,
     sections: Map<String, String>,
     activatorPath: String,
 ): ModuleIntegrityProblem? {
-    val prefix =
-        when (kind) {
-            FlashableModuleKind.Kmod -> "kmod"
-            FlashableModuleKind.Kpm -> "kpm"
-            FlashableModuleKind.Zygisk -> "zygisk"
-            FlashableModuleKind.Ports -> "ports"
-        }
+    // A staged install pending reboot is not an integrity failure.
+    if (modulePendingReboot(kind, module, sections)) return null
+    val prefix = sectionPrefix(kind)
     return classifyModuleIntegrity(
         kind = kind,
         module = module,
@@ -113,5 +136,8 @@ internal fun renderModuleIntegrityProblem(
 
 internal fun ModuleState.withBrokenReason(reason: ModuleBrokenReason?): ModuleState =
     if (this is ModuleState.Installed && reason != null) copy(brokenReason = reason) else this
+
+internal fun ModuleState.withPendingReboot(pending: Boolean): ModuleState =
+    if (this is ModuleState.Installed && pending) copy(pendingReboot = true) else this
 
 private val ACTIVATOR_FAILURE_STATES = setOf(ActivatorState.Missing, ActivatorState.NotExecutable)

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/RootSnapshotCache.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/RootSnapshotCache.kt
@@ -204,6 +204,21 @@ internal fun buildRootShellSnapshotCommand(
         echo missing
       fi
     }
+    # 1 when a complete module is staged in modules_update/ awaiting the next
+    # reboot: the root manager keeps the freshly-installed files (activator,
+    # scripts, payload) there and only swaps them into modules/ on boot, so the
+    # active dir legitimately has no activator yet. Distinguishes "just
+    # installed, reboot needed" from a genuinely corrupt install.
+    pending_update() {
+      STAGED=/data/adb/modules_update/${'$'}{1##*/}
+      if [ -x "${'$'}STAGED/activator" ]; then
+        echo 1
+      elif [ -f "${'$'}1/update" ] && [ -d "${'$'}STAGED" ]; then
+        echo 1
+      else
+        echo 0
+      fi
+    }
     now_ms() {
       if [ -n "${'$'}{EPOCHREALTIME:-}" ]; then
         SEC="${'$'}{EPOCHREALTIME%.*}"
@@ -247,6 +262,10 @@ internal fun buildRootShellSnapshotCommand(
       emit_eval kpm_disabled '[ -f $KPM_MODULE_DIR/disable ] && echo 1 || echo 0'
       emit_eval zygisk_disabled '[ -f $ZYGISK_MODULE_DIR/disable ] && echo 1 || echo 0'
       emit_eval ports_disabled '[ -f $PORTS_MODULE_DIR/disable ] && echo 1 || echo 0'
+      emit_eval kmod_pending_update 'pending_update $KMOD_MODULE_DIR'
+      emit_eval kpm_pending_update 'pending_update $KPM_MODULE_DIR'
+      emit_eval zygisk_pending_update 'pending_update $ZYGISK_MODULE_DIR'
+      emit_eval ports_pending_update 'pending_update $PORTS_MODULE_DIR'
       phase_end
     }
     phase_target_files() {

--- a/lsposed/app/src/main/res/values-ru/strings.xml
+++ b/lsposed/app/src/main/res/values-ru/strings.xml
@@ -98,6 +98,7 @@
     <string name="dashboard_not_installed">Не установлен</string>
     <string name="dashboard_installed_inactive">Установлен, неактивен</string>
     <string name="dashboard_installed_restart_app">Установлен, перезапустите VPN Hide</string>
+    <string name="dashboard_module_installed_reboot_needed">Установлен, нужна перезагрузка</string>
     <string name="dashboard_kmod_broken_wrong_variant">Установлен, неподходящий вариант GKI</string>
     <string name="dashboard_kmod_broken_unsupported_kernel">Установлен, ядро не поддерживается</string>
     <string name="dashboard_kmod_broken_no_kprobes">Установлен, ядро без kprobes</string>
@@ -297,6 +298,7 @@
     <string name="dashboard_issue_native_conflict_kernel">Модуль ядра (.ko) и KPM установлены одновременно. Они перехватывают одни и те же функции ядра, и при одновременной работе устройство может полностью зависнуть. Оставьте только один — удалите либо модуль ядра, либо KPM.</string>
     <string name="dashboard_issue_native_conflict_deferred">Модуль ядра (.ko) и KPM установлены одновременно. KPM отключился при загрузке, чтобы не подвесить устройство, и сейчас бездействует. Оставьте только один — удалите KPM (или модуль ядра).</string>
     <string name="dashboard_issue_kpm_awaiting_superkey">KPM установлен, но не активен: APatch/FolkPatch не смог загрузить его через доверенный su-токен. Сохраните SuperKey в Настройки → Безопасность и перезагрузитесь для активации нативного скрытия.</string>
+    <string name="dashboard_issue_module_reboot_to_activate">Модуль %1$s установлен, но ещё не активен — перезагрузите устройство, чтобы он заработал.</string>
     <string name="dashboard_issue_module_activator_missing">Установка модуля %1$s повреждена: отсутствует активатор (%2$s). Переустановите ZIP модуля из последнего релиза.</string>
     <string name="dashboard_issue_module_activator_not_executable">Установка модуля %1$s повреждена: активатор не является исполняемым файлом (%2$s). Переустановите ZIP модуля из последнего релиза.</string>
     <string name="dashboard_issue_kpm_bundle_activator_missing">Установка модуля KPM повреждена: отсутствует активатор (%1$s). Установите полный vpnhide-kpm.zip как APM/Magisk-совместимый модуль через экран «Модули» вашего root-менеджера; не извлекайте и не загружайте внутренний файл vpnhide.kpm отдельно.</string>

--- a/lsposed/app/src/main/res/values-zh-rCN/strings.xml
+++ b/lsposed/app/src/main/res/values-zh-rCN/strings.xml
@@ -131,6 +131,7 @@
     <string name="dashboard_not_installed">未安装</string>
     <string name="dashboard_installed_inactive">已安装，未启用</string>
     <string name="dashboard_installed_restart_app">已安装，重启 VPN Hide 后生效</string>
+    <string name="dashboard_module_installed_reboot_needed">已安装，需要重启</string>
     <string name="dashboard_kmod_broken_wrong_variant">已安装，GKI 变体不匹配</string>
     <string name="dashboard_kmod_broken_unsupported_kernel">已安装，内核不受支持</string>
     <string name="dashboard_kmod_broken_no_kprobes">已安装，内核不支持 kprobes</string>
@@ -318,6 +319,7 @@
     <string name="dashboard_issue_native_conflict_kernel">内核模块（.ko）和 KPM 同时装着。它们挂钩相同的内核函数，两个都生效可能导致设备硬冻结。请只保留其一——卸载内核模块或 KPM。</string>
     <string name="dashboard_issue_native_conflict_deferred">内核模块（.ko）和 KPM 同时装着。KPM 已在开机时主动让位以避免冻结，因此没有起任何作用。请只保留其一——卸载 KPM（或内核模块）。</string>
     <string name="dashboard_issue_kpm_awaiting_superkey">KPM 已安装但未生效：APatch/FolkPatch 无法用受信任的 su 令牌加载它。请在“设置 → 安全”中保存 SuperKey，然后重启以启用原生隐藏。</string>
+    <string name="dashboard_issue_module_reboot_to_activate">%1$s 模块已安装，但尚未启用 — 重启设备后生效。</string>
     <string name="dashboard_issue_module_activator_missing">%1$s 模块安装已损坏：缺少激活器（%2$s）。请从最新发行版重新安装该模块 ZIP。</string>
     <string name="dashboard_issue_module_activator_not_executable">%1$s 模块安装已损坏：激活器不可执行（%2$s）。请从最新发行版重新安装该模块 ZIP。</string>
     <string name="dashboard_issue_kpm_bundle_activator_missing">KPM 模块安装已损坏：缺少激活器（%1$s）。请通过 Root 管理器的模块界面，把完整的 vpnhide-kpm.zip 作为兼容 APM/Magisk 的模块安装；不要单独解压或加载里面的 vpnhide.kpm 文件。</string>

--- a/lsposed/app/src/main/res/values/strings.xml
+++ b/lsposed/app/src/main/res/values/strings.xml
@@ -139,6 +139,7 @@
     <string name="dashboard_not_installed">Not installed</string>
     <string name="dashboard_installed_inactive">Installed, inactive</string>
     <string name="dashboard_installed_restart_app">Installed, restart VPN Hide to activate</string>
+    <string name="dashboard_module_installed_reboot_needed">Installed, reboot needed</string>
     <string name="dashboard_kmod_broken_wrong_variant">Installed, wrong GKI variant</string>
     <string name="dashboard_kmod_broken_unsupported_kernel">Installed, kernel not supported</string>
     <string name="dashboard_kmod_broken_no_kprobes">Installed, kernel has no kprobes</string>
@@ -329,6 +330,7 @@
     <string name="dashboard_issue_native_conflict_kernel">The kernel module (.ko) and the KPM are both installed. They hook the same kernel functions, and having both active can hard-freeze the device. Keep only one — uninstall either the kernel module or the KPM.</string>
     <string name="dashboard_issue_native_conflict_deferred">The kernel module (.ko) and the KPM are both installed. The KPM stood down at boot to avoid a freeze, so it isn\'t doing anything. Keep only one — uninstall the KPM (or the kernel module).</string>
     <string name="dashboard_issue_kpm_awaiting_superkey">The KPM is installed but inactive: APatch/FolkPatch could not load it with the trusted su token. Save your SuperKey in Settings → Security, then reboot to activate native hiding.</string>
+    <string name="dashboard_issue_module_reboot_to_activate">The %1$s module is installed but not active yet — reboot the device to activate it.</string>
     <string name="dashboard_issue_module_activator_missing">The %1$s module installation is corrupted: its activator is missing (%2$s). Reinstall the module ZIP from the latest release.</string>
     <string name="dashboard_issue_module_activator_not_executable">The %1$s module installation is corrupted: its activator is not executable (%2$s). Reinstall the module ZIP from the latest release.</string>
     <string name="dashboard_issue_kpm_bundle_activator_missing">The KPM module installation is corrupted: its activator is missing (%1$s). Install the complete vpnhide-kpm.zip as an APM/Magisk-compatible module through your root manager’s Modules screen; do not extract or load the inner vpnhide.kpm file by itself.</string>

--- a/lsposed/app/src/test/kotlin/dev/okhsunrog/vpnhide/ModuleIntegrityDataTest.kt
+++ b/lsposed/app/src/test/kotlin/dev/okhsunrog/vpnhide/ModuleIntegrityDataTest.kt
@@ -1,7 +1,9 @@
 package dev.okhsunrog.vpnhide
 
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
 class ModuleIntegrityDataTest {
@@ -51,6 +53,87 @@ class ModuleIntegrityDataTest {
         assertNull(classify(ActivatorState.Executable, disabled = false, module = installed))
         assertNull(classify(ActivatorState.Unknown, disabled = false, module = installed))
     }
+
+    @Test
+    fun `missing activator with a staged install is pending reboot, not corruption`() {
+        val sections =
+            sectionsOf(activatorState = "missing", disabled = "0", pendingUpdate = "1")
+
+        assertTrue(modulePendingReboot(FlashableModuleKind.Kpm, installed, sections))
+        // The integrity error is suppressed so the UI shows a reboot warning instead.
+        assertNull(
+            moduleIntegrityProblem(
+                kind = FlashableModuleKind.Kpm,
+                module = installed,
+                sections = sections,
+                activatorPath = KPM_ACTIVATOR,
+            ),
+        )
+    }
+
+    @Test
+    fun `missing activator without a staged install stays a corruption error`() {
+        val sections =
+            sectionsOf(activatorState = "missing", disabled = "0", pendingUpdate = "0")
+
+        assertFalse(modulePendingReboot(FlashableModuleKind.Kpm, installed, sections))
+        assertEquals(
+            ModuleBrokenReason.ActivatorMissing,
+            moduleIntegrityProblem(
+                kind = FlashableModuleKind.Kpm,
+                module = installed,
+                sections = sections,
+                activatorPath = KPM_ACTIVATOR,
+            )?.reason,
+        )
+    }
+
+    @Test
+    fun `pending reboot needs a real activator failure and an enabled installed module`() {
+        // A healthy activator is not pending-reboot even with the staged marker set.
+        assertFalse(
+            modulePendingReboot(
+                FlashableModuleKind.Kpm,
+                installed,
+                sectionsOf(activatorState = "executable", disabled = "0", pendingUpdate = "1"),
+            ),
+        )
+        // A disabled module is not pending-reboot.
+        assertFalse(
+            modulePendingReboot(
+                FlashableModuleKind.Kpm,
+                installed,
+                sectionsOf(activatorState = "missing", disabled = "1", pendingUpdate = "1"),
+            ),
+        )
+        // A module that is not installed is not pending-reboot.
+        assertFalse(
+            modulePendingReboot(
+                FlashableModuleKind.Kpm,
+                ModuleState.NotInstalled,
+                sectionsOf(activatorState = "missing", disabled = "0", pendingUpdate = "1"),
+            ),
+        )
+        // Absent snapshot field defaults to not-pending.
+        assertFalse(
+            modulePendingReboot(
+                FlashableModuleKind.Kpm,
+                installed,
+                mapOf("kpm_activator_state" to "missing", "kpm_disabled" to "0"),
+            ),
+        )
+    }
+
+    private fun sectionsOf(
+        activatorState: String,
+        disabled: String,
+        pendingUpdate: String,
+    ): Map<String, String> =
+        mapOf(
+            "kpm_activator_state" to activatorState,
+            "kpm_disabled" to disabled,
+            "kpm_pending_update" to pendingUpdate,
+        )
 
     private fun classify(
         state: ActivatorState,


### PR DESCRIPTION
A native module that has been installed but not yet rebooted is staged by the root manager in `/data/adb/modules_update/<id>/`, while the active `/data/adb/modules/<id>/` holds only `module.prop` and an `update` marker — the activator is not swapped into place until the next boot. The dashboard read the absent activator as a broken install and showed a red "installation corrupted — reinstall the ZIP" error, when the user just needed to reboot. (Seen with a fresh KPM install: the card said "Installed, activator missing" and the Errors section told the user to reinstall.)

This detects the staged-install state — a complete install present in `modules_update/<id>/` (executable activator, or the `update` marker plus a staged dir) while the active activator is absent — and classifies it as "installed, reboot needed" rather than an integrity failure. The module card turns orange with "Installed, reboot needed" and the dashboard surfaces a reboot **warning** instead of a red corruption **error**, matching how LSPosed's existing `NeedsReboot` state already behaves. Applies to all four module backends (kmod, KPM, Zygisk, Ports).

Verified on a Pixel 8 Pro in exactly this state (KPM installed, not yet rebooted): the red "corrupted, reinstall" error became an orange "Installed, reboot needed" card + a "reboot to activate" warning.

- Root snapshot: new `pending_update` probe per backend (kept optional so old caches/fixtures stay valid); classifier suppresses the integrity error and marks the module `pendingReboot`
- Dashboard: orange reboot-needed card + reboot warning instead of a red corruption error
- Strings: new subtitle + warning in EN / RU / zh-CN
- Debug bundle: record the staged-install state (`staged=` / `staged_activator=` per module) so reports distinguish pending-reboot from genuine corruption
- Tests: cover pending-reboot detection and that a real activator failure without a staged install still reports corruption
