### PR TITLE
fix(ports): wait for the xtables lock instead of failing the apply

### DIFF
--- a/changelog.d/fixed-port-hiding-activation-no-longer-fails-b617.md
+++ b/changelog.d/fixed-port-hiding-activation-no-longer-fails-b617.md
@@ -1,0 +1,9 @@
+_2026-08-19_
+
+## English
+
+Port-hiding activation no longer fails when another process (netd, an OEM firewall) briefly holds the iptables lock — the activator now waits for the lock instead of aborting the whole apply.
+
+## Русский
+
+Активация скрытия портов больше не срывается, когда блокировку iptables на мгновение держит другой процесс (netd, фаервол прошивки) — активатор теперь ждёт освобождения блокировки, а не прерывает всю настройку.

--- a/crates/activator/src/ports.rs
+++ b/crates/activator/src/ports.rs
@@ -11,6 +11,14 @@ use crate::{
     PortRule, PortUidPolicy, PortsActivationReport, PortsRuleset, Result, write_atomic,
 };
 
+// Wait (bounded) for the xtables lock instead of failing instantly. netd, an
+// OEM firewall (e.g. MIUI), or our own back-to-back iptables/ip6tables calls
+// can hold it, so an unguarded restore aborts with "Another app is currently
+// holding the xtables lock" (exit 4) and the whole ports apply is marked
+// failed. Every iptables-family invocation passes these first; the timeout
+// keeps a stuck lock from hanging boot.
+const XTABLES_WAIT: [&str; 2] = ["-w", "5"];
+
 pub(crate) fn build_ports_ruleset(
     chain: &str,
     loopback: &str,
@@ -98,10 +106,15 @@ fn port_match(rule: PortRule) -> String {
 pub(crate) fn apply_ports_rules(rules: &PortsRuleset) -> Result<PortsActivationReport> {
     let mut log = String::new();
 
-    if let Ok(out) = Command::new("iptables").args(["-N", PORTS_CHAIN4]).output() {
+    if let Ok(out) = Command::new("iptables")
+        .args(XTABLES_WAIT)
+        .args(["-N", PORTS_CHAIN4])
+        .output()
+    {
         append_command_output(&mut log, "iptables -N vpnhide_out", &out);
     }
     if let Ok(out) = Command::new("ip6tables")
+        .args(XTABLES_WAIT)
         .args(["-N", PORTS_CHAIN6])
         .output()
     {
@@ -133,6 +146,7 @@ pub(crate) fn apply_ports_rules(rules: &PortsRuleset) -> Result<PortsActivationR
 
 fn run_with_stdin(program: &str, args: &[&str], stdin: &str) -> Result<Output> {
     let mut child = Command::new(program)
+        .args(XTABLES_WAIT)
         .args(args)
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
@@ -147,6 +161,7 @@ fn run_with_stdin(program: &str, args: &[&str], stdin: &str) -> Result<Output> {
 
 fn ensure_output_jump(program: &str, chain: &str, log: &mut String) -> Result<()> {
     let check = Command::new(program)
+        .args(XTABLES_WAIT)
         .args(["-C", "OUTPUT", "-j", chain])
         .output()?;
     append_command_output(log, &format!("{program} -C OUTPUT -j {chain}"), &check);
@@ -154,6 +169,7 @@ fn ensure_output_jump(program: &str, chain: &str, log: &mut String) -> Result<()
         return Ok(());
     }
     let insert = Command::new(program)
+        .args(XTABLES_WAIT)
         .args(["-I", "OUTPUT", "-j", chain])
         .output()?;
     append_command_output(log, &format!("{program} -I OUTPUT -j {chain}"), &insert);


### PR DESCRIPTION
On some devices (reported on a POCO/MIUI phone, Android 13) another process — netd, an OEM firewall, or the activator's own back-to-back IPv4/IPv6 calls — holds the xtables lock while the ports activator runs, so `ip6tables-restore` aborts with `Another app is currently holding the xtables lock. Perhaps you want to use the -w option?` (exit 4). Because the IPv6 restore failed, the whole ports apply was marked failed (`loaded=0`) and localhost-port hiding silently did nothing, even though the IPv4 rules had already applied.

This passes `-w 5` (a bounded wait for the lock) on every `iptables`/`ip6tables` and `iptables-restore`/`ip6tables-restore` invocation, so the activator waits out transient contention instead of aborting; the timeout keeps a genuinely stuck lock from hanging boot. `-w` is supported by `iptables`/`ip6tables` since 1.4.20 and by the `*-restore` tools since 1.6.2 — well below the iptables 1.8.x that Android 9+ (vpnhide's minimum) ships.

- Add a shared `XTABLES_WAIT` (`-w 5`) applied to the chain-create, restore, and OUTPUT-jump calls in the ports activator

Reported via a user debug bundle; the same bundle's kmod failure is the separately-fixed `path_put` load regression.
