### PR TITLE
chore: treat the KPM backend as stable, drop experimental/beta labels

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,7 +10,7 @@ tooling that follows the AGENTS-convention picks it up automatically.
 
 Monorepo for hiding VPN interfaces from selected Android apps. Runtime components plus tooling:
 
-- `kmod/` — kernel-level native backends: `.ko` kretprobe module per GKI generation, plus KPM beta for KernelPatch
+- `kmod/` — kernel-level native backends: `.ko` kretprobe module per GKI generation, plus KPM for KernelPatch
 - `zygisk/` — Rust Zygisk module, inline `libc` hooks via shadowhook
 - `lsposed/` — LSPosed module + Compose target-picker app
 - `portshide/` — localhost port blocker (shell + iptables)
@@ -66,4 +66,4 @@ So when you need diagnostics in the logs and Debug logging is off: **stop and as
 
 ## Design notes
 
-- **KPM backend:** `kmod/kpm/` ships a KernelPatch Module beta packaged as `vpnhide-kpm.zip`. It is a kernel-level Native backend like the `.ko`, but uses KernelPatch inline hooks and one cross-version artifact for the tested Android kernel families 4.9, 4.14, 4.19, 5.4, 5.10, 5.15, 6.1, 6.6, and 6.12. Other minor families are rejected rather than assigned a guessed layout. It requires APatch or KPatch-Next-Module, and must not be active together with the `.ko`; supported GKI devices should still prefer the QEMU-tested `.ko` unless there is a real load/signing problem.
+- **KPM backend:** `kmod/kpm/` ships a KernelPatch Module packaged as `vpnhide-kpm.zip`. It is a kernel-level Native backend like the `.ko`, but uses KernelPatch inline hooks and one cross-version artifact for the tested Android kernel families 4.9, 4.14, 4.19, 5.4, 5.10, 5.15, 6.1, 6.6, and 6.12. Other minor families are rejected rather than assigned a guessed layout. It requires APatch or KPatch-Next-Module, and must not be active together with the `.ko`; on supported GKI devices the QEMU-tested `.ko` is still the default, but KPM is a stable alternative when the `.ko` can't load or the kernel enforces module signatures.

--- a/README.en.md
+++ b/README.en.md
@@ -28,7 +28,7 @@ vpnhide solves both problems with a layered architecture:
 
 **Layer 2 — Native (kmod, KPM, or Zygisk):** covers native detection paths. Exactly one native backend should be active:
 - **kmod** (recommended for supported GKI kernels) — kernel-level `kprobe`/`kretprobe` hooks. Filters `ioctl`, `getifaddrs`/netlink interface, address, route, and policy-rule dumps, and rejects `SO_BINDTODEVICE` / `SO_BINDTOIFINDEX` for hidden interfaces before socket state changes. Zero footprint in the target process: no library injection, nothing to detect.
-- **KPM** (beta) — a KernelPatch Module implementing the same 11 logical kernel hooks without a GKI-variant-specific `.ko`. Useful for old/non-GKI 4.14 / 4.19 / 5.4 kernels and cases where the `.ko` cannot load. Requires a KernelPatch runtime: APatch or KPatch-Next-Module.
+- **KPM** — a KernelPatch Module implementing the same 11 logical kernel hooks without a GKI-variant-specific `.ko`. Useful for old/non-GKI 4.14 / 4.19 / 5.4 kernels and cases where the `.ko` cannot load. Requires a KernelPatch runtime: APatch or KPatch-Next-Module.
 - **Zygisk** — fallback when a kernel-level backend is not possible. Its `libc.so` inline hooks include best-effort `setsockopt` filtering, run inside the target process, and can be bypassed by direct syscalls, so banking and anti-fraud apps may detect it. For those apps, leave Native off and rely on the Java layer.
 
 **Layer 3 — Ports module (portshide):** a separate Magisk module. It blocks selected apps from reaching `127.0.0.1` / `::1` (via iptables), so they can't detect a locally bound VPN / proxy daemon by its open port (the **Ports** role).
@@ -48,7 +48,7 @@ vpnhide hides three things from selected apps, all configured per app via the fo
 You always need the **VPN Hide app** (`vpnhide.apk`) + LSPosed/Vector for the Java layer + exactly one Native backend for native hiding. The app can also use the optional Ports module if you want localhost port blocking:
 
 - **`kmod`** (stable default) — fully out-of-process, invisible to anti-tamper. Requires a supported GKI kernel: 5.10, 5.15, 6.1, 6.6, or 6.12.
-- **`KPM`** (beta) — kernel-level backend for 4.14 / 4.19 / 5.4 and other cases where the `.ko` does not fit. Requires APatch or KPatch-Next-Module.
+- **`KPM`** — kernel-level backend for 4.14 / 4.19 / 5.4 and other cases where the `.ko` does not fit. Requires APatch or KPatch-Next-Module.
 - **`Zygisk`** — fallback if kmod/KPM are unavailable or you do not want to install a KernelPatch runtime.
 - **`portshide`** (optional) — install this if you want to block selected apps from probing localhost ports.
 
@@ -72,7 +72,7 @@ Download the latest release from [Releases](https://github.com/okhsunrog/vpnhide
 Open the VPN Hide app. The **Dashboard** tab will detect your device and kernel, and tell you which Native backend to install:
 
 - For a supported GKI kernel, it recommends a specific kmod file, e.g. `vpnhide-kmod-android14-6.1.zip`.
-- For old/non-GKI 4.14 / 4.19 / 5.4 kernels, it recommends `vpnhide-kpm.zip` (beta). If no KernelPatch runtime is detected yet, the app asks you to install KPatch-Next-Module first or use Zygisk as a fallback.
+- For old/non-GKI 4.14 / 4.19 / 5.4 kernels, it recommends `vpnhide-kpm.zip`. If no KernelPatch runtime is detected yet, the app asks you to install KPatch-Next-Module first or use Zygisk as a fallback.
 - For other kernels, it recommends `vpnhide-zygisk.zip`.
 
 Install the recommended module:
@@ -171,7 +171,7 @@ Any issues found are shown as actionable cards with specific instructions.
 
 | Directory | What | How |
 |---|---|---|
-| **[kmod/](kmod/)** | `.ko` kernel module + KPM backend (C) | Two kernel-level Native backends: the stable GKI `.ko` using `kretprobe`, and the KPM beta using KernelPatch inline hooks. Both have zero footprint in the target app's process; only one should be active. ([details](kmod/README.md), [KPM](kmod/kpm/README.md)) |
+| **[kmod/](kmod/)** | `.ko` kernel module + KPM backend (C) | Two kernel-level Native backends: the GKI `.ko` using `kretprobe`, and the KPM using KernelPatch inline hooks. Both have zero footprint in the target app's process; only one should be active. ([details](kmod/README.md), [KPM](kmod/kpm/README.md)) |
 | **[lsposed/](lsposed/)** | LSPosed module + app (Kotlin + Rust) | Hooks `writeToParcel` in `system_server` for per-UID Binder filtering. The APK provides a dashboard (module status, version checks, LSPosed config validation, install recommendations), the Hiding tab for Java / Native / Apps / Ports roles, and diagnostics. ([details](lsposed/README.md)) |
 | **[portshide/](portshide/)** | Ports module (Shell + iptables) | Blocks selected apps from reaching `127.0.0.1` / `::1`, hiding locally bound VPN / proxy daemons from localhost port probes. ([details](portshide/README.md)) |
 | **[zygisk/](zygisk/)** | Zygisk module (Rust) | Inline-hooks `libc.so` in the target app's process. Fallback when a kernel-level backend is unavailable. ([details](zygisk/README.md)) |
@@ -218,7 +218,7 @@ it in Settings and reboot; when disabled its global VFS probes are not installed
 
 Important: `ioctl` and netlink dumps are available to a regular app without help from SELinux; on Linux 5.7+, so is the first socket-interface bind. This is how detectors such as RKNHardering bypass the `/proc/net/route` denial through netlink (see [issue #86](https://github.com/okhsunrog/vpnhide/issues/86)). Kernel-level backends (kmod/KPM) cover the native paths marked above with no target-process footprint. Zygisk covers libc-routed calls only; a direct raw syscall bypasses its hooks. On older kernels, the kernel itself rejects an unprivileged interface bind. Everything else is either often SELinux-blocked on stock (device-dependent) or goes through Java APIs and is covered by LSPosed.
 
-KPM is beta: it implements the same 11 logical kernel hooks as the `.ko`, while the full vector map documents the remaining ABI and behavior differences on older kernels.
+KPM implements the same 11 logical kernel hooks as the `.ko`, while the full vector map documents the remaining ABI and behavior differences on older kernels.
 
 The full vector map — per-layer breakdown, SELinux caveats, and known gaps — lives in [docs/detection-vectors.md](docs/detection-vectors.md).
 
@@ -274,7 +274,7 @@ vpnhide hides an active VPN from specific apps. It is NOT designed for:
 ## Known limitations
 
 - `kmod` requires a supported GKI kernel with `CONFIG_KPROBES=y` (standard on Android 12+ devices)
-- KPM is beta and requires a KernelPatch runtime (APatch or KPatch-Next-Module); do not install KPM together with the `.ko`
+- KPM requires a KernelPatch runtime (APatch or KPatch-Next-Module); do not install KPM together with the `.ko`
 - `lsposed` requires LSPosed, LSPosed-Next, or Vector
 - `zygisk` is arm64 only
 - Direct `svc #0` syscalls bypass Zygisk's libc hooks — use a kernel-level backend (kmod or KPM) for that

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ vpnhide решает обе проблемы многослойной архит
 
 **Уровень 2 — нативный (kmod, KPM или Zygisk):** покрывает нативные пути обнаружения. Активным должен быть ровно один Native-бэкенд:
 - **kmod** (рекомендуется для поддерживаемых GKI-ядер) — хуки `kprobe`/`kretprobe` на уровне ядра. Фильтрует `ioctl`, `getifaddrs`/netlink-дампы интерфейсов, адресов, маршрутов и policy rules, а также отклоняет `SO_BINDTODEVICE` / `SO_BINDTOIFINDEX` для скрытых интерфейсов до изменения состояния сокета. Нулевой след в процессе приложения: никаких инъекций библиотек, нечего обнаруживать.
-- **KPM** (бета) — KernelPatch Module с теми же 11 логическими kernel-хуками, но без привязки к GKI-варианту `.ko`. Полезен для старых/non-GKI ядер 4.9 / 4.14 / 4.19 / 5.4 и ситуаций, где `.ko` не может загрузиться. Требует KernelPatch runtime: APatch или KPatch-Next-Module.
+- **KPM** — KernelPatch Module с теми же 11 логическими kernel-хуками, но без привязки к GKI-варианту `.ko`. Полезен для старых/non-GKI ядер 4.9 / 4.14 / 4.19 / 5.4 и ситуаций, где `.ko` не может загрузиться. Требует KernelPatch runtime: APatch или KPatch-Next-Module.
 - **Zygisk** — запасной вариант, если kernel-level backend поставить нельзя. Inline-хуки `libc.so`, включая best-effort фильтрацию `setsockopt`, работают внутри процесса приложения и обходятся прямыми системными вызовами, поэтому банковские и anti-fraud приложения могут их обнаруживать. Для таких приложений лучше оставлять Native выключенным и полагаться на Java-уровень.
 
 **Уровень 3 — модуль скрытия портов (portshide):** отдельный Magisk-модуль. Через iptables блокирует выбранным приложениям доступ к `127.0.0.1` / `::1`, чтобы они не могли обнаружить локально запущенный VPN / proxy-демон по открытому порту (роль Ports).
@@ -48,7 +48,7 @@ vpnhide скрывает от выбранных приложений три в�
 Всегда нужно **приложение VPN Hide** (`vpnhide.apk`) + LSPosed/Vector для Java-уровня + ровно один Native-бэкенд для нативного скрытия. Дополнительно приложение может использовать необязательный Ports-модуль для блокировки localhost-портов:
 
 - **`kmod`** (стабильный вариант по умолчанию) — полностью out-of-process, невидим для anti-tamper. Требуется поддерживаемое GKI-ядро: 5.10, 5.15, 6.1, 6.6 или 6.12.
-- **`KPM`** (бета) — kernel-level backend для 4.9 / 4.14 / 4.19 / 5.4 и других случаев, где `.ko` не подходит. Нужен APatch или KPatch-Next-Module.
+- **`KPM`** — kernel-level backend для 4.9 / 4.14 / 4.19 / 5.4 и других случаев, где `.ko` не подходит. Нужен APatch или KPatch-Next-Module.
 - **`Zygisk`** — fallback, если kmod/KPM недоступны или вы не хотите ставить KernelPatch runtime.
 - **`portshide`** (необязательно) — установите, если хотите блокировать выбранным приложениям доступ к localhost-портам.
 
@@ -72,7 +72,7 @@ vpnhide скрывает от выбранных приложений три в�
 Откройте приложение VPN Hide. На вкладке **«Обзор»** приложение определит устройство и ядро и покажет, какой Native-бэкенд лучше установить:
 
 - Для поддерживаемого GKI-ядра будет рекомендован конкретный файл kmod, например `vpnhide-kmod-android14-6.1.zip`.
-- Для non-GKI/старых ядер 4.9 / 4.14 / 4.19 / 5.4 будет рекомендован `vpnhide-kpm.zip` (бета). Если KernelPatch runtime ещё не найден, приложение попросит сначала установить KPatch-Next-Module или использовать Zygisk как fallback.
+- Для non-GKI/старых ядер 4.9 / 4.14 / 4.19 / 5.4 будет рекомендован `vpnhide-kpm.zip`. Если KernelPatch runtime ещё не найден, приложение попросит сначала установить KPatch-Next-Module или использовать Zygisk как fallback.
 - Для остальных ядер будет рекомендован `vpnhide-zygisk.zip`.
 
 Установите рекомендованный модуль:
@@ -171,7 +171,7 @@ su -c /data/adb/modules/vpnhide_ports/activator
 
 | Директория | Что | Как |
 |---|---|---|
-| **[kmod/](kmod/)** | Модуль ядра `.ko` + KPM backend (C) | Два kernel-level Native-бэкенда: стабильный GKI `.ko` на `kretprobe` и KPM-бета на KernelPatch inline hooks. Оба дают нулевой след в процессе приложения; активным должен быть только один. ([подробнее](kmod/README.md), [KPM](kmod/kpm/README.md)) |
+| **[kmod/](kmod/)** | Модуль ядра `.ko` + KPM backend (C) | Два kernel-level Native-бэкенда: стабильный GKI `.ko` на `kretprobe` и KPM на KernelPatch inline hooks. Оба дают нулевой след в процессе приложения; активным должен быть только один. ([подробнее](kmod/README.md), [KPM](kmod/kpm/README.md)) |
 | **[lsposed/](lsposed/)** | LSPosed-модуль + приложение (Kotlin + Rust) | Хуки `writeToParcel` в `system_server` для per-UID фильтрации Binder. APK предоставляет обзорную панель (статус модулей, проверка версий, валидация конфигурации LSPosed, рекомендации по установке), вкладку «Скрытие» для ролей Java / Native / Apps / Ports и диагностику. ([подробнее](lsposed/README.md)) |
 | **[portshide/](portshide/)** | Модуль скрытия портов (Shell + iptables) | Блокирует выбранным приложениям доступ к `127.0.0.1` / `::1`, скрывая локально запущенные VPN / proxy-демоны от проверок localhost-портов. ([подробнее](portshide/README.md)) |
 | **[zygisk/](zygisk/)** | Zygisk-модуль (Rust) | Inline-хуки `libc.so` в процессе приложения. Fallback, когда kernel-level backend недоступен. ([подробнее](zygisk/README.md)) |
@@ -275,7 +275,7 @@ vpnhide скрывает активный VPN от конкретных прил
 ## Известные ограничения
 
 - `kmod` требует поддерживаемое GKI-ядро с `CONFIG_KPROBES=y` (стандарт на устройствах Android 12+)
-- KPM — бета и требует KernelPatch runtime (APatch или KPatch-Next-Module); не ставьте KPM одновременно с `.ko`
+- KPM требует KernelPatch runtime (APatch или KPatch-Next-Module); не ставьте KPM одновременно с `.ko`
 - `lsposed` требует LSPosed, LSPosed-Next или Vector
 - `zygisk` — только arm64
 - Прямые системные вызовы `svc #0` обходят хуки libc в Zygisk — для этого нужен kernel-level backend (kmod или KPM)

--- a/README.zh.md
+++ b/README.zh.md
@@ -30,7 +30,7 @@ vpnhide 用分层架构同时解决这两个问题：
 
 **第 2 层 —— 原生（kmod、KPM 或 Zygisk）：** 覆盖原生检测路径。同一时间应恰好有一个原生后端处于活动状态：
 - **kmod**（推荐用于受支持的 GKI 内核）—— 内核级 `kprobe`/`kretprobe` 钩子。过滤 `ioctl`、`getifaddrs`/netlink 的接口、地址、路由和策略规则转储，并在套接字状态改变前对隐藏接口拒绝 `SO_BINDTODEVICE` / `SO_BINDTOIFINDEX`。在目标进程中零足迹：无库注入，无可检测之物。
-- **KPM**（测试版）—— 一个 KernelPatch 模块，实现与之相同的 11 个逻辑内核钩子，无需针对特定 GKI 变体的 `.ko`。适用于旧的/非 GKI 的 4.14 / 4.19 / 5.4 内核，以及 `.ko` 无法加载的情况。需要 KernelPatch 运行时：APatch 或 KPatch-Next-Module。
+- **KPM** —— 一个 KernelPatch 模块，实现与之相同的 11 个逻辑内核钩子，无需针对特定 GKI 变体的 `.ko`。适用于旧的/非 GKI 的 4.14 / 4.19 / 5.4 内核，以及 `.ko` 无法加载的情况。需要 KernelPatch 运行时：APatch 或 KPatch-Next-Module。
 - **Zygisk** —— 当无法使用内核级后端时的回退方案。它的 `libc.so` 内联钩子包含尽力而为的 `setsockopt` 过滤，运行在目标进程内部，可被直接系统调用绕过，因此银行和反欺诈应用可能会检测到它。对于这类应用，请关闭原生并依赖 Java 层。
 
 **第 3 层 —— 端口模块（portshide）：** 一个独立的 Magisk 模块。它阻止选定应用访问 `127.0.0.1` / `::1`（通过 iptables），使其无法通过本地绑定的 VPN / 代理守护进程的开放端口来检测它们（**Ports** 角色）。
@@ -50,7 +50,7 @@ vpnhide 对选定应用隐藏三样东西，全部通过四个 **J / N / A / P**
 你始终需要 **VPN Hide 应用**（`vpnhide.apk`）+ 用于 Java 层的 LSPosed/Vector + 恰好一个用于原生隐藏的原生后端。若你想要本地回环端口拦截，应用还可选用可选的端口模块：
 
 - **`kmod`**（稳定默认）—— 完全在进程外，对防篡改不可见。需要受支持的 GKI 内核：5.10、5.15、6.1、6.6 或 6.12。
-- **`KPM`**（测试版）—— 用于 4.14 / 4.19 / 5.4 以及 `.ko` 不适配的其他情况的内核级后端。需要 APatch 或 KPatch-Next-Module。
+- **`KPM`** —— 用于 4.14 / 4.19 / 5.4 以及 `.ko` 不适配的其他情况的内核级后端。需要 APatch 或 KPatch-Next-Module。
 - **`Zygisk`** —— 当 kmod/KPM 不可用，或你不想安装 KernelPatch 运行时时的回退方案。
 - **`portshide`**（可选）—— 若你想阻止选定应用探测本地回环端口，请安装它。
 
@@ -74,7 +74,7 @@ vpnhide 对选定应用隐藏三样东西，全部通过四个 **J / N / A / P**
 打开 VPN Hide 应用。**概览**标签页会检测你的设备和内核，并告诉你应安装哪个原生后端：
 
 - 对于受支持的 GKI 内核，它会推荐特定的 kmod 文件，例如 `vpnhide-kmod-android14-6.1.zip`。
-- 对于旧的/非 GKI 的 4.14 / 4.19 / 5.4 内核，它会推荐 `vpnhide-kpm.zip`（测试版）。若尚未检测到 KernelPatch 运行时，应用会要求你先安装 KPatch-Next-Module，或使用 Zygisk 作为回退。
+- 对于旧的/非 GKI 的 4.14 / 4.19 / 5.4 内核，它会推荐 `vpnhide-kpm.zip`。若尚未检测到 KernelPatch 运行时，应用会要求你先安装 KPatch-Next-Module，或使用 Zygisk 作为回退。
 - 对于其他内核，它会推荐 `vpnhide-zygisk.zip`。
 
 安装推荐的模块：
@@ -173,7 +173,7 @@ su -c /data/adb/modules/vpnhide_ports/activator
 
 | 目录 | 是什么 | 如何工作 |
 |---|---|---|
-| **[kmod/](kmod/)** | `.ko` 内核模块 + KPM 后端（C） | 两个内核级原生后端：使用 `kretprobe` 的稳定 GKI `.ko`，以及使用 KernelPatch 内联钩子的 KPM 测试版。两者在目标应用进程中均零足迹；只应有一个处于活动状态。（[详情](kmod/README.md)，[KPM](kmod/kpm/README.md)） |
+| **[kmod/](kmod/)** | `.ko` 内核模块 + KPM 后端（C） | 两个内核级原生后端：使用 `kretprobe` 的稳定 GKI `.ko`，以及使用 KernelPatch 内联钩子的 KPM。两者在目标应用进程中均零足迹；只应有一个处于活动状态。（[详情](kmod/README.md)，[KPM](kmod/kpm/README.md)） |
 | **[lsposed/](lsposed/)** | LSPosed 模块 + 应用（Kotlin + Rust） | 在 `system_server` 中挂钩 `writeToParcel`，实现按 UID 的 Binder 过滤。APK 提供概览（模块状态、版本检查、LSPosed 配置校验、安装建议）、用于 Java / Native / Apps / Ports 角色的隐藏标签页，以及诊断。（[详情](lsposed/README.md)） |
 | **[portshide/](portshide/)** | 端口模块（Shell + iptables） | 阻止选定应用访问 `127.0.0.1` / `::1`，使本地绑定的 VPN / 代理守护进程免于本地回环端口探测。（[详情](portshide/README.md)） |
 | **[zygisk/](zygisk/)** | Zygisk 模块（Rust） | 在目标应用进程中内联挂钩 `libc.so`。当内核级后端不可用时的回退方案。（[详情](zygisk/README.md)） |
@@ -219,7 +219,7 @@ su -c /data/adb/modules/vpnhide_ports/activator
 
 重要：`ioctl` 和 netlink 转储对普通应用无需 SELinux 帮助即可使用；在 Linux 5.7+ 上，首次套接字接口绑定也是如此。这正是 RKNHardering 等检测器通过 netlink 绕过 `/proc/net/route` 拒绝的方式（见 [issue #86](https://github.com/okhsunrog/vpnhide/issues/86)）。内核级后端（kmod/KPM）覆盖上表标注的原生路径，且在目标进程中无足迹。Zygisk 仅覆盖经 libc 路由的调用；直接的原始系统调用会绕过其钩子。在较旧的内核上，内核本身会拒绝非特权的接口绑定。其余的要么在原厂上常被 SELinux 阻断（视设备而定），要么经由 Java API 并由 LSPosed 覆盖。
 
-KPM 为测试版：它实现与 `.ko` 相同的 11 个逻辑内核钩子，而完整的向量图记录了在较旧内核上剩余的 ABI 与行为差异。
+KPM 实现与 `.ko` 相同的 11 个逻辑内核钩子，而完整的向量图记录了在较旧内核上剩余的 ABI 与行为差异。
 
 完整的向量图 —— 按层细分、SELinux 注意事项和已知缺口 —— 位于 [docs/detection-vectors.md](docs/detection-vectors.md)。
 
@@ -275,7 +275,7 @@ vpnhide 对特定应用隐藏活动的 VPN。它并非为以下用途设计：
 ## 已知限制
 
 - `kmod` 需要带 `CONFIG_KPROBES=y` 的受支持 GKI 内核（Android 12+ 设备上为标准配置）
-- KPM 为测试版，需要 KernelPatch 运行时（APatch 或 KPatch-Next-Module）；不要将 KPM 与 `.ko` 一起安装
+- KPM 需要 KernelPatch 运行时（APatch 或 KPatch-Next-Module）；不要将 KPM 与 `.ko` 一起安装
 - `lsposed` 需要 LSPosed、LSPosed-Next 或 Vector
 - `zygisk` 仅支持 arm64
 - 直接的 `svc #0` 系统调用会绕过 Zygisk 的 libc 钩子 —— 为此请使用内核级后端（kmod 或 KPM）

--- a/changelog.d/changed-the-kpm-kernelpatch-module-backend-is-0873.md
+++ b/changelog.d/changed-the-kpm-kernelpatch-module-backend-is-0873.md
@@ -1,0 +1,9 @@
+_2026-08-19_
+
+## English
+
+The KPM (KernelPatch Module) backend is now considered stable — its experimental/beta labels and the "if something breaks, fall back" warning cards have been removed.
+
+## Русский
+
+Бэкенд KPM (KernelPatch Module) теперь считается стабильным — убраны пометки «экспериментальный/бета» и предупреждающие карточки «если что-то сломается, откатитесь».

--- a/docs/detection-vectors.md
+++ b/docs/detection-vectors.md
@@ -52,7 +52,7 @@ Key consequences:
 - **The kernel backends (kmod `.ko` and KPM) are the bypass-proof native layers.**
   A detector reading `/proc/net/route` with a raw `openat` syscall, or driving
   netlink without libc, defeats Zygisk but not a kernel backend. kmod is the
-  stable default for supported GKI kernels; KPM is the beta KernelPatch path for
+  stable default for supported GKI kernels; KPM is the KernelPatch path for
   old/non-GKI kernels and `.ko` load failures.
 - **lsposed is the only layer that can fake the high-level Java network model**
   (`ConnectivityManager`, `LinkProperties`, capabilities, callbacks) and

--- a/docs/development.md
+++ b/docs/development.md
@@ -33,7 +33,7 @@ The Rust crate at `lsposed/native/` is built via cargo-ndk by the `buildRustProb
 |---|---|
 | `zygisk/` | Zygisk native module (Rust, inline `libc` hooks) |
 | `lsposed/` | LSPosed module + target-picker Android app (Kotlin, Compose) |
-| `kmod/` | Kernel-level native backends: GKI `.ko` (C, kretprobes) and KPM beta (KernelPatch inline hooks) |
+| `kmod/` | Kernel-level native backends: GKI `.ko` (C, kretprobes) and KPM (KernelPatch inline hooks) |
 | `portshide/` | Localhost port blocker (shell + iptables) |
 | `scripts/` | Release & changelog tooling |
 | `update-json/` | Magisk/KSU update metadata |

--- a/kmod/README.md
+++ b/kmod/README.md
@@ -63,7 +63,7 @@ CI builds are provided for all 7 GKI generations: `android12-5.10` through `andr
 
 For old/non-GKI kernels or devices where the `.ko` cannot load, see the
 [KPM backend](kpm/README.md). It covers the same kernel-level Native role through
-KernelPatch inline hooks and is packaged as `vpnhide-kpm.zip` (beta).
+KernelPatch inline hooks and is packaged as `vpnhide-kpm.zip`.
 
 ## Build
 

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DashboardData.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DashboardData.kt
@@ -452,7 +452,7 @@ internal fun parseKernelAndroidBranch(raw: String): String? =
  *         primary plus an alternative via `variantAmbiguous=true`;
  *         the UI shows "try primary, if it doesn't load try alt".
  *  3. Non-GKI kernels that KernelPatch covers (4.9 / 4.14 / 4.19 / 5.4 —
- *     no GKI KMI, no DDK kmod build) → KPM (beta), the single
+ *     no GKI KMI, no DDK kmod build) → KPM, the single
  *     universal binary. [kpatchRuntimeAvailable] decides whether the
  *     UI also asks the user to install the KPatch-Next-Module first.
  *  4. Any other series or an unparseable kernel version → fall back to
@@ -550,7 +550,7 @@ internal fun buildNativeInstallRecommendation(
 
     // Non-GKI kernels KernelPatch supports (4.9 / 4.14 / 4.19 / 5.4) — no GKI KMI and
     // no DDK kmod build, but they're in the KPM kver offset table
-    // (kmod/kpm/kver_offsets.h). Recommend the universal KPM (beta).
+    // (kmod/kpm/kver_offsets.h). Recommend the universal KPM.
     if (kernelSeries in KPM_NON_GKI_SERIES) {
         return NativeInstallRecommendation(
             androidVersion = deviceAndroidLabel,
@@ -1560,20 +1560,6 @@ internal suspend fun loadDashboardState(
 
             else -> {}
         }
-    }
-
-    // The KPM backend is experimental (beta). When it's the active native
-    // backend, surface a neutral note with a contact-author action so users can
-    // reach the author if something misbehaves, and point them at the more
-    // battle-tested alternative for their kernel (kmod on GKI, else Zygisk).
-    if (moduleActive(kpm)) {
-        val experimentalText =
-            if (kernelRecommendation?.recommended == NativeBackendId.Kmod) {
-                res.getString(R.string.dashboard_issue_kpm_experimental_kmod)
-            } else {
-                res.getString(R.string.dashboard_issue_kpm_experimental_zygisk)
-            }
-        info(experimentalText, action = DashboardMessageAction.ContactAuthor)
     }
 
     // More than one native backend active. Disabled / inactive modules may

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DashboardScreen.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DashboardScreen.kt
@@ -1122,21 +1122,23 @@ private fun NativeInstallRecommendationCard(recommendation: NativeInstallRecomme
                 style = MaterialTheme.typography.bodyMedium,
                 fontWeight = FontWeight.Medium,
             )
-            // Trailing note per backend: zygisk's detectability caveat, kmod's
-            // "stable; KPM is a universal beta alternative" mention, or KPM's
-            // beta disclaimer.
+            // Trailing note per backend: zygisk's detectability caveat, or kmod's
+            // "stable; KPM is a universal alternative" mention. KPM itself needs
+            // no caveat note.
             val note =
                 when (recommendation.recommended) {
                     NativeBackendId.Zygisk -> R.string.dashboard_install_recommendation_zygisk_warning
                     NativeBackendId.Kmod -> R.string.dashboard_install_recommendation_kmod_kpm_alt
-                    NativeBackendId.Kpm -> R.string.dashboard_install_recommendation_kpm_beta_note
+                    NativeBackendId.Kpm -> null
                 }
-            Spacer(Modifier.height(8.dp))
-            Text(
-                text = stringResource(note),
-                style = MaterialTheme.typography.bodySmall,
-                color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.8f),
-            )
+            if (note != null) {
+                Spacer(Modifier.height(8.dp))
+                Text(
+                    text = stringResource(note),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.8f),
+                )
+            }
             // Bright primary: one-tap download of the exact recommended zip.
             // Plain secondary: the full releases page, for the ambiguous-variant
             // case (grab the alternative) or picking anything else.

--- a/lsposed/app/src/main/res/values-ru/strings.xml
+++ b/lsposed/app/src/main/res/values-ru/strings.xml
@@ -230,15 +230,12 @@
     <string name="dashboard_install_recommendation_kmod_ambiguous">Рекомендуется модуль ядра. GKI-ветку вашего ядра не удаётся определить из uname -r, поэтому сначала попробуйте %1$s; если после перезагрузки он не загрузится в ядро — установите %2$s.</string>
     <string name="dashboard_install_recommendation_zygisk">Для вашего устройства модуль ядра не поддерживается. Установите %1$s.</string>
     <string name="dashboard_install_recommendation_zygisk_warning">Банковские и платёжные приложения могут обнаруживать Zygisk-хуки, если для них включён Native. Для таких приложений оставьте Native выключенным и полагайтесь на LSPosed (Java-уровень).</string>
-    <string name="dashboard_install_recommendation_kpm">Для вашего ядра рекомендуется KPM (бета) — единый универсальный модуль, скрывающий VPN на уровне ядра, невидимый для анти-тампер проверок. Скачайте %1$s.</string>
-    <string name="dashboard_install_recommendation_kpm_needs_runtime">Для вашего ядра рекомендуется KPM (бета) — скрытие на уровне ядра, невидимое для анти-тампер проверок. Сначала нужно установить KPatch-Next-Module. Если не хотите его ставить — используйте vpnhide-zygisk.zip. Файл KPM: %1$s.</string>
-    <string name="dashboard_install_recommendation_kpm_beta_note">KPM экспериментальный (бета). Если что-то не работает — можно вернуться на Zygisk и связаться с автором.</string>
-    <string name="dashboard_install_recommendation_kmod_kpm_alt">Модуль ядра — стабильное и наиболее протестированное решение. KPM (бета) — альтернатива: один универсальный модуль без привязки к GKI-варианту; полезен, если модуль ядра не загружается в ваше ядро (неподходящий вариант или ядро требует подписанные модули).</string>
+    <string name="dashboard_install_recommendation_kpm">Для вашего ядра рекомендуется KPM — единый универсальный модуль, скрывающий VPN на уровне ядра, невидимый для анти-тампер проверок. Скачайте %1$s.</string>
+    <string name="dashboard_install_recommendation_kpm_needs_runtime">Для вашего ядра рекомендуется KPM — скрытие на уровне ядра, невидимое для анти-тампер проверок. Сначала нужно установить KPatch-Next-Module. Если не хотите его ставить — используйте vpnhide-zygisk.zip. Файл KPM: %1$s.</string>
+    <string name="dashboard_install_recommendation_kmod_kpm_alt">Модуль ядра — стабильное и наиболее протестированное решение. KPM — альтернатива: один универсальный модуль без привязки к GKI-варианту; полезен, если модуль ядра не загружается в ваше ядро (неподходящий вариант или ядро требует подписанные модули).</string>
     <string name="dashboard_install_recommendation_download">Скачать %1$s</string>
     <string name="dashboard_install_recommendation_all_releases">Все релизы</string>
-    <string name="dashboard_issue_kpm_capable_but_zygisk">Ваше ядро поддерживает более скрытный KPM (бета), но установлен только Zygisk. Банковские и платёжные приложения могут обнаруживать Zygisk; KPM скрывает VPN на уровне ядра. Стоит установить %1$s.</string>
-    <string name="dashboard_issue_kpm_experimental_kmod">KPM пока экспериментальный (бета) и сейчас активен. При проблемах попробуйте модуль ядра (kmod) и, пожалуйста, свяжитесь с автором.</string>
-    <string name="dashboard_issue_kpm_experimental_zygisk">KPM пока экспериментальный (бета) и сейчас активен. При проблемах попробуйте Zygisk и, пожалуйста, свяжитесь с автором.</string>
+    <string name="dashboard_issue_kpm_capable_but_zygisk">Ваше ядро поддерживает более скрытный KPM, но установлен только Zygisk. Банковские и платёжные приложения могут обнаруживать Zygisk; KPM скрывает VPN на уровне ядра. Стоит установить %1$s.</string>
     <!-- Community / contact modal -->
     <string name="contact_title">Сообщество и обратная связь</string>
     <string name="contact_body">Вопросы, сообщения об ошибках или обратная связь? Свяжитесь с автором.</string>

--- a/lsposed/app/src/main/res/values-zh-rCN/strings.xml
+++ b/lsposed/app/src/main/res/values-zh-rCN/strings.xml
@@ -251,15 +251,12 @@
     <string name="dashboard_install_recommendation_kmod_ambiguous">推荐使用内核模块。无法从 uname -r 判断内核的 GKI 分支，因此请先试 %1$s；若重启后仍未加载进内核，再改装 %2$s。</string>
     <string name="dashboard_install_recommendation_zygisk">当前设备不支持内核模块，请安装 %1$s。</string>
     <string name="dashboard_install_recommendation_zygisk_warning">为银行和支付类应用开启原生时，它们可能会察觉到 Zygisk 钩子。对这类应用请关闭原生，依赖 LSPosed（Java 层）隐藏。</string>
-    <string name="dashboard_install_recommendation_kpm">针对当前内核，推荐使用 KPM（测试版）——单个通用模块，在内核级隐藏，对防篡改检测不可见。请下载 %1$s。</string>
-    <string name="dashboard_install_recommendation_kpm_needs_runtime">针对当前内核，推荐使用 KPM（测试版）——内核级隐藏，对防篡改检测不可见。它需要先装好 KPatch-Next-Module。若不想装，可改用 vpnhide-zygisk.zip。KPM 文件：%1$s。</string>
-    <string name="dashboard_install_recommendation_kpm_beta_note">KPM 为实验性（测试版）。若有问题，可回退到 Zygisk 并联系作者。</string>
-    <string name="dashboard_install_recommendation_kmod_kpm_alt">内核模块是最稳定、测试最充分的选择。KPM（测试版）是备选方案——单个通用模块，不用去匹配 GKI 变体——当内核模块加载不进内核时（变体不匹配，或内核强制模块签名）会很有用。</string>
+    <string name="dashboard_install_recommendation_kpm">针对当前内核，推荐使用 KPM——单个通用模块，在内核级隐藏，对防篡改检测不可见。请下载 %1$s。</string>
+    <string name="dashboard_install_recommendation_kpm_needs_runtime">针对当前内核，推荐使用 KPM——内核级隐藏，对防篡改检测不可见。它需要先装好 KPatch-Next-Module。若不想装，可改用 vpnhide-zygisk.zip。KPM 文件：%1$s。</string>
+    <string name="dashboard_install_recommendation_kmod_kpm_alt">内核模块是最稳定、测试最充分的选择。KPM 是备选方案——单个通用模块，不用去匹配 GKI 变体——当内核模块加载不进内核时（变体不匹配，或内核强制模块签名）会很有用。</string>
     <string name="dashboard_install_recommendation_download">下载 %1$s</string>
     <string name="dashboard_install_recommendation_all_releases">全部发行版</string>
-    <string name="dashboard_issue_kpm_capable_but_zygisk">当前内核支持更隐蔽的 KPM（测试版），但目前只装了 Zygisk。Zygisk 会被银行/支付类应用检测到；KPM 则在内核级隐藏。可考虑安装 %1$s。</string>
-    <string name="dashboard_issue_kpm_experimental_kmod">KPM 后端为实验性（测试版），当前正在生效。若遇到问题，请改用内核模块（kmod），并联系作者。</string>
-    <string name="dashboard_issue_kpm_experimental_zygisk">KPM 后端为实验性（测试版），当前正在生效。若遇到问题，请改用 Zygisk，并联系作者。</string>
+    <string name="dashboard_issue_kpm_capable_but_zygisk">当前内核支持更隐蔽的 KPM，但目前只装了 Zygisk。Zygisk 会被银行/支付类应用检测到；KPM 则在内核级隐藏。可考虑安装 %1$s。</string>
     <!-- Community / contact modal -->
     <string name="contact_title">社区与反馈</string>
     <string name="contact_body">有疑问、Bug 反馈或建议？可在此联系作者。</string>

--- a/lsposed/app/src/main/res/values/strings.xml
+++ b/lsposed/app/src/main/res/values/strings.xml
@@ -262,15 +262,12 @@
     <string name="dashboard_install_recommendation_kmod_ambiguous">Kernel module is recommended. Your kernel\'s GKI branch isn\'t identifiable from uname -r, so try %1$s first; if it doesn\'t load into the kernel after reboot, install %2$s instead.</string>
     <string name="dashboard_install_recommendation_zygisk">Kernel module is not supported for your device. Install %1$s.</string>
     <string name="dashboard_install_recommendation_zygisk_warning">Banking and payment apps may detect Zygisk hooks when Native is enabled for them. Leave Native off for those apps and rely on LSPosed (Java-level) hiding.</string>
-    <string name="dashboard_install_recommendation_kpm">KPM (beta) is recommended for your kernel — a single universal module that hides at the kernel level, invisible to anti-tamper. Download %1$s.</string>
-    <string name="dashboard_install_recommendation_kpm_needs_runtime">KPM (beta) is recommended for your kernel — kernel-level hiding, invisible to anti-tamper. It needs the KPatch-Next-Module installed first. If you\'d rather not install that, use vpnhide-zygisk.zip instead. KPM artifact: %1$s.</string>
-    <string name="dashboard_install_recommendation_kpm_beta_note">KPM is experimental (beta). If something doesn\'t work, you can fall back to Zygisk and contact the author.</string>
-    <string name="dashboard_install_recommendation_kmod_kpm_alt">The kernel module is the stable, most-tested choice. KPM (beta) is an alternative — one universal module, no GKI variant to match — useful if the kernel module won\'t load into your kernel (wrong variant, or the kernel enforces module signatures).</string>
+    <string name="dashboard_install_recommendation_kpm">KPM is recommended for your kernel — a single universal module that hides at the kernel level, invisible to anti-tamper. Download %1$s.</string>
+    <string name="dashboard_install_recommendation_kpm_needs_runtime">KPM is recommended for your kernel — kernel-level hiding, invisible to anti-tamper. It needs the KPatch-Next-Module installed first. If you\'d rather not install that, use vpnhide-zygisk.zip instead. KPM artifact: %1$s.</string>
+    <string name="dashboard_install_recommendation_kmod_kpm_alt">The kernel module is the stable, most-tested choice. KPM is an alternative — one universal module, no GKI variant to match — useful if the kernel module won\'t load into your kernel (wrong variant, or the kernel enforces module signatures).</string>
     <string name="dashboard_install_recommendation_download">Download %1$s</string>
     <string name="dashboard_install_recommendation_all_releases">All releases</string>
-    <string name="dashboard_issue_kpm_capable_but_zygisk">Your kernel supports the stealthier KPM (beta), but only Zygisk is installed. Zygisk is detectable by banking/payment apps; KPM hides at the kernel level. Consider installing %1$s.</string>
-    <string name="dashboard_issue_kpm_experimental_kmod">The KPM backend is experimental (beta) and currently active. If you hit problems, try the kernel module (kmod) instead, and please contact the author.</string>
-    <string name="dashboard_issue_kpm_experimental_zygisk">The KPM backend is experimental (beta) and currently active. If you hit problems, try Zygisk instead, and please contact the author.</string>
+    <string name="dashboard_issue_kpm_capable_but_zygisk">Your kernel supports the stealthier KPM, but only Zygisk is installed. Zygisk is detectable by banking/payment apps; KPM hides at the kernel level. Consider installing %1$s.</string>
     <!-- Community / contact modal -->
     <string name="contact_title">Community &amp; feedback</string>
     <string name="contact_body">Questions, bug reports, or feedback? Reach the author here.</string>

--- a/lsposed/app/src/test/kotlin/dev/okhsunrog/vpnhide/BuildNativeInstallRecommendationTest.kt
+++ b/lsposed/app/src/test/kotlin/dev/okhsunrog/vpnhide/BuildNativeInstallRecommendationTest.kt
@@ -150,7 +150,7 @@ class BuildNativeInstallRecommendationTest {
     @Test
     fun `non-GKI 4_14 recommends KPM, not zygisk`() {
         // 4.14 has no GKI KMI and no DDK kmod build, but it's in the KPM kver
-        // offset table — recommend the universal KPM (beta) instead of the
+        // offset table — recommend the universal KPM instead of the
         // detectable zygisk fallback.
         val r = buildNativeInstallRecommendation("4.14.302-g92e0d94b6cba", "Android 13")!!
         assertEquals(NativeBackendId.Kpm, r.recommended)


### PR DESCRIPTION
KPM has been validated across the supported kernel families and on real hardware, so it is no longer experimental. This removes the beta/experimental framing everywhere it is presented as a current status.

App:
- Drops the "KPM is experimental — if you hit problems, fall back to kmod/Zygisk and contact the author" note shown on the dashboard while KPM is the active backend
- Drops the beta caveat note under the KPM install recommendation
- Strips "(beta)" from the KPM recommendation and capability strings (EN / RU / zh-CN)

Docs:
- Removes "beta" from the KPM descriptions in README.md, README.en.md, README.zh.md, CLAUDE.md, docs/development.md, docs/detection-vectors.md, and kmod/README.md

Deliberately left as-is:
- Historical changelog entries (`assets/changelog.json`, `update-json/changelog.md`) — KPM genuinely was beta when those releases shipped
- The "`.ko` is the default on supported GKI devices" guidance — that reflects per-KMI QEMU test coverage, not KPM stability

Quality gates pass (unit tests, ktlint, detekt). No functional change beyond removing the warning message and labels.
