### PR TITLE
fix(kpm): fail safe when a vendor kernel's layout differs from the offset table

### DIFF
--- a/changelog.d/fixed-kpm-harden-the-route-and-interface-b7bf.md
+++ b/changelog.d/fixed-kpm-harden-the-route-and-interface-b7bf.md
@@ -1,0 +1,9 @@
+_2026-08-19_
+
+## English
+
+KPM: harden the route and interface hooks against vendor kernels whose struct layout differs from the built-in offset table — a mismatched offset now degrades to "not hidden" instead of risking an out-of-bounds skb write or a dereference of a bogus device pointer (reported as a spontaneous reboot on a vendor 5.4 kernel).
+
+## Русский
+
+KPM: route- и interface-хуки теперь устойчивы к вендорским ядрам, чей layout структур отличается от встроенной таблицы смещений — неверное смещение приводит к «не скрыто» вместо риска записи за границей skb или разыменования мусорного указателя устройства (проявлялось как самопроизвольная перезагрузка на вендорском ядре 5.4).

--- a/kmod/kpm/vpnhide_kpm.c
+++ b/kmod/kpm/vpnhide_kpm.c
@@ -462,10 +462,20 @@ static int iface_is_vpn(const char *name)
 	return vpnhide_iface_is_vpn(buf);
 }
 
-/* Read net_device.name at the selected table's version-specific offset. */
+/* Read net_device.name at the selected table's version-specific offset.
+ *
+ * `dev` is resolved through version-specific struct offsets (dev_from_fib_info,
+ * dev_from_fib6_info, deref2). On a vendor kernel whose layout differs from the
+ * offset table, that resolution can yield a bogus value; reject anything that
+ * is not a kernel-space pointer so a wrong table degrades to "not hidden"
+ * instead of dereferencing garbage and panicking. ptr_is_kernel is defined
+ * further down but forward-declared for this early use. */
+static int ptr_is_kernel(const void *p);
 static const char *netdev_name(void *dev)
 {
-	return dev ? (const char *)((char *)dev + off->netdev_name) : 0;
+	if (!ptr_is_kernel(dev))
+		return 0;
+	return (const char *)((char *)dev + off->netdev_name);
 }
 
 /* Every hook_fargsN type shares this hook_fargs0_t prefix. Keep the common skb
@@ -1006,7 +1016,10 @@ static void sock_ioctl_after(hook_fargs3_t *fargs, void *udata)
 /*  these close the address path. dev = ifa->{ifa_dev|idev}->dev.       */
 /* ================================================================== */
 
-/* p = *(*(base+off1)+off2) with NULL guards (two-pointer deref). */
+/* p = *(*(base+off1)+off2) with NULL guards (two-pointer deref). The
+ * intermediate pointer is validated as kernel-space before the second deref:
+ * if off1 is wrong on a vendor kernel, *(base+off1) is a bogus value, and
+ * dereferencing it would fault — bail instead. */
 static void *deref2(void *base, unsigned int off1, unsigned int off2)
 {
 	void *p;
@@ -1014,7 +1027,7 @@ static void *deref2(void *base, unsigned int off1, unsigned int off2)
 	if (!base)
 		return 0;
 	p = *(void **)((char *)base + off1);
-	if (!p)
+	if (!ptr_is_kernel(p))
 		return 0;
 	return *(void **)((char *)p + off2);
 }
@@ -1760,9 +1773,17 @@ static int resolve_symbols(void)
 		logki(MODNAME ": using safe raw user-copy routines\n");
 	}
 
-	_skb_trim = (void *)kallsyms_lookup_name("__skb_trim");
+	/* Prefer skb_trim over __skb_trim. Both roll the skb back to the saved
+	 * pre-fill length, but skb_trim guards with `if (skb->len > len)` using
+	 * the kernel's own (correct) skb->len, so a wrong off->skb_len — which
+	 * saves a bogus length on a vendor kernel whose sk_buff layout differs —
+	 * degrades to a no-op instead of __skb_trim unconditionally pushing the
+	 * tail past the allocation (out-of-bounds skb write -> slab corruption ->
+	 * delayed panic). __skb_trim stays as a fallback only if skb_trim is
+	 * somehow unresolvable. */
+	_skb_trim = (void *)kallsyms_lookup_name("skb_trim");
 	if (!_skb_trim)
-		_skb_trim = (void *)kallsyms_lookup_name("skb_trim");
+		_skb_trim = (void *)kallsyms_lookup_name("__skb_trim");
 	_netdev_get_name = (void *)lookup_fn("netdev_get_name");
 
 	if (!_skb_trim) {


### PR DESCRIPTION
A user reported that installing the KPM backend on a vendor 5.4 kernel (HyperOS, Magisk + KPatch-Next) caused a spontaneous reboot ~3 minutes after boot. They disabled KPM and switched back to Zygisk.

Root cause (audit): the KPM selects struct-field offsets by kernel major.minor alone (`vpnhide_select_offsets`) and never validates them against the running kernel. On a vendor build whose layout differs from the android-common reference, a route/interface hook reads or writes at the wrong offset. Because `netlink_dump` reuses one skb across many messages, a wrong write corrupts the slab and the device panics minutes later — exactly when an app is polling routes/interfaces.

This makes the shared hook paths fail safe instead of trusting the offset table blindly:

- **`netdev_name()`** rejects a `dev` pointer that isn't kernel-space (reusing the existing `ptr_is_kernel` predicate). `dev` is resolved via version-specific offsets (`dev_from_fib_info` / `dev_from_fib6_info` / `deref2`); a wrong table yields a bogus value that would fault on dereference. It now degrades to "not a VPN interface" (no hiding) instead of panicking.
- **`deref2()`** validates the intermediate pointer as kernel-space before the second dereference.
- **prefer `skb_trim` over `__skb_trim`**: `skb_trim` guards with `if (skb->len > len)` against the kernel's *real* `skb->len`, so a wrong `off->skb_len` becomes a no-op instead of `__skb_trim` pushing the skb tail past its allocation (out-of-bounds write → slab corruption → delayed panic).

Net effect: a mismatched offset now means "the KPM backend silently doesn't hide on this kernel" — a safe degradation the app already surfaces — rather than a kernel panic. The correct, tested kernels are unaffected: on the QEMU matrix and GKI hardware a real `dev` is kernel-space and the saved pre-fill length is always ≤ the real length.

Which of the three paths bit this specific device needs the pstore/last_kmsg backtrace to confirm; the fix hardens the whole class. `make kpm` builds clean under `-Werror`; relying on CI's kpm-qemu / kpm-qemu-legacy (incl. 5.4) to confirm no regression on the reference kernels.

Follow-up worth considering separately: a load-time self-check of the fragile 5.4 offsets, and softening the "KPM is stable" wording for kernel families not yet validated on hardware (only 4.14 and 6.1 have been).
