### PR TITLE
fix(lsposed): skip locked/stopped profiles in the app scan instead of blocking

### DIFF
--- a/changelog.d/fixed-a-locked-or-stopped-android-profile-ec2c.md
+++ b/changelog.d/fixed-a-locked-or-stopped-android-profile-ec2c.md
@@ -1,0 +1,9 @@
+_2026-08-19_
+
+## English
+
+A locked or stopped Android profile (a locked Private Space, a paused work profile) no longer blocks the whole app list with a "couldn't read all profiles" error — its apps are skipped with a soft notice, and the rest of the list loads.
+
+## Русский
+
+Заблокированный или остановленный профиль Android (заблокированное Private Space, приостановленный рабочий профиль) больше не блокирует весь список приложений ошибкой «не удалось прочитать все профили» — его приложения пропускаются с мягким уведомлением, а остальной список загружается.

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/AppListCache.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/AppListCache.kt
@@ -92,6 +92,12 @@ internal object AppListCache : StateCache<List<AppSummary>>(
     private val _userNames = MutableStateFlow<Map<Int, String>>(emptyMap())
     val userNames: StateFlow<Map<Int, String>> = _userNames.asStateFlow()
 
+    // Display names of profiles skipped because they are stopped/locked (a
+    // locked Private Space, a paused work profile) and cannot be enumerated.
+    // The list loads without them; the UI shows a soft notice naming them.
+    private val _lockedProfiles = MutableStateFlow<List<String>>(emptyList())
+    val lockedProfiles: StateFlow<List<String>> = _lockedProfiles.asStateFlow()
+
     @Volatile private var appContext: Context? = null
 
     /** Kick off an initial load if not already loaded or loading. */
@@ -136,6 +142,10 @@ internal object AppListCache : StateCache<List<AppSummary>>(
             val inventory = requireCompletePackageInventory(RootSnapshotCache.getOrLoad().sections)
             _userNames.value =
                 inventory.profiles.mapValues { (_, profile) -> profileDisplayName(appContext, profile) }
+            _lockedProfiles.value =
+                inventory.skippedLockedUserIds.map { id ->
+                    profileDisplayName(appContext, inventory.profiles.getValue(id))
+                }
             inventory.packages.entries
                 .map { (pkg, meta) ->
                     val info = runCatching { pm.getApplicationInfo(pkg, 0) }.getOrNull()

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/PackageInventoryData.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/PackageInventoryData.kt
@@ -20,7 +20,15 @@ internal data class PackageInventoryEntry(
 internal data class PackageInventory(
     val packages: Map<String, PackageInventoryEntry>,
     val profiles: Map<Int, UserProfileInfo>,
+    // Running profiles whose package scan genuinely failed — a real problem that
+    // blocks loading (an incomplete list must not be saved and silently drop
+    // targets).
     val failedUserIds: Set<Int>,
+    // Stopped/locked profiles (a locked Private Space, a paused work profile)
+    // whose packages cannot be enumerated. This is expected, not an error: the
+    // rest of the list still loads and the UI shows a soft notice rather than
+    // the blocking failure card.
+    val skippedLockedUserIds: Set<Int>,
     val userListComplete: Boolean,
 ) {
     val complete: Boolean get() = userListComplete && failedUserIds.isEmpty() && packages.isNotEmpty()
@@ -110,12 +118,19 @@ internal fun parsePackageInventory(
     }
 
     val expectedUserIds = profiles.keys
-    val failedUserIds = expectedUserIds.filterTo(sortedSetOf()) { packageStatuses[it] != 0 || it !in usersWithPackages }
+    val notEnumerated = expectedUserIds.filter { packageStatuses[it] != 0 || it !in usersWithPackages }
+    // A stopped/locked profile can never be enumerated by `pm` — treat that as an
+    // expected skip, not a failure. Only a *running* profile that failed to scan
+    // blocks the list. Unknown running state (profiles[it]?.running == null) is
+    // treated as running, so a profile we could not classify still counts.
+    val (skippedLockedUserIds, failedUserIds) =
+        notEnumerated.partition { profiles[it]?.running == false }
     val userListComplete = userListStatuses.any { it == 0 } && expectedUserIds.isNotEmpty()
     return PackageInventory(
         packages = packages.mapValues { (_, entry) -> entry.freeze() },
         profiles = profiles,
-        failedUserIds = failedUserIds,
+        failedUserIds = failedUserIds.toSortedSet(),
+        skippedLockedUserIds = skippedLockedUserIds.toSortedSet(),
         userListComplete = userListComplete,
     )
 }

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/TargetPickerScaffold.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/TargetPickerScaffold.kt
@@ -161,6 +161,7 @@ internal fun <T : TargetEntry> TargetPickerScreen(
     val cachedApps by AppListCache.apps.collectAsState()
     val appListError by AppListCache.error.collectAsState()
     val userNames by AppListCache.userNames.collectAsState()
+    val lockedProfiles by AppListCache.lockedProfiles.collectAsState()
     val targets by TargetsCache.snapshot.collectAsState()
     val targetsError by TargetsCache.error.collectAsState()
 
@@ -264,6 +265,18 @@ internal fun <T : TargetEntry> TargetPickerScreen(
         if (appListError != null && cachedApps != null) {
             StatusBanner(
                 text = stringResource(R.string.profile_scan_stale_message),
+                containerColor = StatusColors.warningContainer(),
+                contentColor = StatusColors.warningHeader(),
+                modifier = Modifier.padding(horizontal = 12.dp, vertical = 8.dp),
+            )
+        }
+        if (lockedProfiles.isNotEmpty()) {
+            StatusBanner(
+                text =
+                    stringResource(
+                        R.string.profile_scan_locked_skipped_message,
+                        lockedProfiles.joinToString(", "),
+                    ),
                 containerColor = StatusColors.warningContainer(),
                 contentColor = StatusColors.warningHeader(),
                 modifier = Modifier.padding(horizontal = 12.dp, vertical = 8.dp),

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/UserProfileData.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/UserProfileData.kt
@@ -30,6 +30,13 @@ internal data class UserProfileInfo(
     val id: Int,
     val name: String?,
     val kind: UserProfileKind,
+    // Whether the profile is currently running. `pm list users` marks a running
+    // user with a trailing `running` token; a locked Private Space or a paused
+    // work / stopped secondary user has none. A stopped user's packages cannot
+    // be enumerated (`pm list packages --user N` fails), which is expected — the
+    // scan skips it instead of failing the whole list. Unknown ⇒ true, so a
+    // profile we cannot classify is still required (preserves completeness).
+    val running: Boolean = true,
 )
 
 // Verbose row, Android 13+:
@@ -89,14 +96,20 @@ internal fun parseUserProfiles(raw: String): Map<Int, UserProfileInfo> {
         val legacy = legacyUserLine.find(line) ?: return@forEach
         val id = legacy.groupValues[1].toIntOrNull() ?: return@forEach
         val name = normalizeName(legacy.groupValues[2])
+        // The `running` marker trails the closing brace on the plain row
+        // (`UserInfo{10:Work:1030} running`); its absence means the profile is
+        // stopped/locked. The name lives inside the braces, so slicing after
+        // `}` cannot false-match a profile named "running".
+        val running = line.substringAfterLast('}').contains("running")
         val existing = out[id]
         out[id] =
             if (existing == null) {
-                UserProfileInfo(id = id, name = name, kind = UserProfileKind.UNKNOWN)
+                UserProfileInfo(id = id, name = name, kind = UserProfileKind.UNKNOWN, running = running)
             } else {
                 // The verbose row already classified this profile; the plain
-                // row can still supply a name the verbose row printed as null.
-                existing.copy(name = existing.name ?: name)
+                // row can still supply a name the verbose row printed as null,
+                // and it is the authoritative source for the running state.
+                existing.copy(name = existing.name ?: name, running = running)
             }
     }
     return out

--- a/lsposed/app/src/main/res/values-ru/strings.xml
+++ b/lsposed/app/src/main/res/values-ru/strings.xml
@@ -29,6 +29,7 @@
     <string name="profile_scan_failed_title">Не удалос прочитать все профили Android</string>
     <string name="profile_scan_failed_message">VPN Hide не получил полный список приложений из одного или нескольких профилей. Неполный список не загружен. При необходимости разблокируйте или запустите профиль, затем нажмите «Повторить».</string>
     <string name="profile_scan_stale_message">Не удалось обновить все профили Android. Показан прежний полный список; настройки не удалялись.</string>
+    <string name="profile_scan_locked_skipped_message">Заблокированный или остановленный профиль (%1$s) пропущен — его приложения не показаны. Разблокируйте или запустите его и нажмите «Обновить», чтобы включить.</string>
 
     <string name="apps_help_title">Как это работает</string>
     <string name="java_hooks_title">Java-хуки</string>

--- a/lsposed/app/src/main/res/values-zh-rCN/strings.xml
+++ b/lsposed/app/src/main/res/values-zh-rCN/strings.xml
@@ -30,6 +30,7 @@
     <string name="profile_scan_failed_title">未能扫描全部 Android 用户资料</string>
     <string name="profile_scan_failed_message">VPN Hide 没有从一个或多个用户资料拿到完整的应用列表，也没有加载不完整的列表。如有需要，请先解锁或启动对应资料，再点按“重试”。</string>
     <string name="profile_scan_stale_message">未能刷新全部 Android 用户资料。正在显示上一次的完整应用列表；没有删除任何设置。</string>
+    <string name="profile_scan_locked_skipped_message">已跳过一个锁定或已停止的用户资料（%1$s）——其应用未显示。请解锁或启动它，然后点击刷新以纳入。</string>
     <string name="apps_help_title">工作原理</string>
     <string name="java_hooks_title">Java 钩子</string>
     <string name="native_hooks_title">原生钩子</string>

--- a/lsposed/app/src/main/res/values/strings.xml
+++ b/lsposed/app/src/main/res/values/strings.xml
@@ -29,6 +29,7 @@
     <string name="profile_scan_failed_title">Couldn’t scan every Android profile</string>
     <string name="profile_scan_failed_message">VPN Hide did not receive a complete app list from one or more profiles. No partial list was loaded. Unlock or start the profile if needed, then tap Retry.</string>
     <string name="profile_scan_stale_message">Couldn’t refresh every Android profile. Showing the previous complete app list; no settings were removed.</string>
+    <string name="profile_scan_locked_skipped_message">A locked or stopped profile (%1$s) was skipped — its apps aren’t shown. Unlock or start it, then tap refresh to include it.</string>
     <string name="apps_help_title">How it works</string>
     <string name="chip_java" translatable="false">J</string>
     <string name="chip_native" translatable="false">N</string>

--- a/lsposed/app/src/test/kotlin/dev/okhsunrog/vpnhide/PackageInventoryDataTest.kt
+++ b/lsposed/app/src/test/kotlin/dev/okhsunrog/vpnhide/PackageInventoryDataTest.kt
@@ -37,12 +37,12 @@ class PackageInventoryDataTest {
     }
 
     @Test
-    fun `reports a failed profile instead of accepting a partial list`() {
+    fun `reports a failed running profile instead of accepting a partial list`() {
         val users =
             """
             ${PM_USERS_STATUS_PREFIX}plain:0
-            UserInfo{0:Owner:c13}
-            UserInfo{10:Work:1030}
+            UserInfo{0:Owner:c13} running
+            UserInfo{10:Work:1030} running
             """.trimIndent()
         val packages =
             """
@@ -58,16 +58,17 @@ class PackageInventoryDataTest {
 
         assertFalse(inventory.complete)
         assertEquals(setOf(10), inventory.failedUserIds)
+        assertTrue(inventory.skippedLockedUserIds.isEmpty())
         assertTrue(inventory.incompleteMessage().contains("10"))
     }
 
     @Test
-    fun `successful but empty profile output is incomplete`() {
+    fun `a running profile with empty output is a failure`() {
         val users =
             """
             ${PM_USERS_STATUS_PREFIX}plain:0
-            UserInfo{0:Owner:c13}
-            UserInfo{10:Private:1030}
+            UserInfo{0:Owner:c13} running
+            UserInfo{10:Private:1030} running
             """.trimIndent()
         val packages =
             """
@@ -79,6 +80,36 @@ class PackageInventoryDataTest {
             """.trimIndent()
 
         assertEquals(setOf(10), parsePackageInventory(packages, users).failedUserIds)
+    }
+
+    @Test
+    fun `a stopped or locked profile is skipped, not a failure`() {
+        // No trailing `running` on user 10 — a locked Private Space / paused
+        // work profile whose packages `pm` cannot enumerate. The rest of the
+        // list still loads and it is reported as a soft skip.
+        val users =
+            """
+            ${PM_USERS_STATUS_PREFIX}plain:0
+            Users:
+            UserInfo{0:Owner:c13} running
+            UserInfo{10:Private space:1090}
+            """.trimIndent()
+        val packages =
+            """
+            $PM_USER_BEGIN_PREFIX${0}
+            package:/system/framework/framework-res.apk=android uid:1000
+            $PM_USER_END_PREFIX${0}:0
+            $PM_USER_BEGIN_PREFIX${10}
+            Error: user 10 is not running
+            $PM_USER_END_PREFIX${10}:7
+            """.trimIndent()
+
+        val inventory = parsePackageInventory(packages, users)
+
+        assertTrue(inventory.complete)
+        assertTrue(inventory.failedUserIds.isEmpty())
+        assertEquals(setOf(10), inventory.skippedLockedUserIds)
+        assertFalse(inventory.profiles.getValue(10).running)
     }
 
     @Test

--- a/lsposed/app/src/test/kotlin/dev/okhsunrog/vpnhide/UserProfileDataTest.kt
+++ b/lsposed/app/src/test/kotlin/dev/okhsunrog/vpnhide/UserProfileDataTest.kt
@@ -1,10 +1,26 @@
 package dev.okhsunrog.vpnhide
 
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
 class UserProfileDataTest {
+    @Test
+    fun `plain rows carry running state - a stopped or locked profile has no running token`() {
+        val profiles =
+            parseUserProfiles(
+                """
+                Users:
+                	UserInfo{0:Owner:c13} running
+                	UserInfo{10:Private space:1090}
+                """.trimIndent(),
+            )
+        assertTrue(profiles.getValue(0).running)
+        assertFalse(profiles.getValue(10).running)
+    }
+
     @Test
     fun `only android main user can run the app`() {
         assertEquals(true, isMainAppProfile(10_123))


### PR DESCRIPTION
A user on 1.2.1 (Motorola Edge 50 Neo, Android 16) hit "Не удалось прочитать все профили Android" — the red card that blocks the whole app list. The device has a **user 10** (a locked Private Space or a stopped secondary/dual-app user, visible as UID `1010225` in its connectivity dump). When a Private Space is locked its apps are stopped, so `pm list packages --user 10` fails — [expected Android behavior](https://source.android.com/docs/security/features/private-space), not a vendor bug.

The per-user scan (added in 1.2.0 for completeness, because `--user all` under-reports on some OEM ROMs) treated any non-enumerable profile as a hard failure, so one locked profile made the whole picker unusable — even though the user only manages user-0 apps and intends to keep the Private Space locked.

The fix uses the running state that `pm list users` already reports (a running user has a trailing `running` token; a locked/stopped one does not):

- A **running** profile that fails to scan is still a real error and still blocks — an incomplete list must not be saved and silently drop targets.
- A **stopped/locked** profile that fails is expected: it's skipped, the rest of the list loads, and a soft warning banner names the skipped profile with an "unlock and refresh" hint (mirroring the existing stale-scan banner).
- Unknown running state is treated as running, preserving the completeness guarantee.

This keeps the per-user approach's completeness (the reason we moved off `--user all`) while matching the graceful degradation the fork achieves with `--user all` — best of both.

Changes: parse `running` per user (`UserProfileData`); split `PackageInventory` failures into hard `failedUserIds` (running) vs soft `skippedLockedUserIds`; expose the skipped profiles from `AppListCache`; soft banner in the picker; new EN/RU/zh string. Tests cover the running-vs-stopped parse and the failure-vs-skip split. Quality gates pass (unit tests, ktlint, detekt).
