### PR TITLE
feat(diagnostics): capture a privacy-safe per-user app-scan summary in the bundle

### DIFF
--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DebugExport.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DebugExport.kt
@@ -190,6 +190,7 @@ internal fun buildCommonDiagnosticTextFiles(
         "device_info.txt" to buildDeviceInfoText(context, selfNeedsRestart, shellSnapshot),
         "backends.txt" to buildBackendsText(context, shellSnapshot),
         "modules.txt" to buildModulesText(shellSnapshot),
+        "profiles.txt" to buildProfilesText(shellSnapshot),
         "config.txt" to buildConfigText(shellSnapshot),
         "interfaces.txt" to buildInterfacesText(shellSnapshot),
         "proc_net.txt" to buildProcNetText(shellSnapshot),
@@ -282,6 +283,15 @@ private fun buildConfigText(shellSnapshot: DebugShellSnapshot): String =
     buildString {
         appendDebugSection("canonical config", shellSnapshot.section("canonical_config"))
         appendDebugSection("Ports load_status", shellSnapshot.section("ports_load_status"))
+    }
+
+// Android users/profiles and the per-user app-scan result (exit codes, package
+// counts, format flags). Names and the full package list are deliberately
+// redacted/omitted — this is enough to diagnose "couldn't read all profiles"
+// failures without exposing which apps a user has installed.
+private fun buildProfilesText(shellSnapshot: DebugShellSnapshot): String =
+    buildString {
+        appendDebugSection("App scan diagnostics", shellSnapshot.section("app_scan_diagnostics"))
     }
 
 private fun buildInterfacesText(shellSnapshot: DebugShellSnapshot): String =

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DebugShellSnapshot.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DebugShellSnapshot.kt
@@ -328,6 +328,32 @@ internal fun buildDebugShellSnapshotCommand(): String =
         )
     }
 
+    # Privacy-safe summary of the per-user app scan: profile list with names
+    # redacted, then per-user exit code / package counts / format flags / first
+    # stderr line — NO package names or paths. This is what diagnoses "couldn't
+    # read all profiles" cases (which user fails, and whether it is a non-zero
+    # exit, an empty list, or a `-U`/`-f` format the parser misses). The full
+    # package inventory is intentionally never written to the bundle.
+    emit_eval app_scan_diagnostics '
+      PLAIN=${'$'}(pm list users 2>/dev/null)
+      echo "--- pm list users (names redacted) ---"
+      printf "%s\n" "${'$'}PLAIN" | sed -E "s/(UserInfo\{[0-9]+:)[^:]*(:[0-9a-fA-F]*\})/\1<name>\2/"
+      IDS=${'$'}(printf "%s\n" "${'$'}PLAIN" | sed -n "s/.*UserInfo{\([0-9][0-9]*\):.*/\1/p")
+      [ -z "${'$'}IDS" ] && IDS=0
+      echo "--- per-user pm list packages -U -f (counts only, no names) ---"
+      for U in ${'$'}IDS; do
+        RUN=0
+        printf "%s\n" "${'$'}PLAIN" | grep "UserInfo{${'$'}U:" | grep -qw running && RUN=1
+        ERR=${'$'}(pm list packages -U -f --user "${'$'}U" 2>&1 1>/dev/null | head -2 | tr "\n" " ")
+        OUT=${'$'}(pm list packages -U -f --user "${'$'}U" 2>/dev/null)
+        EX=${'$'}?
+        TOTAL=${'$'}(printf "%s\n" "${'$'}OUT" | grep -c "^package:")
+        WUID=${'$'}(printf "%s\n" "${'$'}OUT" | grep -c "^package:.* uid:")
+        WPATH=${'$'}(printf "%s\n" "${'$'}OUT" | grep -c "^package:[^ ]*=")
+        echo "user=${'$'}U running=${'$'}RUN exit=${'$'}EX package_lines=${'$'}TOTAL with_uid=${'$'}WUID with_path=${'$'}WPATH stderr=[${'$'}ERR]"
+      done
+    '
+
     emit_cmd network_addr ip -d addr
     emit_eval network_operstate 'for IFACE in /sys/class/net/*; do echo "${'$'}(basename "${'$'}IFACE"): ${'$'}(cat "${'$'}IFACE/operstate" 2>/dev/null)"; done'
     emit_cmd network_routes ip route show table all


### PR DESCRIPTION
"Couldn't read all Android profiles" reports (e.g. the Motorola Edge 50 Neo on 1.2.1) can't be diagnosed from a debug bundle today: the per-user package inventory is intentionally never exported (the full package list is user-identifying), so there's no way to see which user failed or why.

This adds an `app_scan_diagnostics` section, written to a new `profiles.txt`, capturing — with no package names or paths — exactly what's needed to root-cause these cases:

- `pm list users` with profile names redacted (id, flags, and the trailing `running` marker preserved)
- per user: running state, `pm list packages -U -f --user N` exit code, count of `package:` lines, how many carry `uid:` / an apk path (`-U`/`-f` format sanity), and the first stderr line

That distinguishes the three failure modes — non-zero exit, empty list, or an output format the parser misses — while never revealing which apps a profile has installed.

Context: a Pixel 8 Pro check confirmed non-running profiles (locked Private Space, stopped second user) enumerate fine (`pm list packages --user N` → EXIT=0, full list), which is why the "locked profile" theory (and PR #292, now draft) was wrong. With this section, the next such bundle will show the real cause directly.

Validated the shell against a `pm` stub: a failing user surfaces its exit code + stderr, a healthy one its counts. No changelog — internal diagnostics tooling, no user-facing behavior change. Gates pass (compile, unit tests, ktlint, detekt).
