### PR TITLE
fix(lsposed): accept an empty-but-successful profile scan instead of blocking

### DIFF
--- a/changelog.d/fixed-the-app-list-no-longer-fails-75ef.md
+++ b/changelog.d/fixed-the-app-list-no-longer-fails-75ef.md
@@ -1,0 +1,9 @@
+_2026-08-19_
+
+## English
+
+The app list no longer fails to load with a "couldn't read all Android profiles" error when a profile is legitimately empty — a scan that succeeds (exit 0) with no packages is now accepted, and only a profile whose scan actually errors blocks the list (seen on a Motorola vendor profile that reports zero apps).
+
+## Русский
+
+Список приложений больше не падает с ошибкой «не удалось прочитать все профили Android», когда профиль просто пуст — успешное сканирование (код 0) без приложений теперь принимается, и список блокирует только профиль, чьё сканирование реально завершилось ошибкой (проявлялось на вендорском профиле Motorola, отдающем ноль приложений).

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/PackageInventoryData.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/PackageInventoryData.kt
@@ -78,7 +78,6 @@ internal fun parsePackageInventory(
     val profiles = parseUserProfiles(usersRaw)
     val userListStatuses = parseUserListStatuses(usersRaw)
     val packageStatuses = linkedMapOf<Int, Int>()
-    val usersWithPackages = mutableSetOf<Int>()
     val packages = linkedMapOf<String, MutablePackageInventoryEntry>()
     var currentUserId: Int? = null
 
@@ -102,7 +101,6 @@ internal fun parsePackageInventory(
                 if (entry.apkPath == null) entry.apkPath = parsed.apkPath
                 val userIds = currentUserId?.let(::listOf) ?: parsed.uids.map { it / PACKAGE_UIDS_PER_USER }
                 userIds.forEach { userId ->
-                    usersWithPackages += userId
                     entry.uidsByUser.getOrPut(userId) { linkedSetOf() }.addAll(parsed.uids)
                 }
             }
@@ -110,7 +108,14 @@ internal fun parsePackageInventory(
     }
 
     val expectedUserIds = profiles.keys
-    val failedUserIds = expectedUserIds.filterTo(sortedSetOf()) { packageStatuses[it] != 0 || it !in usersWithPackages }
+    // A profile is failed only when its scan did not succeed: a non-zero
+    // `pm list packages` exit, or no END marker at all (a truncated scan →
+    // status is null → null != 0). An exit-0 scan that returned no packages is
+    // a *success* — the profile is legitimately empty (seen on a Motorola
+    // vendor profile: user 10 running, exit 0, zero packages). Treating
+    // empty-but-successful as a failure used to block the whole app list with
+    // "couldn't read all profiles".
+    val failedUserIds = expectedUserIds.filterTo(sortedSetOf()) { packageStatuses[it] != 0 }
     val userListComplete = userListStatuses.any { it == 0 } && expectedUserIds.isNotEmpty()
     return PackageInventory(
         packages = packages.mapValues { (_, entry) -> entry.freeze() },

--- a/lsposed/app/src/test/kotlin/dev/okhsunrog/vpnhide/PackageInventoryDataTest.kt
+++ b/lsposed/app/src/test/kotlin/dev/okhsunrog/vpnhide/PackageInventoryDataTest.kt
@@ -62,12 +62,14 @@ class PackageInventoryDataTest {
     }
 
     @Test
-    fun `successful but empty profile output is incomplete`() {
+    fun `a profile that scans successfully but empty is not a failure`() {
+        // Motorola vendor profile: user 10 is running, pm exits 0, but returns
+        // zero packages. A successful empty scan must not block the whole list.
         val users =
             """
             ${PM_USERS_STATUS_PREFIX}plain:0
-            UserInfo{0:Owner:c13}
-            UserInfo{10:Private:1030}
+            UserInfo{0:Owner:c13} running
+            UserInfo{10:Vendor:1001010} running
             """.trimIndent()
         val packages =
             """
@@ -76,6 +78,30 @@ class PackageInventoryDataTest {
             $PM_USER_END_PREFIX${0}:0
             $PM_USER_BEGIN_PREFIX${10}
             $PM_USER_END_PREFIX${10}:0
+            """.trimIndent()
+
+        val inventory = parsePackageInventory(packages, users)
+
+        assertTrue(inventory.complete)
+        assertTrue(inventory.failedUserIds.isEmpty())
+    }
+
+    @Test
+    fun `a truncated scan with no end marker is still a failure`() {
+        // User 10 is listed but its per-user block never closed (no END marker),
+        // so its status is unknown — treat that as a failure, not a success.
+        val users =
+            """
+            ${PM_USERS_STATUS_PREFIX}plain:0
+            UserInfo{0:Owner:c13} running
+            UserInfo{10:Work:1030} running
+            """.trimIndent()
+        val packages =
+            """
+            $PM_USER_BEGIN_PREFIX${0}
+            package:/system/framework/framework-res.apk=android uid:1000
+            $PM_USER_END_PREFIX${0}:0
+            $PM_USER_BEGIN_PREFIX${10}
             """.trimIndent()
 
         assertEquals(setOf(10), parsePackageInventory(packages, users).failedUserIds)


### PR DESCRIPTION
The `profiles.txt` diagnostics added in 1.2.2 (#293) pinpointed the real cause of the "Не удалось прочитать все профили Android" report on the Motorola Edge 50 Neo (Android 16):

```
UserInfo{10:<name>:1001010} running
user=10 running=1 exit=0 package_lines=0 with_uid=0 with_path=0 stderr=[]
```

User 10 is a **running** vendor profile, and `pm list packages -U -f --user 10` **succeeds (exit 0) but returns zero packages** — a legitimately empty profile. The scan treated "exit 0 but empty" (`it !in usersWithPackages`) as a hard failure, so one empty profile blocked the entire app list.

The fix trusts the exit code: a profile is failed only on a non-zero `pm list packages` exit, or a missing END marker (a truncated scan → null status). An exit-0 scan with no packages is a success. `usersWithPackages` is no longer consulted (and removed as dead).

This supersedes **#292** (please close it): its premise — that a *locked* profile can't be enumerated — was disproven on a Pixel 8 Pro, where a locked Private Space and a stopped second user both enumerate fine (`pm list packages --user N` reads DE metadata). The Motorola profile is running and its scan succeeds; it's just empty.

Tests: the old "empty output is incomplete" test is flipped to "empty-but-successful is not a failure" (with the Motorola signature), plus a new test that a truncated scan (no END marker) still fails, and the existing non-zero-exit failure test is unchanged. Gates pass (unit tests, ktlint, detekt).
