### PR TITLE
fix(kpm): resolve hook targets renamed with a Clang LTO .llvm suffix

### DIFF
--- a/changelog.d/fixed-kpm-resolve-hook-targets-renamed-with-7da1.md
+++ b/changelog.d/fixed-kpm-resolve-hook-targets-renamed-with-7da1.md
@@ -1,0 +1,9 @@
+_2026-08-19_
+
+## English
+
+KPM: resolve hook targets renamed with a Clang LTO `.llvm.<hash>` suffix — on some kernels built with Clang ThinLTO (seen on a crDroid 5.4 build) ipv6_route_seq_show was LTO-mangled, so the IPv6 /proc/net/ipv6_route hook silently didn't install and native hiding showed as partial. Now it installs.
+
+## Русский
+
+KPM: теперь находит целевые функции хуков, переименованные Clang LTO в `.llvm.<hash>` — на части ядер, собранных с Clang ThinLTO (замечено на сборке crDroid 5.4), ipv6_route_seq_show был так переименован, из-за чего хук на IPv6 /proc/net/ipv6_route молча не ставился и нативное скрытие было частичным. Теперь ставится.

--- a/kmod/kpm/vpnhide_kpm.c
+++ b/kmod/kpm/vpnhide_kpm.c
@@ -1653,9 +1653,12 @@ static void iterate_dir_after(hook_fargs2_t *fargs, void *udata)
 /*
  * Resolve a hook target by name, tolerating compiler-renamed clones. GCC may
  * emit a static function as `name.isra.N` / `name.constprop.N` (a specialised
- * clone) — kallsyms_lookup_name("name") then misses it. The clang-built GKI
- * images usually retain the plain name, while gcc-built legacy QEMU images can
- * rename e.g. fib_nl_fill_rule -> fib_nl_fill_rule.isra.N.
+ * clone) — kallsyms_lookup_name("name") then misses it. Clang with (Thin)LTO
+ * promotes a local symbol to `name.llvm.<hash>` (seen on a vendor 5.4 build
+ * where ipv6_route_seq_show became ipv6_route_seq_show.llvm.NNN while the plain
+ * fib_route_seq_show stayed — leaving the IPv6 route hook uninstalled). The
+ * clang-built GKI images usually retain the plain name, while gcc-built legacy
+ * QEMU images can rename e.g. fib_nl_fill_rule -> fib_nl_fill_rule.isra.N.
  * Fall back only to compiler clone forms observed in supported reference
  * kernels. Other dotted symbols (for example cold fragments) are not valid
  * substitutes for the complete function.
@@ -1682,6 +1685,8 @@ static int vpnhide_is_clone_suffix(const char *suffix)
 
 	if (!number)
 		number = vpnhide_skip_prefix(suffix, ".constprop.");
+	if (!number)
+		number = vpnhide_skip_prefix(suffix, ".llvm.");
 	if (!number || *number < '0' || *number > '9')
 		return 0;
 	do {


### PR DESCRIPTION
A user on a Clang-ThinLTO-built 5.4 vendor kernel (Redmi Note 11 Pro 5G, veux — a Qualcomm/crDroid build) reported the KPM status as Partial on 1.2.2. Decoding it: `hooks 0xa0003fd error 0x4` — `error 0x4` is `PARTIAL_HOOKS`, and the mask is missing exactly bit 1, `IPV6_ROUTE_SEQ_SHOW` (`/proc/net/ipv6_route`). The other nine kernel hooks installed.

Reconstructing kallsyms from the device's own boot image showed why: `ipv6_route_seq_show` is emitted as `ipv6_route_seq_show.llvm.13305129763893609866` — Clang (Thin)LTO promoted the local symbol with a `.llvm.<hash>` suffix — while the plain `fib_route_seq_show` (IPv4, bit 0) stayed unmangled. `install_hook()` resolves via `lookup_fn()`, which already tolerates GCC clones (`.isra.N` / `.constprop.N`) but not the Clang LTO form, so the IPv6 route hook silently failed to install → Partial.

This recognizes the `.llvm.<digits>` suffix in `vpnhide_is_clone_suffix`, alongside the GCC clone forms. The matcher still requires the suffix to start exactly after the base name and be all digits, so it can't false-match a longer symbol. Because every hook installs through `lookup_fn`, this covers all hook targets, not just the IPv6 route one.

The `.llvm.` mangling is a compiler (LTO) artifact, independent of the SoC — it's the ROM's build config, not the chipset. Not an offset problem (the other nine hooks work, so the layout matches this kernel) and no kernel sources needed — purely symbol-name resolution. `make kpm` builds clean; relying on CI kpm-qemu/kpm-qemu-legacy for regression. This is the "Partial → full" follow-up to #291 (which stopped the crash on vendor 5.4 kernels); together they make the KPM both safe and complete on such kernels.
