### PR TITLE
Add SO_BINDTODEVICE self-check and fix the bind-interface leak on LTO GKI kernels

### DIFF
--- a/changelog.d/added-diagnostics-now-probe-the-so-bindtodevice-c6cd.md
+++ b/changelog.d/added-diagnostics-now-probe-the-so-bindtodevice-c6cd.md
@@ -1,0 +1,9 @@
+_2026-08-19_
+
+## English
+
+Diagnostics now probe the SO_BINDTODEVICE bind-to-interface vector, catching apps that can still bind a socket to the VPN interface
+
+## Русский
+
+Диагностика теперь проверяет вектор SO_BINDTODEVICE — ловит случаи, когда приложение всё ещё может привязать сокет к VPN-интерфейсу

--- a/changelog.d/fixed-so-bindtodevice-hiding-could-fail-on-e4a8.md
+++ b/changelog.d/fixed-so-bindtodevice-hiding-could-fail-on-e4a8.md
@@ -1,0 +1,9 @@
+_2026-08-19_
+
+## English
+
+SO_BINDTODEVICE hiding could fail on GKI kernels where the compiler dropped setsockopt's unused level argument, letting a target app still bind a socket to the VPN interface
+
+## Русский
+
+Скрытие SO_BINDTODEVICE могло не срабатывать на части GKI-ядер, где компилятор выкидывал неиспользуемый аргумент level у setsockopt — приложение всё ещё могло привязать сокет к VPN-интерфейсу

--- a/kmod/kpm/vpnhide_kpm.c
+++ b/kmod/kpm/vpnhide_kpm.c
@@ -710,7 +710,6 @@ static int ptr_is_kernel(const void *p)
 /*  after the user copy but still before the socket mutation.          */
 /* ================================================================== */
 
-#define VPNHIDE_SOL_SOCKET 1u
 #define VPNHIDE_SO_BINDTODEVICE 25u
 #define VPNHIDE_SO_BINDTOIFINDEX 62u
 
@@ -829,8 +828,14 @@ static void socket_bind_before_common(hook_fargs8_t *fargs, int takes_sk)
 	unsigned char *snapshot = (unsigned char *)&fargs->local;
 	unsigned int i;
 
-	if ((unsigned int)fargs->arg1 != VPNHIDE_SOL_SOCKET ||
-	    !hook_active(VPNHIDE_HOOK_SOCKET_BIND_INTERFACE))
+	/* No `level` gate on purpose. Reaching sock_setsockopt / sk_setsockopt
+	 * proves level == SOL_SOCKET by control flow, and sk_setsockopt never reads
+	 * its `level` parameter — so whole-kernel LTO elides setting it at the direct
+	 * __sys_setsockopt -> sk_setsockopt call, and fargs->arg1 is then garbage
+	 * (observed 0). A `arg1 != SOL_SOCKET` check would wrongly pass the bind
+	 * through and leak on those builds (the same defect fixed in the .ko). Gate
+	 * on the hook toggle alone. */
+	if (!hook_active(VPNHIDE_HOOK_SOCKET_BIND_INTERFACE))
 		return;
 	if (optname != VPNHIDE_SO_BINDTODEVICE &&
 	    optname != VPNHIDE_SO_BINDTOIFINDEX)

--- a/kmod/vpnhide_kmod.c
+++ b/kmod/vpnhide_kmod.c
@@ -578,6 +578,22 @@ enum socket_bind_action {
 	VPNHIDE_BIND_FAULT,
 };
 
+/* Human-readable action for the debug trace. Never returns NULL. */
+static const char *socket_bind_action_str(enum socket_bind_action action)
+{
+	switch (action) {
+	case VPNHIDE_BIND_PASSTHROUGH:
+		return "passthrough";
+	case VPNHIDE_BIND_FROZEN:
+		return "frozen";
+	case VPNHIDE_BIND_DENY:
+		return "deny";
+	case VPNHIDE_BIND_FAULT:
+		return "fault";
+	}
+	return "?";
+}
+
 /* 1 = VPN interface, 0 = physical/non-VPN, -1 = unknown. Unknown positive
  * indexes fail closed: sock_bindtoindex accepts a non-existent positive index,
  * which would otherwise leave observable state on the socket. */
@@ -668,6 +684,10 @@ static noinline int vpnhide_sock_setsockopt(struct socket *sock, int level,
 		prepare_socket_bind(sock ? READ_ONCE(sock->sk) : NULL, level,
 				    optname, optval, optlen, &snapshot);
 
+	vpnhide_dbg("sock_setsockopt_entry: uid=%u level=%d optname=%d action=%s\n",
+		    from_kuid(&init_user_ns, current_uid()), level, optname,
+		    socket_bind_action_str(action));
+
 	if (action == VPNHIDE_BIND_DENY) {
 		record_hook_hit(VPNHIDE_HOOK_SOCKET_BIND_INTERFACE);
 		return -ENODEV;
@@ -699,6 +719,10 @@ static noinline int vpnhide_sk_setsockopt(struct sock *sk, int level,
 	union socket_bind_snapshot snapshot;
 	enum socket_bind_action action = prepare_socket_bind(
 		sk, level, optname, optval, optlen, &snapshot);
+
+	vpnhide_dbg("sk_setsockopt_entry: uid=%u level=%d optname=%d action=%s\n",
+		    from_kuid(&init_user_ns, current_uid()), level, optname,
+		    socket_bind_action_str(action));
 
 	if (action == VPNHIDE_BIND_DENY) {
 		record_hook_hit(VPNHIDE_HOOK_SOCKET_BIND_INTERFACE);

--- a/kmod/vpnhide_kmod.c
+++ b/kmod/vpnhide_kmod.c
@@ -688,12 +688,13 @@ static noinline int vpnhide_sock_setsockopt(struct socket *sock, int level,
 {
 	union socket_bind_snapshot snapshot;
 	enum socket_bind_action action =
-		prepare_socket_bind(sock ? READ_ONCE(sock->sk) : NULL,
-				    optname, optval, optlen, &snapshot);
+		prepare_socket_bind(sock ? READ_ONCE(sock->sk) : NULL, optname,
+				    optval, optlen, &snapshot);
 
-	vpnhide_dbg("sock_setsockopt_entry: uid=%u level=%d optname=%d action=%s\n",
-		    from_kuid(&init_user_ns, current_uid()), level, optname,
-		    socket_bind_action_str(action));
+	vpnhide_dbg(
+		"sock_setsockopt_entry: uid=%u level=%d optname=%d action=%s\n",
+		from_kuid(&init_user_ns, current_uid()), level, optname,
+		socket_bind_action_str(action));
 
 	if (action == VPNHIDE_BIND_DENY) {
 		record_hook_hit(VPNHIDE_HOOK_SOCKET_BIND_INTERFACE);
@@ -724,12 +725,13 @@ static noinline int vpnhide_sk_setsockopt(struct sock *sk, int level,
 					  unsigned int optlen)
 {
 	union socket_bind_snapshot snapshot;
-	enum socket_bind_action action = prepare_socket_bind(
-		sk, optname, optval, optlen, &snapshot);
+	enum socket_bind_action action =
+		prepare_socket_bind(sk, optname, optval, optlen, &snapshot);
 
-	vpnhide_dbg("sk_setsockopt_entry: uid=%u level=%d optname=%d action=%s\n",
-		    from_kuid(&init_user_ns, current_uid()), level, optname,
-		    socket_bind_action_str(action));
+	vpnhide_dbg(
+		"sk_setsockopt_entry: uid=%u level=%d optname=%d action=%s\n",
+		from_kuid(&init_user_ns, current_uid()), level, optname,
+		socket_bind_action_str(action));
 
 	if (action == VPNHIDE_BIND_DENY) {
 		record_hook_hit(VPNHIDE_HOOK_SOCKET_BIND_INTERFACE);

--- a/kmod/vpnhide_kmod.c
+++ b/kmod/vpnhide_kmod.c
@@ -613,11 +613,18 @@ static int classify_bind_ifindex(struct sock *sk, int ifindex)
 }
 
 static enum socket_bind_action
-prepare_socket_bind(struct sock *sk, int level, int optname, sockptr_t optval,
+prepare_socket_bind(struct sock *sk, int optname, sockptr_t optval,
 		    unsigned int optlen, union socket_bind_snapshot *snapshot)
 {
-	if (level != SOL_SOCKET ||
-	    !hook_active(VPNHIDE_HOOK_SOCKET_BIND_INTERFACE))
+	/* No `level` gate on purpose. Both hooked functions (sock_setsockopt,
+	 * sk_setsockopt) ARE the SOL_SOCKET option handler — reaching them proves
+	 * level == SOL_SOCKET by control flow. We must NOT read the ABI `level`
+	 * argument: sk_setsockopt never uses it, so whole-kernel LTO elides setting
+	 * it at the direct __sys_setsockopt -> sk_setsockopt call (the wrapper then
+	 * sees garbage, e.g. 0, and a `level != SOL_SOCKET` check would wrongly pass
+	 * the bind through — the SO_BINDTODEVICE leak on LTO GKI builds where
+	 * sock_setsockopt is inlined away). Gate on the hook toggle alone. */
+	if (!hook_active(VPNHIDE_HOOK_SOCKET_BIND_INTERFACE))
 		return VPNHIDE_BIND_PASSTHROUGH;
 	if (optname != SO_BINDTODEVICE && optname != SO_BINDTOIFINDEX)
 		return VPNHIDE_BIND_PASSTHROUGH;
@@ -681,7 +688,7 @@ static noinline int vpnhide_sock_setsockopt(struct socket *sock, int level,
 {
 	union socket_bind_snapshot snapshot;
 	enum socket_bind_action action =
-		prepare_socket_bind(sock ? READ_ONCE(sock->sk) : NULL, level,
+		prepare_socket_bind(sock ? READ_ONCE(sock->sk) : NULL,
 				    optname, optval, optlen, &snapshot);
 
 	vpnhide_dbg("sock_setsockopt_entry: uid=%u level=%d optname=%d action=%s\n",
@@ -718,7 +725,7 @@ static noinline int vpnhide_sk_setsockopt(struct sock *sk, int level,
 {
 	union socket_bind_snapshot snapshot;
 	enum socket_bind_action action = prepare_socket_bind(
-		sk, level, optname, optval, optlen, &snapshot);
+		sk, optname, optval, optlen, &snapshot);
 
 	vpnhide_dbg("sk_setsockopt_entry: uid=%u level=%d optname=%d action=%s\n",
 		    from_kuid(&init_user_ns, current_uid()), level, optname,

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/AgentControl.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/AgentControl.kt
@@ -511,7 +511,7 @@ private fun buildProtectionState(snapshot: TargetsSnapshot): AgentProtectionStat
     )
 }
 
-private fun StatisticsState.toAgentStatisticsState(selfPackage: String? = null): AgentStatisticsState {
+internal fun StatisticsState.toAgentStatisticsState(selfPackage: String? = null): AgentStatisticsState {
     val apps = buildAppProbeStats(this, selfPackage)
     return AgentStatisticsState(
         hasAnyData = hasAnyData,

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DebugExport.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DebugExport.kt
@@ -116,6 +116,14 @@ private suspend fun buildDebugState(
             bootLsposedLogcat = if (options.forensics) captureBootLsposedLogcat() else "",
             lsposedConfigDb = if (options.forensics) buildLsposedConfigText(context) else "",
             hookReport = shellSnapshot?.let { buildHookDiagnosticsText(context, it, counterBaseline) },
+            // Always carry the point-in-time hook counters (a few KB, already in the
+            // snapshot): the per-uid SOCKET_BIND_INTERFACE deny-count is what tells a
+            // dead redirect from a working one, and a bundle that silently dropped it
+            // is exactly the blind spot this closes. Not gated behind forensics.
+            statistics =
+                runCatching {
+                    buildStatisticsState(rootSnapshot).toAgentStatisticsState(selfPackage = context.packageName)
+                }.getOrNull(),
             debugCapture = session?.toDebugCaptureInfo(),
             errors = errors,
             options = options,

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/NativeChecks.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/NativeChecks.kt
@@ -51,6 +51,16 @@ internal val NATIVE_CHECKS: List<NativeCheckSpec> =
                 ),
         ),
         NativeCheckSpec(
+            // setsockopt(SO_BINDTODEVICE, tun0): the kernel backends (kmod/KPM) own
+            // this vector — they deny it in sock_setsockopt / sk_setsockopt (6.1+)
+            // before sk_bound_dev_if mutates. Zygisk has only an opportunistic
+            // bionic-routed setsockopt hook and does not claim the vector in its
+            // owned mask, so under zygisk a leak here is (correctly) unowned.
+            id = "so_bindtodevice",
+            labelRes = R.string.check_so_bindtodevice,
+            expectedHooks = setOf(HookIds.Hook.SOCKET_BIND_INTERFACE),
+        ),
+        NativeCheckSpec(
             id = "netlink_getlink",
             labelRes = R.string.check_netlink_getlink,
             expectedHooks =

--- a/lsposed/app/src/main/res/values/strings.xml
+++ b/lsposed/app/src/main/res/values/strings.xml
@@ -415,6 +415,7 @@
     <string name="check_ioctl_mtu" translatable="false">ioctl SIOCGIFMTU tun0</string>
     <string name="check_ioctl_conf" translatable="false">ioctl SIOCGIFCONF enum</string>
     <string name="check_getifaddrs" translatable="false">getifaddrs() enum</string>
+    <string name="check_so_bindtodevice" translatable="false">setsockopt SO_BINDTODEVICE tun0</string>
     <string name="check_netlink_getlink" translatable="false">netlink RTM_GETLINK</string>
     <string name="check_netlink_getroute" translatable="false">netlink RTM_GETROUTE</string>
     <string name="check_netlink_getrule" translatable="false">netlink RTM_GETRULE</string>

--- a/lsposed/native/src/lib.rs
+++ b/lsposed/native/src/lib.rs
@@ -302,6 +302,73 @@ fn check_getifaddrs() -> CheckOutput {
     }
 }
 
+/// `setsockopt(SO_BINDTODEVICE, "tun0")` — the pre-mutation bind-interface vector
+/// (kmod/KPM `socket_bind_interface`, RKNHardering probe n18). A target that can
+/// bind a socket to tun0 has leaked the interface's existence and can pin traffic
+/// to it; the kernel backend denies this by returning ENODEV *before* mutating
+/// `sk_bound_dev_if`.
+///
+/// Classification mirrors the backend contract and RKNHardering's own semantics
+/// (only a completed bind is a leak):
+///
+/// - `rc == 0` → the bind succeeded → the interface is bindable/visible (FAIL).
+/// - `ENODEV` → the hook denied it (or the iface is absent) → not visible (PASS);
+///   the root ground-truth differential decides which.
+/// - `EPERM`/`EACCES`/other → the app could not complete the bind for a reason that
+///   is NOT our hook (capability/SELinux). Report as a permission block, never as a
+///   backend success or a leak.
+fn check_setsockopt_bindtodevice() -> CheckOutput {
+    unsafe {
+        with_inet_dgram_socket(|fd| {
+            // Include the NUL terminator in optlen, exactly like the RKNHardering
+            // probe (name.size() + 1); the kernel reads optval as a C string.
+            let name = b"tun0\0";
+            let ret = libc::setsockopt(
+                fd,
+                libc::SOL_SOCKET,
+                libc::SO_BINDTODEVICE,
+                name.as_ptr().cast(),
+                name.len() as libc::socklen_t,
+            );
+            if ret == 0 {
+                // Confirm the bind actually took, exactly like the RKNHardering
+                // probe: a skip_origin-style hook (zygisk) returns 0 without binding,
+                // which neutralises the vector rather than leaking it. Only a
+                // getsockopt that echoes back tun0 is a real leak.
+                let mut dev = [0u8; libc::IFNAMSIZ];
+                let mut dev_len = dev.len() as libc::socklen_t;
+                let got = libc::getsockopt(
+                    fd,
+                    libc::SOL_SOCKET,
+                    libc::SO_BINDTODEVICE,
+                    dev.as_mut_ptr().cast(),
+                    &mut dev_len,
+                );
+                let bound = got == 0 && cstr_to_str(dev.as_ptr().cast()) == "tun0";
+                return if bound {
+                    CheckOutput::fail(
+                        "setsockopt(tun0, SO_BINDTODEVICE) succeeded and getsockopt confirmed — interface bindable/visible",
+                    )
+                } else {
+                    CheckOutput::pass(
+                        "setsockopt(tun0, SO_BINDTODEVICE) returned 0 but getsockopt shows unbound — bind neutralised",
+                    )
+                };
+            }
+            let err = last_os_errno();
+            match err {
+                libc::ENODEV | libc::ENXIO => CheckOutput::pass(
+                    "setsockopt(tun0, SO_BINDTODEVICE) returned ENODEV — interface not visible",
+                ),
+                _ => CheckOutput::selinux_blocked(format!(
+                    "SO_BINDTODEVICE denied (errno {err}: {}) — capability/SELinux block, not a backend hook",
+                    last_os_error()
+                )),
+            }
+        })
+    }
+}
+
 fn check_proc_file(path: &str) -> CheckOutput {
     match fs::read_to_string(path) {
         Err(e) => {
@@ -970,6 +1037,7 @@ fn run_all() -> Vec<CheckJson> {
         j("ioctl_mtu", check_ioctl_siocgifmtu()),
         j("ioctl_conf", check_ioctl_siocgifconf()),
         j("getifaddrs", check_getifaddrs()),
+        j("so_bindtodevice", check_setsockopt_bindtodevice()),
         j("netlink_getlink", check_netlink_getlink()),
         j("netlink_getroute", check_netlink_getroute()),
         j("netlink_getrule", check_netlink_getrule()),


### PR DESCRIPTION
A target app could still `setsockopt(SOL_SOCKET, SO_BINDTODEVICE, "tun0")` and bind a socket to the VPN interface on GKI kernels built with whole-kernel LTO where `sock_setsockopt` is inlined into `__sys_setsockopt` (observed on a Xiaomi HyperOS `6.1.138-android14-11` device). The kernel backends' bind redirect gated on `level != SOL_SOCKET`, but `sk_setsockopt` never reads its `level` parameter, so LTO elides setting it at the direct `__sys_setsockopt -> sk_setsockopt` call — the redirect wrapper then read garbage (observed `level=0`) and passed the bind straight through while every other hook worked. The app also had no self-test for this vector, so a real leak stayed invisible in every bundle. This adds the missing self-check plus the observability that pinned it down, then fixes both kernel backends. Root-caused from the reporter's `boot.img` vmlinux (no `w1` set before `bl sk_setsockopt`; `sk_setsockopt` dispatches on optname only), cross-checked against the `android14-6.1` source (the `sk_setsockopt` body never references `level`) and an on-device trace (`sk_setsockopt_entry level=0 optname=25 passthrough`).

- Add a native `so_bindtodevice` diagnostics probe (`lsposed/native`): the app does `setsockopt(SO_BINDTODEVICE, "tun0")` from its own process and, like the RKNHardering probe, treats it as a leak only when the bind actually takes (getsockopt echoes `tun0` back), so a skip_origin-style zygisk hook that returns 0 without binding is not a false positive; `ENODEV` is the backend's pre-mutation denial, `EPERM`/`EACCES` a capability/SELinux block that is never credited as a backend success.
- kmod: drop the dead `level` gate in the bind redirect; reaching `sock_setsockopt`/`sk_setsockopt` proves `level == SOL_SOCKET` by control flow, so gate on the hook toggle alone. The live args (`sk`, `optname`, `optval`, `optlen`) are used by the callee and never elided, so they stay correct.
- KPM: the same fix (its `socket_bind_before_common` had the identical `arg1 != SOL_SOCKET` read); drops the now-unused `VPNHIDE_SOL_SOCKET` define.
- kmod: `vpnhide_dbg` trace in the socket-bind redirect wrappers (uid, level, optname, decided action), gated by the existing debug flag, so a forced-debug export shows whether the redirect fired and what it decided.
- Always include the point-in-time hook counters (incl. the socket-bind deny count) in the file debug export, not only over the agent bridge.
- Zygisk needs no change: it hooks the userspace libc `setsockopt`, where the app passes real arguments over a normal ABI and `level` is never elided.

Testing

- Pixel 8 Pro (GKI `android14-6.1`), both before and after the fix: `so_bindtodevice` reports `hidden_backend`, the per-uid `socket_bind_interface` deny counter increments, and with debug logging on the trace shows `optname=25 action=deny`; no verdict regression. (The Pixel build keeps `sock_setsockopt` out-of-line, so `level` is a live, ABI-preserved argument there.)
- Fix validation on the affected Xiaomi HyperOS device is pending; the fixed `.ko` has been handed to the reporter.
