### PR TITLE
Pack the plain debug export as a .zip so it attaches on forums

### DIFF
--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DebugExport.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DebugExport.kt
@@ -44,7 +44,13 @@ internal suspend fun exportDebug(
             if (attachKernelImage) {
                 writeKernelBundleZip(context, timestamp, state.toJson())
             } else {
-                File(context.cacheDir, "vpnhide_debug_$timestamp.json").apply { writeText(state.toJson()) }
+                // Bundle the single state.json in a .zip too: forums/messengers (4pda,
+                // the main report channel) whitelist .zip but reject a bare .json, and
+                // the JSON compresses ~10x. Every export kind is now a .zip carrying
+                // state.json, so the caller has one format to handle.
+                File(context.cacheDir, "vpnhide_debug_$timestamp.zip").also {
+                    writeDiagnosticZip(it, mapOf("state.json" to state.toJson()))
+                }
             }
         } catch (c: CancellationException) {
             throw c
@@ -139,11 +145,11 @@ private suspend fun buildDebugState(
 internal fun isoNow(): String = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssZ", Locale.US).format(Date())
 
 /**
- * Pack a small ZIP: named text entries + raw file entries. Retained for the two
- * captures with a non-text payload — the full-logcat recorder (a multi-MB raw log)
- * and the kernel-image export (binary partition images) — each of which carries the
- * canonical `state.json` alongside its payload. The plain debug export is a single
- * `.json` and does not use this.
+ * Pack a ZIP: named text entries + raw file entries. The one packaging primitive for
+ * every debug export — the plain debug export (just `state.json`), the kernel-image
+ * export (+ binary partition images), and the full-logcat recorder (+ a multi-MB raw
+ * log). Every bundle is a `.zip` carrying the canonical `state.json`; the heavy
+ * variants add their payload alongside it.
  */
 internal fun writeDiagnosticZip(
     zipFile: File,

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DiagnosticsScreen.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DiagnosticsScreen.kt
@@ -218,15 +218,14 @@ fun DebugToolsSection(
     var exporting by remember { mutableStateOf(false) }
     var showModal by remember { mutableStateOf(false) }
     var resultFile by remember { mutableStateOf<File?>(null) }
-    var resultIsZip by remember { mutableStateOf(false) }
 
     // One export recipe, shared with the agent bridge's getState.
     var optForensics by remember { mutableStateOf(true) }
     var optAppList by remember { mutableStateOf(false) }
     var optKernelImage by remember { mutableStateOf(false) }
 
-    val mime = if (resultIsZip) "application/zip" else "application/json"
-    val saveLauncher = rememberZipSaveLauncher("debug-export", mimeType = mime) { resultFile }
+    // Every export kind is now a .zip (carrying state.json), so one MIME type fits all.
+    val saveLauncher = rememberZipSaveLauncher("debug-export") { resultFile }
 
     Column(modifier = modifier.fillMaxWidth()) {
         EnhancedCard(
@@ -324,7 +323,6 @@ fun DebugToolsSection(
                         exporting = true
                         scope.launch {
                             resultFile = exportDebug(cm, context, restartState, options, kernel)
-                            resultIsZip = kernel
                             exporting = false
                         }
                     }
@@ -361,7 +359,7 @@ fun DebugToolsSection(
                             shareLabel = stringResource(R.string.btn_share_debug),
                             sharePrimary = true,
                             onSave = { saveLauncher.launch(file.name) },
-                            onShare = { shareFileViaProvider(context, file, mime) },
+                            onShare = { shareFileViaProvider(context, file, "application/zip") },
                         )
                         TextButton(
                             onClick = doExport,

--- a/lsposed/app/src/main/res/values-ru/strings.xml
+++ b/lsposed/app/src/main/res/values-ru/strings.xml
@@ -379,7 +379,7 @@
     <string name="debug_export_modal_title">Что включить</string>
     <string name="debug_export_modal_confirm">Экспорт</string>
     <string name="debug_export_collect_again">Собрать заново</string>
-    <string name="debug_export_opt_forensics">Форензик-логи</string>
+    <string name="debug_export_opt_forensics">Расширенный лог</string>
     <string name="debug_export_opt_forensics_desc">dmesg, logcat и сырые пробы ядра/сети. Файл больше; обычно именно это и нужно для баг-репорта.</string>
     <string name="debug_export_opt_applist">Список приложений</string>
     <string name="debug_export_opt_applist_desc">Раскрывает, какие приложения у тебя установлены. По умолчанию выкл; включай только по просьбе разработчика.</string>

--- a/lsposed/app/src/main/res/values-zh-rCN/strings.xml
+++ b/lsposed/app/src/main/res/values-zh-rCN/strings.xml
@@ -83,7 +83,7 @@
     <string name="debug_export_modal_title">包含哪些内容</string>
     <string name="debug_export_modal_confirm">导出</string>
     <string name="debug_export_collect_again">重新收集</string>
-    <string name="debug_export_opt_forensics">取证日志</string>
+    <string name="debug_export_opt_forensics">详细日志</string>
     <string name="debug_export_opt_forensics_desc">dmesg、logcat 及内核/网络原始探测。文件更大；通常正是错误报告所需。</string>
     <string name="debug_export_opt_applist">已安装应用列表</string>
     <string name="debug_export_opt_applist_desc">会暴露你安装了哪些应用。默认关闭；仅在开发者要求时开启。</string>

--- a/lsposed/app/src/main/res/values/strings.xml
+++ b/lsposed/app/src/main/res/values/strings.xml
@@ -90,7 +90,7 @@
     <string name="debug_export_modal_title">What to include</string>
     <string name="debug_export_modal_confirm">Export</string>
     <string name="debug_export_collect_again">Collect again</string>
-    <string name="debug_export_opt_forensics">Forensic logs</string>
+    <string name="debug_export_opt_forensics">Verbose logs</string>
     <string name="debug_export_opt_forensics_desc">dmesg, logcat and raw kernel/network probes. Bigger file; usually what a bug report needs.</string>
     <string name="debug_export_opt_applist">Installed-app list</string>
     <string name="debug_export_opt_applist_desc">Reveals which apps you have installed. Off by default; enable only when the developer asks.</string>


### PR DESCRIPTION
The standalone debug export produced a bare `.json`, but forums and messengers — 4pda in particular, where most bug reports come from — whitelist `.zip` and reject `.json`, so a tester had to repack the file by hand before sending it. This bundles the single `state.json` inside a `.zip`, exactly like the kernel-image and full-logcat exports already do, so every export kind is now a `.zip` carrying `state.json` (heavy variants add their payload alongside it). The JSON also compresses ~10x, so the attachment is smaller.

Because there is no longer a `.json` vs `.zip` split, this also removes the branching that PR #296 introduced.

- `exportDebug`: the plain path now writes `vpnhide_debug_<ts>.zip` with `state.json` via the existing `writeDiagnosticZip` primitive instead of a raw `.json`.
- Drop the `resultIsZip` flag and the conditional MIME type in the diagnostics screen — the save/share path is always `application/zip`.
- All three export kinds now go through the one `writeDiagnosticZip` packaging primitive; its doc comment is updated to match.
- The agent bridge `getState` is unchanged — it returns raw JSON programmatically and is never an attachment.

Also renames the export modal's "Forensic logs" toggle to "Verbose logs" (EN/RU/zh) — "forensic" read as unusual and opaque to users; the internal `StateContentOptions.forensics` field is unchanged.
