### PR TITLE
Refresh stale diagnostics/detection-vector docs

### DIFF
--- a/docs/detection-vectors.md
+++ b/docs/detection-vectors.md
@@ -233,10 +233,14 @@ Since Linux 5.7, an unprivileged process can perform the first interface
 bind, so `curl --interface tun0 ...` or a raw `setsockopt` syscall is a real
 local oracle even without root. The kernel backends deny VPN names and indices
 with `ENODEV` **before** `sk_bound_dev_if` changes. The `.ko` redirects
-`sock_setsockopt` (and `sk_setsockopt` on 6.1+) to a typed wrapper because a
+`sock_setsockopt` **and** `sk_setsockopt` (6.1+) to a typed wrapper because a
 return-only kretprobe would be too late; KPM uses KernelPatch's pre-hook
-`skip_origin`. Both freeze the 5.9+ `sockptr_t` input before validation to close
-userspace TOCTOU. On 5.7-5.8, KPM instead hooks the resolved-ifindex mutation
+`skip_origin`. Both symbols are hooked because a whole-kernel-LTO build can inline
+`sock_setsockopt` into `__sys_setsockopt`, leaving `sk_setsockopt` the only symbol
+on the syscall path — and the wrapper must not trust the ABI `level` argument
+(LTO drops it as dead, since `sk_setsockopt` never reads it), because reaching
+either function already proves the call is `SOL_SOCKET`. Both freeze the 5.9+
+`sockptr_t` input before validation to close userspace TOCTOU. On 5.7-5.8, KPM instead hooks the resolved-ifindex mutation
 helper; if LTO removes that static symbol, status is deliberately partial.
 Before 5.7, the kernel itself rejects the first interface bind without
 `CAP_NET_RAW`, and KPM preserves that native result exactly rather than adding

--- a/docs/diagnostics.md
+++ b/docs/diagnostics.md
@@ -146,6 +146,7 @@ ordinary libc-routed probes but not raw syscalls or aliases. Full hiding matrix 
 | `ioctl_flags`, `ioctl_mtu` | `SIOCGIF*` by name | `dev_ioctl` | ENODEV for tun0 |
 | `ioctl_conf` | `SIOCGIFCONF` | `sock_ioctl` | tun0 absent from ifconf |
 | `getifaddrs`, `netlink_getlink` | RTM_GETLINK / getifaddrs | `rtnl_fill_ifinfo`, `inet*_fill_ifaddr` | |
+| `so_bindtodevice` | `setsockopt(SO_BINDTODEVICE, tun0)` | `socket_bind_interface` | ENODEV = hidden; a bind that succeeds *and* `getsockopt` echoes `tun0` = leak |
 | `netlink_getroute` | RTM_GETROUTE v4/v6 | `fib_dump_info`, `rt6_fill_node` | |
 | `netlink_getrule` | RTM_GETRULE policy rules | `fib_nl_fill_rule` | v4+v6; kernel-only vector |
 | `proc_route` | `/proc/net/route` | `fib_route_seq_show` | main table — empty for split-tunnel VPN |
@@ -155,16 +156,20 @@ ordinary libc-routed probes but not raw syscalls or aliases. Full hiding matrix 
 | `sys_class_net` | `/sys/class/net` | `filesystem_iface_paths` (`.ko`/KPM/Zygisk, optional) | kernel: resolved-dentry and reboot-gated; Zygisk: best-effort libc and restart-gated |
 | `proc_sys_net` | `/proc/sys/net/*/{conf,neigh}` | `filesystem_iface_paths` (`.ko`/KPM/Zygisk, optional) | kernel: resolved-dentry and reboot-gated; Zygisk: best-effort libc and restart-gated |
 
-`socket_bind_interface` intentionally has no app-process root-differential row
-yet. An honest test needs the hidden interface name/index from the root view,
-must pass that exact value into the already-targeted app process, and then must
-inspect the socket from a non-target UID; simply checking the returned errno
-would bless the broken return-only implementation this hook was designed to
-avoid. The QEMU `bind-probe` performs that full state-level test with a raw
-syscall and an inherited socket. Runtime hits still appear in Statistics.
-The Zygisk fallback has a separate `zygisk_setsockopt` hook for libc-routed
-calls, but the raw diagnostic probe bypasses it by design; Zygisk does not emit
-per-hook statistics yet.
+The `so_bindtodevice` check probes this vector from the app process —
+`setsockopt(SO_BINDTODEVICE, "tun0")`, classified by the same root differential.
+To avoid blessing a broken return-only implementation on errno alone, a bind is a
+leak **only** when it takes: `getsockopt` must echo `tun0` back (so a hook that
+returns 0 without binding — or the kernel's own capability block — is not a false
+positive), while `ENODEV` is the backend's pre-mutation denial. This catches the
+common failure (a bindable VPN interface), but a single process cannot verify the
+*pre-mutation* property itself — that the socket was never bound before `ENODEV`.
+The QEMU `bind-probe` still performs that full state-level test with a raw syscall
+and a second, non-target UID inspecting the inherited socket. Runtime deny hits
+also appear in Statistics. Zygisk has its own libc-routed `zygisk_setsockopt` hook
+but does not claim this vector in its owned-hook mask (so a leak here reads as an
+unowned surface under Zygisk, not a tile failure) and emits no per-hook statistics
+yet.
 
 Java-level checks (LSPosed) cover the framework side — `hasTransport(VPN)`,
 `NET_CAPABILITY_NOT_VPN`, `VpnTransportInfo`, `getAllNetworks`, `LinkProperties`,

--- a/docs/lsposed-hook-debugging.md
+++ b/docs/lsposed-hook-debugging.md
@@ -67,18 +67,18 @@ vpnhide 1 stats         # per-uid per-hook fire counters
 0x27fe 0xa:0x1 0xb:0x1 0xd:0x1 0xe:0x1 0x10:0xc
 ```
 
-It reaches a debug bundle **two ways**, both via a root read (`emit_file` in
-`DebugShellSnapshot.kt`):
+It reaches a debug bundle **two ways** (the bundle is a single `state.json`
+packed in the export zip; the state file is read as root into the snapshot):
 
-- **`hook_report.txt`** — parsed and rendered (status mask, `metadata:` block,
-  installed/missing hooks, counter deltas). This is what you normally read.
-- **`debug_capture.txt`** — the raw file verbatim, under "LSPosed hook state".
+- the **`hookReport`** field — parsed and rendered (status mask, `metadata:`
+  block, installed/missing hooks, counter deltas). This is what you normally read.
+- the raw file verbatim, in the **`sections.lsposed_state`** entry.
 
 Because the read is root-backed and the file is always written, `cs_*` telemetry
 lands in the bundle **even with debug logging off**. Debug logging only enriches
 the *logcat* portions of the bundle.
 
-## 3. Reading `hook_report.txt` (the LSPOSED section)
+## 3. Reading the `hookReport` field (the LSPOSED section)
 
 ```
 LSPOSED:
@@ -163,7 +163,7 @@ The install runs at early boot with debug logging **off** (the flag is read that
 early and defaults false), so the `HookLog.i` install lines are never emitted;
 and even when emitted they are gone by report time (ring-buffer rotation). This
 was confirmed on a *working* device: debug on, zero install lines in logcat, yet
-hooks attached. Always use the state file / `hook_report.txt`, not logcat, to
+hooks attached. Always use the state file / the `hookReport` field, not logcat, to
 answer "did the hooks attach".
 
 ## 7. Collecting a report (users / testers)
@@ -182,7 +182,7 @@ Steps:
 3. Diagnostics → **Collect debug logs** → send the zip.
 
 Debug logging does **not** need to be on for `cs_*` — it only adds the logcat
-sections. Open `hook_report.txt` and read §3–§5.
+sections. Open the bundle's `hookReport` field and read §3–§5.
 
 ## 8. The attach mechanism (developers)
 

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/AgentControl.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/AgentControl.kt
@@ -199,7 +199,7 @@ internal object AgentControl {
     /**
      * Import canonical JSON and immediately activate native/ports runtime state.
      *
-     * @param json Canonical JSON as produced by exportCanonicalConfig.
+     * @param json Canonical config JSON (the `/data/system/vpnhide_config.json` format).
      */
     suspend fun importCanonicalConfig(
         context: Context,

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/LsposedState.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/LsposedState.kt
@@ -209,8 +209,8 @@ internal object LsposedStats {
             meta[LsposedStateMetadata.INSTALL_FAILURES] = failures.joinToString("; ")
         }
         // cs_* connectivity attach telemetry (resolved class, classloader chain,
-        // path, per-method hooked counts, attempt log). hook_report.txt renders
-        // every meta key, so these appear automatically in a debug bundle.
+        // path, per-method hooked counts, attempt log). The rendered hookReport
+        // emits every meta key, so these appear automatically in a debug bundle.
         meta.putAll(connectivityMeta)
         return meta
     }


### PR DESCRIPTION
Audited the docs against current code after the recent diagnostics refactor (single `state.json` bundle, one `getState` bridge) and the SO_BINDTODEVICE fix. Most docs were already current; these three had genuinely stale content, plus two stale code comments.

- `docs/diagnostics.md`: added the missing `so_bindtodevice` row to the check→hook table, and rewrote the socket-bind paragraph that still claimed the vector "intentionally has no app-process root-differential row yet" — the check exists now (setsockopt probe, `getsockopt`-confirmed leak, root differential), with the QEMU `bind-probe` kept as the deeper pre-mutation state-level test.
- `docs/detection-vectors.md`: clarified why both `sock_setsockopt` and `sk_setsockopt` are hooked (a whole-kernel-LTO build can inline `sock_setsockopt` away, leaving `sk_setsockopt` the only symbol on the syscall path) and that the wrapper must not trust the ABI `level` argument (LTO drops it) — the reasoning behind the recent leak fix.
- `docs/lsposed-hook-debugging.md`: the debug bundle is one `state.json` now, not separate `.txt` files — `hook_report.txt` → the `hookReport` field, the raw block → `sections.lsposed_state`.
- Two stale code comments: a `@param` referencing the removed `exportCanonicalConfig` bridge endpoint, and a `hook_report.txt` mention.

Verified with parallel audits that the remaining docs (state, storage, protocol, limits, adb-root, releasing, changelog, kmod/BUILDING, lsposed/AGENTS, agent-mcp README, development, CONTRIBUTING, all module READMEs) are current.