### PR TITLE
feat(diagnostics): unify the VPN routing gate; warn before incomplete captures

### DIFF
--- a/changelog.d/added-warn-before-collecting-a-debug-log-542a.md
+++ b/changelog.d/added-warn-before-collecting-a-debug-log-542a.md
@@ -1,0 +1,9 @@
+_2026-08-20_
+
+## English
+
+Warn before collecting a debug log or logcat recording while the VPN is off or VPN Hide is not routed through the tunnel — such captures are incomplete and hard to diagnose. Offers to re-check or proceed anyway.
+
+## Русский
+
+Предупреждение перед сбором отладочного лога или записью logcat, если VPN выключен или VPN Hide не пропущен через туннель — такие логи неполные и плохо помогают диагностике. Можно перепроверить или всё равно собрать.

--- a/changelog.d/changed-the-vpn-tunnel-check-is-now-07ae.md
+++ b/changelog.d/changed-the-vpn-tunnel-check-is-now-07ae.md
@@ -1,0 +1,9 @@
+_2026-08-20_
+
+## English
+
+The VPN-tunnel check is now shared across the whole app — re-checking in one place updates every screen, and Diagnostics now reacts automatically when you turn the VPN on or off.
+
+## Русский
+
+Проверка VPN-туннеля теперь общая для всего приложения: повтор в одном месте обновляет все экраны, а диагностика сама реагирует на включение и выключение VPN.

--- a/changelog.d/fixed-settings-switches-no-longer-flicker-off-52bf.md
+++ b/changelog.d/fixed-settings-switches-no-longer-flicker-off-52bf.md
@@ -1,0 +1,9 @@
+_2026-08-20_
+
+## English
+
+Settings switches no longer flicker off/on while a debug log is being collected, and the debug-export sheet no longer keeps a stale collected file when reopened.
+
+## Русский
+
+Переключатели в настройках больше не мигают во время сбора отладочного лога, а окно экспорта при повторном открытии не сохраняет прошлый собранный файл.

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/AgentControl.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/AgentControl.kt
@@ -457,14 +457,14 @@ private suspend fun currentCanonicalConfig(refresh: Boolean): CanonicalConfig {
         ?: buildCanonicalConfigFromTargetsSnapshot(snapshot)
 }
 
-private fun applyCanonicalConfig(
+private suspend fun applyCanonicalConfig(
     context: Context,
     canonical: CanonicalConfig,
     targetRestartRecommended: Boolean = true,
 ): AgentMutationResult {
     val next = canonicalConfigWithSelfTarget(canonical, context.packageName)
     val write =
-        CanonicalConfigRepository.persist(
+        CanonicalConfigRepository.commit(
             next,
             activation = CanonicalActivation(native = true, ports = true),
         )

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/AppPickerScreen.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/AppPickerScreen.kt
@@ -374,7 +374,7 @@ private fun HelpInfoBlock(
  * running the installed activator; LSPosed reads the JSON directly; the ports
  * activator derives its observer set from the same JSON.
  */
-private fun persistUnifiedSelection(
+private suspend fun persistUnifiedSelection(
     ctx: SaveContext,
     selections: Collection<AppRoleSelection>,
     autoHideSignals: Collection<AppAutoHideSignal>,
@@ -387,7 +387,7 @@ private fun persistUnifiedSelection(
             snapshot = TargetsCache.snapshot.value,
             autoHideSignals = autoHideSignals,
         )
-    return CanonicalConfigRepository.persist(
+    return CanonicalConfigRepository.commit(
         canonical,
         activation = CanonicalActivation(native = true, ports = true),
     )

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/CanonicalConfigRepository.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/CanonicalConfigRepository.kt
@@ -1,5 +1,10 @@
 package dev.okhsunrog.vpnhide
 
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.withContext
+
 /** Runtime channels that must be re-derived after the canonical config changes. */
 internal data class CanonicalActivation(
     val native: Boolean = true,
@@ -40,23 +45,32 @@ internal fun buildCanonicalPersistenceCommand(
  * system_server and native readers.
  */
 internal object CanonicalConfigRepository {
-    @Synchronized
-    fun persist(
+    private val writeMutex = Mutex()
+
+    suspend fun commit(
         config: CanonicalConfig,
         coupledCommands: List<String> = emptyList(),
         activation: CanonicalActivation = CanonicalActivation(),
         timeoutSec: Long = SU_DEFAULT_TIMEOUT_SEC,
-    ): CanonicalWriteResult {
-        val command = buildCanonicalPersistenceCommand(config, coupledCommands, activation)
-        val (exit, output) = suExec(command, timeoutSec)
-        if (exit == 0) invalidateCanonicalConfigCaches()
-        return CanonicalWriteResult(exit, output)
-    }
-}
+    ): CanonicalWriteResult =
+        writeMutex.withLock {
+            val command = buildCanonicalPersistenceCommand(config, coupledCommands, activation)
+            val (exit, output) = withContext(Dispatchers.IO) { suExec(command, timeoutSec) }
+            if (exit == 0) refreshDerivedCaches()
+            CanonicalWriteResult(exit, output)
+        }
 
-private fun invalidateCanonicalConfigCaches() {
-    RootSnapshotCache.invalidate()
-    TargetsCache.invalidate()
-    DashboardCache.invalidate()
-    StatisticsCache.invalidate()
+    // Reload each derived cache in place — swap old→new, so no observer sees a null blank
+    // between the write and the reload (the toggle-flicker fix). Root first: the others
+    // derive from it and reuse it via force=false. Failures keep the stale value.
+    internal suspend fun refreshDerivedCaches() {
+        runCatching { RootSnapshotCache.refresh() }
+        runCatching { TargetsCache.refreshInPlace(force = false) }
+        runCatching { DashboardCache.refreshInPlace(force = false) }
+        runCatching { StatisticsCache.refreshInPlace(force = false) }
+        // Tolerates RoutingGateCache not being initialized yet (load() throws on a
+        // null appContext before any screen has called ensureLoaded/refresh) — a
+        // config write racing app startup should not crash the write itself.
+        runCatching { RoutingGateCache.refreshInPlace(force = false) }
+    }
 }

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/ConfigChannels.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/ConfigChannels.kt
@@ -73,7 +73,7 @@ internal fun runRuntimeConfigReconcile() {
  * nothing. Best-effort, blocking; call from a background dispatcher. Returns
  * true when it wrote (and re-activated) a new config.
  */
-internal fun reconcileAutoHiddenPackages(
+internal suspend fun reconcileAutoHiddenPackages(
     context: Context,
     config: CanonicalConfig,
     signals: Collection<AppAutoHideSignal>,
@@ -81,7 +81,7 @@ internal fun reconcileAutoHiddenPackages(
     val selfPkg = context.packageName
     if (!autoHiddenPackagesNeedReconcile(config, selfPkg, signals)) return false
     val next = applyAutoHiddenPackages(config, selfPkg, signals)
-    val result = CanonicalConfigRepository.persist(next)
+    val result = CanonicalConfigRepository.commit(next)
     if (!result.succeeded) {
         VpnHideLog.w(
             LogTags.STARTUP,

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DashboardScreen.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DashboardScreen.kt
@@ -123,6 +123,24 @@ fun DashboardScreen(
         return
     }
 
+    // Routed but no tiles yet: the app was opened with the VPN off (checks never ran),
+    // then the VPN came up. We have no routed protection to show, so refresh and render
+    // the same full-screen skeleton as the initial load — ABOVE the scrolling Column,
+    // because the skeleton scrolls itself and must not nest inside another vertical
+    // scroll. Never flash the now-wrong "VPN off" hero. (The common toggle case keeps
+    // its Checked tiles via the sticky DiagnosticsCache, so it never lands here.)
+    val gateState = state
+    if (gateState != null && loadError == null &&
+        liveGate == DiagnosticGate.ROUTED && gateState.protection !is ProtectionCheck.Checked
+    ) {
+        LaunchedEffect(Unit) {
+            DashboardCache.refresh(scope, context, selfNeedsRestart)
+            DiagnosticsCache.retry(scope, context, selfNeedsRestart)
+        }
+        DashboardLoadingState(modifier = modifier)
+        return
+    }
+
     Column(
         modifier =
             modifier
@@ -171,23 +189,13 @@ fun DashboardScreen(
         val loadedState = s ?: return@Column
 
         // Overlay the live gate onto the cached protection: a live block (VPN off /
-        // self-not-routed / needs-restart) always wins over whatever DashboardCache
-        // last measured. When the live gate says ROUTED, fall back to the cached
-        // protection — either it's already Checked (the common case), or it's a stale
-        // Blocked/Failed left over from before the VPN came up, in which case the
-        // effect below refreshes it and the cached value updates in place once the
-        // refresh lands (no separate "refreshing" placeholder needed: the stale
-        // banner/hero just holds for the brief refresh window, matching the existing
-        // loading/skeleton treatment elsewhere in this screen).
+        // self-not-routed / needs-restart) always wins over whatever DashboardCache last
+        // measured, so the hero/prompt react to a VPN toggle immediately. The ROUTED-but-
+        // no-tiles-yet case is handled above the scroll container (full-screen skeleton),
+        // so here the live gate is either a block or ROUTED with Checked tiles.
         val effectiveProtection: ProtectionCheck =
             liveGate?.blockedOrNull()?.let { ProtectionCheck.Blocked(it) } ?: loadedState.protection
         val effectiveState = loadedState.copy(protection = effectiveProtection)
-        LaunchedEffect(liveGate) {
-            if (liveGate == DiagnosticGate.ROUTED && loadedState.protection !is ProtectionCheck.Checked) {
-                DashboardCache.refresh(scope, context, selfNeedsRestart)
-                DiagnosticsCache.retry(scope, context, selfNeedsRestart)
-            }
-        }
 
         // Messages split by severity. Only errors/warnings affect the hero:
         // info messages are neutral notes rendered below without changing the

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DashboardScreen.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DashboardScreen.kt
@@ -65,6 +65,10 @@ fun DashboardScreen(
     val state by DashboardCache.state.collectAsState()
     val loadError by DashboardCache.error.collectAsState()
     val updateInfo by UpdateCheckCache.info.collectAsState()
+    // The LIVE gate — kept fresh by VpnTransportWatcher on every VPN transport change —
+    // overlays onto the cached DashboardCache.state.protection below so the hero and the
+    // blocked-prompt react to a VPN toggling on/off without waiting for a manual refresh.
+    val liveGate by RoutingGateCache.gate.collectAsState()
     var showChangelog by remember { mutableStateOf(false) }
     var changelogData by remember { mutableStateOf<ChangelogData?>(null) }
     var showContact by remember { mutableStateOf(false) }
@@ -166,6 +170,25 @@ fun DashboardScreen(
         }
         val loadedState = s ?: return@Column
 
+        // Overlay the live gate onto the cached protection: a live block (VPN off /
+        // self-not-routed / needs-restart) always wins over whatever DashboardCache
+        // last measured. When the live gate says ROUTED, fall back to the cached
+        // protection — either it's already Checked (the common case), or it's a stale
+        // Blocked/Failed left over from before the VPN came up, in which case the
+        // effect below refreshes it and the cached value updates in place once the
+        // refresh lands (no separate "refreshing" placeholder needed: the stale
+        // banner/hero just holds for the brief refresh window, matching the existing
+        // loading/skeleton treatment elsewhere in this screen).
+        val effectiveProtection: ProtectionCheck =
+            liveGate?.blockedOrNull()?.let { ProtectionCheck.Blocked(it) } ?: loadedState.protection
+        val effectiveState = loadedState.copy(protection = effectiveProtection)
+        LaunchedEffect(liveGate) {
+            if (liveGate == DiagnosticGate.ROUTED && loadedState.protection !is ProtectionCheck.Checked) {
+                DashboardCache.refresh(scope, context, selfNeedsRestart)
+                DiagnosticsCache.retry(scope, context, selfNeedsRestart)
+            }
+        }
+
         // Messages split by severity. Only errors/warnings affect the hero:
         // info messages are neutral notes rendered below without changing the
         // overall "Protected" state or issue count.
@@ -174,7 +197,7 @@ fun DashboardScreen(
         val infos = loadedState.messages.filter { it.severity == DashboardMessageSeverity.INFO }
 
         // Hero: the whole setup's health at a glance.
-        DashboardHeroCard(state = loadedState, errorCount = errors.size, warningCount = warnings.size)
+        DashboardHeroCard(state = effectiveState, errorCount = errors.size, warningCount = warnings.size)
 
         // Critical protection states sit right under the hero (not in a separate
         // mid-screen section): the VPN needs turning on, or a self-restart is
@@ -184,11 +207,15 @@ fun DashboardScreen(
         // Per-layer verdict (Checked) renders in the cards below; only a blocked gate
         // shows a hero banner. Retry re-reads dashboard state (re-runs its own VPN +
         // protection probes) and re-runs the diag cache so both screens recover together.
+        // One re-check drives every surface: RoutingGateCache.refresh so the export
+        // sheet / logcat card banners update immediately too, plus the two caches
+        // that actually re-derive their own state off the (now shared) gate.
         val onRetry = {
+            RoutingGateCache.refresh(scope, context, selfNeedsRestart)
             DashboardCache.refresh(scope, context, selfNeedsRestart)
             DiagnosticsCache.retry(scope, context, selfNeedsRestart)
         }
-        val protection = loadedState.protection
+        val protection = effectiveProtection
         when {
             (protection as? ProtectionCheck.Blocked)?.gate == DiagnosticGate.VPN_OFF -> {
                 Spacer(Modifier.height(12.dp))

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DebugCaptureLogging.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DebugCaptureLogging.kt
@@ -159,7 +159,7 @@ private suspend fun applyCanonicalDebugToggle(
     val canonical = debugToggledCanonicalConfig(resolvedSnapshot, enabled)
     if (canonical == null) {
         VpnHideLog.enabled = enabled
-        invalidateDebugCaptureState()
+        refreshDebugCaptureState()
         delay(DEBUG_CAPTURE_OBSERVER_DELAY_MS)
         return DebugCaptureLoggingStep(
             requestedEnabled = enabled,
@@ -170,10 +170,10 @@ private suspend fun applyCanonicalDebugToggle(
         )
     }
 
-    val result = CanonicalConfigRepository.persist(canonical)
+    val result = CanonicalConfigRepository.commit(canonical)
 
     VpnHideLog.enabled = enabled
-    invalidateDebugCaptureState()
+    refreshDebugCaptureState()
     delay(DEBUG_CAPTURE_OBSERVER_DELAY_MS)
     return DebugCaptureLoggingStep(
         requestedEnabled = enabled,
@@ -200,8 +200,10 @@ internal fun debugToggledCanonicalConfig(
             runCatching { parseCanonicalConfig(it) }.getOrNull()
         }?.copy(debug = enabled)
 
-private fun invalidateDebugCaptureState() {
-    RootSnapshotCache.invalidate()
-    TargetsCache.invalidate()
-    DashboardCache.invalidate()
+// Atomic refresh (not invalidate): after commit() already refreshed the caches in
+// place, dropping to null here would just re-open the flicker window this whole
+// change exists to close. In the canonical == null fallback path (no persist ran)
+// this refresh is the coherence step instead.
+private suspend fun refreshDebugCaptureState() {
+    CanonicalConfigRepository.refreshDerivedCaches()
 }

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DebugExport.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DebugExport.kt
@@ -102,12 +102,8 @@ private suspend fun buildDebugState(
         val session = loggingSession?.let { it.withRestore(restoreDebugCaptureLogging(it)) }
         restoreAttempted = true
 
-        val gate =
-            resolveDiagnosticGate(
-                vpnActive = isVpnActive(),
-                selfRouted = GroundTruthProbe.selfRoutedThroughVpn(context),
-                selfNeedsRestart = selfNeedsRestart,
-            )
+        // Same gate the collect-warning shows, off the snapshot just refreshed above.
+        val gate = captureGateFrom(rootSnapshot, context, selfNeedsRestart)
         buildVpnHideState(
             context = context,
             captureKind = "debug",
@@ -143,6 +139,26 @@ private suspend fun buildDebugState(
 
 /** ISO-8601 timestamp for [VpnHideState.generatedAt] (the serializer has no clock). */
 internal fun isoNow(): String = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssZ", Locale.US).format(Date())
+
+/**
+ * The gate that decides whether a debug/logcat capture taken *right now* would be
+ * meaningful, computed from a root snapshot. The ONE place both the export and the
+ * pre-collect warning derive it, so they can never disagree. Cheap and stateless —
+ * a VPN-iface read plus one self-routing probe — and independent of the
+ * once-per-process [DiagnosticsCache]; that cache freezes its verdict on the first
+ * run (typically with the VPN up), which is exactly why it must NOT back a "is a
+ * capture worth taking now" check.
+ */
+internal fun captureGateFrom(
+    snapshot: RootSnapshot,
+    context: Context,
+    selfNeedsRestart: Boolean,
+): DiagnosticGate =
+    resolveDiagnosticGate(
+        vpnActive = isVpnActiveFromSnapshot(snapshot.sections["vpn_ifaces"].orEmpty()),
+        selfRouted = GroundTruthProbe.selfRoutedThroughVpn(context),
+        selfNeedsRestart = selfNeedsRestart,
+    )
 
 /**
  * Pack a ZIP: named text entries + raw file entries. The one packaging primitive for

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DebugLoggingPrefs.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DebugLoggingPrefs.kt
@@ -37,7 +37,7 @@ internal suspend fun setDebugLoggingEnabled(enabled: Boolean) {
             )
             ?: return
 
-    val result = CanonicalConfigRepository.persist(canonical)
+    val result = CanonicalConfigRepository.commit(canonical)
     if (!result.succeeded) {
         VpnHideLog.e(
             TAG,

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DiagnosticReport.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DiagnosticReport.kt
@@ -44,6 +44,10 @@ internal fun resolveDiagnosticGate(
         else -> DiagnosticGate.ROUTED
     }
 
+/** The blocking gate to surface, or null when ROUTED (measurement is meaningful). */
+internal fun DiagnosticGate.blockedOrNull(): DiagnosticGate? =
+    takeIf { it == DiagnosticGate.VPN_OFF || it == DiagnosticGate.SELF_NOT_ROUTED || it == DiagnosticGate.NEEDS_RESTART }
+
 /**
  * One fully-classified check: the root-differential [outcome] plus the evidence
  * behind it — the app-view [appDetail], the root [groundTruthDetail] (native

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DiagnosticsCache.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DiagnosticsCache.kt
@@ -168,24 +168,23 @@ internal object DiagnosticsCache {
         _state.value = State.Running
         try {
             StartupTrace.mark("diagnostics_cache_start")
-            // Probe lazily and fold each decision through the one shared classifier
-            // ([resolveDiagnosticGate]) so the live path, the debug export, and the
-            // dashboard all order the gate identically. selfNeedsRestart is false
-            // here — callers pre-gate on it, so this path is only reached when it is.
-            val vpnActive = withContext(Dispatchers.IO) { isVpnActive() }
-            if (!vpnActive) {
-                _state.value = State.Blocked(resolveDiagnosticGate(vpnActive = false, selfRouted = null, selfNeedsRestart = false))
-                StartupTrace.mark("diagnostics_cache_vpn_off")
-                return
+            // The gate now comes from the shared RoutingGateCache (folded through the
+            // same resolveDiagnosticGate / captureGateFrom every other surface uses),
+            // so the live path, the debug export, and the dashboard can never disagree
+            // about VPN-off / self-not-routed / routed. selfNeedsRestart=false below is
+            // safe — run()'s restartPending guard already ensures doRun is only reached
+            // once every caller reporting into this cache has reported false.
+            RoutingGateCache.ensureLoaded(cacheScope, appContext, selfNeedsRestart = false)
+            withContext(Dispatchers.IO) { RoutingGateCache.refreshInPlace(force = true) }
+            val gate = RoutingGateCache.gate.value
+            if (gate == null) {
+                throw IllegalStateException(RoutingGateCache.error.value ?: "routing gate unavailable")
             }
-            // Self-in-tunnel gate: a VPN is up, but is *this* app routed through it?
-            // A null answer (no root to tell) does not block — a no-root device is
-            // already handled as VPN-off above.
-            val selfRouted = withContext(Dispatchers.IO) { GroundTruthProbe.selfRoutedThroughVpn(appContext) }
-            val gate = resolveDiagnosticGate(vpnActive = true, selfRouted = selfRouted, selfNeedsRestart = false)
             if (gate != DiagnosticGate.ROUTED) {
                 _state.value = State.Blocked(gate)
-                StartupTrace.mark("diagnostics_cache_self_not_routed")
+                StartupTrace.mark(
+                    if (gate == DiagnosticGate.VPN_OFF) "diagnostics_cache_vpn_off" else "diagnostics_cache_self_not_routed",
+                )
                 return
             }
             val cm = appContext.getSystemService(ConnectivityManager::class.java)

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DiagnosticsScreen.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DiagnosticsScreen.kt
@@ -72,6 +72,11 @@ fun DiagnosticsScreen(
     // so each check can be shown against the vectors the backend actually OWNS. Null
     // until the dashboard has loaded (then we fall back to the raw, ownership-less list).
     val dashState by DashboardCache.state.collectAsState()
+    // The LIVE gate — kept fresh by VpnTransportWatcher on every VPN transport change —
+    // decides which blocking banner to show. DiagnosticsCache's own gate (inside
+    // State.Blocked) is process-sticky and only re-derived on an explicit retry, so it
+    // must not drive the banner here (see the module doc on RoutingGateCache).
+    val liveGate by RoutingGateCache.gate.collectAsState()
     val tallyFmt = stringResource(R.string.diag_summary_tally)
 
     // Kick off the diagnostics run once per process. The cache parks at
@@ -82,10 +87,23 @@ fun DiagnosticsScreen(
         // Ensure the backend/ownership state is available even when the user opens
         // Diagnostics without visiting the Dashboard first (cheap no-op if cached).
         DashboardCache.ensureLoaded(scope, context, selfNeedsRestart)
+        // Same belt-and-suspenders init as DashboardCache above: usually already
+        // seeded by StartupCoordinator.ensureInitialCaches, but a cheap no-op here
+        // guarantees the shared gate is ready even if Diagnostics is opened first.
+        RoutingGateCache.ensureLoaded(scope, context, selfNeedsRestart)
+    }
+    // The live gate is the trigger to (re)compute the frozen check results: once the
+    // VPN comes up (or this app becomes routed), the results must be measured even if
+    // DiagnosticsCache is still sitting on a stale Blocked/Failed from before. run() is
+    // idempotent — a no-op on an already-complete Ready — so this is cheap on every
+    // recomposition where liveGate hasn't changed.
+    LaunchedEffect(liveGate) {
+        if (liveGate == DiagnosticGate.ROUTED) {
+            DiagnosticsCache.run(scope, context, selfNeedsRestart)
+        }
     }
 
     val results = (diagState as? DiagnosticsCache.State.Ready)?.results
-    val blockedGate = (diagState as? DiagnosticsCache.State.Blocked)?.gate
     // Native probes that couldn't run (ECONNREFUSED from socket()) classify as
     // NotMeasured(NoNetworkPermission). Java-level checks never produce that state,
     // so this isolates the "app has no network permission" banner from everything else.
@@ -100,12 +118,27 @@ fun DiagnosticsScreen(
     ) {
         Spacer(Modifier.height(8.dp))
 
+        // One re-check drives every surface: RoutingGateCache.refresh so the export
+        // sheet / logcat card banners update immediately too, plus the two caches
+        // that actually re-derive their own state off the (now shared) gate.
         val onRetry = {
+            RoutingGateCache.refresh(scope, context, selfNeedsRestart)
             DiagnosticsCache.retry(scope, context, selfNeedsRestart)
             DashboardCache.refresh(scope, context, selfNeedsRestart)
         }
         when {
-            blockedGate == DiagnosticGate.NEEDS_RESTART -> {
+            // Still probing (first load, or a re-check in flight before the shared gate
+            // has a value yet).
+            liveGate == null -> {
+                Box(
+                    modifier = Modifier.fillMaxWidth().padding(vertical = 32.dp),
+                    contentAlignment = Alignment.Center,
+                ) {
+                    CircularProgressIndicator()
+                }
+            }
+
+            liveGate == DiagnosticGate.NEEDS_RESTART -> {
                 StatusBanner(
                     text = stringResource(R.string.banner_added_self),
                     containerColor = MaterialTheme.colorScheme.tertiaryContainer,
@@ -113,20 +146,25 @@ fun DiagnosticsScreen(
                 )
             }
 
-            blockedGate == DiagnosticGate.VPN_OFF -> {
+            liveGate == DiagnosticGate.VPN_OFF -> {
                 VpnOffPrompt(onRetry = onRetry)
             }
 
-            blockedGate == DiagnosticGate.SELF_NOT_ROUTED -> {
+            liveGate == DiagnosticGate.SELF_NOT_ROUTED -> {
                 SelfNotRoutedPrompt(onRetry = onRetry)
             }
 
+            // ROUTED: the live gate says the measurement is meaningful — render from
+            // DiagnosticsCache's own (frozen, process-scoped) results exactly as before.
             diagState is DiagnosticsCache.State.Failed -> {
                 DiagnosticsFailedPrompt(onRetry = onRetry)
             }
 
             diagState is DiagnosticsCache.State.Running ||
-                diagState is DiagnosticsCache.State.NotRun -> {
+                diagState is DiagnosticsCache.State.NotRun ||
+                diagState is DiagnosticsCache.State.Blocked -> {
+                // Transitional: the LaunchedEffect(liveGate) above already kicked off
+                // (or will kick off) a run now that the gate is ROUTED.
                 Box(
                     modifier = Modifier.fillMaxWidth().padding(vertical = 32.dp),
                     contentAlignment = Alignment.Center,
@@ -206,26 +244,12 @@ private fun rememberZipSaveLauncher(
     }
 }
 
-@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun DebugToolsSection(
     selfNeedsRestart: Boolean?,
     modifier: Modifier = Modifier,
 ) {
-    val context = LocalContext.current
-    val cm = context.getSystemService(ConnectivityManager::class.java)
-    val scope = rememberCoroutineScope()
-    var exporting by remember { mutableStateOf(false) }
     var showModal by remember { mutableStateOf(false) }
-    var resultFile by remember { mutableStateOf<File?>(null) }
-
-    // One export recipe, shared with the agent bridge's getState.
-    var optForensics by remember { mutableStateOf(true) }
-    var optAppList by remember { mutableStateOf(false) }
-    var optKernelImage by remember { mutableStateOf(false) }
-
-    // Every export kind is now a .zip (carrying state.json), so one MIME type fits all.
-    val saveLauncher = rememberZipSaveLauncher("debug-export") { resultFile }
 
     Column(modifier = modifier.fillMaxWidth()) {
         EnhancedCard(
@@ -263,110 +287,186 @@ fun DebugToolsSection(
 
         Spacer(Modifier.height(16.dp))
 
+        // The logcat card measures its own gate (persistent while the card is shown).
         LogcatRecordCard(selfNeedsRestart = selfNeedsRestart)
     }
 
     if (showModal) {
-        // Changing any toggle invalidates a result produced with the old recipe.
-        val clearResult = { resultFile = null }
-        ModalBottomSheet(onDismissRequest = { if (!exporting) showModal = false }) {
-            Column(
-                modifier =
-                    Modifier
-                        .fillMaxWidth()
-                        .padding(horizontal = 24.dp)
-                        .padding(bottom = 24.dp),
-            ) {
-                Text(
-                    text = stringResource(R.string.debug_export_modal_title),
-                    style = MaterialTheme.typography.titleMedium,
-                    fontWeight = FontWeight.Bold,
+        DebugExportSheet(selfNeedsRestart = selfNeedsRestart, onDismiss = { showModal = false })
+    }
+}
+
+/**
+ * The debug-export bottom sheet's own composable, so every piece of its state — the
+ * collected file, the option toggles, and the capture gate — lives in the sheet's own
+ * composition scope instead of the section's. Called only from `if (showModal)`, it is
+ * torn down on dismiss and rebuilt fresh on the next open: a reopened sheet never shows
+ * a stale collected file, a stale Save/Share row, or stale toggle choices left over from
+ * the previous run.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun DebugExportSheet(
+    selfNeedsRestart: Boolean?,
+    onDismiss: () -> Unit,
+) {
+    val context = LocalContext.current
+    val cm = context.getSystemService(ConnectivityManager::class.java)
+    val scope = rememberCoroutineScope()
+    var exporting by remember { mutableStateOf(false) }
+    var resultFile by remember { mutableStateOf<File?>(null) }
+
+    // One export recipe, shared with the agent bridge's getState.
+    var optForensics by remember { mutableStateOf(true) }
+    var optAppList by remember { mutableStateOf(false) }
+    var optKernelImage by remember { mutableStateOf(false) }
+
+    // Every export kind is now a .zip (carrying state.json), so one MIME type fits all.
+    val saveLauncher = rememberZipSaveLauncher("debug-export") { resultFile }
+
+    // Changing any toggle invalidates a result produced with the old recipe.
+    val clearResult = { resultFile = null }
+    // Recreated with this composable, so a reopened sheet never flashes the previous
+    // verdict while a fresh probe runs (e.g. user closed the blocked sheet, turned the
+    // VPN on, reopened). rememberCaptureGate re-measures on first composition = on open.
+    val gate = rememberCaptureGate(selfNeedsRestart)
+    val incompleteGate = gate.incompleteGate
+    val rechecking = gate.rechecking
+    val onRecheck = gate.recheck
+    ModalBottomSheet(onDismissRequest = { if (!exporting) onDismiss() }) {
+        Column(
+            modifier =
+                Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 24.dp)
+                    .padding(bottom = 24.dp),
+        ) {
+            Text(
+                text = stringResource(R.string.debug_export_modal_title),
+                style = MaterialTheme.typography.titleMedium,
+                fontWeight = FontWeight.Bold,
+            )
+            Spacer(Modifier.height(12.dp))
+            ExportToggle(
+                title = stringResource(R.string.debug_export_opt_forensics),
+                description = stringResource(R.string.debug_export_opt_forensics_desc),
+                checked = optForensics,
+                enabled = !exporting,
+                onCheckedChange = {
+                    optForensics = it
+                    clearResult()
+                },
+            )
+            ExportToggle(
+                title = stringResource(R.string.debug_export_opt_applist),
+                description = stringResource(R.string.debug_export_opt_applist_desc),
+                checked = optAppList && optForensics,
+                enabled = optForensics && !exporting,
+                onCheckedChange = {
+                    optAppList = it
+                    clearResult()
+                },
+            )
+            ExportToggle(
+                title = stringResource(R.string.debug_export_opt_kernel),
+                description = stringResource(R.string.debug_export_opt_kernel_desc),
+                checked = optKernelImage,
+                enabled = !exporting,
+                onCheckedChange = {
+                    optKernelImage = it
+                    clearResult()
+                },
+            )
+            Spacer(Modifier.height(16.dp))
+
+            val doExport = {
+                selfNeedsRestart?.let { restartState ->
+                    val options =
+                        StateContentOptions(forensics = optForensics, appList = optAppList && optForensics)
+                    val kernel = optKernelImage
+                    exporting = true
+                    scope.launch {
+                        resultFile = exportDebug(cm, context, restartState, options, kernel)
+                        exporting = false
+                    }
+                }
+                Unit
+            }
+
+            val file = resultFile
+
+            // Configure phase only: warn that a VPN-off / not-in-tunnel capture
+            // will be incomplete. The encouraged action (Re-check) rides on the
+            // banner; collecting anyway becomes a de-emphasized escape hatch below.
+            if (incompleteGate != null && !exporting && file == null) {
+                CaptureIncompleteWarning(
+                    gate = incompleteGate,
+                    rechecking = rechecking,
+                    onRecheck = onRecheck,
                 )
                 Spacer(Modifier.height(12.dp))
-                ExportToggle(
-                    title = stringResource(R.string.debug_export_opt_forensics),
-                    description = stringResource(R.string.debug_export_opt_forensics_desc),
-                    checked = optForensics,
-                    enabled = !exporting,
-                    onCheckedChange = {
-                        optForensics = it
-                        clearResult()
-                    },
-                )
-                ExportToggle(
-                    title = stringResource(R.string.debug_export_opt_applist),
-                    description = stringResource(R.string.debug_export_opt_applist_desc),
-                    checked = optAppList && optForensics,
-                    enabled = optForensics && !exporting,
-                    onCheckedChange = {
-                        optAppList = it
-                        clearResult()
-                    },
-                )
-                ExportToggle(
-                    title = stringResource(R.string.debug_export_opt_kernel),
-                    description = stringResource(R.string.debug_export_opt_kernel_desc),
-                    checked = optKernelImage,
-                    enabled = !exporting,
-                    onCheckedChange = {
-                        optKernelImage = it
-                        clearResult()
-                    },
-                )
-                Spacer(Modifier.height(16.dp))
+            }
 
-                val doExport = {
-                    selfNeedsRestart?.let { restartState ->
-                        val options =
-                            StateContentOptions(forensics = optForensics, appList = optAppList && optForensics)
-                        val kernel = optKernelImage
-                        exporting = true
-                        scope.launch {
-                            resultFile = exportDebug(cm, context, restartState, options, kernel)
-                            exporting = false
-                        }
+            when {
+                // In-progress: a disabled progress button, no competing actions.
+                exporting -> {
+                    EnhancedButton(onClick = {}, enabled = false, modifier = Modifier.fillMaxWidth()) {
+                        ButtonSpinner()
+                        Spacer(Modifier.width(8.dp))
+                        Text(stringResource(R.string.btn_export_debug_running))
                     }
-                    Unit
                 }
 
-                val file = resultFile
-                when {
-                    // In-progress: a disabled progress button, no competing actions.
-                    exporting -> {
-                        EnhancedButton(onClick = {}, enabled = false, modifier = Modifier.fillMaxWidth()) {
+                // Configure phase, capture would be incomplete: no prominent primary
+                // (that would invite a blind tap) — only "collect anyway" + Cancel.
+                file == null && incompleteGate != null -> {
+                    TextButton(onClick = doExport, modifier = Modifier.fillMaxWidth()) {
+                        Text(stringResource(R.string.capture_collect_anyway))
+                    }
+                    TextButton(
+                        onClick = onDismiss,
+                        modifier = Modifier.fillMaxWidth(),
+                    ) {
+                        Text(stringResource(R.string.btn_cancel))
+                    }
+                }
+
+                // Configure phase: the one primary action. Held disabled while a
+                // fresh gate re-check is in flight so the user can't collect on a
+                // stale "routed" verdict before the VPN-off warning resolves.
+                file == null -> {
+                    EnhancedButton(
+                        onClick = doExport,
+                        enabled = selfNeedsRestart != null && !rechecking,
+                        modifier = Modifier.fillMaxWidth(),
+                    ) {
+                        if (rechecking) {
                             ButtonSpinner()
                             Spacer(Modifier.width(8.dp))
-                            Text(stringResource(R.string.btn_export_debug_running))
                         }
-                    }
-
-                    // Configure phase: the one primary action.
-                    file == null -> {
-                        EnhancedButton(
-                            onClick = doExport,
-                            enabled = selfNeedsRestart != null,
-                            modifier = Modifier.fillMaxWidth(),
-                        ) {
-                            Text(stringResource(R.string.debug_export_modal_confirm))
-                        }
-                    }
-
-                    // Result phase: Save/Share are primary; re-running is a de-emphasized
-                    // secondary action, so there is no ambiguous "Export" to double-tap.
-                    else -> {
-                        FileSaveShareRow(
-                            saveLabel = stringResource(R.string.btn_save_debug),
-                            shareLabel = stringResource(R.string.btn_share_debug),
-                            sharePrimary = true,
-                            onSave = { saveLauncher.launch(file.name) },
-                            onShare = { shareFileViaProvider(context, file, "application/zip") },
+                        Text(
+                            stringResource(
+                                if (rechecking) R.string.capture_checking_vpn else R.string.debug_export_modal_confirm,
+                            ),
                         )
-                        TextButton(
-                            onClick = doExport,
-                            modifier = Modifier.align(Alignment.CenterHorizontally),
-                        ) {
-                            Text(stringResource(R.string.debug_export_collect_again))
-                        }
+                    }
+                }
+
+                // Result phase: Save/Share are primary; re-running is a de-emphasized
+                // secondary action, so there is no ambiguous "Export" to double-tap.
+                else -> {
+                    FileSaveShareRow(
+                        saveLabel = stringResource(R.string.btn_save_debug),
+                        shareLabel = stringResource(R.string.btn_share_debug),
+                        sharePrimary = true,
+                        onSave = { saveLauncher.launch(file.name) },
+                        onShare = { shareFileViaProvider(context, file, "application/zip") },
+                    )
+                    TextButton(
+                        onClick = doExport,
+                        modifier = Modifier.align(Alignment.CenterHorizontally),
+                    ) {
+                        Text(stringResource(R.string.debug_export_collect_again))
                     }
                 }
             }
@@ -407,6 +507,13 @@ private fun LogcatRecordCard(selfNeedsRestart: Boolean?) {
     val context = LocalContext.current
     val scope = rememberCoroutineScope()
     val state by LogcatRecorder.state.collectAsState()
+
+    // Own gate: the card is always visible, so it holds its VPN-off/not-in-tunnel
+    // verdict until re-checked (re-measured on entry and on the banner's re-check).
+    val gate = rememberCaptureGate(selfNeedsRestart)
+    val incompleteGate = gate.incompleteGate
+    val rechecking = gate.rechecking
+    val onRecheck = gate.recheck
 
     // Tick every second while recording so the elapsed counter updates
     // even when sizeBytes happens to hold steady.
@@ -496,26 +603,143 @@ private fun LogcatRecordCard(selfNeedsRestart: Boolean?) {
                         )
                         Spacer(Modifier.height(8.dp))
                     }
-                    EnhancedButton(
-                        onClick = {
-                            val restartState = selfNeedsRestart ?: return@EnhancedButton
-                            scope.launch { LogcatRecorder.start(context, restartState) }
-                        },
-                        enabled = selfNeedsRestart != null,
-                        modifier = Modifier.fillMaxWidth(),
-                    ) {
-                        Icon(
-                            Icons.Default.FiberManualRecord,
-                            contentDescription = null,
-                            modifier = Modifier.size(18.dp),
+                    if (incompleteGate != null) {
+                        // Same VPN-off / not-in-tunnel guard as the debug export: a
+                        // recording started now captures nothing worth diagnosing.
+                        CaptureIncompleteWarning(
+                            gate = incompleteGate,
+                            rechecking = rechecking,
+                            onRecheck = onRecheck,
                         )
-                        Spacer(Modifier.width(8.dp))
-                        Text(stringResource(R.string.logcat_btn_start))
+                        Spacer(Modifier.height(8.dp))
+                        TextButton(
+                            onClick = {
+                                val restartState = selfNeedsRestart ?: return@TextButton
+                                scope.launch { LogcatRecorder.start(context, restartState) }
+                            },
+                            enabled = selfNeedsRestart != null,
+                            modifier = Modifier.fillMaxWidth(),
+                        ) {
+                            Text(stringResource(R.string.logcat_start_anyway))
+                        }
+                    } else {
+                        EnhancedButton(
+                            onClick = {
+                                val restartState = selfNeedsRestart ?: return@EnhancedButton
+                                scope.launch { LogcatRecorder.start(context, restartState) }
+                            },
+                            enabled = selfNeedsRestart != null,
+                            modifier = Modifier.fillMaxWidth(),
+                        ) {
+                            Icon(
+                                Icons.Default.FiberManualRecord,
+                                contentDescription = null,
+                                modifier = Modifier.size(18.dp),
+                            )
+                            Spacer(Modifier.width(8.dp))
+                            Text(stringResource(R.string.logcat_btn_start))
+                        }
                     }
                 }
             }
         }
     }
+}
+
+/** Composition-scoped capture-gate state: [incompleteGate] non-null when a capture
+ * now would be incomplete, [rechecking] while a probe is in flight, [recheck] to
+ * re-measure. Lifetime follows the call site — see [rememberCaptureGate]. */
+private data class CaptureGate(
+    val incompleteGate: DiagnosticGate?,
+    val rechecking: Boolean,
+    val recheck: () -> Unit,
+)
+
+/**
+ * Reads the shared [RoutingGateCache] — the same cheap probe (VPN-iface read +
+ * self-routing) the export used to run privately via the now-removed
+ * `measureCaptureGate` — so a re-check from any surface (this sheet, the logcat
+ * card, Dashboard, Diagnostics' own retry) updates every other one through the one
+ * underlying [StateFlow].
+ *
+ * [awaitingFreshSinceOpen] preserves the old per-open freshness guarantee on top of
+ * that shared state: a reopened sheet must never flash a stale verdict left over from
+ * before it was closed (e.g. the sheet was dismissed VPN-off, the user turns the VPN
+ * on, then reopens it — the shared cache still holds the old VPN_OFF gate until this
+ * composition's own recheck lands). It starts true and flips to false only once THIS
+ * composition's own triggered reload has completed, so [CaptureGate.incompleteGate]
+ * reports null (show "checking", not a banner) until then.
+ *
+ * Scope follows the call site: called under `if (showModal)` the state is recreated
+ * on every open, so a reopened sheet always re-measures; called in the always-visible
+ * logcat card it persists until re-checked.
+ */
+@Composable
+private fun rememberCaptureGate(selfNeedsRestart: Boolean?): CaptureGate {
+    val context = LocalContext.current
+    val scope = rememberCoroutineScope()
+    val sharedGate by RoutingGateCache.gate.collectAsState()
+    val sharedLoading by RoutingGateCache.loading.collectAsState()
+    var awaitingFreshSinceOpen by remember { mutableStateOf(true) }
+
+    val recheck: () -> Unit = {
+        selfNeedsRestart?.let { needsRestart ->
+            awaitingFreshSinceOpen = true
+            scope.launch {
+                RoutingGateCache.ensureLoaded(scope, context, needsRestart)
+                RoutingGateCache.refreshInPlace(force = true)
+                awaitingFreshSinceOpen = false
+            }
+        }
+        Unit
+    }
+    LaunchedEffect(selfNeedsRestart) { recheck() }
+    return CaptureGate(
+        incompleteGate =
+            sharedGate
+                ?.takeUnless { awaitingFreshSinceOpen }
+                ?.takeIf { it == DiagnosticGate.VPN_OFF || it == DiagnosticGate.SELF_NOT_ROUTED },
+        rechecking = awaitingFreshSinceOpen || sharedLoading,
+        recheck = recheck,
+    )
+}
+
+/**
+ * Red banner shown before a debug export or a logcat recording when the freshly
+ * measured gate says the capture would be incomplete (VPN off, or this app not routed
+ * through the tunnel). The encouraged action is a Re-check (re-measures the gate);
+ * collecting anyway stays available as a de-emphasized button next to this banner.
+ * Message adapts to the gate so the fix is actionable.
+ */
+@Composable
+private fun CaptureIncompleteWarning(
+    gate: DiagnosticGate,
+    rechecking: Boolean,
+    onRecheck: () -> Unit,
+) {
+    val message =
+        when (gate) {
+            DiagnosticGate.SELF_NOT_ROUTED -> stringResource(R.string.capture_incomplete_not_routed)
+            else -> stringResource(R.string.capture_incomplete_vpn_off)
+        }
+    StatusBanner(
+        text = message,
+        containerColor = StatusColors.errorContainer(),
+        contentColor = MaterialTheme.colorScheme.onSurface,
+        action = {
+            EnhancedButton(
+                onClick = onRecheck,
+                enabled = !rechecking,
+                modifier = Modifier.fillMaxWidth(),
+            ) {
+                if (rechecking) {
+                    ButtonSpinner()
+                    Spacer(Modifier.width(8.dp))
+                }
+                Text(stringResource(R.string.capture_incomplete_recheck))
+            }
+        },
+    )
 }
 
 private fun formatElapsed(seconds: Long): String {

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/FilesystemHidingSettings.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/FilesystemHidingSettings.kt
@@ -189,7 +189,7 @@ private fun filesystemHidingStatusText(state: FilesystemHidingState): String =
         }
     }
 
-private fun writeFilesystemHidingSetting(enabled: Boolean): Int {
+private suspend fun writeFilesystemHidingSetting(enabled: Boolean): Int {
     val snapshot = TargetsCache.snapshot.value ?: return 1
     val base = buildCanonicalConfigFromTargetsSnapshot(snapshot)
     val canonical =
@@ -205,6 +205,6 @@ private fun writeFilesystemHidingSetting(enabled: Boolean): Int {
                 ),
         )
     return CanonicalConfigRepository
-        .persist(canonical, activation = CanonicalActivation(native = false))
+        .commit(canonical, activation = CanonicalActivation(native = false))
         .exitCode
 }

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/HiddenAppsSettingsScreen.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/HiddenAppsSettingsScreen.kt
@@ -448,7 +448,7 @@ private fun HiddenAppsSaveBar(
     }
 }
 
-private fun writeHiddenApps(
+private suspend fun writeHiddenApps(
     context: android.content.Context,
     base: CanonicalConfig,
     visiblePackages: Set<String>,
@@ -465,5 +465,5 @@ private fun writeHiddenApps(
             excludedPackages = excludedPackages,
             signals = signals,
         )
-    return CanonicalConfigRepository.persist(canonical).exitCode
+    return CanonicalConfigRepository.commit(canonical).exitCode
 }

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/JavaChecks.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/JavaChecks.kt
@@ -108,11 +108,6 @@ internal fun Iterable<CheckResult>.protectionScore(): CheckScore {
     return CheckScore(passed = measured.count { it.outcome !is CheckOutcome.Leak }, total = measured.size)
 }
 
-internal suspend fun isVpnActive(): Boolean {
-    val snapshot = RootSnapshotCache.getOrLoad()
-    return isVpnActiveFromSnapshot(snapshot.sections["vpn_ifaces"].orEmpty())
-}
-
 // ==========================================================================
 //  Check runner — runs directly in the main process
 // ==========================================================================

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/MainActivity.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/MainActivity.kt
@@ -72,6 +72,11 @@ class MainActivity : ComponentActivity() {
             RootSnapshotCache.setRuntimeProbeSource(GroundTruthProbe.prepare(this)?.absolutePath)
             // Load canonical debug state before runtime work so first suExec and dashboard bootstrap agree.
             VpnHideLog.init()
+            // Process-scoped, registered once: auto-refreshes RoutingGateCache on VPN
+            // up/down so Diagnostics/Dashboard/export/logcat react without a manual
+            // re-check. Safe before RoutingGateCache has ever loaded — its trigger is
+            // a no-op refreshInPlace guarded by runCatching until a screen seeds it.
+            VpnTransportWatcher.start(this)
         }
         setContent {
             VpnHideApp(mainProfile)
@@ -440,6 +445,11 @@ private fun MainScreen() {
             LifecycleEventObserver { _, event ->
                 if (event == Lifecycle.Event.ON_RESUME) {
                     startupCoordinator.ensureUpdateFresh(scope)
+                    // Belt-and-suspenders re-probe of the routing gate on foreground
+                    // return (throttled), covering the case where the background VPN
+                    // transport callback was frozen/missed while we were away — e.g. the
+                    // user left to toggle their VPN in another app and came back.
+                    RoutingGateCache.refreshIfStale(scope)
                 }
             }
         lifecycleOwner.lifecycle.addObserver(observer)

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/RoutingGateCache.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/RoutingGateCache.kt
@@ -1,0 +1,89 @@
+package dev.okhsunrog.vpnhide
+
+import android.content.Context
+import android.os.SystemClock
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.StateFlow
+
+/** Foreground-return re-probes are coalesced to at most one per this window. */
+private const val RESUME_REFRESH_THROTTLE_MS = 4_000L
+
+/**
+ * Shared, app-scoped source for the routing gate — is a VPN up, and is THIS
+ * app routed through it. This used to be computed independently in three
+ * places (the debug-export sheet, the logcat-record card, and
+ * [DiagnosticsCache]'s own gate fold), so a re-check in one place never
+ * updated the others and each surface could disagree about the current
+ * state. One [StateCache] of [DiagnosticGate] now backs all of them:
+ * [ensureLoaded] / [refresh] mirror [DashboardCache]'s stash-then-delegate
+ * shape, and [gate] is the one [StateFlow] every screen collects.
+ *
+ * [load] always folds through [captureGateFrom] (VPN-iface read off the root
+ * snapshot + [GroundTruthProbe.selfRoutedThroughVpn]) — the same pure probe
+ * the export/logcat gate used to call directly — so the value here is never
+ * a looser, framework-only approximation.
+ */
+internal object RoutingGateCache : StateCache<DiagnosticGate>(
+    traceName = "routing_gate",
+    logTag = LogTags.DIAG,
+) {
+    val gate: StateFlow<DiagnosticGate?> get() = value
+
+    @Volatile private var appContext: Context? = null
+
+    @Volatile private var selfNeedsRestart: Boolean = false
+
+    // Monotonic timestamp of the last actual (re)load — stamped in load() so it counts
+    // every refresh source (VpnTransportWatcher, manual re-check, config write). Used to
+    // throttle the belt-and-suspenders foreground-return re-probe below.
+    @Volatile private var lastLoadAtMs: Long = 0L
+
+    fun ensureLoaded(
+        scope: CoroutineScope,
+        context: Context,
+        selfNeedsRestart: Boolean,
+    ) {
+        this.appContext = context.applicationContext
+        this.selfNeedsRestart = selfNeedsRestart
+        ensure(scope)
+    }
+
+    fun refresh(
+        scope: CoroutineScope,
+        context: Context,
+        selfNeedsRestart: Boolean,
+    ) {
+        this.appContext = context.applicationContext
+        this.selfNeedsRestart = selfNeedsRestart
+        forceRefresh(scope)
+    }
+
+    /**
+     * Re-probe the gate on a foreground return, but at most once per
+     * [RESUME_REFRESH_THROTTLE_MS] — a cheap safety net for aggressive-OEM freezers
+     * that may delay or drop the background [VpnTransportWatcher] callback. Because
+     * the throttle keys off [load]'s stamp (every refresh source), a resume right
+     * after the watcher already refreshed is a no-op. Safe to call on every ON_RESUME.
+     *
+     * Deliberately reuses the already-stashed `appContext`/`selfNeedsRestart` (set by
+     * the UI/startup [ensureLoaded]) rather than taking them from the caller: a
+     * lifecycle observer captures its composable's vars once and would otherwise pass a
+     * stale (e.g. still-null → false) `selfNeedsRestart`, clobbering the real one. No-op
+     * until the cache has been initialized at least once.
+     */
+    fun refreshIfStale(
+        scope: CoroutineScope,
+        throttleMs: Long = RESUME_REFRESH_THROTTLE_MS,
+    ) {
+        if (appContext == null) return
+        if (SystemClock.elapsedRealtime() - lastLoadAtMs < throttleMs) return
+        forceRefresh(scope)
+    }
+
+    override suspend fun load(force: Boolean): DiagnosticGate {
+        lastLoadAtMs = SystemClock.elapsedRealtime()
+        val context = requireNotNull(appContext) { "RoutingGateCache.load before ensureLoaded/refresh" }
+        val snapshot = if (force) RootSnapshotCache.refresh() else RootSnapshotCache.getOrLoad()
+        return captureGateFrom(snapshot, context, selfNeedsRestart)
+    }
+}

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/RoutingGateCache.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/RoutingGateCache.kt
@@ -3,7 +3,9 @@ package dev.okhsunrog.vpnhide
 import android.content.Context
 import android.os.SystemClock
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.withContext
 
 /** Foreground-return re-probes are coalesced to at most one per this window. */
 private const val RESUME_REFRESH_THROTTLE_MS = 4_000L
@@ -80,10 +82,15 @@ internal object RoutingGateCache : StateCache<DiagnosticGate>(
         forceRefresh(scope)
     }
 
-    override suspend fun load(force: Boolean): DiagnosticGate {
-        lastLoadAtMs = SystemClock.elapsedRealtime()
-        val context = requireNotNull(appContext) { "RoutingGateCache.load before ensureLoaded/refresh" }
-        val snapshot = if (force) RootSnapshotCache.refresh() else RootSnapshotCache.getOrLoad()
-        return captureGateFrom(snapshot, context, selfNeedsRestart)
-    }
+    // Always on IO: captureGateFrom runs the blocking `su` self-routing probe, so a
+    // caller that awaits a refresh from the main dispatcher (e.g. a card's
+    // rememberCaptureGate scrolling into view) must not run it on the UI thread. The
+    // old measureCaptureGate wrapped this; keep it wrapped here so no caller has to.
+    override suspend fun load(force: Boolean): DiagnosticGate =
+        withContext(Dispatchers.IO) {
+            lastLoadAtMs = SystemClock.elapsedRealtime()
+            val context = requireNotNull(appContext) { "RoutingGateCache.load before ensureLoaded/refresh" }
+            val snapshot = if (force) RootSnapshotCache.refresh() else RootSnapshotCache.getOrLoad()
+            captureGateFrom(snapshot, context, selfNeedsRestart)
+        }
 }

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/SettingsScreen.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/SettingsScreen.kt
@@ -842,7 +842,7 @@ private fun SuperkeySettingsSection() {
     }
 }
 
-private fun writeSuperkeySetting(
+private suspend fun writeSuperkeySetting(
     remember: Boolean,
     superkey: String,
 ): Int {
@@ -853,7 +853,7 @@ private fun writeSuperkeySetting(
     val canonical = base.copy(settings = base.settings.copy(rememberSuperkey = remember))
     val secretCommand = if (remember) buildSuperkeyWriteCommand(superkey) else buildSuperkeyClearCommand()
     return CanonicalConfigRepository
-        .persist(
+        .commit(
             canonical,
             coupledCommands = listOf(secretCommand),
             activation = CanonicalActivation(native = remember),
@@ -893,7 +893,7 @@ private fun writeTextToUri(
         } ?: error("openOutputStream returned null")
     }.isSuccess
 
-private fun importConfigFromUri(
+private suspend fun importConfigFromUri(
     context: android.content.Context,
     uri: Uri,
 ): ConfigImportResult {
@@ -906,7 +906,7 @@ private fun importConfigFromUri(
         }.getOrNull() ?: return ConfigImportResult.InvalidJson
     val canonical = parseImportedCanonicalConfig(raw, context.packageName) ?: return ConfigImportResult.InvalidJson
     val result =
-        CanonicalConfigRepository.persist(
+        CanonicalConfigRepository.commit(
             canonical,
             activation = CanonicalActivation(native = true, ports = true),
         )
@@ -1154,7 +1154,7 @@ private fun UnavailableConfiguredAppRow(
     }
 }
 
-private fun writeAutoHideSetting(
+private suspend fun writeAutoHideSetting(
     context: android.content.Context,
     apps: List<AppSummary>,
     transform: (CanonicalSettings) -> CanonicalSettings,
@@ -1169,10 +1169,10 @@ private fun writeAutoHideSetting(
             selfPkg = context.packageName,
             signals = apps.map(AppSummary::toAutoHideSignal),
         )
-    return CanonicalConfigRepository.persist(canonical).exitCode
+    return CanonicalConfigRepository.commit(canonical).exitCode
 }
 
-private fun writeRemoveUnavailableConfiguredApps(
+private suspend fun writeRemoveUnavailableConfiguredApps(
     context: android.content.Context,
     packages: Set<String>,
 ): Int {
@@ -1181,7 +1181,7 @@ private fun writeRemoveUnavailableConfiguredApps(
     val base = buildCanonicalConfigFromTargetsSnapshot(snapshot)
     val canonical = removeConfiguredPackages(base, packages, context.packageName)
     return CanonicalConfigRepository
-        .persist(
+        .commit(
             canonical,
             activation = CanonicalActivation(native = true, ports = true),
         ).exitCode

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/ShellUtils.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/ShellUtils.kt
@@ -254,7 +254,7 @@ internal fun cleanupStaleZygiskStatus(
  * applied to the current process, restart needed for zygisk).
  * Called once at app startup; result is shared with all screens.
  */
-internal fun ensureSelfInTargets(
+internal suspend fun ensureSelfInTargets(
     selfPkg: String,
     timeoutSec: Long = SELF_TARGETS_TIMEOUT_SEC,
 ): SelfTargetPreparation {
@@ -333,12 +333,12 @@ private fun buildCanonicalSelfUpdate(
     )
 }
 
-private fun writeStartupCanonical(
+private suspend fun writeStartupCanonical(
     canonical: CanonicalConfig,
     timeoutSec: Long,
 ): String? {
     val result =
-        CanonicalConfigRepository.persist(
+        CanonicalConfigRepository.commit(
             canonical,
             activation = CanonicalActivation(native = true, ports = true),
             timeoutSec = timeoutSec,

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/StartupCoordinator.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/StartupCoordinator.kt
@@ -26,12 +26,12 @@ internal sealed interface StartupSelfTargetState {
 internal class StartupCoordinator(
     private val appContext: Context,
     private val appVersionName: String = BuildConfig.VERSION_NAME,
-    private val prepareSelfTargetsCommand: (String) -> SelfTargetPreparation = ::ensureSelfInTargets,
+    private val prepareSelfTargetsCommand: suspend (String) -> SelfTargetPreparation = ::ensureSelfInTargets,
     private val cleanupZygiskStatus: (Context, String?) -> Unit = ::cleanupStaleZygiskStatus,
     private val seedRootSnapshotInventory: (PackageInventorySeed?) -> Unit = RootSnapshotCache::seedPackageInventory,
     private val markStartupEvent: (String) -> Unit = StartupTrace::mark,
     private val reconcileRuntimeConfig: () -> Unit = { runRuntimeConfigReconcile() },
-    private val reconcileAutoHidden: (CanonicalConfig, List<AppAutoHideSignal>) -> Unit =
+    private val reconcileAutoHidden: suspend (CanonicalConfig, List<AppAutoHideSignal>) -> Unit =
         { config, signals -> reconcileAutoHiddenPackages(appContext, config, signals) },
     private val loadCanonicalConfig: suspend () -> CanonicalConfig? =
         { parseTargetsSnapshot(RootSnapshotCache.getOrLoad()).canonicalConfig },
@@ -93,6 +93,10 @@ internal class StartupCoordinator(
     ) {
         AppListCache.ensureLoaded(scope, appContext)
         DashboardCache.ensureLoaded(scope, appContext, selfNeedsRestart)
+        // Seed the shared routing gate as early as selfNeedsRestart is known — this is
+        // also the earliest point the process-scoped VPN transport watcher (Phase 3)
+        // can find inputs to refresh against.
+        RoutingGateCache.ensureLoaded(scope, appContext, selfNeedsRestart)
         // The cache parks at Blocked(NEEDS_RESTART) itself when selfNeedsRestart — this
         // is also the first run() call, so it stamps the process-constant flag.
         DiagnosticsCache.run(scope, appContext, selfNeedsRestart)
@@ -134,7 +138,7 @@ internal class StartupCoordinator(
         }
     }
 
-    private fun reconcileRuntimeConfigNow(rootSnapshot: RootSnapshot) {
+    private suspend fun reconcileRuntimeConfigNow(rootSnapshot: RootSnapshot) {
         val canonicalConfig = parseTargetsSnapshot(rootSnapshot).canonicalConfig
         val reconciled = canonicalConfig?.let { canonicalConfigForStartupDebugReconcile(it) }
         // A capture interrupted mid-flight left effective `debug` out of sync with
@@ -145,7 +149,7 @@ internal class StartupCoordinator(
             reconcileRuntimeConfig()
             return
         }
-        val result = CanonicalConfigRepository.persist(reconciled)
+        val result = CanonicalConfigRepository.commit(reconciled)
         if (!result.succeeded) {
             VpnHideLog.w(
                 LogTags.STARTUP,

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/StateCache.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/StateCache.kt
@@ -59,6 +59,22 @@ internal abstract class StateCache<T>(
         inflight = scope.launch { reload(force = true) }
     }
 
+    /**
+     * Reload the value in place and await it: recompute via [load] and swap the result in
+     * one assignment, so subscribers keep the current value until the fresh one is ready —
+     * no null gap, hence no UI flicker. For suspend callers (a config write) that must
+     * leave the cache coherent before returning. On failure the stale value is kept and
+     * the error surfaced. Contrast [invalidate], which drops to null and defers the reload.
+     *
+     * @param force forwarded to [load]; pass false to reuse an already-refreshed upstream
+     *   (e.g. the root snapshot) instead of busting it again.
+     */
+    suspend fun refreshInPlace(force: Boolean = true) {
+        inflight?.cancel()
+        inflight = null
+        reload(force)
+    }
+
     /** Drop the cached value/error so the next [ensure] reloads. */
     open fun invalidate() {
         _value.value = null

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/VpnTransportWatcher.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/VpnTransportWatcher.kt
@@ -1,0 +1,82 @@
+package dev.okhsunrog.vpnhide
+
+import android.content.Context
+import android.net.ConnectivityManager
+import android.net.Network
+import android.net.NetworkCapabilities
+import android.net.NetworkRequest
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.FlowPreview
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.debounce
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.launch
+
+private const val VPN_TRANSPORT_DEBOUNCE_MS = 750L
+
+/**
+ * Process-scoped VPN transport watcher (Phase 3 of the routing-gate unification):
+ * a lightweight [ConnectivityManager] callback whose ONLY job is to trigger a fresh
+ * [RoutingGateCache] probe when a VPN network appears, disappears, or changes
+ * capabilities, so Diagnostics/Dashboard/export/logcat auto-update on VPN up/down
+ * instead of waiting for the user to press a manual re-check.
+ *
+ * It is deliberately just a trigger. The gate VALUE must still come from the
+ * root-shell probe path ([RoutingGateCache.load] -> [captureGateFrom] -> the root
+ * `operstate` read + [GroundTruthProbe.selfRoutedThroughVpn]) — NEVER from
+ * [NetworkCapabilities] itself. In split-tunnel or hardened setups the framework's
+ * view of "is a VPN network up" and the kernel/root ground truth diverge, and
+ * deriving the gate from the callback's capabilities would regress exactly the
+ * correctness this project's diagnostics exist to guarantee.
+ *
+ * Callbacks land on a binder thread, so every event is funneled through a
+ * [MutableSharedFlow] and debounced ~750ms before the actual (suspend, `su`-backed)
+ * refresh — a burst of onCapabilitiesChanged around VPN up/down collapses into one
+ * probe, and [StateCache]'s single-inflight [refreshInPlace][StateCache.refreshInPlace]
+ * guards against overlap with a manual re-check.
+ *
+ * The manual "re-check" buttons remain everywhere as a fallback for what this
+ * callback cannot see: root access just granted, a split-tunnel "app-in-tunnel"
+ * change with no VPN transport event, or a missed callback.
+ */
+internal object VpnTransportWatcher {
+    private val watcherScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+    private val events = MutableSharedFlow<Unit>(extraBufferCapacity = 8)
+
+    @Volatile private var started = false
+
+    /** Registers the callback once for the process lifetime. Safe to call from
+     * every `onCreate` (e.g. after an activity recreation) — idempotent. */
+    @OptIn(FlowPreview::class)
+    fun start(context: Context) {
+        if (started) return
+        started = true
+
+        events
+            .debounce(VPN_TRANSPORT_DEBOUNCE_MS)
+            .onEach { runCatching { RoutingGateCache.refreshInPlace(force = true) } }
+            .launchIn(watcherScope)
+
+        val cm = context.applicationContext.getSystemService(ConnectivityManager::class.java) ?: return
+        val request = NetworkRequest.Builder().addTransportType(NetworkCapabilities.TRANSPORT_VPN).build()
+        val callback =
+            object : ConnectivityManager.NetworkCallback() {
+                override fun onAvailable(network: Network) = signal()
+
+                override fun onLost(network: Network) = signal()
+
+                override fun onCapabilitiesChanged(
+                    network: Network,
+                    networkCapabilities: NetworkCapabilities,
+                ) = signal()
+
+                private fun signal() {
+                    watcherScope.launch { events.emit(Unit) }
+                }
+            }
+        runCatching { cm.registerNetworkCallback(request, callback) }
+    }
+}

--- a/lsposed/app/src/main/res/values-ru/strings.xml
+++ b/lsposed/app/src/main/res/values-ru/strings.xml
@@ -379,6 +379,12 @@
     <string name="debug_export_modal_title">Что включить</string>
     <string name="debug_export_modal_confirm">Экспорт</string>
     <string name="debug_export_collect_again">Собрать заново</string>
+    <string name="capture_incomplete_vpn_off">VPN выключен. В логе не будет главного, и диагностировать по нему почти нечего. Включите VPN и проверьте ещё раз.</string>
+    <string name="capture_incomplete_not_routed">VPN включён, но VPN Hide не пропущен через туннель (split tunneling) — скрывать нечего, и лог выйдет неполным. Добавьте VPN Hide в туннель и проверьте ещё раз.</string>
+    <string name="capture_incomplete_recheck">Проверить VPN ещё раз</string>
+    <string name="capture_checking_vpn">Проверяю VPN туннель</string>
+    <string name="capture_collect_anyway">Всё равно собрать неполный лог</string>
+    <string name="logcat_start_anyway">Всё равно записать неполный лог</string>
     <string name="debug_export_opt_forensics">Расширенный лог</string>
     <string name="debug_export_opt_forensics_desc">dmesg, logcat и сырые пробы ядра/сети. Файл больше; обычно именно это и нужно для баг-репорта.</string>
     <string name="debug_export_opt_applist">Список приложений</string>

--- a/lsposed/app/src/main/res/values-zh-rCN/strings.xml
+++ b/lsposed/app/src/main/res/values-zh-rCN/strings.xml
@@ -83,6 +83,12 @@
     <string name="debug_export_modal_title">包含哪些内容</string>
     <string name="debug_export_modal_confirm">导出</string>
     <string name="debug_export_collect_again">重新收集</string>
+    <string name="capture_incomplete_vpn_off">VPN 未开启。日志将缺少关键信息，几乎无法用于诊断。请开启 VPN 后重新检测。</string>
+    <string name="capture_incomplete_not_routed">VPN 已开启，但 VPN Hide 未经过其隧道（分应用代理）。日志将不完整。请将 VPN Hide 加入隧道后重新检测。</string>
+    <string name="capture_incomplete_recheck">重新检测 VPN</string>
+    <string name="capture_checking_vpn">正在检测 VPN 隧道</string>
+    <string name="capture_collect_anyway">仍然收集不完整日志</string>
+    <string name="logcat_start_anyway">仍然录制不完整日志</string>
     <string name="debug_export_opt_forensics">详细日志</string>
     <string name="debug_export_opt_forensics_desc">dmesg、logcat 及内核/网络原始探测。文件更大；通常正是错误报告所需。</string>
     <string name="debug_export_opt_applist">已安装应用列表</string>

--- a/lsposed/app/src/main/res/values/strings.xml
+++ b/lsposed/app/src/main/res/values/strings.xml
@@ -90,6 +90,12 @@
     <string name="debug_export_modal_title">What to include</string>
     <string name="debug_export_modal_confirm">Export</string>
     <string name="debug_export_collect_again">Collect again</string>
+    <string name="capture_incomplete_vpn_off">VPN is off. This log will contain incomplete information and is little help for diagnosis. Turn the VPN on and re-check.</string>
+    <string name="capture_incomplete_not_routed">A VPN is up, but VPN Hide is not routed through it (split tunneling). This log will be incomplete. Add VPN Hide to the tunnel and re-check.</string>
+    <string name="capture_incomplete_recheck">Re-check VPN</string>
+    <string name="capture_checking_vpn">Checking VPN tunnel</string>
+    <string name="capture_collect_anyway">Collect an incomplete log anyway</string>
+    <string name="logcat_start_anyway">Record an incomplete log anyway</string>
     <string name="debug_export_opt_forensics">Verbose logs</string>
     <string name="debug_export_opt_forensics_desc">dmesg, logcat and raw kernel/network probes. Bigger file; usually what a bug report needs.</string>
     <string name="debug_export_opt_applist">Installed-app list</string>


### PR DESCRIPTION
Warns before collecting a debug log or logcat recording while the VPN is off or VPN Hide isn't routed through the tunnel — the most common reason a report can't be diagnosed. The routing-gate check ("is a VPN up, and are we routed through it") is now one shared source every screen observes, so a single re-check updates Diagnostics, the Dashboard, the export sheet and the logcat card together, and the gate banners react automatically when the VPN is toggled. Config writes now refresh the derived caches in place instead of nulling them, so the settings switches no longer flicker during log collection.

- Warn (with a re-check and a "collect anyway" option) before an incomplete debug-export/logcat capture; the gate is measured fresh at collect time, and all collect-flow state is scoped to its sheet so a reopen starts clean
- Add `RoutingGateCache` as the one routing-gate source; fold the gate out of `DiagnosticsCache`; drive the Diagnostics/Dashboard gate banners off the live gate, while check results stay process-scoped
- Auto-refresh the gate via a debounced VPN-transport `ConnectivityManager` callback (a trigger only — the value still comes from the root probe) plus a throttled re-probe on foreground return; the manual re-check stays as a fallback
- Refresh the derived caches atomically after a config write (`persist` → `commit`, now suspend) instead of invalidating them, fixing the toggle flicker
- The export button reads "Checking VPN tunnel" while probing; strings added in en/ru/zh

Testing: built and exercised on a Pixel 8 Pro (KernelSU-Next, GKI 6.1) — verified the VPN-off/not-routed warning on both capture paths, one re-check propagating to every surface, automatic banner updates on VPN on/off (including returning from another app after toggling the VPN), and that the settings switches no longer flicker during a debug-log capture.
