### PR TITLE
fix(picker): load the app list on devices with very many installed apps (ARG_MAX)

### DIFF
--- a/changelog.d/fixed-fix-the-app-list-failing-to-bc92.md
+++ b/changelog.d/fixed-fix-the-app-list-failing-to-bc92.md
@@ -1,0 +1,9 @@
+_2026-08-20_
+
+## English
+
+Fix the app list failing to load on devices with a very large number of installed apps (common on MIUI/HyperOS), which wrongly reported an incomplete list and asked to unlock a profile.
+
+## Русский
+
+Исправлена загрузка списка приложений на устройствах с очень большим числом установленных приложений (часто на MIUI/HyperOS): раньше список ошибочно считался неполным и приложение просило разблокировать профиль.

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DebugShellSnapshot.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DebugShellSnapshot.kt
@@ -345,11 +345,18 @@ internal fun buildDebugShellSnapshotCommand(): String =
         RUN=0
         printf "%s\n" "${'$'}PLAIN" | grep "UserInfo{${'$'}U:" | grep -qw running && RUN=1
         ERR=${'$'}(pm list packages -U -f --user "${'$'}U" 2>&1 1>/dev/null | head -2 | tr "\n" " ")
-        OUT=${'$'}(pm list packages -U -f --user "${'$'}U" 2>/dev/null)
+        # Stage pm's stdout in a temp file rather than a shell variable: a very
+        # large app list (bloatware-heavy MIUI/HyperOS) exceeds the kernel's
+        # single-argument limit, so `printf "%s\n" "${'$'}OUT"` would fail with
+        # "Argument list too long" and count zero packages. A file never hits
+        # ARG_MAX. pm is the only command on its line, so ${'$'}? is pm's status.
+        OUT_FILE=/data/local/tmp/vpnhide_app_scan.${'$'}${'$'}.${'$'}U
+        pm list packages -U -f --user "${'$'}U" >"${'$'}OUT_FILE" 2>/dev/null
         EX=${'$'}?
-        TOTAL=${'$'}(printf "%s\n" "${'$'}OUT" | grep -c "^package:")
-        WUID=${'$'}(printf "%s\n" "${'$'}OUT" | grep -c "^package:.* uid:")
-        WPATH=${'$'}(printf "%s\n" "${'$'}OUT" | grep -c "^package:[^ ]*=")
+        TOTAL=${'$'}(grep -c "^package:" "${'$'}OUT_FILE")
+        WUID=${'$'}(grep -c "^package:.* uid:" "${'$'}OUT_FILE")
+        WPATH=${'$'}(grep -c "^package:[^ ]*=" "${'$'}OUT_FILE")
+        rm -f "${'$'}OUT_FILE"
         echo "user=${'$'}U running=${'$'}RUN exit=${'$'}EX package_lines=${'$'}TOTAL with_uid=${'$'}WUID with_path=${'$'}WPATH stderr=[${'$'}ERR]"
       done
     '

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/PackageInventoryData.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/PackageInventoryData.kt
@@ -164,10 +164,16 @@ internal fun buildPerUserPackageInventoryShell(
       PM_USER_IDS=0
     fi
     for PM_USER_ID in ${'$'}PM_USER_IDS; do
-      PM_USER_PACKAGES="${'$'}(pm list packages -U -f --user "${'$'}PM_USER_ID" $stderrRedirect)"
-      PM_USER_STATUS=${'$'}?
       echo "$PM_USER_BEGIN_PREFIX${'$'}PM_USER_ID"
-      [ -n "${'$'}PM_USER_PACKAGES" ] && printf '%s\n' "${'$'}PM_USER_PACKAGES"
+      # Stream pm's stdout straight into the section instead of staging it in a
+      # shell variable and re-emitting it. A device with a very large app list
+      # (bloatware-heavy MIUI/HyperOS) produces a package list bigger than the
+      # kernel's single-argument limit (MAX_ARG_STRLEN, ~128 KiB); passing it as
+      # one argv word to printf/echo fails with "Argument list too long" and
+      # emits nothing, so an exit-0 scan looked like an empty inventory. pm is
+      # the last command in the section, so ${'$'}? below is pm's own exit status.
+      pm list packages -U -f --user "${'$'}PM_USER_ID" $stderrRedirect
+      PM_USER_STATUS=${'$'}?
       echo "$PM_USER_END_PREFIX${'$'}PM_USER_ID:${'$'}PM_USER_STATUS"
     done
     echo "${sectionEndPrefix}pm_packages"


### PR DESCRIPTION
Fixes the target picker failing to load the installed-app list on devices with a very large number of installed apps (common on MIUI/HyperOS), where it wrongly reported an incomplete list and asked the user to "unlock a profile" even when only user 0 exists and is unlocked.

Root cause: the per-user `pm list packages -U -f` output was staged in a shell variable and re-emitted / counted via `printf '%s\n' "$var"`. When the list is large enough, that single argv word exceeds the kernel's `MAX_ARG_STRLEN` (~128 KiB per argument), so the shell prints nothing with "Argument list too long". `pm` still exits 0, so the scan looks like a successful-but-empty inventory — which the completeness check turns into a hard "incomplete list, unlock a profile" block. No locked profile is ever involved; the maintainer's Pixel stays under the limit so it never reproduces.

- Stream `pm`'s stdout straight into the `pm_packages` section instead of `VAR=$(pm …)` + `printf '%s\n' "$VAR"`; `pm` is the last command so its own exit status is still captured for the per-user marker, and the stderr redirect is unchanged
- Count the `app_scan_diagnostics` per-user scan from a temp file (`grep -c … "$file"`) instead of `printf '%s\n' "$OUT" | grep -c`, so the counters never hit ARG_MAX either
- Both rewrites are POSIX/mksh-safe (no bash-only constructs), so they work under Android `/system/bin/sh` and `su`; the completeness / locked-profile logic and the emitted line format are unchanged

Testing: `PackageInventoryDataTest` (which executes the rewritten shell via `sh -c` against a mocked `pm`) passes; installed on a Pixel 8 Pro and confirmed the app list still loads normally. The overflow itself only reproduces on a bloatware-heavy ROM (e.g. MIUI/HyperOS), so field confirmation from an affected user is pending.
