### PR TITLE
Import (or delete) configs left by pre-1.0 versions

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -119,7 +119,7 @@ su -c /data/adb/modules/vpnhide_zygisk/activator
 su -c /data/adb/modules/vpnhide_ports/activator
 ```
 
-Run only activators for modules that are actually installed. LSPosed reads the JSON directly from `system_server`; it does not need an activator. Old `/data/adb/vpnhide_*` `targets.txt` files are no longer user config and are only used for migration from older releases.
+Run only activators for modules that are actually installed. LSPosed reads the JSON directly from `system_server`; it does not need an activator. Old `/data/adb/vpnhide_*` `targets.txt` files are the pre-1.0 config. They are no longer user config: the app imports them into the JSON once and deletes them.
 
 </details>
 

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ su -c /data/adb/modules/vpnhide_zygisk/activator
 su -c /data/adb/modules/vpnhide_ports/activator
 ```
 
-Запускайте только activator тех модулей, которые действительно установлены. LSPosed читает JSON напрямую из `system_server`, отдельный activator для него не нужен. Старые `targets.txt` в `/data/adb/vpnhide_*` больше не являются пользовательской настройкой и используются только для миграции старых конфигов.
+Запускайте только activator тех модулей, которые действительно установлены. LSPosed читает JSON напрямую из `system_server`, отдельный activator для него не нужен. Старые `targets.txt` в `/data/adb/vpnhide_*` — это конфиг версий до 1.0. Пользовательской настройкой они больше не являются: приложение один раз переносит их в JSON и удаляет.
 
 </details>
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -121,7 +121,7 @@ su -c /data/adb/modules/vpnhide_zygisk/activator
 su -c /data/adb/modules/vpnhide_ports/activator
 ```
 
-只运行实际已安装模块的激活器。LSPosed 直接从 `system_server` 读取该 JSON；它不需要激活器。旧的 `/data/adb/vpnhide_*` `targets.txt` 文件不再是用户配置，仅用于从旧版本迁移。
+只运行实际已安装模块的激活器。LSPosed 直接从 `system_server` 读取该 JSON；它不需要激活器。旧的 `/data/adb/vpnhide_*` `targets.txt` 文件是 1.0 之前版本的配置。它们不再是用户配置：应用会将其一次性导入该 JSON 并删除。
 
 </details>
 

--- a/changelog.d/fixed-settings-from-versions-before-1-0-1b32.md
+++ b/changelog.d/fixed-settings-from-versions-before-1-0-1b32.md
@@ -1,0 +1,9 @@
+_2026-08-21_
+
+## English
+
+Settings from versions before 1.0 are imported again. Upgrading straight from 0.7.x to 1.2.x left the old lists on disk unused, so the app looked reset. They are now folded into the current config automatically when nothing is configured yet, and offered on the dashboard (merge or replace) when something already is.
+
+## Русский
+
+Настройки от версий до 1.0 снова переносятся. При обновлении сразу с 0.7.x на 1.2.x старые списки оставались лежать на диске без дела, и приложение выглядело сброшенным. Теперь они переносятся автоматически, если ещё ничего не настроено, и предлагаются на дашборде (объединить или заменить), если настройки уже есть.

--- a/changelog.d/fixed-settings-from-versions-before-1-0-1b32.md
+++ b/changelog.d/fixed-settings-from-versions-before-1-0-1b32.md
@@ -2,8 +2,8 @@ _2026-08-21_
 
 ## English
 
-Settings from versions before 1.0 are imported again. Upgrading straight from 0.7.x to 1.2.x left the old lists on disk unused, so the app looked reset. They are now folded into the current config automatically when nothing is configured yet, and offered on the dashboard (merge or replace) when something already is.
+Settings from versions before 1.0 are imported again. Upgrading straight from 0.7.x to 1.2.x left the old lists on disk unused, so the app looked reset. They are now folded into the current config automatically when nothing is configured yet; when something already is, the dashboard offers to merge them, replace the current list with them, or delete them without importing. Either way the old files finally get cleaned off the device.
 
 ## Русский
 
-Настройки от версий до 1.0 снова переносятся. При обновлении сразу с 0.7.x на 1.2.x старые списки оставались лежать на диске без дела, и приложение выглядело сброшенным. Теперь они переносятся автоматически, если ещё ничего не настроено, и предлагаются на дашборде (объединить или заменить), если настройки уже есть.
+Настройки от версий до 1.0 снова переносятся. При обновлении сразу с 0.7.x на 1.2.x старые списки оставались лежать на диске без дела, и приложение выглядело сброшенным. Теперь они переносятся автоматически, если ещё ничего не настроено; а если настройки уже есть, на дашборде можно объединить их со старыми, заменить текущий список старым или удалить старые файлы, ничего не перенося. В любом случае старый мусор наконец убирается с устройства.

--- a/docs/debug-bundle.md
+++ b/docs/debug-bundle.md
@@ -195,7 +195,7 @@ to an `emit_*` line in
 
 **LSPosed / Java layer** — `lsposed_state`, `lsposed_framework` (which framework: LSPosed/Vector), `lsposed_files` (config DB perms).
 
-**Config / targets** — `canonical_config` (the desired-state JSON, mirrored into top-level `config`).
+**Config / targets** — `canonical_config` (the desired-state JSON, mirrored into top-level `config`). `legacy_kmod_targets` / `legacy_kpm_targets` / `legacy_zygisk_targets` / `legacy_lsposed_targets` / `legacy_ports_observers` / `legacy_hidden_pkgs` / `legacy_observer_uids` — the pre-1.0 config files ([state.md §1](state.md)). Non-empty only on an install that upgraded across 1.2.0 without importing yet: the import deletes them, so a bundle showing both these and a populated `canonical_config` means the user was offered the merge/replace banner and hasn't answered.
 
 **App enumeration** — `app_scan_diagnostics` (privacy-safe: per-user exit code + package counts + first stderr line, **no names/paths** — diagnoses "couldn't read all profiles" / the ARG_MAX overflow). `pm_users` / `pm_packages` carry the real names/paths and are **redacted out unless `appList` was opted in** (§10).
 

--- a/docs/state.md
+++ b/docs/state.md
@@ -38,6 +38,35 @@ The app writes it atomically via temp-file + `mv`. If it is absent, native
 activators treat it as an empty config and app startup creates a new config
 containing the mandatory VPN Hide self-target.
 
+### Pre-1.0 Config Files (import inputs)
+
+Nothing writes these; up to 0.7.1 they *were* the user's config. 1.0.0 folded
+them into the canonical JSON on first launch, 1.2.0 dropped that fold (and the
+cleanup with it), so a device upgrading 0.7.x → 1.2.x kept the files and lost
+the settings. `LegacyConfigImport.kt` reads them again:
+
+- `/data/adb/vpnhide_kmod/targets.txt`, `…_kpm/targets.txt`,
+  `…_zygisk/targets.txt` — native role, package names.
+- `/data/adb/vpnhide_lsposed/targets.txt` — Java role, package names.
+- `/data/adb/vpnhide_ports/observers.txt` — ports role, package names.
+- `/data/system/vpnhide_hidden_pkgs.txt` — hidden packages, package names.
+- `/data/system/vpnhide_observer_uids.txt` — app-hiding role, **UIDs**, mapped
+  back through the current `pm list packages -U` inventory.
+- `/data/system/vpnhide_uids.txt` — derived from the LSPosed list by the old
+  `service.sh`; deleted with the rest, never read back.
+
+The import runs silently at startup when the canonical config holds no
+user-configured app, and is offered as a Dashboard banner (merge / replace /
+hide) plus a Settings → Configuration entry when it does. Either way it deletes
+every file above — and `rmdir`s `/data/adb/vpnhide_zygisk` and
+`/data/adb/vpnhide_lsposed`, which hold nothing else — in the same root
+transaction as the config write. Absence of the files is the "already imported"
+marker; declining only sets `legacyImportDismissed` in the app's `ui_settings`
+DataStore, which silences the banner and nothing else.
+
+`/data/adb/vpnhide_kmod`, `…_kpm` and `…_ports` survive: they carry live
+`load_status` / `load_dmesg` / `ctl.lock`.
+
 ---
 
 ## 2. Module Install Dirs
@@ -353,5 +382,6 @@ zygote app fork:
 | Persistent root-managed | `/data/system/vpnhide_config.json`, `/data/adb/vpnhide/superkey` |
 | Module-dir derived state | `/data/adb/modules/vpnhide_zygisk/targets.txt` |
 | Removed on module uninstall | `/data/adb/vpnhide_kmod/`, `/data/adb/vpnhide_kpm/`, `/data/adb/vpnhide_ports/` when empty after deleting module-specific files |
+| Removed on pre-1.0 config import (or Full Reset) | the import inputs in section 1, plus `/data/adb/vpnhide_zygisk/`, `/data/adb/vpnhide_lsposed/` |
 | Wiped on module reinstall | files under `/data/adb/modules/vpnhide_*/` |
 | Wiped on app reinstall | app SharedPreferences, except Vector redirects the physical path under `/data/misc/<uuid>/prefs/` |

--- a/docs/state.md
+++ b/docs/state.md
@@ -56,13 +56,18 @@ the settings. `LegacyConfigImport.kt` reads them again:
   `service.sh`; deleted with the rest, never read back.
 
 The import runs silently at startup when the canonical config holds no
-user-configured app, and is offered as a Dashboard banner (merge / replace /
-hide) plus a Settings → Configuration entry when it does. Either way it deletes
-every file above — and `rmdir`s `/data/adb/vpnhide_zygisk` and
-`/data/adb/vpnhide_lsposed`, which hold nothing else — in the same root
-transaction as the config write. Absence of the files is the "already imported"
-marker; declining only sets `legacyImportDismissed` in the app's `ui_settings`
-DataStore, which silences the banner and nothing else.
+user-configured app. When it does hold one, a Dashboard banner and a Settings →
+Configuration entry offer three actions: merge, replace, or **delete without
+importing** (for the user who has already reconfigured by hand and only wants
+the leftovers gone — nothing else on the device removes them). All three delete
+every file above and `rmdir` `/data/adb/vpnhide_zygisk` and
+`/data/adb/vpnhide_lsposed`, which hold nothing else; merge and replace do it in
+the same root transaction as the config write, delete runs on its own (no config
+write, no activator — the running config does not change).
+
+Absence of the files is the "already imported" marker. The banner's *Hide*
+button only sets `legacyImportDismissed` in the app's `ui_settings` DataStore:
+files stay, and the Settings entry keeps every action reachable.
 
 `/data/adb/vpnhide_kmod`, `…_kpm` and `…_ports` survive: they carry live
 `load_status` / `load_dmesg` / `ctl.lock`.

--- a/docs/storage.md
+++ b/docs/storage.md
@@ -68,6 +68,12 @@ shared canonical file nor consume extra native target slots.
 - **Import / export = copy this one file.** It contains no device-specific secret,
   so it is safe to back up / move / share. (This is *why* the superkey is **not**
   stored here — §6.)
+- **Pre-1.0 configs are imported into it, not read alongside it.** Installs older
+  than 1.0.0 kept per-component `targets.txt`/observer files; the app folds them
+  into this JSON and deletes them (silently at startup when nothing is configured
+  yet, otherwise via a Dashboard banner offering merge / replace). Paths and
+  exact behaviour: [state.md §1](state.md), code in `LegacyConfigImport.kt`.
+  Nothing outside that importer reads them — no backend has a legacy read path.
 
 ### 2.1 Canonical JSON schema
 

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DashboardData.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DashboardData.kt
@@ -315,6 +315,9 @@ internal data class DashboardState(
     // diagnostics screen can rebuild the canonical DiagnosticReport (which vectors
     // the active backend owns) rather than deriving ownership a second way.
     val installedOptionalHooks: Set<HookIds.Hook> = emptySet(),
+    // A pre-1.0 config still on disk next to a config that already has roles —
+    // the startup importer leaves that case to the user (LegacyConfigImport).
+    val legacyImport: LegacyImportPrompt? = null,
 )
 
 internal enum class HeroStatus { Protected, Attention, Unprotected, VpnOff }
@@ -1814,5 +1817,6 @@ internal suspend fun loadDashboardState(
         protection = protection,
         messages = messages,
         installedOptionalHooks = installedOptionalHooks,
+        legacyImport = parseLegacyConfigCandidate(shellSnapshot, targetsSnapshot.uidToPkg)?.toPrompt(),
     )
 }

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DashboardScreen.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DashboardScreen.kt
@@ -73,12 +73,19 @@ fun DashboardScreen(
     var changelogData by remember { mutableStateOf<ChangelogData?>(null) }
     var showContact by remember { mutableStateOf(false) }
     var showDonate by remember { mutableStateOf(false) }
+    // Captured when the banner is tapped, not read live: a successful import
+    // refreshes the dashboard (prompt → null) while the dialog is still showing
+    // its result.
+    var legacyImportDialog by remember { mutableStateOf<LegacyImportPrompt?>(null) }
 
     if (showContact) {
         ContactModal(onDismiss = { showContact = false })
     }
     if (showDonate) {
         DonateModal(onDismiss = { showDonate = false })
+    }
+    legacyImportDialog?.let { prompt ->
+        LegacyImportDialog(prompt = prompt, onDismiss = { legacyImportDialog = null })
     }
 
     // Both caches are reactive to tab switches without re-doing work:
@@ -269,6 +276,21 @@ fun DashboardScreen(
         updateInfo?.let { info ->
             Spacer(Modifier.height(8.dp))
             UpdateAvailableCard(info)
+        }
+
+        // A pre-1.0 config is still on disk and this install already has roles,
+        // so the startup importer left the call to the user.
+        val legacyPrompt = loadedState.legacyImport
+        if (legacyPrompt != null && !LocalSettingsState.current.legacyImportDismissed) {
+            val interactor = LocalSettingsInteractor.current
+            Spacer(Modifier.height(8.dp))
+            LegacyImportBanner(
+                prompt = legacyPrompt,
+                containerColor = infoBg,
+                contentColor = onBannerColor,
+                onImport = { legacyImportDialog = legacyPrompt },
+                onHide = { interactor.setLegacyImportDismissed(true) },
+            )
         }
 
         val onContact = { showContact = true }

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DebugShellSnapshot.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DebugShellSnapshot.kt
@@ -320,6 +320,14 @@ internal fun buildDebugShellSnapshotCommand(): String =
     '
 
     emit_file canonical_config $CANONICAL_CONFIG_FILE
+    # Pre-1.0 lists. Present only on an install that upgraded across the 1.2.0
+    # gap without importing yet, so a bundle still shows what the import would
+    # have folded in (it deletes them once it runs).
+    ${
+        LEGACY_CONFIG_SECTIONS.entries.joinToString("\n    ") { (section, path) ->
+            "emit_file $section $path"
+        }
+    }
     ${
         buildPerUserPackageInventoryShell(
             sectionBeginPrefix = DEBUG_SNAPSHOT_BEGIN_PREFIX,

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/FullReset.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/FullReset.kt
@@ -14,13 +14,16 @@ package dev.okhsunrog.vpnhide
 //  - the app's own /data/data (SharedPreferences, zygisk heartbeat) — wiped
 //    when the APK is uninstalled.
 
-// Plain files under /data/system (rm -f).
+// Plain files under /data/system (rm -f). The pre-1.0 lists are included so a
+// reset device doesn't come back offering to import the config it just wiped.
 internal val FULL_RESET_FILES =
-    listOf(
-        CANONICAL_CONFIG_FILE,
-        LSPOSED_STATE_FILE,
-        LEGACY_HOOK_STATUS_FILE,
-    )
+    (
+        listOf(
+            CANONICAL_CONFIG_FILE,
+            LSPOSED_STATE_FILE,
+            LEGACY_HOOK_STATUS_FILE,
+        ) + LEGACY_FILES
+    ).distinct()
 
 // Data directories under /data/adb (rm -rf — covers load status, the APatch
 // superkey, and other backend state). Each is an explicit path — never a
@@ -31,7 +34,7 @@ internal val FULL_RESET_DIRS =
         "/data/adb/vpnhide_kmod",
         "/data/adb/vpnhide_kpm",
         "/data/adb/vpnhide_ports",
-    )
+    ) + LEGACY_ORPHAN_DIRS
 
 /** Single su command that removes every leftover service file/dir. Idempotent:
  *  paths a module's uninstall.sh already removed are simply no-ops. */

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/LegacyConfigImport.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/LegacyConfigImport.kt
@@ -1,0 +1,326 @@
+package dev.okhsunrog.vpnhide
+
+import kotlinx.serialization.Serializable
+
+// Import of the pre-1.0 on-disk configuration.
+//
+// Up to 0.7.1 the user's choices lived in flat text files, one per component.
+// 1.0.0 moved everything into the canonical JSON and folded the old files in on
+// first launch; 1.2.0 dropped that fold, so anyone jumping 0.7.x -> 1.2.x came
+// up with an empty config and their setup looked reset. The old files survive on
+// disk — 1.2.0 stopped deleting them as well — so the choices are recoverable.
+//
+// Two entry points:
+//  - startup, silent: the canonical JSON holds no user-configured app, so the
+//    legacy roles cannot conflict with anything (1.0.0's behaviour, restored).
+//  - Dashboard banner / Settings: the canonical JSON already carries roles, so
+//    the user picks merge / replace / skip.
+//
+// Either way the legacy files are deleted in the same root transaction as the
+// config write. "Files gone" IS the imported marker, so no extra state is
+// needed; a skip keeps them (and the Settings entry) available.
+
+/** Package lists, one name per line (v0.7.x and earlier). */
+internal const val LEGACY_KMOD_TARGETS = "/data/adb/vpnhide_kmod/targets.txt"
+internal const val LEGACY_KPM_TARGETS = "/data/adb/vpnhide_kpm/targets.txt"
+internal const val LEGACY_ZYGISK_TARGETS = "/data/adb/vpnhide_zygisk/targets.txt"
+internal const val LEGACY_LSPOSED_TARGETS = "/data/adb/vpnhide_lsposed/targets.txt"
+internal const val LEGACY_PORTS_OBSERVERS = "/data/adb/vpnhide_ports/observers.txt"
+internal const val LEGACY_HIDDEN_PKGS = "/data/system/vpnhide_hidden_pkgs.txt"
+
+// App-hiding observers were only ever persisted as resolved UIDs, so importing
+// them needs the current package inventory to map back to names.
+internal const val LEGACY_OBSERVER_UIDS = "/data/system/vpnhide_observer_uids.txt"
+
+// Derived by the old service.sh from the LSPosed package list — never a user
+// choice, so it is deleted with the rest but not read back.
+internal const val LEGACY_JAVA_UIDS = "/data/system/vpnhide_uids.txt"
+
+/**
+ * Directories that existed only to hold the legacy files. `vpnhide_kmod`,
+ * `vpnhide_kpm` and `vpnhide_ports` are deliberately absent: those are live
+ * today (load_status / load_dmesg / ctl.lock) and must survive the import.
+ */
+internal val LEGACY_ORPHAN_DIRS = listOf("/data/adb/vpnhide_zygisk", "/data/adb/vpnhide_lsposed")
+
+internal val LEGACY_FILES =
+    listOf(
+        LEGACY_KMOD_TARGETS,
+        LEGACY_KPM_TARGETS,
+        LEGACY_ZYGISK_TARGETS,
+        LEGACY_LSPOSED_TARGETS,
+        LEGACY_PORTS_OBSERVERS,
+        LEGACY_HIDDEN_PKGS,
+        LEGACY_OBSERVER_UIDS,
+        LEGACY_JAVA_UIDS,
+        LEGACY_HOOK_STATUS_FILE,
+    )
+
+/** Root-snapshot section name carrying each legacy file's contents. */
+internal val LEGACY_CONFIG_SECTIONS =
+    mapOf(
+        "legacy_kmod_targets" to LEGACY_KMOD_TARGETS,
+        "legacy_kpm_targets" to LEGACY_KPM_TARGETS,
+        "legacy_zygisk_targets" to LEGACY_ZYGISK_TARGETS,
+        "legacy_lsposed_targets" to LEGACY_LSPOSED_TARGETS,
+        "legacy_ports_observers" to LEGACY_PORTS_OBSERVERS,
+        "legacy_hidden_pkgs" to LEGACY_HIDDEN_PKGS,
+        "legacy_observer_uids" to LEGACY_OBSERVER_UIDS,
+    )
+
+/** How an import folds into a canonical config that already has app roles. */
+internal enum class LegacyImportMode {
+    /** Union of roles per package. Nothing already configured is lost. */
+    Merge,
+
+    /** The legacy lists become the app roles; `settings` and self stay. */
+    Replace,
+}
+
+/** Roles a single package held across the legacy files. */
+internal data class LegacyRoles(
+    val java: Boolean = false,
+    val native: Boolean = false,
+    val appHiding: Boolean = false,
+    val ports: Boolean = false,
+    val hidden: Boolean = false,
+)
+
+/**
+ * What a pre-1.0 install left on disk, already resolved to package names.
+ * Never empty: [parseLegacyConfigCandidate] returns null when there is nothing
+ * to offer.
+ */
+internal data class LegacyConfigCandidate(
+    val roles: Map<String, LegacyRoles>,
+    /** Observer UIDs with no installed package today (app uninstalled since). */
+    val unresolvedObserverUids: Int = 0,
+) {
+    fun count(predicate: (LegacyRoles) -> Boolean): Int = roles.values.count(predicate)
+}
+
+/**
+ * True when the config carries a hiding choice the user made. Packages that only
+ * carry `hidden` are excluded on purpose: those are the VPN apps auto-hide marks
+ * by itself, so a config holding nothing else is still "untouched" and can take
+ * a silent import.
+ */
+internal fun hasUserConfiguredApps(
+    config: CanonicalConfig,
+    selfPkg: String,
+): Boolean =
+    config.apps.any { (pkg, app) ->
+        pkg != selfPkg && (app.java || app.native.enabled || app.appHiding || app.ports)
+    }
+
+internal fun parseLegacyConfigCandidate(
+    sections: Map<String, String>,
+    uidToPkg: Map<Int, String>,
+): LegacyConfigCandidate? {
+    fun packages(section: String): Set<String> =
+        parseConfigLines(sections[section].orEmpty())
+            .filter { it.isValidPackageName() }
+            .toSet()
+
+    val native =
+        packages("legacy_kmod_targets") +
+            packages("legacy_kpm_targets") +
+            packages("legacy_zygisk_targets")
+    val java = packages("legacy_lsposed_targets")
+    val ports = packages("legacy_ports_observers")
+    val hidden = packages("legacy_hidden_pkgs")
+    val observerUids =
+        parseConfigLines(sections["legacy_observer_uids"].orEmpty())
+            .mapNotNull { it.toIntOrNull() }
+            .toSet()
+    val appHiding = observerUids.mapNotNull { resolveLegacyUid(it, uidToPkg) }.toSet()
+
+    val packages = (native + java + ports + hidden + appHiding).sorted()
+    if (packages.isEmpty()) return null
+    return LegacyConfigCandidate(
+        roles =
+            packages.associateWith { pkg ->
+                LegacyRoles(
+                    java = pkg in java,
+                    native = pkg in native,
+                    appHiding = pkg in appHiding,
+                    ports = pkg in ports,
+                    hidden = pkg in hidden,
+                )
+            },
+        unresolvedObserverUids = observerUids.count { resolveLegacyUid(it, uidToPkg) == null },
+    )
+}
+
+/**
+ * Map a persisted UID back to a package. Falls back to the app id (UID modulo
+ * the per-user offset) so an observer picked in a work profile still resolves
+ * after the profile was removed or renumbered.
+ */
+private fun resolveLegacyUid(
+    uid: Int,
+    uidToPkg: Map<Int, String>,
+): String? {
+    uidToPkg[uid]?.let { return it }
+    val appId = uid % PER_USER_RANGE
+    return uidToPkg.entries.firstOrNull { (known, _) -> known % PER_USER_RANGE == appId }?.value
+}
+
+private const val PER_USER_RANGE = 100_000
+
+// Guards against feeding a truncated/corrupt file's junk into the config. Same
+// shape Android itself accepts for a package name.
+private val PACKAGE_NAME_REGEX = Regex("[A-Za-z][A-Za-z0-9_]*(\\.[A-Za-z0-9_]+)+")
+
+private fun String.isValidPackageName(): Boolean = PACKAGE_NAME_REGEX.matches(this)
+
+/**
+ * Fold [candidate] into [base] and return the config to write. The self package
+ * always keeps its full roles, whichever mode ran.
+ */
+internal fun applyLegacyImport(
+    base: CanonicalConfig,
+    candidate: LegacyConfigCandidate,
+    mode: LegacyImportMode,
+    selfPkg: String,
+): CanonicalConfig {
+    val kept =
+        when (mode) {
+            LegacyImportMode.Merge -> {
+                base.apps
+            }
+
+            // Replace drops the user's app roles, but not the auto-hide marks:
+            // those are derived from VpnService signals and tracked by
+            // settings.autoHiddenPackages, and the reconcile only rewrites when
+            // that SET changes (autoHiddenPackagesNeedReconcile). Dropping the
+            // per-app `hidden` flag while the set still lists the package would
+            // leave the VPN app visible to observers with nothing to fix it.
+            LegacyImportMode.Replace -> {
+                base.apps
+                    .filterKeys { it in base.settings.autoHiddenPackages }
+                    .filterValues { it.hidden }
+                    .mapValues { (_, app) -> CanonicalApp(hidden = app.hidden) }
+            }
+        }
+    val merged = kept.toMutableMap()
+    candidate.roles.forEach { (pkg, roles) ->
+        merged[pkg] = (kept[pkg] ?: CanonicalApp()).withLegacyRoles(roles)
+    }
+    val apps = merged.filterValues { it.hasAnyRole }.toSortedMap()
+    return canonicalConfigWithSelfTarget(base.copy(apps = apps), selfPkg)
+}
+
+/**
+ * Union of the current roles and the legacy ones. Legacy files have no
+ * hook-level granularity, so a role that is already on keeps its current
+ * per-hook selection and a role the import switches on gets every hook.
+ */
+private fun CanonicalApp.withLegacyRoles(roles: LegacyRoles): CanonicalApp =
+    copy(
+        java = java || roles.java,
+        javaHooks = javaHooks.takeIf { java },
+        native =
+            if (native.enabled) {
+                native
+            } else if (roles.native) {
+                NativeRole.All
+            } else {
+                NativeRole.Disabled
+            },
+        appHiding = appHiding || roles.appHiding,
+        ports = ports || roles.ports,
+        portPolicy = portPolicy.takeIf { ports },
+        hidden = hidden || roles.hidden,
+    )
+
+/**
+ * What the Dashboard card and its dialog render: how much a pending import would
+ * bring in. Part of [DashboardState], so a debug bundle taken before the user
+ * decides still shows what was found on disk.
+ */
+@Serializable
+internal data class LegacyImportPrompt(
+    val packages: Int,
+    val java: Int,
+    val native: Int,
+    val appHiding: Int,
+    val ports: Int,
+    val hidden: Int,
+    val unresolvedObserverUids: Int,
+)
+
+internal fun LegacyConfigCandidate.toPrompt(): LegacyImportPrompt =
+    LegacyImportPrompt(
+        packages = roles.size,
+        java = count { it.java },
+        native = count { it.native },
+        appHiding = count { it.appHiding },
+        ports = count { it.ports },
+        hidden = count { it.hidden },
+        unresolvedObserverUids = unresolvedObserverUids,
+    )
+
+/** Outcome of a user-driven import, mapped to a message by the caller. */
+internal sealed interface LegacyImportOutcome {
+    data class Imported(
+        val packages: Int,
+    ) : LegacyImportOutcome
+
+    /** The files disappeared between rendering the card and confirming it. */
+    data object NothingToImport : LegacyImportOutcome
+
+    data class Failed(
+        val detail: String,
+    ) : LegacyImportOutcome
+}
+
+/**
+ * Runs a user-confirmed import. Re-reads the current state rather than trusting
+ * the card's snapshot: the config may have been edited on another screen (or by
+ * the startup importer) since the card was built.
+ */
+internal object LegacyConfigImporter {
+    suspend fun import(
+        mode: LegacyImportMode,
+        selfPkg: String,
+    ): LegacyImportOutcome {
+        val snapshot =
+            runCatching { RootSnapshotCache.getOrLoad() }
+                .getOrElse { return LegacyImportOutcome.Failed(it.message ?: "root snapshot failed") }
+        val targets = parseTargetsSnapshot(snapshot)
+        val candidate =
+            parseLegacyConfigCandidate(snapshot.sections, targets.uidToPkg)
+                ?: return LegacyImportOutcome.NothingToImport
+        val updated =
+            applyLegacyImport(targets.canonicalConfig ?: CanonicalConfig(), candidate, mode, selfPkg)
+        val result =
+            CanonicalConfigRepository.commit(
+                updated,
+                coupledCommands = listOf(buildLegacyConfigDeleteCommand()),
+                activation = CanonicalActivation(native = true, ports = true),
+            )
+        if (!result.succeeded) {
+            VpnHideLog.w(
+                LogTags.APP,
+                "legacy import failed (exit=${result.exitCode}): ${result.output.trim()}",
+            )
+            return LegacyImportOutcome.Failed("exit=${result.exitCode}")
+        }
+        VpnHideLog.i(LogTags.APP, "legacy import ($mode) applied for ${candidate.roles.size} packages")
+        return LegacyImportOutcome.Imported(candidate.roles.size)
+    }
+}
+
+/**
+ * Deletes every legacy file, then the two directories that held nothing else.
+ * Runs as a coupled command inside the canonical write transaction (joined with
+ * `&&`), so it must not report failure: `rm -f` already tolerates absent files,
+ * and the rmdir is explicitly forgiven — the directories are gone on most
+ * devices, and a non-empty one is left alone on purpose.
+ */
+internal fun buildLegacyConfigDeleteCommand(): String =
+    listOf(
+        "rm -f ${LEGACY_FILES.joinToString(" ")}",
+        "{ rmdir ${LEGACY_ORPHAN_DIRS.joinToString(" ")} 2>/dev/null || true; }",
+    ).joinToString(" && ")

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/LegacyConfigImport.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/LegacyConfigImport.kt
@@ -261,11 +261,35 @@ internal fun LegacyConfigCandidate.toPrompt(): LegacyImportPrompt =
         unresolvedObserverUids = unresolvedObserverUids,
     )
 
-/** Outcome of a user-driven import, mapped to a message by the caller. */
+/** What the user chose to do with the pre-1.0 files. */
+internal enum class LegacyImportAction {
+    Merge,
+    Replace,
+
+    /**
+     * Delete the files without importing anything. The point of the whole flow
+     * for a user who has already reconfigured the app by hand and just wants the
+     * leftovers off the device.
+     */
+    Discard,
+    ;
+
+    val mode: LegacyImportMode?
+        get() =
+            when (this) {
+                Merge -> LegacyImportMode.Merge
+                Replace -> LegacyImportMode.Replace
+                Discard -> null
+            }
+}
+
+/** Outcome of a user-driven action, mapped to a message by the caller. */
 internal sealed interface LegacyImportOutcome {
     data class Imported(
         val packages: Int,
     ) : LegacyImportOutcome
+
+    data object Discarded : LegacyImportOutcome
 
     /** The files disappeared between rendering the card and confirming it. */
     data object NothingToImport : LegacyImportOutcome
@@ -276,13 +300,13 @@ internal sealed interface LegacyImportOutcome {
 }
 
 /**
- * Runs a user-confirmed import. Re-reads the current state rather than trusting
+ * Runs a user-confirmed action. Re-reads the current state rather than trusting
  * the card's snapshot: the config may have been edited on another screen (or by
  * the startup importer) since the card was built.
  */
 internal object LegacyConfigImporter {
-    suspend fun import(
-        mode: LegacyImportMode,
+    suspend fun run(
+        action: LegacyImportAction,
         selfPkg: String,
     ): LegacyImportOutcome {
         val snapshot =
@@ -292,6 +316,7 @@ internal object LegacyConfigImporter {
         val candidate =
             parseLegacyConfigCandidate(snapshot.sections, targets.uidToPkg)
                 ?: return LegacyImportOutcome.NothingToImport
+        val mode = action.mode ?: return discard()
         val updated =
             applyLegacyImport(targets.canonicalConfig ?: CanonicalConfig(), candidate, mode, selfPkg)
         val result =
@@ -309,6 +334,23 @@ internal object LegacyConfigImporter {
         }
         VpnHideLog.i(LogTags.APP, "legacy import ($mode) applied for ${candidate.roles.size} packages")
         return LegacyImportOutcome.Imported(candidate.roles.size)
+    }
+
+    /**
+     * Delete only. No canonical write and no activator run: the config the
+     * backends are already using does not change, just the dead files go away.
+     * The caches still need a reload so the banner and the Settings entry
+     * disappear without a manual refresh.
+     */
+    private suspend fun discard(): LegacyImportOutcome {
+        val (exit, output) = suExecAsync(buildLegacyConfigDeleteCommand())
+        if (exit != 0) {
+            VpnHideLog.w(LogTags.APP, "legacy discard failed (exit=$exit): ${output.trim()}")
+            return LegacyImportOutcome.Failed("exit=$exit")
+        }
+        CanonicalConfigRepository.refreshDerivedCaches()
+        VpnHideLog.i(LogTags.APP, "legacy config files deleted without importing")
+        return LegacyImportOutcome.Discarded
     }
 }
 

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/LegacyImportUi.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/LegacyImportUi.kt
@@ -1,0 +1,192 @@
+package dev.okhsunrog.vpnhide
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import dev.okhsunrog.vpnhide.ui.components.ButtonSpinner
+import dev.okhsunrog.vpnhide.ui.components.EnhancedOutlinedButton
+import kotlinx.coroutines.launch
+
+/**
+ * Dashboard banner for a pre-1.0 config found next to a config that already has
+ * roles — the case the startup importer deliberately does not decide by itself
+ * (see [LegacyConfigImport]).
+ *
+ * "Hide" only silences the banner ([AppSettings.legacyImportDismissed]); the
+ * files stay on disk and Settings → Configuration keeps the import available,
+ * so a mis-tap costs nothing.
+ */
+@Composable
+internal fun LegacyImportBanner(
+    prompt: LegacyImportPrompt,
+    containerColor: Color,
+    contentColor: Color,
+    onImport: () -> Unit,
+    onHide: () -> Unit,
+) {
+    StatusBanner(
+        text = stringResource(R.string.legacy_import_banner, prompt.packages),
+        containerColor = containerColor,
+        contentColor = contentColor,
+        action = {
+            Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                EnhancedOutlinedButton(onClick = onImport) {
+                    Text(stringResource(R.string.legacy_import_banner_action))
+                }
+                EnhancedOutlinedButton(onClick = onHide) {
+                    Text(stringResource(R.string.legacy_import_banner_hide))
+                }
+            }
+        },
+    )
+}
+
+private sealed interface LegacyImportUiState {
+    data object Choosing : LegacyImportUiState
+
+    data object Running : LegacyImportUiState
+
+    data class Done(
+        val outcome: LegacyImportOutcome,
+    ) : LegacyImportUiState
+}
+
+/**
+ * Merge / replace picker for the pending import.
+ *
+ * Merge is offered first because it cannot lose anything: roles are unioned per
+ * package. Replace exists for the user who wants the old list verbatim and
+ * drops the current app roles — `settings` (auto-hide, superkey, optional
+ * features) and VPN Hide's own entry survive either way.
+ */
+@Composable
+internal fun LegacyImportDialog(
+    prompt: LegacyImportPrompt,
+    onDismiss: () -> Unit,
+) {
+    val context = LocalContext.current
+    val scope = rememberCoroutineScope()
+    var state by remember { mutableStateOf<LegacyImportUiState>(LegacyImportUiState.Choosing) }
+
+    fun run(mode: LegacyImportMode) {
+        state = LegacyImportUiState.Running
+        scope.launch {
+            state = LegacyImportUiState.Done(LegacyConfigImporter.import(mode, context.packageName))
+        }
+    }
+
+    val running = state is LegacyImportUiState.Running
+    AlertDialog(
+        onDismissRequest = { if (!running) onDismiss() },
+        title = { Text(stringResource(R.string.legacy_import_title)) },
+        text = {
+            when (val current = state) {
+                is LegacyImportUiState.Running -> {
+                    Row(
+                        horizontalArrangement = Arrangement.spacedBy(12.dp),
+                        verticalAlignment = Alignment.CenterVertically,
+                    ) {
+                        ButtonSpinner(size = 20.dp, color = MaterialTheme.colorScheme.primary)
+                        Text(stringResource(R.string.legacy_import_running))
+                    }
+                }
+
+                is LegacyImportUiState.Done -> {
+                    Text(
+                        when (val outcome = current.outcome) {
+                            is LegacyImportOutcome.Imported -> {
+                                stringResource(R.string.legacy_import_done, outcome.packages)
+                            }
+
+                            LegacyImportOutcome.NothingToImport -> {
+                                stringResource(R.string.legacy_import_nothing)
+                            }
+
+                            is LegacyImportOutcome.Failed -> {
+                                stringResource(R.string.legacy_import_failed, outcome.detail)
+                            }
+                        },
+                    )
+                }
+
+                LegacyImportUiState.Choosing -> {
+                    Column(verticalArrangement = Arrangement.spacedBy(10.dp)) {
+                        Text(
+                            stringResource(
+                                R.string.legacy_import_summary,
+                                prompt.packages,
+                                prompt.java,
+                                prompt.native,
+                                prompt.appHiding,
+                                prompt.ports,
+                                prompt.hidden,
+                            ),
+                        )
+                        if (prompt.unresolvedObserverUids > 0) {
+                            Text(
+                                text =
+                                    stringResource(
+                                        R.string.legacy_import_unresolved,
+                                        prompt.unresolvedObserverUids,
+                                    ),
+                                style = MaterialTheme.typography.bodySmall,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            )
+                        }
+                        Text(
+                            text = stringResource(R.string.legacy_import_explain),
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+                    }
+                }
+            }
+        },
+        confirmButton = {
+            when (state) {
+                LegacyImportUiState.Choosing -> {
+                    TextButton(onClick = { run(LegacyImportMode.Merge) }) {
+                        Text(stringResource(R.string.legacy_import_merge))
+                    }
+                }
+
+                is LegacyImportUiState.Done -> {
+                    TextButton(onClick = onDismiss) {
+                        Text(stringResource(R.string.reset_close))
+                    }
+                }
+
+                LegacyImportUiState.Running -> {
+                    Unit
+                }
+            }
+        },
+        dismissButton = {
+            if (state is LegacyImportUiState.Choosing) {
+                Row(horizontalArrangement = Arrangement.spacedBy(4.dp)) {
+                    TextButton(onClick = { run(LegacyImportMode.Replace) }) {
+                        Text(stringResource(R.string.legacy_import_replace))
+                    }
+                    TextButton(onClick = onDismiss) {
+                        Text(stringResource(R.string.btn_cancel))
+                    }
+                }
+            }
+        },
+    )
+}

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/LegacyImportUi.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/LegacyImportUi.kt
@@ -3,6 +3,9 @@ package dev.okhsunrog.vpnhide
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
@@ -14,6 +17,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
@@ -28,8 +32,8 @@ import kotlinx.coroutines.launch
  * (see [LegacyConfigImport]).
  *
  * "Hide" only silences the banner ([AppSettings.legacyImportDismissed]); the
- * files stay on disk and Settings → Configuration keeps the import available,
- * so a mis-tap costs nothing.
+ * files stay on disk and Settings → Configuration keeps every action — import
+ * and delete alike — reachable, so a mis-tap costs nothing.
  */
 @Composable
 internal fun LegacyImportBanner(
@@ -67,12 +71,17 @@ private sealed interface LegacyImportUiState {
 }
 
 /**
- * Merge / replace picker for the pending import.
+ * What to do with the pre-1.0 files: merge, replace, or delete them unread.
  *
- * Merge is offered first because it cannot lose anything: roles are unioned per
- * package. Replace exists for the user who wants the old list verbatim and
- * drops the current app roles — `settings` (auto-hide, superkey, optional
- * features) and VPN Hide's own entry survive either way.
+ * Merge leads because it cannot lose anything: roles are unioned per package.
+ * Replace is for the user who wants the old list verbatim and drops the current
+ * app roles — `settings` (auto-hide, superkey, optional features) and VPN Hide's
+ * own entry survive either way. Delete is the exit for everyone who has already
+ * reconfigured by hand and only wants the leftovers gone; without it the files
+ * would sit in `/data/adb` forever, since nothing else removes them.
+ *
+ * The three actions are full-width rows in the body rather than dialog buttons:
+ * three labels side by side overflow the button row on narrow screens.
  */
 @Composable
 internal fun LegacyImportDialog(
@@ -83,10 +92,10 @@ internal fun LegacyImportDialog(
     val scope = rememberCoroutineScope()
     var state by remember { mutableStateOf<LegacyImportUiState>(LegacyImportUiState.Choosing) }
 
-    fun run(mode: LegacyImportMode) {
+    fun run(action: LegacyImportAction) {
         state = LegacyImportUiState.Running
         scope.launch {
-            state = LegacyImportUiState.Done(LegacyConfigImporter.import(mode, context.packageName))
+            state = LegacyImportUiState.Done(LegacyConfigImporter.run(action, context.packageName))
         }
     }
 
@@ -111,6 +120,10 @@ internal fun LegacyImportDialog(
                         when (val outcome = current.outcome) {
                             is LegacyImportOutcome.Imported -> {
                                 stringResource(R.string.legacy_import_done, outcome.packages)
+                            }
+
+                            LegacyImportOutcome.Discarded -> {
+                                stringResource(R.string.legacy_import_discarded)
                             }
 
                             LegacyImportOutcome.NothingToImport -> {
@@ -153,16 +166,22 @@ internal fun LegacyImportDialog(
                             style = MaterialTheme.typography.bodySmall,
                             color = MaterialTheme.colorScheme.onSurfaceVariant,
                         )
+                        Spacer(Modifier.height(2.dp))
+                        ActionRow(R.string.legacy_import_merge) { run(LegacyImportAction.Merge) }
+                        ActionRow(R.string.legacy_import_replace) { run(LegacyImportAction.Replace) }
+                        ActionRow(
+                            textRes = R.string.legacy_import_discard,
+                            color = MaterialTheme.colorScheme.error,
+                        ) { run(LegacyImportAction.Discard) }
                     }
                 }
             }
         },
         confirmButton = {
             when (state) {
-                LegacyImportUiState.Choosing -> {
-                    TextButton(onClick = { run(LegacyImportMode.Merge) }) {
-                        Text(stringResource(R.string.legacy_import_merge))
-                    }
+                // The three choices live in the body; nothing to confirm here.
+                LegacyImportUiState.Choosing, LegacyImportUiState.Running -> {
+                    Unit
                 }
 
                 is LegacyImportUiState.Done -> {
@@ -170,23 +189,25 @@ internal fun LegacyImportDialog(
                         Text(stringResource(R.string.reset_close))
                     }
                 }
-
-                LegacyImportUiState.Running -> {
-                    Unit
-                }
             }
         },
         dismissButton = {
             if (state is LegacyImportUiState.Choosing) {
-                Row(horizontalArrangement = Arrangement.spacedBy(4.dp)) {
-                    TextButton(onClick = { run(LegacyImportMode.Replace) }) {
-                        Text(stringResource(R.string.legacy_import_replace))
-                    }
-                    TextButton(onClick = onDismiss) {
-                        Text(stringResource(R.string.btn_cancel))
-                    }
+                TextButton(onClick = onDismiss) {
+                    Text(stringResource(R.string.btn_cancel))
                 }
             }
         },
     )
+}
+
+@Composable
+private fun ActionRow(
+    textRes: Int,
+    color: Color = MaterialTheme.colorScheme.primary,
+    onClick: () -> Unit,
+) {
+    EnhancedOutlinedButton(onClick = onClick, modifier = Modifier.fillMaxWidth()) {
+        Text(stringResource(textRes), color = color)
+    }
 }

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/RootSnapshotCache.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/RootSnapshotCache.kt
@@ -275,6 +275,18 @@ internal fun buildRootShellSnapshotCommand(
       emit_eval superkey_saved '[ -s $SUPERKEY_FILE ] && echo 1 || echo 0'
       phase_end
     }
+    # Pre-1.0 per-component lists. Nothing writes them today, so a non-empty
+    # section means an install that skipped the 1.0.x migration window and can
+    # still have its choices recovered (LegacyConfigImport).
+    phase_legacy_config() {
+      phase_start legacy_config
+      ${
+        LEGACY_CONFIG_SECTIONS.entries.joinToString("\n      ") { (section, path) ->
+            "emit_file $section $path"
+        }
+    }
+      phase_end
+    }
     phase_kmod_status_files() {
       phase_start kmod_status_files
       emit_file current_boot_id /proc/sys/kernel/random/boot_id
@@ -396,6 +408,7 @@ internal fun buildRootShellSnapshotCommand(
     run_all_phases_sequential() {
       phase_module_props
       phase_target_files
+      phase_legacy_config
       phase_kmod_status_files
       phase_runtime_status_files
       __VPNHIDE_PM_PACKAGES_PHASE__

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/SettingsScreen.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/SettingsScreen.kt
@@ -460,7 +460,16 @@ private fun ConfigBackupSection() {
     var pendingExport by remember { mutableStateOf<String?>(null) }
     var pendingPackageListExport by remember { mutableStateOf<String?>(null) }
     var packageListDialogOpen by remember { mutableStateOf(false) }
+    var legacyImportDialog by remember { mutableStateOf<LegacyImportPrompt?>(null) }
     var status by remember { mutableStateOf<String?>(null) }
+    val rootSnapshot by RootSnapshotCache.snapshot.collectAsState()
+    // Pre-1.0 config still on disk (see LegacyConfigImport). Derived from the
+    // shared root snapshot TargetsCache already loads — no extra su round-trip.
+    val legacyPrompt =
+        remember(rootSnapshot, targets) {
+            val uidToPkg = targets?.uidToPkg ?: return@remember null
+            rootSnapshot?.let { parseLegacyConfigCandidate(it.sections, uidToPkg)?.toPrompt() }
+        }
     val exportDone = stringResource(R.string.settings_config_export_done)
     val exportFailed = stringResource(R.string.settings_config_export_failed)
     val importDone = stringResource(R.string.settings_config_import_done)
@@ -597,7 +606,28 @@ private fun ConfigBackupSection() {
             enabled = targets != null && operation == ConfigOperation.Idle,
             onClick = { packageListDialogOpen = true },
         )
+        // Only rendered while pre-1.0 files are actually on disk — the import
+        // deletes them, so this row disappears once it has run. Keeps the option
+        // reachable for anyone who hid the Dashboard banner.
+        legacyPrompt?.let { prompt ->
+            PreferenceRow(
+                title = stringResource(R.string.settings_legacy_import_title),
+                subtitle = stringResource(R.string.settings_legacy_import_sub, prompt.packages),
+                icon = Icons.Default.FileUpload,
+                enabled = operation == ConfigOperation.Idle,
+                onClick = { legacyImportDialog = prompt },
+            )
+        }
         SettingsStatusLine(status)
+    }
+
+    // Captured on tap: the import clears the on-disk files, so reading the
+    // prompt live would tear the dialog down before it shows its result.
+    legacyImportDialog?.let { prompt ->
+        LegacyImportDialog(
+            prompt = prompt,
+            onDismiss = { legacyImportDialog = null },
+        )
     }
 
     val packageListConfig = targets?.let(::buildConfigExportCanonical)

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/ShellUtils.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/ShellUtils.kt
@@ -265,7 +265,7 @@ internal suspend fun ensureSelfInTargets(
     }
     val update = buildCanonicalSelfUpdate(sections, selfPkg)
     if (update.writeRequired) {
-        writeStartupCanonical(update.canonical, timeoutSec)?.let {
+        writeStartupCanonical(update.canonical, update.legacyImported, timeoutSec)?.let {
             return selfTargetPreparationFailure(SelfTargetFailureKind.ConfigWriteFailed, it)
         }
         RootSnapshotCache.invalidate()
@@ -287,6 +287,9 @@ private data class CanonicalSelfUpdate(
     val canonical: CanonicalConfig,
     val selfNeedsRestart: Boolean,
     val writeRequired: Boolean,
+    /** Non-null when [canonical] already carries a silently imported pre-1.0
+     *  config, so the same write must retire the legacy files. */
+    val legacyImported: LegacyConfigCandidate? = null,
 )
 
 private data class SelfTargetFailureDetail(
@@ -319,27 +322,50 @@ private fun buildCanonicalSelfUpdate(
 ): CanonicalSelfUpdate {
     val targets = parseTargetsSnapshot(RootSnapshot(sections))
     val baseCanonical = targets.canonicalConfig ?: CanonicalConfig()
+    // Nothing configured yet + a pre-1.0 config still on disk: fold it in without
+    // asking, the way 1.0.0 did. There is no user choice to conflict with, and
+    // the alternative — a device that upgraded from 0.7.x showing an empty list —
+    // reads as "the update wiped my settings". A config that DOES carry roles is
+    // left alone here; the Dashboard offers merge/replace/skip instead.
+    val legacy =
+        parseLegacyConfigCandidate(sections, targets.uidToPkg)
+            ?.takeIf { !hasUserConfiguredApps(baseCanonical, selfPkg) }
+    val imported =
+        legacy?.let { applyLegacyImport(baseCanonical, it, LegacyImportMode.Merge, selfPkg) }
+            ?: baseCanonical
+    if (legacy != null) {
+        VpnHideLog.i(
+            TAG,
+            "ensureSelfInTargets: importing pre-1.0 config (${legacy.roles.size} packages, " +
+                "${legacy.unresolvedObserverUids} unresolved observer uids)",
+        )
+    }
     val previousSelf = baseCanonical.apps[selfPkg]
     val selfNeedsRestart =
         previousSelf == null ||
             !previousSelf.java ||
             previousSelf.javaHooks != null ||
             previousSelf.native != NativeRole.All
-    val updatedCanonical = canonicalConfigWithSelfTarget(baseCanonical, selfPkg)
+    val updatedCanonical = canonicalConfigWithSelfTarget(imported, selfPkg)
     return CanonicalSelfUpdate(
         canonical = updatedCanonical,
         selfNeedsRestart = selfNeedsRestart,
-        writeRequired = targets.canonicalConfig == null || updatedCanonical != baseCanonical,
+        writeRequired = targets.canonicalConfig == null || updatedCanonical != baseCanonical || legacy != null,
+        legacyImported = legacy,
     )
 }
 
 private suspend fun writeStartupCanonical(
     canonical: CanonicalConfig,
+    legacyImported: LegacyConfigCandidate?,
     timeoutSec: Long,
 ): String? {
     val result =
         CanonicalConfigRepository.commit(
             canonical,
+            // Same transaction as the config write: the legacy files are only
+            // retired once their contents are safely in the canonical JSON.
+            coupledCommands = if (legacyImported != null) listOf(buildLegacyConfigDeleteCommand()) else emptyList(),
             activation = CanonicalActivation(native = true, ports = true),
             timeoutSec = timeoutSec,
         )

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/settings/AppSettings.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/settings/AppSettings.kt
@@ -65,6 +65,12 @@ data class AppSettings(
      * reaction and never again.
      */
     val donatePromptDismissed: Boolean = false,
+    /**
+     * The user declined importing a pre-1.0 config found on disk. The files stay
+     * where they are, so Settings → Advanced can still run the import later; this
+     * only stops the Dashboard card from asking again.
+     */
+    val legacyImportDismissed: Boolean = false,
 ) {
     companion object {
         /** Brand seed — a crisp blue-teal, used as the non-dynamic fallback palette. */

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/settings/SettingsInteractor.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/settings/SettingsInteractor.kt
@@ -47,6 +47,8 @@ interface SettingsInteractor {
     fun setSuppressVersionWarnings(value: Boolean)
 
     fun setDonatePromptDismissed(value: Boolean)
+
+    fun setLegacyImportDismissed(value: Boolean)
 }
 
 /**
@@ -84,6 +86,8 @@ class RepositorySettingsInteractor(
     override fun setSuppressVersionWarnings(value: Boolean) = launch { repository.setSuppressVersionWarnings(value) }
 
     override fun setDonatePromptDismissed(value: Boolean) = launch { repository.setDonatePromptDismissed(value) }
+
+    override fun setLegacyImportDismissed(value: Boolean) = launch { repository.setLegacyImportDismissed(value) }
 
     private inline fun launch(crossinline block: suspend () -> Unit) {
         scope.launch { block() }

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/settings/SettingsRepository.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/settings/SettingsRepository.kt
@@ -41,6 +41,7 @@ class SettingsRepository(
         val SETTINGS_HINT_SEEN = booleanPreferencesKey("settings_hint_seen")
         val SUPPRESS_VERSION_WARNINGS = booleanPreferencesKey("suppress_version_warnings")
         val DONATE_PROMPT_DISMISSED = booleanPreferencesKey("donate_prompt_dismissed")
+        val LEGACY_IMPORT_DISMISSED = booleanPreferencesKey("legacy_import_dismissed")
 
         // Worker-internal state (not a user-facing setting, so not surfaced in
         // AppSettings): the last release the background update worker already
@@ -71,6 +72,8 @@ class SettingsRepository(
                     p[Keys.SUPPRESS_VERSION_WARNINGS] ?: defaults.suppressVersionWarnings,
                 donatePromptDismissed =
                     p[Keys.DONATE_PROMPT_DISMISSED] ?: defaults.donatePromptDismissed,
+                legacyImportDismissed =
+                    p[Keys.LEGACY_IMPORT_DISMISSED] ?: defaults.legacyImportDismissed,
             )
         }
 
@@ -101,6 +104,8 @@ class SettingsRepository(
     suspend fun setSuppressVersionWarnings(value: Boolean) = edit { it[Keys.SUPPRESS_VERSION_WARNINGS] = value }
 
     suspend fun setDonatePromptDismissed(value: Boolean) = edit { it[Keys.DONATE_PROMPT_DISMISSED] = value }
+
+    suspend fun setLegacyImportDismissed(value: Boolean) = edit { it[Keys.LEGACY_IMPORT_DISMISSED] = value }
 
     /** Last release the background update worker has already notified about, if any. */
     suspend fun lastNotifiedUpdateVersion(): String? =

--- a/lsposed/app/src/main/res/values-ru/strings.xml
+++ b/lsposed/app/src/main/res/values-ru/strings.xml
@@ -271,16 +271,18 @@
 
     <!-- Перенос настроек, оставшихся от версий до 1.0 -->
     <string name="legacy_import_banner">На устройстве найдены настройки от версии до 1.0. Приложений в них: %1$d. Сейчас у вас уже есть настроенные приложения, поэтому автоматически ничего не переносилось.</string>
-    <string name="legacy_import_banner_action">Перенести</string>
+    <string name="legacy_import_banner_action">Разобраться</string>
     <string name="legacy_import_banner_hide">Скрыть</string>
     <string name="legacy_import_title">Перенос старых настроек</string>
     <string name="legacy_import_summary">Найдено приложений: %1$d. Java — %2$d, Native — %3$d, Apps — %4$d, Ports — %5$d, скрываемых — %6$d.</string>
     <string name="legacy_import_unresolved">Роль Apps хранилась в виде UID, и %1$d из них уже не принадлежат ни одному установленному приложению — они будут пропущены.</string>
-    <string name="legacy_import_explain">«Объединить» — оставить всё, что настроено сейчас, и добавить к нему старые роли. «Заменить» — отбросить текущий список приложений и взять старый. Настройки автоскрытия и запись самого VPN Hide сохраняются в обоих случаях. После успешного переноса старые файлы удаляются.</string>
+    <string name="legacy_import_explain">«Объединить» — оставить всё, что настроено сейчас, и добавить к нему старые роли. «Заменить» — отбросить текущий список приложений и взять старый; настройки автоскрытия и запись самого VPN Hide сохраняются в обоих случаях. «Удалить» — стереть старые файлы, не читая: выбирайте, если вы уже всё настроили заново и хотите просто убрать их с устройства. Во всех трёх случаях старые файлы удаляются, вернуть их будет нельзя.</string>
     <string name="legacy_import_merge">Объединить</string>
     <string name="legacy_import_replace">Заменить</string>
-    <string name="legacy_import_running">Переносим настройки…</string>
+    <string name="legacy_import_discard">Удалить, ничего не перенося</string>
+    <string name="legacy_import_running">Работаем…</string>
     <string name="legacy_import_done">Перенесено приложений: %1$d.</string>
+    <string name="legacy_import_discarded">Старые файлы удалены. Ничего не перенесено.</string>
     <string name="legacy_import_nothing">Переносить нечего — старых файлов на устройстве больше нет.</string>
     <string name="legacy_import_failed">Не удалось перенести (%1$s). Возможно, не выдан root-доступ.</string>
     <!-- Full reset / leftover cleanup -->
@@ -504,8 +506,8 @@
     <string name="settings_config_import_done">Конфиг импортирован.</string>
     <string name="settings_config_import_invalid">Импорт не удался: некорректный JSON-конфиг.</string>
     <string name="settings_config_import_root_failed">Импорт не удался: не получилось записать root-конфиг.</string>
-    <string name="settings_legacy_import_title">Перенести настройки от версии до 1.0</string>
-    <string name="settings_legacy_import_sub">На устройстве остались настройки старой версии, приложений в них: %1$d</string>
+    <string name="settings_legacy_import_title">Настройки от версии до 1.0</string>
+    <string name="settings_legacy_import_sub">Приложений в них: %1$d — перенести или удалить</string>
     <string name="settings_package_list_title">Экспорт списка пакетов</string>
     <string name="settings_package_list_sub">Скопировать или сохранить ID пакетов для VPN-клиентов</string>
     <string name="settings_package_list_dialog_body">Экспортирует ID пакетов из сохранённого конфига скрытия. JSON-резервная копия выше остаётся полным конфигом VPN Hide.</string>

--- a/lsposed/app/src/main/res/values-ru/strings.xml
+++ b/lsposed/app/src/main/res/values-ru/strings.xml
@@ -268,6 +268,21 @@
     <string name="donate_banner">VPN Hide бесплатный и без рекламы. Если он вам полезен — можно поддержать разработку.</string>
     <string name="donate_banner_support">Поддержать</string>
     <string name="donate_banner_hide">Скрыть</string>
+
+    <!-- Перенос настроек, оставшихся от версий до 1.0 -->
+    <string name="legacy_import_banner">На устройстве найдены настройки от версии до 1.0. Приложений в них: %1$d. Сейчас у вас уже есть настроенные приложения, поэтому автоматически ничего не переносилось.</string>
+    <string name="legacy_import_banner_action">Перенести</string>
+    <string name="legacy_import_banner_hide">Скрыть</string>
+    <string name="legacy_import_title">Перенос старых настроек</string>
+    <string name="legacy_import_summary">Найдено приложений: %1$d. Java — %2$d, Native — %3$d, Apps — %4$d, Ports — %5$d, скрываемых — %6$d.</string>
+    <string name="legacy_import_unresolved">Роль Apps хранилась в виде UID, и %1$d из них уже не принадлежат ни одному установленному приложению — они будут пропущены.</string>
+    <string name="legacy_import_explain">«Объединить» — оставить всё, что настроено сейчас, и добавить к нему старые роли. «Заменить» — отбросить текущий список приложений и взять старый. Настройки автоскрытия и запись самого VPN Hide сохраняются в обоих случаях. После успешного переноса старые файлы удаляются.</string>
+    <string name="legacy_import_merge">Объединить</string>
+    <string name="legacy_import_replace">Заменить</string>
+    <string name="legacy_import_running">Переносим настройки…</string>
+    <string name="legacy_import_done">Перенесено приложений: %1$d.</string>
+    <string name="legacy_import_nothing">Переносить нечего — старых файлов на устройстве больше нет.</string>
+    <string name="legacy_import_failed">Не удалось перенести (%1$s). Возможно, не выдан root-доступ.</string>
     <!-- Full reset / leftover cleanup -->
     <string name="settings_reset_section">Сброс</string>
     <string name="reset_button">Удалить оставшиеся файлы</string>
@@ -489,6 +504,8 @@
     <string name="settings_config_import_done">Конфиг импортирован.</string>
     <string name="settings_config_import_invalid">Импорт не удался: некорректный JSON-конфиг.</string>
     <string name="settings_config_import_root_failed">Импорт не удался: не получилось записать root-конфиг.</string>
+    <string name="settings_legacy_import_title">Перенести настройки от версии до 1.0</string>
+    <string name="settings_legacy_import_sub">На устройстве остались настройки старой версии, приложений в них: %1$d</string>
     <string name="settings_package_list_title">Экспорт списка пакетов</string>
     <string name="settings_package_list_sub">Скопировать или сохранить ID пакетов для VPN-клиентов</string>
     <string name="settings_package_list_dialog_body">Экспортирует ID пакетов из сохранённого конфига скрытия. JSON-резервная копия выше остаётся полным конфигом VPN Hide.</string>

--- a/lsposed/app/src/main/res/values-zh-rCN/strings.xml
+++ b/lsposed/app/src/main/res/values-zh-rCN/strings.xml
@@ -301,6 +301,21 @@
     <string name="donate_banner">VPN Hide 免费且无广告。如果它对你有用，可以支持它的开发。</string>
     <string name="donate_banner_support">支持</string>
     <string name="donate_banner_hide">隐藏</string>
+
+    <!-- 导入 1.0 之前版本遗留在设备上的配置 -->
+    <string name="legacy_import_banner">在设备上找到了 1.0 之前版本的配置，其中包含 %1$d 个应用。当前配置中已有设置好的应用，因此没有自动导入。</string>
+    <string name="legacy_import_banner_action">导入</string>
+    <string name="legacy_import_banner_hide">隐藏</string>
+    <string name="legacy_import_title">导入旧配置</string>
+    <string name="legacy_import_summary">共找到 %1$d 个应用：Java %2$d，Native %3$d，Apps %4$d，Ports %5$d，隐藏 %6$d。</string>
+    <string name="legacy_import_unresolved">Apps 角色是以 UID 保存的，其中 %1$d 个已不对应任何已安装的应用，将被跳过。</string>
+    <string name="legacy_import_explain">「合并」保留当前的全部设置，并在其上加入旧的角色。「替换」丢弃当前的应用列表，改用旧的列表。两种方式都会保留自动隐藏设置以及 VPN Hide 自身的条目。导入成功后旧文件会被删除。</string>
+    <string name="legacy_import_merge">合并</string>
+    <string name="legacy_import_replace">替换</string>
+    <string name="legacy_import_running">正在导入…</string>
+    <string name="legacy_import_done">已导入 %1$d 个应用。</string>
+    <string name="legacy_import_nothing">没有可导入的内容 — 旧文件已不存在。</string>
+    <string name="legacy_import_failed">导入失败（%1$s）。可能是未授予 root 权限。</string>
     <!-- Full reset / leftover cleanup -->
     <string name="settings_reset_section">重置</string>
     <string name="reset_button">移除残留文件</string>
@@ -477,6 +492,8 @@
     <string name="settings_config_import_done">配置已导入。</string>
     <string name="settings_config_import_invalid">导入失败：配置 JSON 无效。</string>
     <string name="settings_config_import_root_failed">导入失败：Root 写入配置失败。</string>
+    <string name="settings_legacy_import_title">导入 1.0 之前版本的配置</string>
+    <string name="settings_legacy_import_sub">设备上仍保留着旧版本的配置，其中包含 %1$d 个应用</string>
     <string name="settings_package_list_title">软件包列表导出</string>
     <string name="settings_package_list_sub">复制或保存 VPN 客户端的软件包 ID</string>
     <string name="settings_package_list_dialog_body">从已保存的隐藏配置导出软件包 ID。上方的 JSON 备份仍是完整的 VPN Hide 配置。</string>

--- a/lsposed/app/src/main/res/values-zh-rCN/strings.xml
+++ b/lsposed/app/src/main/res/values-zh-rCN/strings.xml
@@ -304,16 +304,18 @@
 
     <!-- 导入 1.0 之前版本遗留在设备上的配置 -->
     <string name="legacy_import_banner">在设备上找到了 1.0 之前版本的配置，其中包含 %1$d 个应用。当前配置中已有设置好的应用，因此没有自动导入。</string>
-    <string name="legacy_import_banner_action">导入</string>
+    <string name="legacy_import_banner_action">查看</string>
     <string name="legacy_import_banner_hide">隐藏</string>
     <string name="legacy_import_title">导入旧配置</string>
     <string name="legacy_import_summary">共找到 %1$d 个应用：Java %2$d，Native %3$d，Apps %4$d，Ports %5$d，隐藏 %6$d。</string>
     <string name="legacy_import_unresolved">Apps 角色是以 UID 保存的，其中 %1$d 个已不对应任何已安装的应用，将被跳过。</string>
-    <string name="legacy_import_explain">「合并」保留当前的全部设置，并在其上加入旧的角色。「替换」丢弃当前的应用列表，改用旧的列表。两种方式都会保留自动隐藏设置以及 VPN Hide 自身的条目。导入成功后旧文件会被删除。</string>
+    <string name="legacy_import_explain">「合并」保留当前的全部设置，并在其上加入旧的角色。「替换」丢弃当前的应用列表，改用旧的列表；两者都会保留自动隐藏设置以及 VPN Hide 自身的条目。「删除」则不读取内容直接清除旧文件 — 如果你已经重新配置好，只想把它们从设备上清掉，就选这个。三种方式都会删除旧文件，且无法撤销。</string>
     <string name="legacy_import_merge">合并</string>
     <string name="legacy_import_replace">替换</string>
-    <string name="legacy_import_running">正在导入…</string>
+    <string name="legacy_import_discard">直接删除，不导入</string>
+    <string name="legacy_import_running">正在处理…</string>
     <string name="legacy_import_done">已导入 %1$d 个应用。</string>
+    <string name="legacy_import_discarded">旧文件已删除，未导入任何内容。</string>
     <string name="legacy_import_nothing">没有可导入的内容 — 旧文件已不存在。</string>
     <string name="legacy_import_failed">导入失败（%1$s）。可能是未授予 root 权限。</string>
     <!-- Full reset / leftover cleanup -->
@@ -492,8 +494,8 @@
     <string name="settings_config_import_done">配置已导入。</string>
     <string name="settings_config_import_invalid">导入失败：配置 JSON 无效。</string>
     <string name="settings_config_import_root_failed">导入失败：Root 写入配置失败。</string>
-    <string name="settings_legacy_import_title">导入 1.0 之前版本的配置</string>
-    <string name="settings_legacy_import_sub">设备上仍保留着旧版本的配置，其中包含 %1$d 个应用</string>
+    <string name="settings_legacy_import_title">1.0 之前版本的配置</string>
+    <string name="settings_legacy_import_sub">其中包含 %1$d 个应用 — 可导入或删除</string>
     <string name="settings_package_list_title">软件包列表导出</string>
     <string name="settings_package_list_sub">复制或保存 VPN 客户端的软件包 ID</string>
     <string name="settings_package_list_dialog_body">从已保存的隐藏配置导出软件包 ID。上方的 JSON 备份仍是完整的 VPN Hide 配置。</string>

--- a/lsposed/app/src/main/res/values/strings.xml
+++ b/lsposed/app/src/main/res/values/strings.xml
@@ -315,16 +315,18 @@
 
     <!-- Import of a pre-1.0 configuration left on disk -->
     <string name="legacy_import_banner">A configuration from a version before 1.0 was found on this device: %1$d apps. Your current setup already has apps configured, so it was not imported automatically.</string>
-    <string name="legacy_import_banner_action">Import</string>
+    <string name="legacy_import_banner_action">Review</string>
     <string name="legacy_import_banner_hide">Hide</string>
     <string name="legacy_import_title">Import old configuration</string>
     <string name="legacy_import_summary">Found %1$d apps: Java %2$d, Native %3$d, Apps %4$d, Ports %5$d, hidden %6$d.</string>
     <string name="legacy_import_unresolved">%1$d app-hiding entries were saved as UIDs that no longer match an installed app and will be skipped.</string>
-    <string name="legacy_import_explain">Merge keeps everything configured now and adds the old roles on top. Replace drops the current app list and uses the old one instead. Auto-hide settings and VPN Hide\'s own entry are kept either way. The old files are removed once the import succeeds.</string>
+    <string name="legacy_import_explain">Merge keeps everything configured now and adds the old roles on top. Replace drops the current app list and uses the old one instead; auto-hide settings and VPN Hide\'s own entry are kept either way. Delete removes the old files without reading them — pick it if you have already set everything up again and just want them off the device. All three delete the files; this cannot be undone.</string>
     <string name="legacy_import_merge">Merge</string>
     <string name="legacy_import_replace">Replace</string>
-    <string name="legacy_import_running">Importing…</string>
+    <string name="legacy_import_discard">Delete without importing</string>
+    <string name="legacy_import_running">Working…</string>
     <string name="legacy_import_done">Imported %1$d apps.</string>
+    <string name="legacy_import_discarded">The old files were deleted. Nothing was imported.</string>
     <string name="legacy_import_nothing">Nothing left to import — the old files are already gone.</string>
     <string name="legacy_import_failed">Import failed (%1$s). Root access may have been denied.</string>
     <!-- Full reset / leftover cleanup -->
@@ -534,8 +536,8 @@
     <string name="settings_config_import_done">Config imported.</string>
     <string name="settings_config_import_invalid">Import failed: invalid config JSON.</string>
     <string name="settings_config_import_root_failed">Import failed: root config write failed.</string>
-    <string name="settings_legacy_import_title">Import pre-1.0 configuration</string>
-    <string name="settings_legacy_import_sub">%1$d apps from an older version are still stored on this device</string>
+    <string name="settings_legacy_import_title">Pre-1.0 configuration</string>
+    <string name="settings_legacy_import_sub">%1$d apps left by an older version — import or delete</string>
     <string name="settings_package_list_title">Package list export</string>
     <string name="settings_package_list_sub">Copy or save package IDs for VPN clients</string>
     <string name="settings_package_list_dialog_body">Export package IDs from the saved hiding config. The JSON backup above remains the full VPN Hide config.</string>

--- a/lsposed/app/src/main/res/values/strings.xml
+++ b/lsposed/app/src/main/res/values/strings.xml
@@ -312,6 +312,21 @@
     <string name="donate_banner">VPN Hide is free and has no ads. If it is useful to you, you can support its development.</string>
     <string name="donate_banner_support">Support</string>
     <string name="donate_banner_hide">Hide</string>
+
+    <!-- Import of a pre-1.0 configuration left on disk -->
+    <string name="legacy_import_banner">A configuration from a version before 1.0 was found on this device: %1$d apps. Your current setup already has apps configured, so it was not imported automatically.</string>
+    <string name="legacy_import_banner_action">Import</string>
+    <string name="legacy_import_banner_hide">Hide</string>
+    <string name="legacy_import_title">Import old configuration</string>
+    <string name="legacy_import_summary">Found %1$d apps: Java %2$d, Native %3$d, Apps %4$d, Ports %5$d, hidden %6$d.</string>
+    <string name="legacy_import_unresolved">%1$d app-hiding entries were saved as UIDs that no longer match an installed app and will be skipped.</string>
+    <string name="legacy_import_explain">Merge keeps everything configured now and adds the old roles on top. Replace drops the current app list and uses the old one instead. Auto-hide settings and VPN Hide\'s own entry are kept either way. The old files are removed once the import succeeds.</string>
+    <string name="legacy_import_merge">Merge</string>
+    <string name="legacy_import_replace">Replace</string>
+    <string name="legacy_import_running">Importing…</string>
+    <string name="legacy_import_done">Imported %1$d apps.</string>
+    <string name="legacy_import_nothing">Nothing left to import — the old files are already gone.</string>
+    <string name="legacy_import_failed">Import failed (%1$s). Root access may have been denied.</string>
     <!-- Full reset / leftover cleanup -->
     <string name="settings_reset_section">Reset</string>
     <string name="reset_button">Remove leftover files</string>
@@ -519,6 +534,8 @@
     <string name="settings_config_import_done">Config imported.</string>
     <string name="settings_config_import_invalid">Import failed: invalid config JSON.</string>
     <string name="settings_config_import_root_failed">Import failed: root config write failed.</string>
+    <string name="settings_legacy_import_title">Import pre-1.0 configuration</string>
+    <string name="settings_legacy_import_sub">%1$d apps from an older version are still stored on this device</string>
     <string name="settings_package_list_title">Package list export</string>
     <string name="settings_package_list_sub">Copy or save package IDs for VPN clients</string>
     <string name="settings_package_list_dialog_body">Export package IDs from the saved hiding config. The JSON backup above remains the full VPN Hide config.</string>

--- a/lsposed/app/src/test/kotlin/dev/okhsunrog/vpnhide/FullResetTest.kt
+++ b/lsposed/app/src/test/kotlin/dev/okhsunrog/vpnhide/FullResetTest.kt
@@ -20,8 +20,14 @@ class FullResetTest {
         listOf("kmod", "kpm", "ports").forEach {
             assertTrue("missing /data/adb/vpnhide_$it", cmd.contains("rm -rf /data/adb/vpnhide_$it"))
         }
+        // Pre-1.0 lists too: leaving them behind is what "leftover files" means,
+        // and a reset device would otherwise come back offering to import the
+        // config it just wiped (LegacyConfigImport).
         listOf("vpnhide_uids.txt", "vpnhide_hidden_pkgs.txt", "vpnhide_observer_uids.txt").forEach {
-            assertFalse("retired migration path remains: $it", cmd.contains(it))
+            assertTrue("pre-1.0 path not cleaned: $it", cmd.contains(it))
+        }
+        listOf("vpnhide_zygisk", "vpnhide_lsposed").forEach {
+            assertTrue("missing /data/adb/$it", cmd.contains("rm -rf /data/adb/$it"))
         }
     }
 

--- a/lsposed/app/src/test/kotlin/dev/okhsunrog/vpnhide/LegacyConfigImportTest.kt
+++ b/lsposed/app/src/test/kotlin/dev/okhsunrog/vpnhide/LegacyConfigImportTest.kt
@@ -1,0 +1,199 @@
+package dev.okhsunrog.vpnhide
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * The pre-1.0 importer. Covers the two things a wrong answer costs the user
+ * directly: which packages/roles come back out of the old flat files, and what
+ * merge/replace do to a config that already has roles.
+ */
+class LegacyConfigImportTest {
+    private val selfPkg = "dev.okhsunrog.vpnhide"
+
+    private val uidToPkg =
+        mapOf(
+            10123 to "com.bank.app",
+            1010123 to "com.bank.app",
+            10222 to "com.messenger",
+        )
+
+    private fun sections(vararg pairs: Pair<String, String>): Map<String, String> = pairs.toMap()
+
+    @Test
+    fun `no legacy files means nothing to offer`() {
+        assertNull(parseLegacyConfigCandidate(emptyMap(), uidToPkg))
+        assertNull(
+            parseLegacyConfigCandidate(
+                sections("legacy_kmod_targets" to "\n# comment\n  \n"),
+                uidToPkg,
+            ),
+        )
+    }
+
+    @Test
+    fun `every legacy file maps onto its role`() {
+        val candidate =
+            parseLegacyConfigCandidate(
+                sections(
+                    "legacy_kmod_targets" to "com.bank.app\n",
+                    "legacy_zygisk_targets" to "com.messenger\n",
+                    "legacy_lsposed_targets" to "com.bank.app\ncom.messenger\n",
+                    "legacy_ports_observers" to "com.messenger\n",
+                    "legacy_hidden_pkgs" to "com.vpn.client\n",
+                    "legacy_observer_uids" to "10222\n",
+                ),
+                uidToPkg,
+            )!!
+
+        assertEquals(
+            setOf("com.bank.app", "com.messenger", "com.vpn.client"),
+            candidate.roles.keys,
+        )
+        assertEquals(LegacyRoles(java = true, native = true), candidate.roles["com.bank.app"])
+        assertEquals(
+            LegacyRoles(java = true, native = true, appHiding = true, ports = true),
+            candidate.roles["com.messenger"],
+        )
+        assertEquals(LegacyRoles(hidden = true), candidate.roles["com.vpn.client"])
+        assertEquals(0, candidate.unresolvedObserverUids)
+    }
+
+    @Test
+    fun `observer uid from another user resolves through the app id`() {
+        val candidate =
+            parseLegacyConfigCandidate(
+                // 1010123 = the bank app in user 10; only its user-0 uid is known here.
+                sections("legacy_observer_uids" to "1010123\n"),
+                mapOf(10123 to "com.bank.app"),
+            )!!
+        assertEquals(setOf("com.bank.app"), candidate.roles.keys)
+        assertEquals(0, candidate.unresolvedObserverUids)
+    }
+
+    @Test
+    fun `observer uid of an uninstalled app is counted, not invented`() {
+        val candidate =
+            parseLegacyConfigCandidate(
+                sections(
+                    "legacy_kmod_targets" to "com.bank.app\n",
+                    "legacy_observer_uids" to "10999\n",
+                ),
+                uidToPkg,
+            )!!
+        assertEquals(setOf("com.bank.app"), candidate.roles.keys)
+        assertEquals(1, candidate.unresolvedObserverUids)
+    }
+
+    @Test
+    fun `junk lines never reach the config`() {
+        assertNull(
+            parseLegacyConfigCandidate(
+                sections("legacy_kmod_targets" to "(missing: /data/adb/vpnhide_kmod/targets.txt)\nnodots\n"),
+                uidToPkg,
+            ),
+        )
+    }
+
+    @Test
+    fun `merge unions roles and keeps existing hook overrides`() {
+        val base =
+            CanonicalConfig(
+                apps =
+                    mapOf(
+                        "com.bank.app" to
+                            CanonicalApp(java = true, javaHooks = listOf("lsposed_get_all_networks")),
+                        "com.other" to CanonicalApp(ports = true),
+                    ),
+            )
+        val candidate =
+            LegacyConfigCandidate(
+                roles =
+                    mapOf(
+                        "com.bank.app" to LegacyRoles(java = true, native = true),
+                        "com.messenger" to LegacyRoles(java = true),
+                    ),
+            )
+
+        val merged = applyLegacyImport(base, candidate, LegacyImportMode.Merge, selfPkg)
+
+        // Already-on role keeps its narrower hook selection; the newly enabled
+        // native role gets everything, since legacy files carry no hook detail.
+        assertEquals(listOf("lsposed_get_all_networks"), merged.apps["com.bank.app"]?.javaHooks)
+        assertEquals(NativeRole.All, merged.apps["com.bank.app"]?.native)
+        assertEquals(true, merged.apps["com.messenger"]?.java)
+        assertNull(merged.apps["com.messenger"]?.javaHooks)
+        // Untouched by the import, and still present.
+        assertEquals(true, merged.apps["com.other"]?.ports)
+    }
+
+    @Test
+    fun `replace drops current app roles but keeps settings, self and auto-hidden vpns`() {
+        val base =
+            CanonicalConfig(
+                debug = true,
+                apps =
+                    mapOf(
+                        "com.other" to CanonicalApp(java = true, native = NativeRole.All),
+                        // Auto-hidden by the VpnService scan, and role-bearing:
+                        // the role goes, the hidden mark stays.
+                        "com.vpn.client" to CanonicalApp(java = true, hidden = true),
+                        selfPkg to CanonicalApp(java = true, native = NativeRole.All, hidden = true),
+                    ),
+                settings = CanonicalSettings(autoHideVpnName = true, autoHiddenPackages = setOf("com.vpn.client")),
+            )
+        val candidate = LegacyConfigCandidate(roles = mapOf("com.bank.app" to LegacyRoles(native = true)))
+
+        val replaced = applyLegacyImport(base, candidate, LegacyImportMode.Replace, selfPkg)
+
+        assertEquals(setOf("com.bank.app", "com.vpn.client", selfPkg), replaced.apps.keys)
+        assertEquals(base.settings, replaced.settings)
+        assertTrue(replaced.debug)
+        // Auto-hide mark survives; the app's own roles do not.
+        assertEquals(CanonicalApp(hidden = true), replaced.apps["com.vpn.client"])
+        // Self keeps full roles whatever the mode did.
+        assertEquals(NativeRole.All, replaced.apps[selfPkg]?.native)
+        assertEquals(true, replaced.apps[selfPkg]?.java)
+    }
+
+    @Test
+    fun `auto-hidden vpn apps do not count as a configured setup`() {
+        val autoHiddenOnly =
+            CanonicalConfig(
+                apps =
+                    mapOf(
+                        selfPkg to CanonicalApp(java = true, native = NativeRole.All, hidden = true),
+                        "com.vpn.client" to CanonicalApp(hidden = true),
+                    ),
+            )
+        assertFalse(hasUserConfiguredApps(autoHiddenOnly, selfPkg))
+
+        val configured =
+            autoHiddenOnly.copy(
+                apps = autoHiddenOnly.apps + ("com.bank.app" to CanonicalApp(java = true)),
+            )
+        assertTrue(hasUserConfiguredApps(configured, selfPkg))
+    }
+
+    @Test
+    fun `delete command retires legacy files and only the orphan dirs`() {
+        val cmd = buildLegacyConfigDeleteCommand()
+        LEGACY_FILES.forEach { assertTrue("$it missing from $cmd", cmd.contains(it)) }
+        assertTrue(cmd.contains("rmdir /data/adb/vpnhide_zygisk /data/adb/vpnhide_lsposed"))
+        // Live directories: load_status / load_dmesg / ctl.lock still live here.
+        assertFalse(cmd.contains("rmdir /data/adb/vpnhide_kmod"))
+        assertFalse(cmd.contains("rm -rf"))
+    }
+
+    @Test
+    fun `both shell probes read every legacy path`() {
+        listOf(buildRootShellSnapshotCommand(), buildDebugShellSnapshotCommand()).forEach { cmd ->
+            LEGACY_CONFIG_SECTIONS.forEach { (section, path) ->
+                assertTrue("$section missing", cmd.contains("emit_file $section $path"))
+            }
+        }
+    }
+}


### PR DESCRIPTION
Up to 0.7.1 the hiding config lived in per-component text files. 1.0.0 folded them into the canonical JSON on first launch and 1.2.0 removed that fold, so a device upgrading straight from 0.7.x to 1.2.x kept the files on disk, read none of them, and looked like the update had wiped its settings (reported on 4PDA). Because 1.2.0 also dropped the cleanup that deleted those files, the data is still recoverable on affected devices — and on every other device the files are just leftovers nothing removes.

- read the pre-1.0 lists in the root snapshot and resolve them to roles, mapping observer UIDs back through the current package inventory (falling back to the app id, so a work-profile pick still resolves)
- fold them in silently at startup when the canonical config holds no user-configured app, as 1.0.0 did; packages that only carry `hidden` are auto-hide marks and don't count as configured
- otherwise offer a dashboard banner and a Settings → Configuration entry with three actions: merge (union of roles, keeps existing per-hook selections), replace (legacy list wins; `settings`, VPN Hide's own entry and the auto-hide marks are kept), or delete without importing
- delete the legacy files in the same root transaction as the config write, so "files gone" is the imported marker; the banner's Hide button only sets a DataStore flag and leaves every action reachable from Settings
- clean the same paths on Full Reset, and carry them in the debug bundle so a bundle taken before the user decides shows what was found
- docs: new "Pre-1.0 Config Files" section in state.md, plus storage.md, debug-bundle.md and the three READMEs (whose "only used for migration" line was untrue in 1.2.x)