### PR TITLE
Fix the debug-bundle shell probe and a UTF-8 truncation panic

### DIFF
--- a/changelog.d/fixed-the-diagnostic-bundle-collects-its-forensic-0c38.md
+++ b/changelog.d/fixed-the-diagnostic-bundle-collects-its-forensic-0c38.md
@@ -1,0 +1,9 @@
+_2026-08-21_
+
+## English
+
+The diagnostic bundle collects its forensic sections again. In 1.2.5 an apostrophe inside the root probe script left a quote unbalanced, so the whole batched command failed to parse and bundles came back without the network, module and app-scan sections.
+
+## Русский
+
+Диагностический бандл снова собирает forensic-секции. В 1.2.5 апостроф внутри скрипта root-опроса оставлял кавычку незакрытой, из-за чего вся пакетная команда не разбиралась шеллом и в бандл не попадали секции по сети, модулям и сканированию приложений.

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DebugShellSnapshot.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DebugShellSnapshot.kt
@@ -345,11 +345,15 @@ internal fun buildDebugShellSnapshotCommand(): String =
         RUN=0
         printf "%s\n" "${'$'}PLAIN" | grep "UserInfo{${'$'}U:" | grep -qw running && RUN=1
         ERR=${'$'}(pm list packages -U -f --user "${'$'}U" 2>&1 1>/dev/null | head -2 | tr "\n" " ")
-        # Stage pm's stdout in a temp file rather than a shell variable: a very
-        # large app list (bloatware-heavy MIUI/HyperOS) exceeds the kernel's
+        # NOTE: never write an apostrophe inside this single-quoted block. It is
+        # not a comment to the shell (# only starts one outside quotes), so the
+        # apostrophe closes the quoting and the whole snapshot command stops
+        # parsing.
+        # Stage the pm output in a temp file rather than a shell variable: a very
+        # large app list (bloatware-heavy MIUI/HyperOS) exceeds the kernel
         # single-argument limit, so `printf "%s\n" "${'$'}OUT"` would fail with
         # "Argument list too long" and count zero packages. A file never hits
-        # ARG_MAX. pm is the only command on its line, so ${'$'}? is pm's status.
+        # ARG_MAX. pm is the only command on its line, so ${'$'}? is its status.
         OUT_FILE=/data/local/tmp/vpnhide_app_scan.${'$'}${'$'}.${'$'}U
         pm list packages -U -f --user "${'$'}U" >"${'$'}OUT_FILE" 2>/dev/null
         EX=${'$'}?

--- a/lsposed/app/src/test/kotlin/dev/okhsunrog/vpnhide/ShellSnapshotSyntaxTest.kt
+++ b/lsposed/app/src/test/kotlin/dev/okhsunrog/vpnhide/ShellSnapshotSyntaxTest.kt
@@ -1,0 +1,62 @@
+package dev.okhsunrog.vpnhide
+
+import org.junit.Assert.assertEquals
+import org.junit.Assume.assumeTrue
+import org.junit.Test
+import java.io.File
+import java.util.concurrent.TimeUnit
+
+/**
+ * Parses the generated root/debug probes with a real shell (`sh -n`).
+ *
+ * These scripts are one big `su -c` string: a single quoting slip anywhere kills
+ * the *whole* command, and every section with it — which is invisible to a
+ * `contains("emit_file …")` assertion. The regression that prompted this test
+ * was an apostrophe in a comment inside a single-quoted `emit_eval` block
+ * (`#` starts no comment in there, so the quote just ended early).
+ *
+ * Host `sh` is dash/bash and the device runs mksh, but the POSIX quoting and
+ * compound-command grammar this catches are the same.
+ */
+class ShellSnapshotSyntaxTest {
+    @Test
+    fun `root snapshot command parses`() {
+        assertParses("root_snapshot", buildRootShellSnapshotCommand())
+    }
+
+    @Test
+    fun `root snapshot command parses without the package inventory`() {
+        assertParses("root_snapshot_no_pm", buildRootShellSnapshotCommand(includePmPackages = false))
+    }
+
+    @Test
+    fun `debug snapshot command parses`() {
+        assertParses("debug_snapshot", buildDebugShellSnapshotCommand())
+    }
+
+    @Test
+    fun `hook counter snapshot command parses`() {
+        assertParses("counter_snapshot", buildHookCounterSnapshotCommand())
+    }
+
+    private fun assertParses(
+        name: String,
+        script: String,
+    ) {
+        val sh = listOf("/bin/sh", "/system/bin/sh").firstOrNull { File(it).canExecute() }
+        assumeTrue("no POSIX shell to check against", sh != null)
+        val file = File.createTempFile("vpnhide_$name", ".sh")
+        try {
+            file.writeText(script)
+            val process =
+                ProcessBuilder(sh, "-n", file.absolutePath)
+                    .redirectErrorStream(true)
+                    .start()
+            val output = process.inputStream.bufferedReader().readText()
+            process.waitFor(30, TimeUnit.SECONDS)
+            assertEquals("$name is not valid shell:\n$output", 0, process.exitValue())
+        } finally {
+            file.delete()
+        }
+    }
+}

--- a/lsposed/native/src/lib.rs
+++ b/lsposed/native/src/lib.rs
@@ -369,6 +369,51 @@ fn check_setsockopt_bindtodevice() -> CheckOutput {
     }
 }
 
+/// First `max_bytes` bytes of `line`, backed off to the nearest char boundary.
+///
+/// Interface names are arbitrary bytes, so a `/proc/net` line can legitimately
+/// carry multi-byte UTF-8. Slicing straight at `max_bytes` panics when that byte
+/// lands mid-character, and this crate builds with `panic = "abort"` — the app
+/// would die running its own diagnostics. (Truncation itself is not an edge
+/// case: `/proc/net/route` lines routinely run past 80 bytes.)
+fn truncate_on_char_boundary(line: &str, max_bytes: usize) -> &str {
+    let mut end = line.len().min(max_bytes);
+    while end > 0 && !line.is_char_boundary(end) {
+        end -= 1;
+    }
+    &line[..end]
+}
+
+#[cfg(test)]
+mod truncate_tests {
+    use super::truncate_on_char_boundary;
+
+    #[test]
+    fn keeps_short_lines_whole() {
+        assert_eq!(truncate_on_char_boundary("tun0 up", 80), "tun0 up");
+    }
+
+    #[test]
+    fn cuts_ascii_at_the_byte_budget() {
+        let line = "a".repeat(100);
+        assert_eq!(truncate_on_char_boundary(&line, 80).len(), 80);
+    }
+
+    #[test]
+    fn backs_off_when_the_budget_splits_a_character() {
+        // 'я' is two bytes: byte 80 falls inside the 40th one.
+        let line = "я".repeat(60);
+        let truncated = truncate_on_char_boundary(&line, 81);
+        assert_eq!(truncated.len(), 80);
+        assert!(line.starts_with(truncated));
+    }
+
+    #[test]
+    fn yields_nothing_when_the_first_character_does_not_fit() {
+        assert_eq!(truncate_on_char_boundary("я", 1), "");
+    }
+}
+
 fn check_proc_file(path: &str) -> CheckOutput {
     match fs::read_to_string(path) {
         Err(e) => {
@@ -388,7 +433,7 @@ fn check_proc_file(path: &str) -> CheckOutput {
                 }
                 total += 1;
                 if line.split_ascii_whitespace().any(is_vpn_iface) {
-                    vpn_lines.push(line[..line.len().min(80)].to_string());
+                    vpn_lines.push(truncate_on_char_boundary(line, 80).to_string());
                 }
             }
             if vpn_lines.is_empty() {


### PR DESCRIPTION
Two independent native/diagnostics fixes, both shipping in 1.2.5.

The debug bundle currently collects nothing: an apostrophe in a comment inside the single-quoted `app_scan_diagnostics` block closes the quoting early (`#` starts no comment in there), which splits the `for U in $IDS; do … done` loop across the quote boundary and makes the whole batched `su -c` command fail to parse. Every forensic section is lost with it, leaving only `debug snapshot command failed`. It arrived with the package-list streaming change (fefd7ea).

The second one is a panic: `line[..line.len().min(80)]` in the native checks slices at a fixed byte offset, which panics when byte 80 lands inside a multi-byte character. Interface names are arbitrary bytes, the crate builds with `panic = "abort"`, and the truncation branch itself is routine (`/proc/net/route` lines run past 80 bytes), so the app would die running its own diagnostics.

- rewrite the offending comment without apostrophes and say in place why they cannot appear there
- add a test that runs every generated probe (root, root-without-inventory, debug, hook counters) through `sh -n` — a `contains("emit_file …")` assertion cannot see this class of break
- truncate on the nearest char boundary instead of a fixed character count, keeping the 80-byte budget on the reported detail, with unit tests around the boundary cases

The truncation bug was spotted by DanSqw (github.com/DanSqw/vpnhide).