### PR TITLE
Version the debug bundle, and move the system_server code into hook/

### DIFF
--- a/docs/debug-bundle.md
+++ b/docs/debug-bundle.md
@@ -50,13 +50,38 @@ Everything below is a `state.json` field unless noted.
 
 ## 2. The 30-second triage (read in this order)
 
-1. **`captureKind`, `app.version`, `device`** — what am I even looking at? (model, Android release, ABI, app+backend version).
+1. **`captureKind`, `app.version`, `device`, `schema`** — what am I even looking at? (model, Android release, ABI, app+backend version, and which bundle format — §2.1 if it isn't the one this doc describes).
 2. **`gate`** — was the run *measurable*? Only `ROUTED` yields real verdicts. `VPN_OFF` / `SELF_NOT_ROUTED` / `NEEDS_RESTART` mean "we deliberately measured nothing" — a clean-looking report there is **not** evidence of health. (See §4.)
 3. **`nativeVerdict` / `javaVerdict`** — `Ok` / `Partial` / `Broken` / `null`. `null` = gated (see #2) or not measured.
 4. **`rootShell`** — did the snapshot shell actually have root? If `uid != 0` or `runtimeCheckable=false`, "inactive"/"not verified" readings are unreliable, not facts. (See §6 — this is the #1 misread.)
 5. **`activeBackend` + `kmodLoadStatus`** — which backend is in charge, did it load this boot, any `brokenReason`.
 6. **`errors`** — non-fatal capture failures. If it lists `snapshot truncated at: <section>`, every section at/after that one is missing or partial (see §8).
 7. Then drill into the raw `sections` and logs for the specific symptom (§5, §7, §9 playbooks).
+
+### 2.1 Schema versions
+
+`state.json → schema` says which shape the bundle was written in. **This doc
+describes schema 2.** One number covers the whole bundle; there is no per-object
+version.
+
+| Schema | Shipped in | What changed |
+|---|---|---|
+| 2 | unreleased | Sealed `kind` discriminators are compact snake_case everywhere. Previously `dashboard.lsposed` and `dashboard.protection` carried fully-qualified class names (`dev.okhsunrog.vpnhide.LsposedState.Active`) instead of `active`/`blocked`. The separate `report.schema` field is gone — the top-level one is the only version. |
+| 1 | 1.0.0 – 1.2.5 | Initial format. |
+
+Rules for changing it (enforced by `BundleSchemaGoldenTest`, which pins the
+serialized shape against `app/src/test/resources/bundle/state_golden.json`):
+
+- A field removed, renamed, or given a new meaning → **bump** `VPNHIDE_STATE_SCHEMA`
+  and add a row above.
+- A field added → no bump; a reader of an older bundle just finds it missing.
+- Either way the golden file has to be refreshed
+  (`UPDATE_GOLDEN=1 ./gradlew :app:testDebugUnitTest --tests '*BundleSchemaGoldenTest*'`),
+  so no shape change reaches a release unnoticed.
+
+Bundles are read, not machine-parsed, so nothing rejects an old schema — the
+number exists to tell you *which* doc revision applies to the file in front of
+you.
 
 ---
 
@@ -67,7 +92,7 @@ renders*, so the bundle can't disagree with what the user saw on screen.
 
 | Field | Meaning |
 |---|---|
-| `schema` | State schema version (currently 1). |
+| `schema` | Bundle schema version — **this doc describes 2** (§2.1). |
 | `generatedAt` | ISO-8601 capture time. |
 | `captureKind` | `debug` / `full_system_logcat` / `kernel_images` (§1). |
 | `app` | `{packageName, version}` — `version` is `"1.2.5 (10205)"` (name + versionCode). |

--- a/docs/detection-vectors.md
+++ b/docs/detection-vectors.md
@@ -363,7 +363,7 @@ detectors actually probe:
 | kmod | `kmod/vpnhide_kmod.c` (10 kretprobes + socket-bind redirects + four optional VFS redirects); iface matcher `kmod/generated/iface_lists.h` |
 | KPM | `kmod/kpm/vpnhide_kpm.c` (KernelPatch inline hooks + ctl0, including four optional VFS hooks); offsets in `kmod/kpm/kver_offsets.h` |
 | zygisk | `zygisk/src/hooks.rs` (ioctl/getifaddrs/openat/recv*); `zygisk/src/filter.rs` (procfs + netlink filters) |
-| lsposed | `lsposed/app/.../HookEntry.kt`, `PackageVisibilityHooks.kt`; iface matcher `.../generated/IfaceLists.kt` |
+| lsposed | `lsposed/app/.../hook/HookEntry.kt`, `hook/PackageVisibilityHooks.kt`; iface matcher `.../generated/IfaceLists.kt` |
 | iface match rules | single source of truth `data/interfaces.toml` → `scripts/codegen-interfaces.py` renders all four targets (kmod/KPM C, zygisk Rust, lsposed native Rust, lsposed Kotlin) |
 
 The interface-name patterns (`tun`/`tap`/`wg`/`ppp`/`ipsec`/`xfrm`/`utun`/`l2tp`/`gre`,

--- a/docs/lsposed-hook-debugging.md
+++ b/docs/lsposed-hook-debugging.md
@@ -10,7 +10,7 @@ covers which vector), and [lsposed/AGENTS.md](../lsposed/AGENTS.md) (the Kotlin
 module architecture). The wire the state file speaks is in
 [protocol.md](protocol.md).
 
-The hooks live in `lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/HookEntry.kt`;
+The hooks live in `lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/hook/HookEntry.kt`;
 the state file they publish is written by `LsposedState.kt` and rendered by
 `HookDiagnostics.kt`.
 

--- a/lsposed/AGENTS.md
+++ b/lsposed/AGENTS.md
@@ -70,6 +70,14 @@ reinvent them.** `grep` for an existing helper before writing a new one.
   fragments through `ProcessBuilder("sh", ...)` like `ShellCommandBuildersTest`).
 - **`grep` before adding** any parser / formatter / shell-builder / status
   colour — it probably already exists above.
+- **Changing a `@Serializable` type that reaches the debug bundle bumps the
+  bundle schema.** `BundleSchemaGoldenTest` pins the serialized shape; when it
+  fails, refresh the golden (`UPDATE_GOLDEN=1 ./gradlew :app:testDebugUnitTest
+  --tests '*BundleSchemaGoldenTest*'`) and, if a field was removed/renamed or
+  changed meaning, bump `VPNHIDE_STATE_SCHEMA` + add a row to
+  [docs/debug-bundle.md §2.1](../docs/debug-bundle.md). Sealed subclasses that
+  land in the bundle need an explicit `@SerialName` — without one kotlinx emits
+  the fully-qualified class name, which changes the moment the class moves.
 
 ## Quality gates
 

--- a/lsposed/AGENTS.md
+++ b/lsposed/AGENTS.md
@@ -6,6 +6,19 @@ duplication / god-function drift that AI-assisted edits cause when each change
 only sees its local neighbourhood. **Reuse the abstractions below — don't
 reinvent them.** `grep` for an existing helper before writing a new one.
 
+## Two processes, one APK
+
+The single most important thing about this module: `hook/` is loaded by LSPosed
+**into `system_server`**; everything else runs in the app process. So `hook/`
+carries no Compose, no Activity, no app resources — and nothing outside it may
+touch `de.robv.android.xposed` (absent in the app process). The shared vocabulary
+they both use (canonical-config parsing, `HookRegistry`, `LsposedStats`,
+`LogTags`) stays in the root package. `HookPackageBoundaryTest` enforces both
+directions, since `internal` is module-wide and the compiler will not.
+
+`assets/xposed_init` names the entry class (`…vpnhide.hook.HookEntry`) and
+`proguard-rules.pro` keeps it — moving or renaming it means editing both.
+
 ## Data flow
 
 - **Read path:** one batched root shell → `RootSnapshotCache` → typed snapshots

--- a/lsposed/app/proguard-rules.pro
+++ b/lsposed/app/proguard-rules.pro
@@ -1,5 +1,5 @@
 # Keep Xposed entry points — LSPosed loads these by reflection via assets/xposed_init
--keep class dev.okhsunrog.vpnhide.HookEntry { *; }
+-keep class dev.okhsunrog.vpnhide.hook.HookEntry { *; }
 -keepnames class dev.okhsunrog.vpnhide.** { *; }
 
 # Keep Xposed API types

--- a/lsposed/app/src/main/assets/xposed_init
+++ b/lsposed/app/src/main/assets/xposed_init
@@ -1,1 +1,1 @@
-dev.okhsunrog.vpnhide.HookEntry
+dev.okhsunrog.vpnhide.hook.HookEntry

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DashboardData.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DashboardData.kt
@@ -82,19 +82,23 @@ internal data class ModuleProblem(
 @Serializable
 sealed interface LsposedState {
     @Serializable
+    @SerialName("not_installed")
     data object NotInstalled : LsposedState
 
     @Serializable
+    @SerialName("installed_inactive")
     data class InstalledInactive(
         val version: String?,
     ) : LsposedState
 
     @Serializable
+    @SerialName("needs_reboot")
     data class NeedsReboot(
         val version: String?,
     ) : LsposedState
 
     @Serializable
+    @SerialName("active")
     data class Active(
         val version: String?,
         val targetCount: Int,
@@ -108,6 +112,7 @@ internal sealed interface ProtectionCheck {
     // self-restart. Carries the shared [DiagnosticGate] so the hero/agent explain
     // which without a second enum. Never [DiagnosticGate.ROUTED] — that is [Checked].
     @Serializable
+    @SerialName("blocked")
     data class Blocked(
         val gate: DiagnosticGate,
     ) : ProtectionCheck {
@@ -120,9 +125,11 @@ internal sealed interface ProtectionCheck {
     // just couldn't measure. Distinct from a VPN-off gate so the hero doesn't tell an
     // active-VPN user to turn their VPN on.
     @Serializable
+    @SerialName("failed")
     data object Failed : ProtectionCheck
 
     @Serializable
+    @SerialName("checked")
     data class Checked(
         val native: LayerStatus,
         val java: LayerStatus,

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DiagnosticReport.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DiagnosticReport.kt
@@ -3,12 +3,6 @@ package dev.okhsunrog.vpnhide
 import dev.okhsunrog.vpnhide.generated.HookIds
 import kotlinx.serialization.Serializable
 
-/**
- * Schema version for the serialized report (the debug bundle's `diagnostics.json`
- * and the summary header). Bump when the wire shape changes.
- */
-internal const val DIAGNOSTIC_REPORT_SCHEMA: Int = 1
-
 @Serializable
 internal enum class CheckLayer { NATIVE, JAVA }
 
@@ -98,7 +92,6 @@ internal data class DiagnosticReport(
     val java: LayerReport,
     // False after the fast core phase, true once the slow Java probes have filled in.
     val complete: Boolean,
-    val schema: Int = DIAGNOSTIC_REPORT_SCHEMA,
 ) {
     /** Per-layer Ok/Partial/Broken — the ONLY way to read a report's verdict.
      * Null unless the run was actually measured ([DiagnosticGate.ROUTED]); a

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DiagnosticsScreen.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/DiagnosticsScreen.kt
@@ -37,6 +37,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import dev.okhsunrog.vpnhide.generated.IfaceLists
+import dev.okhsunrog.vpnhide.hook.HookLog
 import dev.okhsunrog.vpnhide.ui.components.ButtonSpinner
 import dev.okhsunrog.vpnhide.ui.components.EnhancedButton
 import dev.okhsunrog.vpnhide.ui.components.EnhancedCard

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/KernelImageExport.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/KernelImageExport.kt
@@ -2,6 +2,7 @@ package dev.okhsunrog.vpnhide
 
 import android.content.Context
 import android.os.Process
+import dev.okhsunrog.vpnhide.hook.HookLog
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/LsposedState.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/LsposedState.kt
@@ -5,6 +5,7 @@ import android.os.Handler
 import android.os.HandlerThread
 import android.os.Process
 import dev.okhsunrog.vpnhide.generated.HookIds
+import dev.okhsunrog.vpnhide.hook.HookLog
 import java.io.File
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.atomic.AtomicBoolean

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/VpnHideState.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/VpnHideState.kt
@@ -18,11 +18,24 @@ import kotlinx.serialization.json.JsonElement
  * object: the derived state, the raw shell sections it was derived from, the
  * captured logs, and the root-shell self-diagnosis.
  *
- * Compatibility is intentionally NOT a concern: nothing consumes this format but
- * an operator (or an AI) reading the file, so fields may be added/removed freely.
- * The invariant that matters is completeness.
+ * Nothing machine-parses this format but an operator (or an AI) reading a bug
+ * report, so the shape may change freely — but a bundle can arrive months late,
+ * from an app version nobody has the source of at hand, so the version it was
+ * written against travels with it.
+ *
+ * The number below is the ONE version of the whole bundle (there is no separate
+ * per-object version). Bump it when a field is removed, renamed, or changes
+ * meaning; a pure addition needs no bump. Either way `BundleSchemaGoldenTest`
+ * fails until the golden file is updated, so no shape change ships unnoticed.
+ * Every version gets a row in the history table in docs/debug-bundle.md — the
+ * number is only worth carrying if it can be looked up.
+ *
+ * 2: sealed `kind` discriminators are compact snake_case everywhere. Before
+ *    this, LsposedState and ProtectionCheck serialized as fully-qualified class
+ *    names, which also made them unmovable between packages.
+ * 1: initial.
  */
-internal const val VPNHIDE_STATE_SCHEMA: Int = 1
+internal const val VPNHIDE_STATE_SCHEMA: Int = 2
 
 /**
  * What to include in a captured [VpnHideState]. The ONE source of truth for the

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/hook/ConnectivityAttachDiagnostics.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/hook/ConnectivityAttachDiagnostics.kt
@@ -1,5 +1,7 @@
-package dev.okhsunrog.vpnhide
+package dev.okhsunrog.vpnhide.hook
 
+import dev.okhsunrog.vpnhide.LsposedStats
+import dev.okhsunrog.vpnhide.bit
 import dev.okhsunrog.vpnhide.generated.HookIds
 import java.util.concurrent.CopyOnWriteArrayList
 

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/hook/HookEntry.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/hook/HookEntry.kt
@@ -1,4 +1,4 @@
-package dev.okhsunrog.vpnhide
+package dev.okhsunrog.vpnhide.hook
 
 import android.net.ConnectivityManager
 import android.net.LinkProperties
@@ -16,6 +16,8 @@ import de.robv.android.xposed.XC_MethodHook
 import de.robv.android.xposed.XposedBridge
 import de.robv.android.xposed.XposedHelpers
 import de.robv.android.xposed.callbacks.XC_LoadPackage
+import dev.okhsunrog.vpnhide.LsposedStats
+import dev.okhsunrog.vpnhide.bit
 import dev.okhsunrog.vpnhide.generated.HookIds
 import dev.okhsunrog.vpnhide.generated.IfaceLists
 import java.util.concurrent.atomic.AtomicBoolean

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/hook/HookLog.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/hook/HookLog.kt
@@ -1,8 +1,10 @@
-package dev.okhsunrog.vpnhide
+package dev.okhsunrog.vpnhide.hook
 
 import android.os.FileObserver
 import android.util.Log
 import de.robv.android.xposed.XposedBridge
+import dev.okhsunrog.vpnhide.GatedLogger
+import dev.okhsunrog.vpnhide.LogTags
 
 /**
  * system_server logcat facade for LSPosed hooks, which can't reach the app's

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/hook/HookReflectionProbe.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/hook/HookReflectionProbe.kt
@@ -1,6 +1,6 @@
 @file:Suppress("DEPRECATION")
 
-package dev.okhsunrog.vpnhide
+package dev.okhsunrog.vpnhide.hook
 
 import android.net.LinkProperties
 import android.net.NetworkInfo

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/hook/PackageVisibilityHooks.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/hook/PackageVisibilityHooks.kt
@@ -1,4 +1,4 @@
-package dev.okhsunrog.vpnhide
+package dev.okhsunrog.vpnhide.hook
 
 import android.content.pm.ApplicationInfo
 import android.content.pm.PackageInfo
@@ -10,6 +10,7 @@ import android.os.Process
 import de.robv.android.xposed.XC_MethodHook
 import de.robv.android.xposed.XposedBridge
 import de.robv.android.xposed.XposedHelpers
+import dev.okhsunrog.vpnhide.LsposedStats
 import dev.okhsunrog.vpnhide.generated.HookIds
 
 /**

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/hook/SystemDataFileWatcher.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/hook/SystemDataFileWatcher.kt
@@ -1,4 +1,4 @@
-package dev.okhsunrog.vpnhide
+package dev.okhsunrog.vpnhide.hook
 
 import android.os.FileObserver
 

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/hook/SystemServerConfigCache.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/hook/SystemServerConfigCache.kt
@@ -1,7 +1,12 @@
-package dev.okhsunrog.vpnhide
+package dev.okhsunrog.vpnhide.hook
 
 import android.os.SystemClock
+import dev.okhsunrog.vpnhide.CANONICAL_CONFIG_FILE
+import dev.okhsunrog.vpnhide.LsposedJavaHookEntries
 import dev.okhsunrog.vpnhide.generated.HookIds
+import dev.okhsunrog.vpnhide.hasHook
+import dev.okhsunrog.vpnhide.hookSelectionMask
+import dev.okhsunrog.vpnhide.parseCanonicalConfig
 import java.io.File
 
 internal data class SystemServerConfig(

--- a/lsposed/app/src/test/kotlin/dev/okhsunrog/vpnhide/BundleSchemaGoldenTest.kt
+++ b/lsposed/app/src/test/kotlin/dev/okhsunrog/vpnhide/BundleSchemaGoldenTest.kt
@@ -1,0 +1,137 @@
+package dev.okhsunrog.vpnhide
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.io.File
+
+/**
+ * Pins the serialized shape of the debug bundle against a checked-in golden file.
+ *
+ * `state.json` is read by people (and agents) triaging bug reports, often months
+ * after the app that wrote it shipped, using docs/debug-bundle.md as the map. A
+ * field that silently renames itself — or a sealed `kind` that changes because a
+ * class moved package — makes that doc quietly wrong and old bundles
+ * un-diffable. Nothing else notices: the encoder happily emits whatever the
+ * classes currently say.
+ *
+ * So the shape is frozen here. When this test fails, the change is real: refresh
+ * the golden with `-DupdateGolden=true`, and if the change removes/renames a
+ * field or alters its meaning, bump [VPNHIDE_STATE_SCHEMA] and add a row to the
+ * history table in docs/debug-bundle.md. A pure addition needs no bump — only
+ * the refreshed golden.
+ */
+class BundleSchemaGoldenTest {
+    private val golden = File("src/test/resources/bundle/state_golden.json")
+
+    @Test
+    fun `the serialized bundle matches the golden file`() {
+        val actual = sampleBundleState().toJson()
+
+        // Env var, not a -D property: Gradle forwards the environment to the test
+        // JVM but not its own system properties.
+        if (System.getenv("UPDATE_GOLDEN") == "1") {
+            golden.parentFile.mkdirs()
+            golden.writeText(actual)
+        }
+
+        assertTrue(
+            "golden file missing — regenerate with: " +
+                "UPDATE_GOLDEN=1 ./gradlew :app:testDebugUnitTest --tests '*BundleSchemaGoldenTest*'",
+            golden.isFile,
+        )
+        assertEquals(
+            "The debug bundle's serialized shape changed. If this is intended: refresh the golden with " +
+                "UPDATE_GOLDEN=1, and bump VPNHIDE_STATE_SCHEMA + add a docs/debug-bundle.md history " +
+                "row when a field was removed, renamed, or changed meaning.",
+            golden.readText(),
+            actual,
+        )
+    }
+
+    @Test
+    fun `no fully-qualified class name reaches the wire`() {
+        // Sealed hierarchies without an explicit @SerialName serialize their
+        // discriminator as the FQCN, which both bloats the bundle and pins the
+        // classes to their current package. Catching it here keeps `kind` values
+        // stable across any future package move.
+        val json = sampleBundleState().toJson()
+        assertTrue("FQCN leaked into the bundle:\n$json", !json.contains("dev.okhsunrog.vpnhide."))
+    }
+
+    @Test
+    fun `the golden carries the current schema number`() {
+        assertTrue(
+            "golden not regenerated after a schema bump",
+            golden.readText().contains("\"schema\": $VPNHIDE_STATE_SCHEMA"),
+        )
+    }
+}
+
+/**
+ * A fixed, fully-populated state: every optional block filled, so the golden
+ * covers the whole shape rather than the fields one capture path happens to set.
+ * Values are constants — no clock, no device — so the encoding is reproducible.
+ */
+internal fun sampleBundleState(): VpnHideState {
+    val kmod = ModuleState.Installed(version = "1.2.5", active = true, runtimeCheckable = true)
+    val backends =
+        NativeBackendStates(
+            kmod = kmod,
+            kpm = ModuleState.NotInstalled,
+            zygisk = ModuleState.Installed(version = "1.2.5", active = false, runtimeCheckable = true),
+        )
+    val report =
+        buildDiagnosticReport(
+            gate = DiagnosticGate.ROUTED,
+            results = CheckResults(native = emptyList()),
+            backend = displayNativeBackend(backends),
+            lsposedActive = true,
+            complete = true,
+        )
+    return VpnHideState(
+        generatedAt = "2026-08-22T12:00:00+0300",
+        captureKind = "debug",
+        app = AppInfo("dev.okhsunrog.vpnhide", "1.2.5 (10205)"),
+        device = DeviceInfo("Google", "Pixel 8 Pro", "17", 36, listOf("arm64-v8a")),
+        selfNeedsRestart = false,
+        gate = report.gate,
+        nativeVerdict = report.nativeVerdict,
+        javaVerdict = report.javaVerdict,
+        report = report,
+        backends = backends,
+        activeBackend = displayNativeBackend(backends),
+        ports = ModuleState.NotInstalled,
+        kmodLoadStatus = null,
+        // The bridge-only block, included here on purpose: LsposedState and
+        // ProtectionCheck are only reachable through it, and they are exactly the
+        // sealed types whose discriminators used to be fully-qualified names.
+        dashboard =
+            DashboardState(
+                kmod = kmod,
+                kpm = ModuleState.NotInstalled,
+                zygisk = backends.zygisk,
+                lsposed = LsposedState.Active(version = "1.2.5", targetCount = 3),
+                ports = ModuleState.NotInstalled,
+                nativeTargetCount = 3,
+                portsTargetCount = 0,
+                nativeBackend = displayNativeBackend(backends),
+                nativeInstallRecommendation = null,
+                kmodLoadStatus = null,
+                protection = ProtectionCheck.Blocked(DiagnosticGate.VPN_OFF),
+                messages = emptyList(),
+            ),
+        rootShell =
+            RootShellDiag.from(
+                mapOf("snapshot_shell_uid" to "uid=0\nid=uid=0(root)\ncontext=u:r:ksu:s0\nerrno_ctl=ok"),
+            ),
+        sections = mapOf("proc_exists" to "1", "current_boot_id" to "boot-1"),
+        dmesg = "vpnhide: loaded",
+        logcat = "",
+        bootLsposedLogcat = "",
+        lsposedConfigDb = "",
+        hookReport = null,
+        debugCapture = null,
+        errors = emptyList(),
+    )
+}

--- a/lsposed/app/src/test/kotlin/dev/okhsunrog/vpnhide/HookPackageBoundaryTest.kt
+++ b/lsposed/app/src/test/kotlin/dev/okhsunrog/vpnhide/HookPackageBoundaryTest.kt
@@ -1,0 +1,58 @@
+package dev.okhsunrog.vpnhide
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.io.File
+
+/**
+ * Guards the one boundary in this module that has a real failure mode: code in
+ * `hook/` is loaded by LSPosed **into `system_server`**, not into the app.
+ *
+ * Nothing in the language enforces it — `internal` is module-wide, so a hook
+ * file can reference a Compose screen or an app-process cache and still compile,
+ * and the mistake only surfaces as a system_server crash on a user's device. The
+ * package split makes the boundary visible; this test makes it stick.
+ */
+class HookPackageBoundaryTest {
+    private val mainSources = File("src/main/kotlin/dev/okhsunrog/vpnhide")
+    private val hookSources = File(mainSources, "hook")
+
+    private fun kotlinFiles(dir: File): List<File> = dir.listFiles().orEmpty().filter { it.isFile && it.extension == "kt" }
+
+    private fun imports(file: File): List<String> =
+        file.readLines().filter { it.startsWith("import ") }.map { it.removePrefix("import ").trim() }
+
+    @Test
+    fun `the hook package exists and is where the Xposed entry lives`() {
+        assertTrue("hook sources missing at ${hookSources.path}", hookSources.isDirectory)
+        assertEquals(
+            "assets/xposed_init must name the entry class by its real package",
+            "dev.okhsunrog.vpnhide.hook.HookEntry",
+            File("src/main/assets/xposed_init").readText().trim(),
+        )
+    }
+
+    @Test
+    fun `hook code pulls in no UI`() {
+        // system_server has no Compose, no Activity, no app resources. An import
+        // that drags any of it in is a crash waiting for the next ROM.
+        val forbidden = listOf("androidx.compose", "androidx.activity", "dev.okhsunrog.vpnhide.ui.")
+        val offenders =
+            kotlinFiles(hookSources).flatMap { file ->
+                imports(file).filter { imp -> forbidden.any(imp::startsWith) }.map { "${file.name}: $it" }
+            }
+        assertEquals("hook/ must stay free of app-process UI", emptyList<String>(), offenders)
+    }
+
+    @Test
+    fun `Xposed APIs stay inside the hook package`() {
+        // The reverse direction: XposedBridge is only linked in the LSPosed-loaded
+        // process, so touching it from app code throws NoClassDefFoundError.
+        val offenders =
+            kotlinFiles(mainSources).flatMap { file ->
+                imports(file).filter { it.startsWith("de.robv.android.xposed") }.map { "${file.name}: $it" }
+            }
+        assertEquals("Xposed imports belong in hook/", emptyList<String>(), offenders)
+    }
+}

--- a/lsposed/app/src/test/kotlin/dev/okhsunrog/vpnhide/hook/SystemServerConfigCacheTest.kt
+++ b/lsposed/app/src/test/kotlin/dev/okhsunrog/vpnhide/hook/SystemServerConfigCacheTest.kt
@@ -1,4 +1,4 @@
-package dev.okhsunrog.vpnhide
+package dev.okhsunrog.vpnhide.hook
 
 import org.junit.Assert.assertEquals
 import org.junit.Test

--- a/lsposed/app/src/test/resources/bundle/state_golden.json
+++ b/lsposed/app/src/test/resources/bundle/state_golden.json
@@ -1,0 +1,165 @@
+{
+    "schema": 2,
+    "generatedAt": "2026-08-22T12:00:00+0300",
+    "captureKind": "debug",
+    "app": {
+        "packageName": "dev.okhsunrog.vpnhide",
+        "version": "1.2.5 (10205)"
+    },
+    "device": {
+        "manufacturer": "Google",
+        "model": "Pixel 8 Pro",
+        "androidRelease": "17",
+        "sdk": 36,
+        "abis": [
+            "arm64-v8a"
+        ]
+    },
+    "selfNeedsRestart": false,
+    "gate": "ROUTED",
+    "nativeVerdict": "Ok",
+    "javaVerdict": "Ok",
+    "report": {
+        "gate": "ROUTED",
+        "native": {
+            "layer": "NATIVE",
+            "backend": "Kmod",
+            "status": {
+                "kind": "active",
+                "hidden": 0,
+                "leaks": 0
+            },
+            "unownedLeaks": 0,
+            "checks": []
+        },
+        "java": {
+            "layer": "JAVA",
+            "backend": null,
+            "status": {
+                "kind": "active",
+                "hidden": 0,
+                "leaks": 0
+            },
+            "unownedLeaks": 0,
+            "checks": []
+        },
+        "complete": true
+    },
+    "backends": {
+        "kmod": {
+            "kind": "installed",
+            "version": "1.2.5",
+            "active": true,
+            "gkiVariant": null,
+            "brokenReason": null,
+            "pendingReboot": false,
+            "runtimeCheckable": true
+        },
+        "kpm": {
+            "kind": "not_installed"
+        },
+        "zygisk": {
+            "kind": "installed",
+            "version": "1.2.5",
+            "active": false,
+            "gkiVariant": null,
+            "brokenReason": null,
+            "pendingReboot": false,
+            "runtimeCheckable": true
+        }
+    },
+    "activeBackend": {
+        "id": "Kmod",
+        "state": {
+            "kind": "installed",
+            "version": "1.2.5",
+            "active": true,
+            "gkiVariant": null,
+            "brokenReason": null,
+            "pendingReboot": false,
+            "runtimeCheckable": true
+        }
+    },
+    "ports": {
+        "kind": "not_installed"
+    },
+    "kmodLoadStatus": null,
+    "dashboard": {
+        "kmod": {
+            "kind": "installed",
+            "version": "1.2.5",
+            "active": true,
+            "gkiVariant": null,
+            "brokenReason": null,
+            "pendingReboot": false,
+            "runtimeCheckable": true
+        },
+        "kpm": {
+            "kind": "not_installed"
+        },
+        "zygisk": {
+            "kind": "installed",
+            "version": "1.2.5",
+            "active": false,
+            "gkiVariant": null,
+            "brokenReason": null,
+            "pendingReboot": false,
+            "runtimeCheckable": true
+        },
+        "lsposed": {
+            "kind": "active",
+            "version": "1.2.5",
+            "targetCount": 3
+        },
+        "ports": {
+            "kind": "not_installed"
+        },
+        "nativeTargetCount": 3,
+        "portsTargetCount": 0,
+        "nativeBackend": {
+            "id": "Kmod",
+            "state": {
+                "kind": "installed",
+                "version": "1.2.5",
+                "active": true,
+                "gkiVariant": null,
+                "brokenReason": null,
+                "pendingReboot": false,
+                "runtimeCheckable": true
+            }
+        },
+        "nativeInstallRecommendation": null,
+        "kmodLoadStatus": null,
+        "protection": {
+            "kind": "blocked",
+            "gate": "VPN_OFF"
+        },
+        "messages": [],
+        "installedOptionalHooks": [],
+        "legacyImport": null
+    },
+    "config": null,
+    "statistics": null,
+    "rootShell": {
+        "uid": 0,
+        "idLine": "uid=0(root)",
+        "context": "u:r:ksu:s0",
+        "errnoCtl": "ok",
+        "runtimeCheckable": true
+    },
+    "sections": {
+        "proc_exists": "1",
+        "current_boot_id": "boot-1"
+    },
+    "dmesg": "vpnhide: loaded",
+    "logcat": "",
+    "bootLsposedLogcat": "",
+    "lsposedConfigDb": "",
+    "hookReport": null,
+    "debugCapture": null,
+    "captureOptions": {
+        "forensics": false,
+        "appList": false
+    },
+    "errors": []
+}


### PR DESCRIPTION
`state.json` carried two schema numbers, both pinned at 1 since the format existed, next to a comment saying compatibility was not a concern. A number that never moves tells a triager nothing about the file in front of them, and nothing stopped the shape from drifting between releases. This makes it a real version and then uses that safety net for the first package move: `hook/` is loaded by LSPosed into system_server, which is the one boundary in this module with a real failure mode, and the flat 96-file package hid it.

- one version for the whole bundle (`DiagnosticReport.schema` is gone), bumped to 2, with a history table and bump rules in docs/debug-bundle.md §2.1
- `LsposedState` and `ProtectionCheck` get explicit `@SerialName` values; without them kotlinx emits the fully-qualified class name as the `kind` discriminator, so those two blocks read `dev.okhsunrog.vpnhide.LsposedState.Active` while every other sealed type reads `active` — and the value would have changed silently the moment the class moved package
- `BundleSchemaGoldenTest` pins the encoded shape against a checked-in golden file and asserts no fully-qualified name reaches the wire, so a shape change cannot ship unnoticed
- `hook/` package: HookEntry, PackageVisibilityHooks, SystemServerConfigCache, HookLog, HookReflectionProbe, ConnectivityAttachDiagnostics and the shared /data/system watcher. Pure move, 12 imports added, no logic touched; the shared vocabulary (HookRegistry, LsposedStats, canonical-config parsing, LogTags) stays at the root package
- `assets/xposed_init` and the R8 keep rule name the new class — verified against the built APK, which carries `dev/okhsunrog/vpnhide/hook/HookEntry` after minification
- `HookPackageBoundaryTest` enforces both directions: no Compose/Activity imports in `hook/`, no Xposed imports outside it, and xposed_init matching the real package

Note for whichever of this and #308 merges second: both touch the serialized report, so the golden file needs refreshing (`UPDATE_GOLDEN=1 ./gradlew :app:testDebugUnitTest --tests '*BundleSchemaGoldenTest*'`). Adding a field needs no schema bump.