### PR TITLE
Clear the standing compiler warnings and gate on them in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -237,7 +237,14 @@ jobs:
         # `:app:lintDebug` (not `:app:lint`) runs Lint on the debug
         # variant only — release-variant Lint covers R8/ProGuard issues
         # and is reserved for ad-hoc local runs / future tag CI.
-        run: cd lsposed && ./gradlew :app:detekt cpdCheck :app:lintDebug :app:testDebugUnitTest
+        # -PvpnhideWarningsAsErrors: the module compiles with zero Kotlin
+        # warnings; this keeps it that way. Off by default so a warning mid-edit
+        # doesn't stop a local build. A toolchain bump that introduces new
+        # warnings fails here — fix or @Suppress them in the bump.
+        run: |
+          cd lsposed
+          ./gradlew -PvpnhideWarningsAsErrors=true \
+            :app:detekt cpdCheck :app:lintDebug :app:testDebugUnitTest
 
   kmod-activator:
     needs: setup
@@ -658,11 +665,11 @@ jobs:
           cd "$GITHUB_WORKSPACE/lsposed"
           case "$GITHUB_REF" in
             refs/tags/v*)
-              ./gradlew assembleRelease
+              ./gradlew -PvpnhideWarningsAsErrors=true assembleRelease
               cp app/build/outputs/apk/release/app-release.apk "$GITHUB_WORKSPACE/vpnhide.apk"
               ;;
             *)
-              ./gradlew assembleDebug
+              ./gradlew -PvpnhideWarningsAsErrors=true assembleDebug
               cp app/build/outputs/apk/debug/app-debug.apk "$GITHUB_WORKSPACE/vpnhide.apk"
               ;;
           esac

--- a/lsposed/app/build.gradle.kts
+++ b/lsposed/app/build.gradle.kts
@@ -281,9 +281,19 @@ android {
     }
 }
 
+// Compiler warnings are errors in CI (`-PvpnhideWarningsAsErrors`), not locally:
+// a warning mid-edit is information, not a reason to stop the build. The module
+// compiles clean, so the gate only has to keep it that way — and the toolchain
+// that decides what warns is pinned (Gradle via the wrapper, AGP/Kotlin/Compose
+// in libs.versions.toml, NDK by ndkVersion above, JDK by the CI image), so new
+// warnings arrive with a deliberate version bump and get dealt with there.
+// A warning that is genuinely correct to keep gets an @Suppress at its site.
+val warningsAsErrors = (project.findProperty("vpnhideWarningsAsErrors") as String?)?.toBoolean() == true
+
 kotlin {
     compilerOptions {
         jvmTarget.set(JvmTarget.JVM_17)
+        allWarningsAsErrors.set(warningsAsErrors)
     }
 }
 

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/FullResetDialog.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/FullResetDialog.kt
@@ -135,7 +135,6 @@ internal fun FullResetDialog(
                 }
 
                 done == false || running -> {
-                    Unit
                 }
 
                 ready -> {
@@ -160,7 +159,6 @@ internal fun FullResetDialog(
                 }
 
                 else -> {
-                    Unit
                 }
             }
         },

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/LegacyImportUi.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/LegacyImportUi.kt
@@ -182,7 +182,6 @@ internal fun LegacyImportDialog(
             when (state) {
                 // The three choices live in the body; nothing to confirm here.
                 LegacyImportUiState.Choosing, LegacyImportUiState.Running -> {
-                    Unit
                 }
 
                 is LegacyImportUiState.Done -> {

--- a/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/diagnostics/DiagnosticsScreen.kt
+++ b/lsposed/app/src/main/kotlin/dev/okhsunrog/vpnhide/diagnostics/DiagnosticsScreen.kt
@@ -708,7 +708,6 @@ private fun rememberCaptureGate(selfNeedsRestart: Boolean?): CaptureGate {
                 awaitingFreshSinceOpen = false
             }
         }
-        Unit
     }
     LaunchedEffect(selfNeedsRestart) { recheck() }
     return CaptureGate(

--- a/lsposed/app/src/test/kotlin/dev/okhsunrog/vpnhide/BundleSchemaGoldenTest.kt
+++ b/lsposed/app/src/test/kotlin/dev/okhsunrog/vpnhide/BundleSchemaGoldenTest.kt
@@ -40,7 +40,7 @@ class BundleSchemaGoldenTest {
         // Env var, not a -D property: Gradle forwards the environment to the test
         // JVM but not its own system properties.
         if (System.getenv("UPDATE_GOLDEN") == "1") {
-            golden.parentFile.mkdirs()
+            golden.parentFile?.mkdirs()
             golden.writeText(actual)
         }
 

--- a/lsposed/app/src/test/kotlin/dev/okhsunrog/vpnhide/DiagnosticReportTest.kt
+++ b/lsposed/app/src/test/kotlin/dev/okhsunrog/vpnhide/DiagnosticReportTest.kt
@@ -191,11 +191,13 @@ class DiagnosticReportTest {
         assertEquals("root: tun0 up", leak.groundTruthDetail)
     }
 
+    private val prettyJson = Json { prettyPrint = true }
+
     @Test
     fun `the report serializes straight to JSON with its outcome and ground truth`() {
         // No hand-written DTO: the domain report IS the serialized form. @SerialName
         // gives the outcome a compact token discriminator, not a fully-qualified name.
-        val json = Json { prettyPrint = true }.encodeToString(leakReport())
+        val json = prettyJson.encodeToString(leakReport())
         assertTrue("compact outcome discriminator", json.contains("\"leak\""))
         assertTrue("ground truth carried", json.contains("\"root: tun0 up\""))
         assertTrue("check id carried", json.contains("\"ioctl_flags\""))


### PR DESCRIPTION
The module compiled with six warnings, which is enough noise that a seventh — a real one — would scroll past unread. Only one was a latent defect. With the module clean, CI now enforces that state.

`BundleSchemaGoldenTest` called `File.parentFile.mkdirs()` on a receiver Kotlin now types as nullable. It cannot be null for the relative path used there, so nothing is broken today, but the warning is on its way to becoming a hard error and the failure mode would be a golden-refresh path that NPEs.

The other five were deliberate, and are documented in the commit rather than left to be re-litigated: four `Unit` literals standing in for empty branches in Compose `when` slots, and one `Json` format rebuilt inside a test body. None needed an `@Suppress` in the end — written plainly, they stop warning by construction.

`allWarningsAsErrors` is gated behind `-PvpnhideWarningsAsErrors=true`, passed by the CI Gradle invocations and off by default, so a warning mid-edit doesn't stop a local build. The usual objection — a toolchain bump reddening someone else's PR — does not apply here: every input that decides what warns is pinned (Gradle by the wrapper, AGP/Kotlin/Compose in `libs.versions.toml`, the NDK by `ndkVersion`, the JDK by the CI container image), so new warnings can only arrive on the PR that does the bumping.

- `golden.parentFile?.mkdirs()`
- drop four `Unit` no-op branch bodies in `FullResetDialog`, `LegacyImportUi`, `DiagnosticsScreen`
- build `DiagnosticReportTest`'s `Json` format once per class instead of per call
- add the `vpnhideWarningsAsErrors` property and pass it from the lint/test and APK-build CI steps

Testing: verified both directions — reintroducing the nullable-receiver warning passes without the flag and fails the build with it.